### PR TITLE
release 0.0.3: campaign configs, resumable release runner, reconstruction driver

### DIFF
--- a/SLURM/submit_release_campaign_arm.sh
+++ b/SLURM/submit_release_campaign_arm.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Per-arm sbatch template for the split release-0.0.3 h600/s30 execution packet
+# (see docs/context/release_0_0_3_slurm_execution_packet.md for the full design
+# rationale). One sbatch submission runs exactly ONE planner arm's already-generated
+# child-campaign command from the plan packet -- it does not invent a new command.
+#
+# This template intentionally keeps the #SBATCH block minimal and lets the submitter
+# pass --job-name, --output, --mem, --cpus-per-task, --time, and --partition on the
+# `sbatch` command line so a single file serves all 14 arms with their own memory
+# tier and log path. See the "Submission loop" section of the execution-packet doc
+# for the exact per-arm sbatch invocations (heavy vs light memory table included).
+#
+# Required environment (pass via `sbatch --export=...`):
+#   ARM_KEY                 planner key exactly as it appears in the split manifest
+#                            and in the plan packet's arms[].planner_keys (e.g. "ppo").
+# Optional environment:
+#   PACKET                  path to the plan packet JSON (default: see below).
+#   CHECKPOINT_STAGING_REPORT
+#                            path to the checkpoint_staging.json written by
+#                            scripts/benchmark/submit_camera_ready_checkpoint_gate.sh
+#                            BEFORE this job was submitted. If set, the job refuses to
+#                            run unless the report exists and reports submit_safe=true
+#                            (issue #4613 contract: stage before sbatch, not inside it).
+#   UV_PROJECT_ENVIRONMENT  optional uv-managed venv path override (LiCCA scratch venv).
+#
+#SBATCH --job-name=rsf-release-arm
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=16G
+#SBATCH --time=08:00:00
+#SBATCH --output=output/slurm/%j-release-arm.out
+
+set -euo pipefail
+
+# --- Resolve repo root the same way whether invoked via sbatch or manually. ---
+PROJECT_ROOT="$(
+  git -C "${SLURM_SUBMIT_DIR:-$(pwd)}" rev-parse --show-toplevel 2>/dev/null \
+    || echo "${SLURM_SUBMIT_DIR:-$(pwd)}"
+)"
+cd "${PROJECT_ROOT}"
+
+ARM_KEY="${ARM_KEY:-}"
+PACKET="${PACKET:-output/benchmarks/release_v0_0_3_split_plan/execution_packet.json}"
+CHECKPOINT_STAGING_REPORT="${CHECKPOINT_STAGING_REPORT:-}"
+
+if [[ -z "${ARM_KEY}" ]]; then
+  echo "error: ARM_KEY is required (sbatch --export=ARM_KEY=<planner_key>,... ...)" >&2
+  exit 2
+fi
+if [[ ! -f "${PACKET}" ]]; then
+  echo "error: execution packet not found: ${PACKET}" >&2
+  echo "       generate it first with scripts/tools/run_split_camera_ready_campaign.py plan" >&2
+  exit 2
+fi
+
+echo "== [release-0.0.3] arm=${ARM_KEY} job=${SLURM_JOB_ID:-manual} node=${SLURMD_NODENAME:-local} =="
+echo "   packet=${PACKET}"
+date
+
+# --- Pre-flight: refuse to run an unstaged learned-policy arm (issue #4613). ---
+# The checkpoint gate must run BEFORE sbatch, on the submit/login node, with --stage
+# (enforced_staged mode). This is a runtime guard, not the staging step itself.
+if [[ -n "${CHECKPOINT_STAGING_REPORT}" ]]; then
+  if [[ ! -f "${CHECKPOINT_STAGING_REPORT}" ]]; then
+    echo "error: checkpoint staging report missing: ${CHECKPOINT_STAGING_REPORT}" >&2
+    echo "       run scripts/benchmark/submit_camera_ready_checkpoint_gate.sh before sbatch." >&2
+    exit 2
+  fi
+  SUBMIT_SAFE="$(python3 -c "
+import json, sys
+payload = json.load(open('${CHECKPOINT_STAGING_REPORT}'))
+print(str(payload.get('submit_safe')).lower())
+" 2>/dev/null || echo "false")"
+  if [[ "${SUBMIT_SAFE}" != "true" ]]; then
+    echo "error: checkpoint staging report reports submit_safe=${SUBMIT_SAFE}; do NOT run." >&2
+    echo "       re-run scripts/benchmark/submit_camera_ready_checkpoint_gate.sh --stage." >&2
+    exit 2
+  fi
+  echo "   checkpoint staging: submit_safe=true (${CHECKPOINT_STAGING_REPORT})"
+fi
+
+# --- Extract this arm's exact planned command + campaign root from the packet. ---
+# The packet's "command" field is the literal argv the `plan` step generated; we do
+# not reconstruct or guess it here, only look it up so one script covers all 14 arms.
+# `mapfile` (not `read var1 var2`) is required here: the command line itself contains
+# spaces, so splitting a single line across two variables would truncate it.
+mapfile -t _ARM_LOOKUP < <(python3 -c "
+import json, sys
+packet = json.load(open('${PACKET}'))
+for arm in packet['arms']:
+    if list(arm['planner_keys']) == ['${ARM_KEY}']:
+        print(arm['command'])
+        print(arm['campaign_root'])
+        break
+else:
+    sys.exit('arm not found: ${ARM_KEY}')
+")
+ARM_COMMAND="${_ARM_LOOKUP[0]:-}"
+ARM_CAMPAIGN_ROOT="${_ARM_LOOKUP[1]:-}"
+
+if [[ -z "${ARM_COMMAND:-}" ]]; then
+  echo "error: could not resolve command for ARM_KEY=${ARM_KEY} from ${PACKET}" >&2
+  exit 2
+fi
+
+echo "   campaign_root=${ARM_CAMPAIGN_ROOT}"
+echo "   command=${ARM_COMMAND}"
+
+# --- Threading guard (issue: macOS/torch segfault mitigation; harmless + correct
+#     thread-limiting on Linux compute nodes too). Each of the campaign's `workers`
+#     worker processes (ProcessPoolExecutor, see robot_sf/benchmark/map_runner.py)
+#     independently imports torch/tensorflow for learned-policy arms; without these
+#     guards each process can additionally spawn N BLAS/OpenMP threads and
+#     oversubscribe the allocated CPUs on top of the process-level memory cost. ---
+export KMP_DUPLICATE_LIB_OK=TRUE
+export OMP_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
+
+# Headless simulation rendering guards (matches SLURM/feature_extractor_comparison
+# templates for this repo).
+export DISPLAY=""
+export MPLBACKEND="Agg"
+export SDL_VIDEODRIVER="dummy"
+
+# --- Module / environment activation. ---
+# LiCCA (SLURM/Licca/README.md): purge interactive modules; prefer the project's
+# uv-managed environment when present (SLURM/Licca/setup_uv_environment.sh stages
+# uv onto scratch), otherwise fall back to the conda/micromamba `robot-sf` env.
+if command -v module >/dev/null 2>&1; then
+  module purge || true
+fi
+if [[ -n "${UV_PROJECT_ENVIRONMENT:-}" ]]; then
+  echo "   using UV_PROJECT_ENVIRONMENT=${UV_PROJECT_ENVIRONMENT}"
+elif [[ -x "${PROJECT_ROOT}/.venv/bin/python" ]]; then
+  echo "   using repo-local .venv"
+elif command -v conda >/dev/null 2>&1; then
+  # shellcheck disable=SC1091
+  eval "$(conda shell.bash hook)"
+  conda activate robot-sf
+  echo "   using conda env 'robot-sf'"
+else
+  echo "warning: no uv venv or conda env detected; relying on 'uv run' to resolve one" >&2
+fi
+
+# --- Per-arm log (in addition to the #SBATCH --output the submitter set). ---
+LOG_DIR="output/slurm/logs"
+mkdir -p "${LOG_DIR}"
+ARM_LOG="${LOG_DIR}/${SLURM_JOB_ID:-manual}-${ARM_KEY}.log"
+
+echo "   log=${ARM_LOG}"
+echo "-- running --"
+
+set +e
+# shellcheck disable=SC2086
+eval ${ARM_COMMAND} 2>&1 | tee "${ARM_LOG}"
+STATUS="${PIPESTATUS[0]}"
+set -e
+
+echo "-- finished arm=${ARM_KEY} exit=${STATUS} at $(date) --"
+# Exit codes mirror scripts/tools/run_camera_ready_benchmark.py:
+#   0 benchmark-success, 2 unexpected failure/malformed, 3 accepted-unavailable-only.
+exit "${STATUS}"

--- a/SLURM/submit_release_single_node.sbatch
+++ b/SLURM/submit_release_single_node.sbatch
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Single-node release-campaign submission (the citable-release path).
+#
+# The release runner (scripts/tools/run_benchmark_release.py) must execute as ONE
+# process to produce a valid release bundle -- it cannot consume split per-arm
+# aggregates (see docs/context/release_0_0_3_slurm_execution_packet.md). This
+# template runs the whole campaign on one fat node with a FIXED --campaign-id so
+# restarts (walltime kill, node failure, --requeue) resume in place instead of
+# starting over. Requires the --campaign-id release-runner passthrough.
+#
+# Usage (from the repo checkout on the cluster, after `uv sync --all-extras` and
+# a passing checkpoint staging preflight):
+#   sbatch SLURM/submit_release_single_node.sbatch \
+#     configs/benchmarks/releases/<release_manifest>.yaml <label> <fixed_campaign_id>
+#
+# Field-tested: 14-arm x 30-seed x h600 campaign, epyc-gpu partition, LiCCA.
+#SBATCH --job-name=rsf_release_single_node
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=36
+#SBATCH --mem=256G
+#SBATCH --time=36:00:00
+#SBATCH --requeue
+#SBATCH --output=output/slurm-release-%j.log
+set -euo pipefail
+MANIFEST="${1:?release manifest path required}"
+LABEL="${2:?release label required}"
+CAMPAIGN_ID="${3:?fixed campaign id required (enables resume across restarts)}"
+cd "$SLURM_SUBMIT_DIR"
+# Thread guards: the campaign parallelizes via its own worker pool (config `workers`);
+# per-worker BLAS/OpenMP threading only oversubscribes the node.
+export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
+exec .venv/bin/python scripts/tools/run_benchmark_release.py \
+  --manifest "$MANIFEST" \
+  --label "$LABEL" \
+  --campaign-id "$CAMPAIGN_ID"

--- a/configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
@@ -54,7 +54,10 @@ horizon: 600
 dt: 0.1
 record_forces: true
 resume: true
-stop_on_failure: true
+# stop_on_failure false: with a fixed --campaign-id the run is resumable, so a single
+# broken arm should surface as a failed row and let the other 13 arms complete; fix,
+# then resume the same campaign id to fill only the gaps.
+stop_on_failure: false
 bootstrap_samples: 300
 bootstrap_confidence: 0.95
 bootstrap_seed: 123

--- a/configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
@@ -6,9 +6,10 @@
 #   - roster: core 7 + 4 hybrid-rule arms (h600 hybrid-roster winners) + guarded_ppo,
 #     predictive_mppi, risk_dwa (h600 launch-packet candidates). socnav_bench stays excluded
 #     (licensed dataset assets, see benchmark_release_0_0_2_scoped_rationale.md).
-#   - workers: 1 -> 8  (~19.7k episodes at h600 are infeasible single-worker locally;
-#     per-episode seeding keeps rows deterministic, bootstrap seed fixed at 123;
-#     parallel-worker precedent: paper_experiment_matrix_v1_h600_hybrid_roster.yaml)
+#   - workers: 1 -> 32  (~19.7k episodes at h600 are infeasible single-worker; sized
+#     for one 128-core/1TB EPYC node -- per-episode seeding keeps rows deterministic,
+#     bootstrap seed fixed at 123; parallel-worker precedent:
+#     paper_experiment_matrix_v1_h600_hybrid_roster.yaml)
 #   - snqi_contract enforcement: enforce -> warn  (h600 precedent: component-dominance
 #     profile shifts at long horizon; a contract violation is a reportable finding,
 #     not a reason to abort a release run. Diagnostics are exported either way.)
@@ -48,7 +49,7 @@ snqi_contract:
   calibration_seed: 123
   calibration_trials: 6000
 
-workers: 8
+workers: 32
 horizon: 600
 dt: 0.1
 record_forces: true

--- a/configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
@@ -1,0 +1,157 @@
+# Extended long-horizon release campaign for benchmark release 0.0.3.
+# Derived from paper_experiment_matrix_v1.yaml (canonical 0.0.2 release campaign) with:
+#   - horizon: 100 -> 600  (successor surface per #257/#4364: timeout no longer dominant,
+#     waiting strategies visible; matches the h600 hybrid-roster precedent)
+#   - seed set: eval (3) -> paper_eval_s30 (30)  (discharges the 30-seed successor promise, #4364)
+#   - roster: core 7 + 4 hybrid-rule arms (h600 hybrid-roster winners) + guarded_ppo,
+#     predictive_mppi, risk_dwa (h600 launch-packet candidates). socnav_bench stays excluded
+#     (licensed dataset assets, see benchmark_release_0_0_2_scoped_rationale.md).
+#   - workers: 1 -> 8  (~19.7k episodes at h600 are infeasible single-worker locally;
+#     per-episode seeding keeps rows deterministic, bootstrap seed fixed at 123;
+#     parallel-worker precedent: paper_experiment_matrix_v1_h600_hybrid_roster.yaml)
+#   - snqi_contract enforcement: enforce -> warn  (h600 precedent: component-dominance
+#     profile shifts at long horizon; a contract violation is a reportable finding,
+#     not a reason to abort a release run. Diagnostics are exported either way.)
+name: paper_experiment_matrix_v2_h600_s30_extended
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+
+amv_profile:
+  name: amv-paper-v1
+  contract_version: "1"
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case: [delivery_robot, shared_space_micromobility]
+    context: [sidewalk, shared_space]
+    speed_regime: [walking_speed, scooter_speed]
+    maneuver_type: [overtake, crossing, bottleneck]
+
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s30
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+
+workers: 8
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+
+kinematics_matrix:
+  - differential_drive
+
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: "{release_tag}"
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+
+planners:
+  # --- core 7 (identical stanzas to the canonical 0.0.2 release campaign) ---
+  - key: prediction_planner
+    algo: prediction_planner
+    planner_group: experimental
+    algo_config: configs/algos/prediction_planner_camera_ready.yaml
+    benchmark_profile: experimental
+
+  - key: goal
+    algo: goal
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: social_force
+    algo: social_force
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: orca
+    algo: orca
+    planner_group: core
+    benchmark_profile: baseline-safe
+    socnav_missing_prereq_policy: fallback
+
+  - key: ppo
+    algo: ppo
+    planner_group: experimental
+    algo_config: configs/baselines/ppo_15m_grid_socnav.yaml
+    benchmark_profile: experimental
+    adapter_impact_eval: true
+
+  - key: socnav_sampling
+    algo: socnav_sampling
+    planner_group: experimental
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fail-fast
+
+  - key: sacadrl
+    algo: sacadrl
+    planner_group: experimental
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fallback
+
+  # --- hybrid-rule arms (stanzas as executed in paper_experiment_matrix_v1_h600_hybrid_roster.yaml) ---
+  - key: scenario_adaptive_hybrid_orca_v1
+    algo: hybrid_rule_local_planner
+    planner_group: experimental
+    algo_config: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml
+    benchmark_profile: experimental
+
+  - key: scenario_adaptive_hybrid_orca_v2_collision_guard
+    algo: hybrid_rule_local_planner
+    planner_group: experimental
+    algo_config: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v2_collision_guard.yaml
+    benchmark_profile: experimental
+
+  - key: hybrid_rule_v3_fast_progress_static_escape
+    algo: hybrid_rule_local_planner
+    planner_group: experimental
+    algo_config: configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml
+    benchmark_profile: experimental
+
+  - key: hybrid_rule_v3_fast_progress_static_escape_continuous
+    algo: hybrid_rule_local_planner
+    planner_group: experimental
+    algo_config: configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape_continuous.yaml
+    benchmark_profile: experimental
+
+  # --- h600 launch-packet candidate arms (stanzas as in their *_compare / certification configs) ---
+  - key: guarded_ppo
+    algo: guarded_ppo
+    planner_group: experimental
+    algo_config: configs/algos/guarded_ppo_camera_ready.yaml
+    benchmark_profile: experimental
+
+  - key: predictive_mppi
+    algo: predictive_mppi
+    planner_group: experimental
+    algo_config: configs/algos/predictive_mppi_camera_ready.yaml
+    benchmark_profile: experimental
+
+  - key: risk_dwa
+    algo: risk_dwa
+    planner_group: experimental
+    algo_config: configs/algos/risk_dwa_camera_ready.yaml
+    benchmark_profile: experimental

--- a/configs/benchmarks/releases/paper_experiment_matrix_v2_h600_s30_release_v0_0_3.yaml
+++ b/configs/benchmarks/releases/paper_experiment_matrix_v2_h600_s30_release_v0_0_3.yaml
@@ -10,7 +10,7 @@ release_id: paper_experiment_matrix_v2_h600_s30_v0_0_3
 release_tag: "0.0.3"
 maturity: pre-1.0
 canonical_campaign_config: ../paper_experiment_matrix_v2_h600_s30_extended.yaml
-campaign_config_sha256: "2d6cc39121790ece94baf5d51b6229d3f67cf319e411d8df0adb0fbf9b6f1366"
+campaign_config_sha256: "143ab63a235f40326c93c93044fba95e808388751f04d8ca979b89d1142ca465"
 expected_paper_profile_version: paper-matrix-v1
 expected_paper_interpretation_profile: baseline-ready-core
 

--- a/configs/benchmarks/releases/paper_experiment_matrix_v2_h600_s30_release_v0_0_3.yaml
+++ b/configs/benchmarks/releases/paper_experiment_matrix_v2_h600_s30_release_v0_0_3.yaml
@@ -10,7 +10,7 @@ release_id: paper_experiment_matrix_v2_h600_s30_v0_0_3
 release_tag: "0.0.3"
 maturity: pre-1.0
 canonical_campaign_config: ../paper_experiment_matrix_v2_h600_s30_extended.yaml
-campaign_config_sha256: "b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2"
+campaign_config_sha256: "2d6cc39121790ece94baf5d51b6229d3f67cf319e411d8df0adb0fbf9b6f1366"
 expected_paper_profile_version: paper-matrix-v1
 expected_paper_interpretation_profile: baseline-ready-core
 

--- a/configs/benchmarks/releases/paper_experiment_matrix_v2_h600_s30_release_v0_0_3.yaml
+++ b/configs/benchmarks/releases/paper_experiment_matrix_v2_h600_s30_release_v0_0_3.yaml
@@ -1,0 +1,86 @@
+# Release manifest for benchmark release 0.0.3 (extended long-horizon surface).
+# Successor to paper_experiment_matrix_v1_release_v0_1.yaml (the rc0.0.3-validated 7-planner
+# h100 set): horizon 600, 30 eval seeds (paper_eval_s30), and a 14-arm roster that adds the
+# four h600 hybrid-rule winners plus guarded_ppo / predictive_mppi / risk_dwa.
+# socnav_bench remains excluded (licensed dataset assets; see
+# docs/context/benchmark_release_0_0_2_scoped_rationale.md).
+schema_version: benchmark-release-manifest.v0.1
+benchmark_protocol_version: 0.1.0
+release_id: paper_experiment_matrix_v2_h600_s30_v0_0_3
+release_tag: "0.0.3"
+maturity: pre-1.0
+canonical_campaign_config: ../paper_experiment_matrix_v2_h600_s30_extended.yaml
+campaign_config_sha256: "b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2"
+expected_paper_profile_version: paper-matrix-v1
+expected_paper_interpretation_profile: baseline-ready-core
+
+scenario:
+  matrix_path: ../../scenarios/classic_interactions_francis2023.yaml
+  matrix_sha256: "d9e148e4b544b4c7e2b6ba98e599aef47046d114e0e25645f021946674cb9dc5"
+
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s30
+  seeds: []
+  seed_sets_path: ../../benchmarks/seed_sets_v1.yaml
+
+metrics:
+  snqi_weights_path: ../snqi_weights_camera_ready_v3.json
+  snqi_weights_sha256: "71a67c3c02faff166f8c96bef8bcf898533981ca2b2c4493829988520fb1aeb2"
+  snqi_baseline_path: ../snqi_baseline_camera_ready_v3.json
+  snqi_baseline_sha256: "329ca5766491e1587979d0a435c7ba676e148ccdff97040a36546bbb9414035a"
+
+planners:
+  keys:
+    - prediction_planner
+    - goal
+    - social_force
+    - orca
+    - ppo
+    - socnav_sampling
+    - sacadrl
+    - scenario_adaptive_hybrid_orca_v1
+    - scenario_adaptive_hybrid_orca_v2_collision_guard
+    - hybrid_rule_v3_fast_progress_static_escape
+    - hybrid_rule_v3_fast_progress_static_escape_continuous
+    - guarded_ppo
+    - predictive_mppi
+    - risk_dwa
+  groups:
+    prediction_planner: experimental
+    goal: core
+    social_force: core
+    orca: core
+    ppo: experimental
+    socnav_sampling: experimental
+    sacadrl: experimental
+    scenario_adaptive_hybrid_orca_v1: experimental
+    scenario_adaptive_hybrid_orca_v2_collision_guard: experimental
+    hybrid_rule_v3_fast_progress_static_escape: experimental
+    hybrid_rule_v3_fast_progress_static_escape_continuous: experimental
+    guarded_ppo: experimental
+    predictive_mppi: experimental
+    risk_dwa: experimental
+
+kinematics:
+  matrix: [differential_drive]
+
+artifacts:
+  required_paths:
+    - campaign_manifest.json
+    - manifest.json
+    - run_meta.json
+    - preflight/validate_config.json
+    - preflight/preview_scenarios.json
+    - reports/campaign_summary.json
+    - reports/campaign_report.md
+    - reports/matrix_summary.json
+    - reports/campaign_table.md
+    - reports/snqi_diagnostics.json
+
+provenance:
+  repository_url: https://github.com/ll7/robot_sf_ll7
+  doi: 10.5281/zenodo.<record-id>
+
+citation_path: ../../../CITATION.cff
+release_checklist_path: ../../../docs/RELEASE.md

--- a/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_goal.yaml
+++ b/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_goal.yaml
@@ -1,0 +1,72 @@
+name: paper_experiment_matrix_v2_h600_s30_extended__arm_goal
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+amv_profile:
+  name: amv-paper-v1
+  contract_version: '1'
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case:
+    - delivery_robot
+    - shared_space_micromobility
+    context:
+    - sidewalk
+    - shared_space
+    speed_regime:
+    - walking_speed
+    - scooter_speed
+    maneuver_type:
+    - overtake
+    - crossing
+    - bottleneck
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s30
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+workers: 8
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix:
+- differential_drive
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: '{release_tag}'
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+planners:
+- key: goal
+  algo: goal
+  planner_group: core
+  benchmark_profile: baseline-safe
+split_provenance:
+  source_config: configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+  source_sha256: b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2
+  split_mode: per_planner
+  arm_key: goal
+  arm_index: 1
+  arm_total: 14
+  tool: split_campaign_config_by_planner.py

--- a/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_guarded_ppo.yaml
+++ b/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_guarded_ppo.yaml
@@ -1,0 +1,73 @@
+name: paper_experiment_matrix_v2_h600_s30_extended__arm_guarded_ppo
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+amv_profile:
+  name: amv-paper-v1
+  contract_version: '1'
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case:
+    - delivery_robot
+    - shared_space_micromobility
+    context:
+    - sidewalk
+    - shared_space
+    speed_regime:
+    - walking_speed
+    - scooter_speed
+    maneuver_type:
+    - overtake
+    - crossing
+    - bottleneck
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s30
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+workers: 8
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix:
+- differential_drive
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: '{release_tag}'
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+planners:
+- key: guarded_ppo
+  algo: guarded_ppo
+  planner_group: experimental
+  algo_config: configs/algos/guarded_ppo_camera_ready.yaml
+  benchmark_profile: experimental
+split_provenance:
+  source_config: configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+  source_sha256: b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2
+  split_mode: per_planner
+  arm_key: guarded_ppo
+  arm_index: 11
+  arm_total: 14
+  tool: split_campaign_config_by_planner.py

--- a/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_hybrid_rule_v3_fast_progress_static_escape.yaml
+++ b/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_hybrid_rule_v3_fast_progress_static_escape.yaml
@@ -1,0 +1,73 @@
+name: paper_experiment_matrix_v2_h600_s30_extended__arm_hybrid_rule_v3_fast_progress_static_escape
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+amv_profile:
+  name: amv-paper-v1
+  contract_version: '1'
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case:
+    - delivery_robot
+    - shared_space_micromobility
+    context:
+    - sidewalk
+    - shared_space
+    speed_regime:
+    - walking_speed
+    - scooter_speed
+    maneuver_type:
+    - overtake
+    - crossing
+    - bottleneck
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s30
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+workers: 8
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix:
+- differential_drive
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: '{release_tag}'
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+planners:
+- key: hybrid_rule_v3_fast_progress_static_escape
+  algo: hybrid_rule_local_planner
+  planner_group: experimental
+  algo_config: configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml
+  benchmark_profile: experimental
+split_provenance:
+  source_config: configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+  source_sha256: b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2
+  split_mode: per_planner
+  arm_key: hybrid_rule_v3_fast_progress_static_escape
+  arm_index: 9
+  arm_total: 14
+  tool: split_campaign_config_by_planner.py

--- a/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_hybrid_rule_v3_fast_progress_static_escape_continuous.yaml
+++ b/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_hybrid_rule_v3_fast_progress_static_escape_continuous.yaml
@@ -1,0 +1,73 @@
+name: paper_experiment_matrix_v2_h600_s30_extended__arm_hybrid_rule_v3_fast_progress_static_escape_continuous
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+amv_profile:
+  name: amv-paper-v1
+  contract_version: '1'
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case:
+    - delivery_robot
+    - shared_space_micromobility
+    context:
+    - sidewalk
+    - shared_space
+    speed_regime:
+    - walking_speed
+    - scooter_speed
+    maneuver_type:
+    - overtake
+    - crossing
+    - bottleneck
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s30
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+workers: 8
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix:
+- differential_drive
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: '{release_tag}'
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+planners:
+- key: hybrid_rule_v3_fast_progress_static_escape_continuous
+  algo: hybrid_rule_local_planner
+  planner_group: experimental
+  algo_config: configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape_continuous.yaml
+  benchmark_profile: experimental
+split_provenance:
+  source_config: configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+  source_sha256: b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2
+  split_mode: per_planner
+  arm_key: hybrid_rule_v3_fast_progress_static_escape_continuous
+  arm_index: 10
+  arm_total: 14
+  tool: split_campaign_config_by_planner.py

--- a/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_orca.yaml
+++ b/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_orca.yaml
@@ -1,0 +1,73 @@
+name: paper_experiment_matrix_v2_h600_s30_extended__arm_orca
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+amv_profile:
+  name: amv-paper-v1
+  contract_version: '1'
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case:
+    - delivery_robot
+    - shared_space_micromobility
+    context:
+    - sidewalk
+    - shared_space
+    speed_regime:
+    - walking_speed
+    - scooter_speed
+    maneuver_type:
+    - overtake
+    - crossing
+    - bottleneck
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s30
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+workers: 8
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix:
+- differential_drive
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: '{release_tag}'
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+planners:
+- key: orca
+  algo: orca
+  planner_group: core
+  benchmark_profile: baseline-safe
+  socnav_missing_prereq_policy: fallback
+split_provenance:
+  source_config: configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+  source_sha256: b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2
+  split_mode: per_planner
+  arm_key: orca
+  arm_index: 3
+  arm_total: 14
+  tool: split_campaign_config_by_planner.py

--- a/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_ppo.yaml
+++ b/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_ppo.yaml
@@ -1,0 +1,74 @@
+name: paper_experiment_matrix_v2_h600_s30_extended__arm_ppo
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+amv_profile:
+  name: amv-paper-v1
+  contract_version: '1'
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case:
+    - delivery_robot
+    - shared_space_micromobility
+    context:
+    - sidewalk
+    - shared_space
+    speed_regime:
+    - walking_speed
+    - scooter_speed
+    maneuver_type:
+    - overtake
+    - crossing
+    - bottleneck
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s30
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+workers: 8
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix:
+- differential_drive
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: '{release_tag}'
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+planners:
+- key: ppo
+  algo: ppo
+  planner_group: experimental
+  algo_config: configs/baselines/ppo_15m_grid_socnav.yaml
+  benchmark_profile: experimental
+  adapter_impact_eval: true
+split_provenance:
+  source_config: configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+  source_sha256: b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2
+  split_mode: per_planner
+  arm_key: ppo
+  arm_index: 4
+  arm_total: 14
+  tool: split_campaign_config_by_planner.py

--- a/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_prediction_planner.yaml
+++ b/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_prediction_planner.yaml
@@ -1,0 +1,73 @@
+name: paper_experiment_matrix_v2_h600_s30_extended__arm_prediction_planner
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+amv_profile:
+  name: amv-paper-v1
+  contract_version: '1'
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case:
+    - delivery_robot
+    - shared_space_micromobility
+    context:
+    - sidewalk
+    - shared_space
+    speed_regime:
+    - walking_speed
+    - scooter_speed
+    maneuver_type:
+    - overtake
+    - crossing
+    - bottleneck
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s30
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+workers: 8
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix:
+- differential_drive
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: '{release_tag}'
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+planners:
+- key: prediction_planner
+  algo: prediction_planner
+  planner_group: experimental
+  algo_config: configs/algos/prediction_planner_camera_ready.yaml
+  benchmark_profile: experimental
+split_provenance:
+  source_config: configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+  source_sha256: b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2
+  split_mode: per_planner
+  arm_key: prediction_planner
+  arm_index: 0
+  arm_total: 14
+  tool: split_campaign_config_by_planner.py

--- a/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_predictive_mppi.yaml
+++ b/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_predictive_mppi.yaml
@@ -1,0 +1,73 @@
+name: paper_experiment_matrix_v2_h600_s30_extended__arm_predictive_mppi
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+amv_profile:
+  name: amv-paper-v1
+  contract_version: '1'
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case:
+    - delivery_robot
+    - shared_space_micromobility
+    context:
+    - sidewalk
+    - shared_space
+    speed_regime:
+    - walking_speed
+    - scooter_speed
+    maneuver_type:
+    - overtake
+    - crossing
+    - bottleneck
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s30
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+workers: 8
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix:
+- differential_drive
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: '{release_tag}'
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+planners:
+- key: predictive_mppi
+  algo: predictive_mppi
+  planner_group: experimental
+  algo_config: configs/algos/predictive_mppi_camera_ready.yaml
+  benchmark_profile: experimental
+split_provenance:
+  source_config: configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+  source_sha256: b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2
+  split_mode: per_planner
+  arm_key: predictive_mppi
+  arm_index: 12
+  arm_total: 14
+  tool: split_campaign_config_by_planner.py

--- a/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_risk_dwa.yaml
+++ b/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_risk_dwa.yaml
@@ -1,0 +1,73 @@
+name: paper_experiment_matrix_v2_h600_s30_extended__arm_risk_dwa
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+amv_profile:
+  name: amv-paper-v1
+  contract_version: '1'
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case:
+    - delivery_robot
+    - shared_space_micromobility
+    context:
+    - sidewalk
+    - shared_space
+    speed_regime:
+    - walking_speed
+    - scooter_speed
+    maneuver_type:
+    - overtake
+    - crossing
+    - bottleneck
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s30
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+workers: 8
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix:
+- differential_drive
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: '{release_tag}'
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+planners:
+- key: risk_dwa
+  algo: risk_dwa
+  planner_group: experimental
+  algo_config: configs/algos/risk_dwa_camera_ready.yaml
+  benchmark_profile: experimental
+split_provenance:
+  source_config: configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+  source_sha256: b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2
+  split_mode: per_planner
+  arm_key: risk_dwa
+  arm_index: 13
+  arm_total: 14
+  tool: split_campaign_config_by_planner.py

--- a/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_sacadrl.yaml
+++ b/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_sacadrl.yaml
@@ -1,0 +1,73 @@
+name: paper_experiment_matrix_v2_h600_s30_extended__arm_sacadrl
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+amv_profile:
+  name: amv-paper-v1
+  contract_version: '1'
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case:
+    - delivery_robot
+    - shared_space_micromobility
+    context:
+    - sidewalk
+    - shared_space
+    speed_regime:
+    - walking_speed
+    - scooter_speed
+    maneuver_type:
+    - overtake
+    - crossing
+    - bottleneck
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s30
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+workers: 8
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix:
+- differential_drive
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: '{release_tag}'
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+planners:
+- key: sacadrl
+  algo: sacadrl
+  planner_group: experimental
+  benchmark_profile: experimental
+  socnav_missing_prereq_policy: fallback
+split_provenance:
+  source_config: configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+  source_sha256: b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2
+  split_mode: per_planner
+  arm_key: sacadrl
+  arm_index: 6
+  arm_total: 14
+  tool: split_campaign_config_by_planner.py

--- a/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_scenario_adaptive_hybrid_orca_v1.yaml
+++ b/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_scenario_adaptive_hybrid_orca_v1.yaml
@@ -1,0 +1,73 @@
+name: paper_experiment_matrix_v2_h600_s30_extended__arm_scenario_adaptive_hybrid_orca_v1
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+amv_profile:
+  name: amv-paper-v1
+  contract_version: '1'
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case:
+    - delivery_robot
+    - shared_space_micromobility
+    context:
+    - sidewalk
+    - shared_space
+    speed_regime:
+    - walking_speed
+    - scooter_speed
+    maneuver_type:
+    - overtake
+    - crossing
+    - bottleneck
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s30
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+workers: 8
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix:
+- differential_drive
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: '{release_tag}'
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+planners:
+- key: scenario_adaptive_hybrid_orca_v1
+  algo: hybrid_rule_local_planner
+  planner_group: experimental
+  algo_config: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml
+  benchmark_profile: experimental
+split_provenance:
+  source_config: configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+  source_sha256: b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2
+  split_mode: per_planner
+  arm_key: scenario_adaptive_hybrid_orca_v1
+  arm_index: 7
+  arm_total: 14
+  tool: split_campaign_config_by_planner.py

--- a/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_scenario_adaptive_hybrid_orca_v2_collision_guard.yaml
+++ b/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_scenario_adaptive_hybrid_orca_v2_collision_guard.yaml
@@ -1,0 +1,73 @@
+name: paper_experiment_matrix_v2_h600_s30_extended__arm_scenario_adaptive_hybrid_orca_v2_collision_guard
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+amv_profile:
+  name: amv-paper-v1
+  contract_version: '1'
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case:
+    - delivery_robot
+    - shared_space_micromobility
+    context:
+    - sidewalk
+    - shared_space
+    speed_regime:
+    - walking_speed
+    - scooter_speed
+    maneuver_type:
+    - overtake
+    - crossing
+    - bottleneck
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s30
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+workers: 8
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix:
+- differential_drive
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: '{release_tag}'
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+planners:
+- key: scenario_adaptive_hybrid_orca_v2_collision_guard
+  algo: hybrid_rule_local_planner
+  planner_group: experimental
+  algo_config: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v2_collision_guard.yaml
+  benchmark_profile: experimental
+split_provenance:
+  source_config: configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+  source_sha256: b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2
+  split_mode: per_planner
+  arm_key: scenario_adaptive_hybrid_orca_v2_collision_guard
+  arm_index: 8
+  arm_total: 14
+  tool: split_campaign_config_by_planner.py

--- a/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_social_force.yaml
+++ b/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_social_force.yaml
@@ -1,0 +1,72 @@
+name: paper_experiment_matrix_v2_h600_s30_extended__arm_social_force
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+amv_profile:
+  name: amv-paper-v1
+  contract_version: '1'
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case:
+    - delivery_robot
+    - shared_space_micromobility
+    context:
+    - sidewalk
+    - shared_space
+    speed_regime:
+    - walking_speed
+    - scooter_speed
+    maneuver_type:
+    - overtake
+    - crossing
+    - bottleneck
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s30
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+workers: 8
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix:
+- differential_drive
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: '{release_tag}'
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+planners:
+- key: social_force
+  algo: social_force
+  planner_group: core
+  benchmark_profile: baseline-safe
+split_provenance:
+  source_config: configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+  source_sha256: b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2
+  split_mode: per_planner
+  arm_key: social_force
+  arm_index: 2
+  arm_total: 14
+  tool: split_campaign_config_by_planner.py

--- a/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_socnav_sampling.yaml
+++ b/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_socnav_sampling.yaml
@@ -1,0 +1,73 @@
+name: paper_experiment_matrix_v2_h600_s30_extended__arm_socnav_sampling
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+amv_profile:
+  name: amv-paper-v1
+  contract_version: '1'
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case:
+    - delivery_robot
+    - shared_space_micromobility
+    context:
+    - sidewalk
+    - shared_space
+    speed_regime:
+    - walking_speed
+    - scooter_speed
+    maneuver_type:
+    - overtake
+    - crossing
+    - bottleneck
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s30
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+workers: 8
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix:
+- differential_drive
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: '{release_tag}'
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+planners:
+- key: socnav_sampling
+  algo: socnav_sampling
+  planner_group: experimental
+  benchmark_profile: experimental
+  socnav_missing_prereq_policy: fail-fast
+split_provenance:
+  source_config: configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml
+  source_sha256: b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2
+  split_mode: per_planner
+  arm_key: socnav_sampling
+  arm_index: 5
+  arm_total: 14
+  tool: split_campaign_config_by_planner.py

--- a/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/split_manifest.json
+++ b/configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/split_manifest.json
@@ -1,0 +1,105 @@
+{
+  "children": [
+    {
+      "filename": "paper_experiment_matrix_v2_h600_s30_extended__arm_prediction_planner.yaml",
+      "planner_keys": [
+        "prediction_planner"
+      ],
+      "sha256": "8fc9ea75eae0ab585a65012775bf245c2cb6deefed6ffc0089532fd257533889"
+    },
+    {
+      "filename": "paper_experiment_matrix_v2_h600_s30_extended__arm_goal.yaml",
+      "planner_keys": [
+        "goal"
+      ],
+      "sha256": "144978a02ffcf1e1d014054e1d15ec6200f41164913988a66116afb386394efb"
+    },
+    {
+      "filename": "paper_experiment_matrix_v2_h600_s30_extended__arm_social_force.yaml",
+      "planner_keys": [
+        "social_force"
+      ],
+      "sha256": "27f5fe3ac0abecfa3b7b93c31b963f2cc63f5d9a31c02ffbf8e151216b5b41c6"
+    },
+    {
+      "filename": "paper_experiment_matrix_v2_h600_s30_extended__arm_orca.yaml",
+      "planner_keys": [
+        "orca"
+      ],
+      "sha256": "20b74c376eef8ffa8dbcda5c0ff436e6d47d2df80803a9ad904c93ddb5ec362e"
+    },
+    {
+      "filename": "paper_experiment_matrix_v2_h600_s30_extended__arm_ppo.yaml",
+      "planner_keys": [
+        "ppo"
+      ],
+      "sha256": "792f6793d47bfcf7658a700545e6e8f572b52ba0add306cce2841fdac78b7270"
+    },
+    {
+      "filename": "paper_experiment_matrix_v2_h600_s30_extended__arm_socnav_sampling.yaml",
+      "planner_keys": [
+        "socnav_sampling"
+      ],
+      "sha256": "c97d5ccf2e5c4359e415bdc27962218495f7c5a3eae6471b6131f4c61fb7a0ea"
+    },
+    {
+      "filename": "paper_experiment_matrix_v2_h600_s30_extended__arm_sacadrl.yaml",
+      "planner_keys": [
+        "sacadrl"
+      ],
+      "sha256": "100247e93b2f61e5d5440010fbc7f7978db6b05555710417a12d93424ab3c8e7"
+    },
+    {
+      "filename": "paper_experiment_matrix_v2_h600_s30_extended__arm_scenario_adaptive_hybrid_orca_v1.yaml",
+      "planner_keys": [
+        "scenario_adaptive_hybrid_orca_v1"
+      ],
+      "sha256": "b865b71862fe28a1042aaead10a9c949c5c3ec8a6a8c8f8611b6d51b2fa6da41"
+    },
+    {
+      "filename": "paper_experiment_matrix_v2_h600_s30_extended__arm_scenario_adaptive_hybrid_orca_v2_collision_guard.yaml",
+      "planner_keys": [
+        "scenario_adaptive_hybrid_orca_v2_collision_guard"
+      ],
+      "sha256": "56bcb65071c507f82697528533ad26f144c78d404c453bc09a62e6fdef52f7ee"
+    },
+    {
+      "filename": "paper_experiment_matrix_v2_h600_s30_extended__arm_hybrid_rule_v3_fast_progress_static_escape.yaml",
+      "planner_keys": [
+        "hybrid_rule_v3_fast_progress_static_escape"
+      ],
+      "sha256": "d50ca61ea00fa6c3ebd15feb67319b0af2e49214931f6fce91d6393732acf8dc"
+    },
+    {
+      "filename": "paper_experiment_matrix_v2_h600_s30_extended__arm_hybrid_rule_v3_fast_progress_static_escape_continuous.yaml",
+      "planner_keys": [
+        "hybrid_rule_v3_fast_progress_static_escape_continuous"
+      ],
+      "sha256": "5ad6f65a018f7b13014962d2e8476fb7e711452776223e1519038226878a80ed"
+    },
+    {
+      "filename": "paper_experiment_matrix_v2_h600_s30_extended__arm_guarded_ppo.yaml",
+      "planner_keys": [
+        "guarded_ppo"
+      ],
+      "sha256": "fa005ecb7bafe9480c6bc2ee376876d6bd3facdbb42605326ffd15dd9ff3fccc"
+    },
+    {
+      "filename": "paper_experiment_matrix_v2_h600_s30_extended__arm_predictive_mppi.yaml",
+      "planner_keys": [
+        "predictive_mppi"
+      ],
+      "sha256": "b7554d416e3996471166c5917996f0323c064cc7d0eca7a7f96c9445a9d6cba9"
+    },
+    {
+      "filename": "paper_experiment_matrix_v2_h600_s30_extended__arm_risk_dwa.yaml",
+      "planner_keys": [
+        "risk_dwa"
+      ],
+      "sha256": "a6b08b94e66880c3e9ba66e0869fc807c9e7bb20d9595c0b57e4a81c9154012a"
+    }
+  ],
+  "source_config": "configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml",
+  "source_sha256": "b3f7718cc27ff07975dc99f9c1c9d7e3183e0312d586945074cd5ac089b3fdf2",
+  "split_mode": "per_planner"
+}

--- a/docs/context/release_0_0_3_slurm_execution_packet.md
+++ b/docs/context/release_0_0_3_slurm_execution_packet.md
@@ -97,8 +97,10 @@ guarded_ppo, predictive_mppi, risk_dwa
 ```
 
 ```bash
+SPLIT_DIR=output/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended  # generated at plan time (gitignored)
+ARM=<planner_key>
 uv run python scripts/tools/run_camera_ready_benchmark.py \
-  --config output/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_<key>.yaml \
+  --config "$SPLIT_DIR/paper_experiment_matrix_v2_h600_s30_extended__arm_${ARM}.yaml" \
   --output-root output/benchmarks/release_v0_0_3_arms \
   --campaign-id release_0_0_3_h600_s30__arm_<key> \
   --mode run --skip-publication-bundle

--- a/docs/context/release_0_0_3_slurm_execution_packet.md
+++ b/docs/context/release_0_0_3_slurm_execution_packet.md
@@ -1,3 +1,6 @@
+> Note: all `output/benchmarks/splits/...` paths in this packet are generated at plan time
+> by `run_split_camera_ready_campaign.py plan` (gitignored), not tracked configs.
+
 # Release 0.0.3 (h600/s30 extended, 14 arms) — SLURM execution packet + local fallback
 
 Date: 2026-07-13. Worktree: `rebase-0_0_3-campaign` at commit `00c5a2410`.
@@ -60,11 +63,11 @@ Commands actually run in this worktree:
 ```bash
 uv run python scripts/tools/split_campaign_config_by_planner.py \
   --config configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml \
-  --out-dir configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended
-# -> Wrote 14 split config(s): configs/benchmarks/splits/.../split_manifest.json
+  --out-dir output/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended
+# -> Wrote 14 split config(s): output/benchmarks/splits/.../split_manifest.json
 
 uv run python scripts/tools/run_split_camera_ready_campaign.py plan \
-  --split-manifest configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/split_manifest.json \
+  --split-manifest output/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/split_manifest.json \
   --output-root output/benchmarks/release_v0_0_3_arms \
   --campaign-prefix release_0_0_3_h600_s30 \
   --packet output/benchmarks/release_v0_0_3_split_plan/execution_packet.json
@@ -79,7 +82,7 @@ deterministically.
 
 | Artifact | Path |
 |---|---|
-| Per-arm child configs + manifest | `configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/` (14 `*.yaml` + `split_manifest.json`) |
+| Per-arm child configs + manifest | `output/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/` (14 `*.yaml` + `split_manifest.json`) |
 | Execution packet (the plan output) | `output/benchmarks/release_v0_0_3_split_plan/execution_packet.json` |
 | Per-arm campaign roots (created when arms run) | `output/benchmarks/release_v0_0_3_arms/release_0_0_3_h600_s30__arm_<key>/` |
 
@@ -95,7 +98,7 @@ guarded_ppo, predictive_mppi, risk_dwa
 
 ```bash
 uv run python scripts/tools/run_camera_ready_benchmark.py \
-  --config configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_<key>.yaml \
+  --config output/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_<key>.yaml \
   --output-root output/benchmarks/release_v0_0_3_arms \
   --campaign-id release_0_0_3_h600_s30__arm_<key> \
   --mode run --skip-publication-bundle
@@ -426,7 +429,7 @@ alone consuming most of that window.
   and `robot_sf/planner/predictive_foresight.py:46` passes that string straight to the foresight
   model with no CPU fallback branch. This machine is Darwin/Apple Silicon with no CUDA device.
   **Before running the `ppo` arm locally, its child config
-  (`configs/benchmarks/splits/.../paper_experiment_matrix_v2_h600_s30_extended__arm_ppo.yaml`)
+  (`output/benchmarks/splits/.../paper_experiment_matrix_v2_h600_s30_extended__arm_ppo.yaml`)
   needs `predictive_foresight_device` overridden to `cpu`** (and the child's sha256 in
   `split_manifest.json` recomputed, then `plan` re-run) — otherwise the arm fails at
   model-load time, not at OOM time.
@@ -458,7 +461,7 @@ for key in prediction_planner predictive_mppi ppo goal social_force orca socnav_
            hybrid_rule_v3_fast_progress_static_escape_continuous guarded_ppo risk_dwa; do
   KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
   uv run python scripts/tools/run_camera_ready_benchmark.py \
-    --config "configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_${key}.yaml" \
+    --config "output/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_${key}.yaml" \
     --output-root output/benchmarks/release_v0_0_3_arms \
     --campaign-id "release_0_0_3_h600_s30__arm_${key}" \
     --mode run --skip-publication-bundle \

--- a/docs/context/release_0_0_3_slurm_execution_packet.md
+++ b/docs/context/release_0_0_3_slurm_execution_packet.md
@@ -1,0 +1,516 @@
+# Release 0.0.3 (h600/s30 extended, 14 arms) — SLURM execution packet + local fallback
+
+Date: 2026-07-13. Worktree: `rebase-0_0_3-campaign` at commit `00c5a2410`.
+
+Provisioning-only note: nothing in this document runs a benchmark, submits Slurm, or
+constitutes benchmark evidence. It plans, documents, and verifies tooling (`plan`/`aggregate`
+are CPU-only per their own docstrings) so a human can execute the campaign safely.
+
+## 0. Campaign under plan
+
+- Campaign config: `configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml`
+  (untracked/new in this worktree) — 14 planner arms, `horizon: 600`, `workers: 8`,
+  `seed_policy.seed_set: paper_eval_s30` (30 seeds), scenario matrix
+  `configs/scenarios/classic_interactions_francis2023.yaml`.
+- Release manifest: `configs/benchmarks/releases/paper_experiment_matrix_v2_h600_s30_release_v0_0_3.yaml`
+  (untracked/new) — `release_id: paper_experiment_matrix_v2_h600_s30_v0_0_3`, pins
+  `campaign_config_sha256` to the campaign config above and lists 10 `artifacts.required_paths`.
+- Episode math: 47 scenarios × 30 seeds × 14 arms = 19,740 episodes (1,410 episodes/arm).
+- Why not the single-process route: `scripts/tools/run_benchmark_release.py --mode run` always
+  calls `run_campaign(cfg, ...)` in-process, arm-by-arm, in one Python process. The prior
+  in-process h600/s30 6-arm run (issue #4826) accumulated a GPU-memory leak across arms and
+  failed after **14 hours** of compute (`docs/context/issue_4826_camera_ready_gpu_lifecycle.md:22`:
+  "A 2 MiB allocation failing on a 44 GiB card after 14 hours"). On this 24 GB local machine,
+  with no discrete GPU (`Darwin`/Apple Silicon) and several arms loading PyTorch/TensorFlow
+  checkpoints, the same in-process route is a proven OOM/leak risk, not merely a slow one.
+
+## 1. Splitter manifest + execution packet (done, verified)
+
+### Splitter-manifest format (read from `scripts/tools/run_split_camera_ready_campaign.py`)
+
+`_validated_children()` (lines 79-149) requires:
+
+```jsonc
+{
+  "source_config": "<path to the parent campaign YAML>",   // must exist, is_file()
+  "source_sha256": "<sha256 hex of source_config, exactly 64 chars>",
+  "children": [
+    {
+      "filename": "<config file relative to the manifest's own directory>",
+      "sha256": "<sha256 hex of that child file, exactly 64 chars>",
+      "planner_keys": ["<planner key>", "..."]   // non-empty, unique across all children
+    }
+  ]
+}
+```
+
+Each child file must parse as YAML with a top-level `seed_policy` mapping. Every declared
+digest is re-verified at `plan` time (and again at `aggregate`/packet-load time), so a stale
+or hand-edited child fails closed with a specific `ValueError`.
+
+### How the packet was generated
+
+The repo already ships the generator for exactly this manifest shape:
+`scripts/tools/split_campaign_config_by_planner.py` (issue #5251). It splits one campaign YAML
+into one child per enabled planner arm, writes `split_manifest.json` next to the children, and
+refuses to run if the campaign already has a `split_provenance` block (no double-splitting).
+
+Commands actually run in this worktree:
+
+```bash
+uv run python scripts/tools/split_campaign_config_by_planner.py \
+  --config configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml \
+  --out-dir configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended
+# -> Wrote 14 split config(s): configs/benchmarks/splits/.../split_manifest.json
+
+uv run python scripts/tools/run_split_camera_ready_campaign.py plan \
+  --split-manifest configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/split_manifest.json \
+  --output-root output/benchmarks/release_v0_0_3_arms \
+  --campaign-prefix release_0_0_3_h600_s30 \
+  --packet output/benchmarks/release_v0_0_3_split_plan/execution_packet.json
+# -> exit 0, "status": "planned_not_executed", 14 arms
+```
+
+No manifest-validation errors occurred — the splitter tool produces an already-valid manifest,
+so no fix-up loop was needed. `plan` was re-run a second time to confirm exit code `0`
+deterministically.
+
+**Artifacts (all under this worktree, not committed):**
+
+| Artifact | Path |
+|---|---|
+| Per-arm child configs + manifest | `configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/` (14 `*.yaml` + `split_manifest.json`) |
+| Execution packet (the plan output) | `output/benchmarks/release_v0_0_3_split_plan/execution_packet.json` |
+| Per-arm campaign roots (created when arms run) | `output/benchmarks/release_v0_0_3_arms/release_0_0_3_h600_s30__arm_<key>/` |
+
+The 14 arm keys (in packet order) and their exact planned command (identical shape, `<key>`
+substituted):
+
+```text
+prediction_planner, goal, social_force, orca, ppo, socnav_sampling, sacadrl,
+scenario_adaptive_hybrid_orca_v1, scenario_adaptive_hybrid_orca_v2_collision_guard,
+hybrid_rule_v3_fast_progress_static_escape, hybrid_rule_v3_fast_progress_static_escape_continuous,
+guarded_ppo, predictive_mppi, risk_dwa
+```
+
+```bash
+uv run python scripts/tools/run_camera_ready_benchmark.py \
+  --config configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_<key>.yaml \
+  --output-root output/benchmarks/release_v0_0_3_arms \
+  --campaign-id release_0_0_3_h600_s30__arm_<key> \
+  --mode run --skip-publication-bundle
+```
+
+Because `--campaign-id` is fixed per arm and the campaign config has `resume: true`, re-running
+the identical command after an interruption resumes the same campaign root instead of starting
+over (`run_camera_ready_benchmark.py --campaign-id` docstring, line ~68).
+
+### Important OOM-relevant finding: `workers: 8` survives the split unchanged
+
+The splitter only overrides `name`, `planners`, and adds `split_provenance`
+(`split_campaign_config_by_planner.py:148-153`); it does **not** reduce the inherited top-level
+`workers: 8`. Each arm's campaign run uses a `ProcessPoolExecutor` (`robot_sf/benchmark/map_runner.py:6,2613,3199`)
+with `workers` OS processes. For the 5 checkpoint-loading arms (see §4), **each of the 8 worker
+processes independently imports PyTorch/TensorFlow and loads the arm's checkpoint** — this
+process-level multiplication, not the checkpoint file size itself (94 MB combined in
+`output/model_cache` today), is the dominant memory-tier driver in §3.
+
+If a human wants to reduce this risk further, the lever is a per-planner `workers:` override
+inside the single planner stanza of an arm's child YAML (`robot_sf/benchmark/camera_ready/_config.py:865`,
+`workers_override`); e.g. adding `workers: 2` under the one `planners: - key: ...` entry in
+`..._arm_ppo.yaml` before re-running `plan` (the child's sha256 in `split_manifest.json` must be
+recomputed and updated first, or the digest check fails closed). This was **not** applied here —
+it changes wall-clock/parallelism, so it is left as a documented option, not a silent edit.
+
+## 2. SLURM reachability + cluster conventions
+
+**SLURM is not reachable from this machine.** `which sbatch sinfo squeue` all report
+"not found" — this is a local development machine (macOS/Darwin, 24 GB RAM), not a login node.
+
+`~/.ssh/config` (read-only, no secrets shown) lists a cluster login host consistent with the
+repo's own cluster docs:
+
+```text
+Host licca licca-li-01
+  HostName licca-li-01.rz.uni-augsburg.de
+```
+
+This matches `SLURM/Licca/README.md`, the repository's public LiCCA cluster guide:
+
+- Login node `licca-li-01`; AMD EPYC compute nodes, 128 cores each.
+- Partitions: `epyc` (general CPU), `epyc-mem` (4 TiB RAM), `epyc-gpu` (3× A100 80GB),
+  `epyc-gpu-sxm` (4× A100-SXM 80GB), `xeon-gpu` (H100-NVL), `test` (short runs).
+- Filesystem: home `/hpc/gpfs2/home/u/$USER` (backed up), scratch
+  `/hpc/gpfs2/scratch/u/$USER` (not backed up), node-local `/tmp` (800 GB, wiped at job exit),
+  `/dev/shm` RAM disk counts toward `--mem`.
+- The README states "the cluster does not support `uv`" and documents a conda/micromamba path
+  (`setup_conda_environment.sh`), **but** `SLURM/Licca/setup_uv_environment.sh` exists and stages
+  a working `uv` (via `curl -LsSf https://astral.sh/uv/install.sh`) into
+  `/hpc/gpfs2/scratch/u/$USER/venvs/robot-sf-uv` after loading `miniforge`/`gcc` modules — so a
+  `uv`-based flow (matching this worktree's `.venv` and the packet's `uv run python ...` commands)
+  is available; confirm with the human whether the scratch uv env is already provisioned before
+  assuming either path.
+- The generic `SLURM/slurm_train.sl` / `SLURM/feature_extractor_comparison/*.slurm` templates add
+  the shared conventions used repo-wide: `module purge` first, `export OMP_NUM_THREADS=1` when the
+  job itself parallelizes (as this campaign's `ProcessPoolExecutor` does), headless rendering guards
+  (`DISPLAY=""`, `MPLBACKEND=Agg`, `SDL_VIDEODRIVER=dummy`), and `#SBATCH --output=output/slurm/%j-<description>.out`
+  (job ID first, gitignored `output/`).
+- `docs/dev/slurm_submission.md` documents `scripts/dev/sbatch_use_max_time.sh` as the preferred
+  wrapper over raw `sbatch --time=...` (it queries live partition/QoS `MaxTime` instead of a
+  hardcoded value) — recommended for the arm submissions here.
+- Auxme-specific scripts under `SLURM/Auxme/*.sl` are stubs in the public repo ("This Auxme batch
+  script moved to the private operations overlay") — they require `ROBOT_SF_PRIVATE_OPS`, which is
+  not configured here and not needed: LiCCA is the public, documented cluster path for this task.
+- No `local.machine.md` exists in this worktree, so `allow_slurm_submission` is unset — per
+  `docs/dev/slurm_submission.md`, autonomous `sbatch` is not permitted from this session even if
+  SLURM were reachable, which it is not.
+
+**GPU note for the `ppo` arm specifically:** `configs/baselines/ppo_15m_grid_socnav.yaml:39` sets
+`predictive_foresight_device: cuda` (hardcoded, not `auto`). `robot_sf/planner/predictive_foresight.py:46`
+passes this string straight through to the foresight model's device; there is no CPU fallback in
+that path. This arm needs a GPU partition (`epyc-gpu`/`epyc-gpu-sxm`/`xeon-gpu` on LiCCA); the other
+13 arms either force `predictive_device: cpu` explicitly (`prediction_planner`, `predictive_mppi`)
+or have no device field (classical arms) or use `device: auto` (`guarded_ppo`), which degrades to
+CPU cleanly.
+
+## 3. Per-arm sbatch template + memory tiers
+
+Template: `SLURM/submit_release_campaign_arm.sh` (new, executable). Design:
+
+- Takes `ARM_KEY` (required) and `PACKET` (defaults to the packet path above) via
+  `sbatch --export=...`; looks up that arm's exact `command` and `campaign_root` from the packet
+  JSON with `mapfile` (not `read var1 var2`, which would corrupt on the command's internal spaces
+  — verified in a local dry run with a synthetic packet before relying on it).
+- Sets `KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1`
+  (macOS/torch segfault guard locally; correct thread-limiting on Linux compute nodes too, given
+  the `ProcessPoolExecutor` fan-out described in §1).
+- Refuses to run (`exit 2`) if `CHECKPOINT_STAGING_REPORT` is set but missing or
+  `submit_safe != true` — a runtime backstop for the pre-sbatch staging contract in §4, not a
+  replacement for it.
+- Built-in resume: the looked-up command already carries the arm's fixed `--campaign-id`.
+- Logs to both the sbatch `--output` (set at submission time, not hardcoded in the template) and
+  a per-arm tee target `output/slurm/logs/<jobid>-<arm_key>.log`.
+- Exit code passthrough matches `scripts/tools/run_camera_ready_benchmark.py`'s own contract
+  (`0` success, `2` unexpected failure, `3` accepted-unavailable-only).
+
+Verified locally (no real benchmark executed): syntax-checked with `bash -n` and `shellcheck`
+(zero findings), then exercised against a synthetic packet with `exit 0`, `exit 3`, a missing
+staging report, `submit_safe: false`, and `submit_safe: true` — all five cases behaved as
+designed (correct log path, correct message, correct propagated exit code).
+
+### Memory tiers
+
+| Tier | Arms | `--mem` | Why |
+|---|---|---|---|
+| Heavy | `prediction_planner`, `predictive_mppi`, `ppo`, `guarded_ppo`, `sacadrl` | `16G` | All 5 are exactly the arms `scripts/benchmark/preflight_campaign_checkpoints.py --config configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml --json` reports as checkpoint-bound (verified locally, see §4 output). `ppo`/`guarded_ppo` load PyTorch (`stable_baselines3`, `robot_sf/baselines/ppo.py`) policy + feature-extractor checkpoints; `prediction_planner`/`predictive_mppi` load a PyTorch predictive proxy model (`robot_sf/planner/predictive_model.py`); `sacadrl` loads a TensorFlow GA3C-CADRL checkpoint (`robot_sf/planner/socnav.py:35`, `import tensorflow.compat.v1 as tf`). With `workers: 8` (ProcessPoolExecutor, unchanged by the split — §1), each arm's job runs up to 8 independent processes that each import a full deep-learning framework and load the checkpoint; framework import + simulation state easily reaches ~1.5-2 GB RSS per worker for these arms, i.e. ~12-16 GB total — 16G is a workable but not generously margined tier. Checkpoint bytes on disk are small (94 MB combined for the 2 currently cached models), so file size is not the driver — process multiplication is. |
+| Light | `goal`, `social_force`, `orca`, `socnav_sampling`, `risk_dwa`, `scenario_adaptive_hybrid_orca_v1`, `scenario_adaptive_hybrid_orca_v2_collision_guard`, `hybrid_rule_v3_fast_progress_static_escape`, `hybrid_rule_v3_fast_progress_static_escape_continuous` | `8G` | Confirmed by grep: none of these 9 arms' `algo_config` files (or their absence, for arms with no `algo_config`) declare `model_id`/`model_path`/`sacadrl_model_id`/`predictive_model_id` — classical/rule-based planners (ORCA, social-force, DWA-style risk, hybrid-rule ORCA blends). 8 worker processes of NumPy-only simulation state is comfortably under 8G in the prior h100 7-arm run's non-`prediction_planner` arms (see §6 for the exact numbers this is based on). |
+
+**Wall-clock is a separate axis from memory.** Within the heavy tier, only `prediction_planner`
+and `predictive_mppi` do expensive **per-simulation-step** predictive rollout computation; `ppo`,
+`guarded_ppo`, and `sacadrl` do one cheap forward pass per step. The h100/3-seed evidence in §6
+shows `prediction_planner` alone was 53% of a 7-arm campaign's wall time while the other 6 arms
+(including `ppo` and `sacadrl`) were comparatively fast — i.e., "heavy" here means memory-tier
+grouping, not a claim that all 5 arms are equally slow.
+
+### Submission loop (documented, not executed — SLURM unreachable + no submission authorization)
+
+```bash
+# 1. One-time: refresh the split + packet if the campaign config changed since §1.
+# 2. Stage checkpoints once for the whole campaign (§4) BEFORE any sbatch call.
+# 3. Submit all 14 arms, tier-appropriate --mem, arm-specific --job-name/--output:
+
+declare -A HEAVY=( [prediction_planner]=1 [predictive_mppi]=1 [ppo]=1 [guarded_ppo]=1 [sacadrl]=1 )
+PACKET=output/benchmarks/release_v0_0_3_split_plan/execution_packet.json
+STAGING_REPORT=output/benchmarks/release_v0_0_3_split_plan/checkpoint_staging.json
+
+for key in prediction_planner goal social_force orca ppo socnav_sampling sacadrl \
+           scenario_adaptive_hybrid_orca_v1 scenario_adaptive_hybrid_orca_v2_collision_guard \
+           hybrid_rule_v3_fast_progress_static_escape \
+           hybrid_rule_v3_fast_progress_static_escape_continuous \
+           guarded_ppo predictive_mppi risk_dwa; do
+  MEM=8G; PARTITION=epyc
+  if [[ -n "${HEAVY[$key]:-}" ]]; then MEM=16G; fi
+  if [[ "$key" == "ppo" ]]; then PARTITION=epyc-gpu; fi   # hardcoded cuda foresight device, §2
+  scripts/dev/sbatch_use_max_time.sh \
+    --sbatch-arg --job-name=rsf-rel003-"$key" \
+    --sbatch-arg --output=output/slurm/%j-rel003-"$key".out \
+    --sbatch-arg --mem="$MEM" \
+    --sbatch-arg --partition="$PARTITION" \
+    --sbatch-arg --export=ALL,ARM_KEY="$key",PACKET="$PACKET",CHECKPOINT_STAGING_REPORT="$STAGING_REPORT" \
+    SLURM/submit_release_campaign_arm.sh
+done
+```
+
+Partition names above (`epyc`, `epyc-gpu`) come from `SLURM/Licca/README.md`; confirm live
+availability with `sinfo` on the login node before submitting, since this session cannot.
+
+## 4. Checkpoint staging (issue #4613 contract)
+
+`docs/context/issue_4613_camera_ready_checkpoint_provisioning.md` is the runbook: the strict
+all-rows campaign policy turns one un-loadable arm checkpoint into a whole-campaign failure
+**after** compute has already run (the runbook cites jobs 13296/13301 failing ~14h in on a
+missing PPO `model_cache` entry). The fix is provisioning at submit time, not inside the job.
+
+Verified locally (network-free `metadata_only` mode, no download attempted):
+
+```bash
+uv run python scripts/benchmark/preflight_campaign_checkpoints.py \
+  --config configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml \
+  --json --report-path /tmp/staging_check.json
+```
+
+Result: `"checked": 5, "resolved": 5, "stage": false, "submit_safe": false`. Exactly 5 arms
+declare a checkpoint — `prediction_planner`, `ppo`, `sacadrl`, `guarded_ppo`, `predictive_mppi`
+(the same 5 as the heavy memory tier above, confirmed by running the tool, not assumed).
+`sacadrl`'s default `ga3c_cadrl_iros18` checkpoint is already `present_local` in this worktree
+(`model/ga3c_cadrl/IROS18/network_01900000.meta`); the other 4 are `stageable_remote`
+(registry-declared GitHub-release/W&B sources, not yet downloaded into `output/model_cache`,
+which today only holds 94 MB for 2 unrelated models) — hence `submit_safe: false`.
+
+**Required pre-sbatch step** (not run in this session — it downloads model weights over the
+network, which is out of scope for a planning-only pass):
+
+```bash
+scripts/benchmark/submit_camera_ready_checkpoint_gate.sh \
+  --config configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml \
+  --report-path output/benchmarks/release_v0_0_3_split_plan/checkpoint_staging.json
+```
+
+This wraps `preflight_campaign_checkpoints.py --stage --json`, downloads + checksum-verifies each
+registry checkpoint into the durable cache, and exits `3` (do-not-submit) on any unresolvable
+checkpoint. Run it **once against the full parent campaign config** (not per-arm child config) —
+all arms share the same `output/model_cache`, so one gate call stages everything the 5 heavy arms
+need; then pass `--report-path` through to every `sbatch --export=...CHECKPOINT_STAGING_REPORT=...`
+call in §3 so the per-arm template's runtime guard can confirm `submit_safe: true` before it runs.
+
+Note that `run_camera_ready_benchmark.py --checkpoint-preflight-mode` only affects the
+**preflight-only** CLI path; `--mode run` (what every arm in the packet uses) always keeps the
+cheap `metadata_only` guard and expects checkpoints already staged
+(`scripts/tools/run_camera_ready_benchmark.py:84-97`) — the gate above is not optional for the 4
+`stageable_remote` arms; skipping it reproduces the exact issue #4613 failure mode.
+
+## 5. Post-run path: aggregate, publication bundle, and the release runner
+
+### `aggregate` (verified locally against the just-generated packet, before any arm has run)
+
+```bash
+uv run python scripts/tools/run_split_camera_ready_campaign.py aggregate \
+  --packet output/benchmarks/release_v0_0_3_split_plan/execution_packet.json \
+  --output-dir output/benchmarks/release_v0_0_3_split_plan/aggregate_dryrun
+```
+
+Result (expected, since no arm has executed yet): `exit 2`, `"status": "blocked"`, 14
+`missing_campaign_artifacts` exclusions (one per arm, each missing `campaign_manifest.json` and
+`campaign_summary.json` under its not-yet-created campaign root). This confirms the tool fails
+closed correctly rather than silently reporting a false success — it is safe to re-run this exact
+command as arms complete; it will report `native_aggregate_complete` only once every arm's root
+has compatible native rows and no arm is missing/incompatible (`_row_exclusion_reason`,
+`aggregate_execution_packet` in `run_split_camera_ready_campaign.py:254-460`).
+
+The aggregate's own schema (`split-camera-ready-native-aggregate.v1`) carries an explicit
+`claim_boundary`: *"Native-row aggregation of independently executed split campaigns. Adapter,
+fallback, degraded, unavailable, failed, missing, and incompatible rows are excluded and cannot
+support benchmark-success claims in this aggregate."* It writes only 3 files at the aggregate
+output dir: `aggregate_manifest.json`, `reports/campaign_summary.json`,
+`reports/campaign_report.md`.
+
+### Can `benchmark_publication_bundle.py` consume the aggregate? Mechanically yes, substantively no.
+
+`scripts/tools/benchmark_publication_bundle.py export --run-dir <dir>` calls
+`export_publication_bundle()` → `list_publication_files()`
+(`robot_sf/benchmark/artifact_publication.py:157-186`), which recursively globs **any** non-hidden
+file under `run-dir` with no required filename — so pointing `--run-dir` at the aggregate output
+dir would technically produce *a* bundle (the 3 files above). `_validate_publication_requirements()`
+(`artifact_publication.py:430-438`) only enforces the stricter preflight-artifact completeness
+check **when `campaign_manifest.json` exists** in the run dir — the aggregate dir never writes
+that file, so the check silently no-ops. This means a thin, mechanically-valid bundle is possible,
+but it is not a release-manifest-validated bundle (next point) and should be labeled with the
+aggregate's own claim boundary if ever exported this way.
+
+### Can `run_benchmark_release.py` consume the aggregate or resume/report over an existing root? No — verified by reading the whole file.
+
+`scripts/tools/run_benchmark_release.py` (`parse_release_args` in `robot_sf/benchmark/release_protocol.py:652-674`)
+exposes exactly `--manifest`, `--output-root`, `--label`, `--mode {run,preflight}`. There is:
+
+- **No `--campaign-id` / `--campaign-root` flag** (unlike `run_camera_ready_benchmark.py`, which
+  has one specifically for resuming a fixed root).
+- **No report-only mode.** `--mode preflight` calls `prepare_campaign_preflight(cfg, ...)`, which
+  generates fresh preflight artifacts, not a report over completed results.
+  `--mode run` (the default) **always** calls `run_campaign(cfg, output_root=..., label=...,
+  skip_publication_bundle=True, invoked_command=...)` (`run_benchmark_release.py:221-227`) — i.e.
+  it always executes the full campaign itself, in-process, from scratch (or resumes via the
+  config's own `resume: true` + whatever campaign_id `run_campaign` derives — but that id is not
+  guaranteed to match `release_0_0_3_h600_s30__native_aggregate`, and there is no CLI surface to
+  force it).
+
+So there is **no way, as currently coded, to point `run_benchmark_release.py` at the split
+aggregate root and have it validate/wrap that data.** The release manifest's own
+`artifacts.required_paths` (10 entries: `campaign_manifest.json`, `manifest.json`, `run_meta.json`,
+`preflight/validate_config.json`, `preflight/preview_scenarios.json`,
+`reports/campaign_summary.json`, `reports/campaign_report.md`, `reports/matrix_summary.json`,
+`reports/campaign_table.md`, `reports/snqi_diagnostics.json`) would also fail the
+`_required_artifacts_missing()` check (`run_benchmark_release.py:103-110`) against the aggregate
+root, since the `aggregate` command only ever writes 3 of those 10 files.
+
+**Documented alternative** (no new tooling built here; this is the closest available path with
+existing code):
+
+1. Treat the split-aggregate `campaign_summary.json`/`campaign_report.md` as **diagnostic/internal
+   evidence only**, under its own `split-camera-ready-native-aggregate.v1` claim boundary — this is
+   already exactly what the tool is designed and labeled to produce, and is sufficient for
+   per-planner comparison analysis.
+2. To get an actual release-manifest-validated, publication-bundle-eligible artifact set from
+   split execution, someone would need to write new tooling to backfill the missing 7 required
+   paths at the aggregate root (a synthetic `campaign_manifest.json`/`manifest.json`/`run_meta.json`
+   stitched from the 14 per-arm roots' own manifests, plus `preflight/*`, `reports/matrix_summary.json`,
+   `reports/campaign_table.md`, `reports/snqi_diagnostics.json` recomputed over the merged rows).
+   That tooling does not exist today — this is a real gap, not a configuration issue, and is
+   flagged here as a blocker for anyone who later wants release-runner-validated evidence from a
+   split campaign rather than a single in-process run.
+3. Alternatively, once GPU-leak fix #4826 lands and the in-process route is judged safe on
+   suitable hardware (a LiCCA GPU node, not this 24 GB local machine), running
+   `run_benchmark_release.py --mode run` natively (unsplit) remains the only currently-coded path
+   to a release-manifest-validated bundle.
+
+## 6. Local fallback (sequential, single 24 GB machine)
+
+### Timing anchor (verified from repo history, not assumed)
+
+`docs/context/camera_ready_all_planners_slurm_2026-05-04.md` records a real prior h100/3-seed,
+7-arm, 48-scenario campaign (`ppo`, `orca`, `socnav_sampling`, `prediction_planner`, `goal`,
+`social_force`, `sacadrl`; `socnav_bench` failed preflight and is excluded from these numbers):
+
+- Total campaign runtime: **1894.28 s** (~31.6 min) for 1008 episodes (144 episodes/arm × 7).
+- `prediction_planner` alone: **1006.07 s** (~16.8 min), 53% of total wall time, for its 144
+  episodes (**6.99 s/episode**).
+- The other 6 arms combined: 888.21 s for 864 episodes (**1.03 s/episode**, blended).
+
+(The task brief's own "~40 min total / ~35 min prediction_planner" figures are the same order of
+magnitude as this measured anchor but roughly 2× higher — no document in this repo matches those
+exact numbers; the analysis below uses the measured 1894.28 s / 1006.07 s anchor since it is
+directly traceable to a specific campaign root and report.)
+
+### Scaling to h600/s30 (1,410 episodes/arm vs 144; horizon ×6)
+
+- Scenario/seed multiplier alone: 1410/144 ≈ **9.79×** episodes per arm.
+- Horizon multiplier is sub-linear and uncertain: episodes that already terminate early
+  (goal-reached/collision) cost about the same regardless of the horizon cap; only episodes that
+  were hitting the old 100-step timeout run longer under a 600-step cap (up to 6× worst case for
+  those episodes specifically). The campaign config's own authoring rationale
+  (`paper_experiment_matrix_v2_h600_s30_extended.yaml`, top comment) states the horizon bump is
+  specifically because "timeout no longer dominant, waiting strategies visible" at h100 — i.e., a
+  non-trivial share of episodes were already near the h100 wall, so a blended per-episode
+  multiplier of roughly **2-4×** (not the full 6×, since not all episodes were timing out) is used
+  below as a central estimate, not a precise figure.
+- `prediction_planner` and `predictive_mppi` (the two arms doing genuinely expensive per-step
+  predictive-rollout computation) are treated at the high end of that range;
+  `ppo`/`guarded_ppo`/`sacadrl` (cheap-forward-pass, checkpoint-loading but not compute-dominant —
+  see §3) and the 9 classical/rule-based arms are treated at the blended 1.03 s/episode anchor.
+
+| Bucket | Arms | Per-episode estimate (h600/s30) | Episodes/arm | Est. wall time/arm |
+|---|---|---:|---:|---:|
+| Dominant predictive compute | `prediction_planner`, `predictive_mppi` | ~14-28 s | 1,410 | ~5.5-11 h **each** |
+| Cheap-inference + classical | remaining 12 arms | ~1-3 s | 1,410 | ~24-70 min **each** |
+
+**Sequential total for all 14 arms on this machine: roughly 16-36 hours** (dominant pair:
+~11-22 h combined; remaining 12 arms: ~4.7-14 h combined). This is a wide, genuinely uncertain
+range — it is bounded on the low end by the measured h100 anchor and on the high end by the
+independent evidence that the prior in-process 6-arm h600/s30 campaign ran at least 14 hours
+before failing on the GPU leak (issue #4826), which is consistent with 1-2 of the dominant arms
+alone consuming most of that window.
+
+### Concrete blockers for local execution of specific arms (found by reading code, not assumed)
+
+- **`ppo` arm will likely error, not just run slowly, on this machine.** Its algo config
+  (`configs/baselines/ppo_15m_grid_socnav.yaml:39`) hardcodes `predictive_foresight_device: cuda`,
+  and `robot_sf/planner/predictive_foresight.py:46` passes that string straight to the foresight
+  model with no CPU fallback branch. This machine is Darwin/Apple Silicon with no CUDA device.
+  **Before running the `ppo` arm locally, its child config
+  (`configs/benchmarks/splits/.../paper_experiment_matrix_v2_h600_s30_extended__arm_ppo.yaml`)
+  needs `predictive_foresight_device` overridden to `cpu`** (and the child's sha256 in
+  `split_manifest.json` recomputed, then `plan` re-run) — otherwise the arm fails at
+  model-load time, not at OOM time.
+- **Checkpoint staging still applies locally.** The same 5 arms in §4 need
+  `submit_camera_ready_checkpoint_gate.sh` (or the plain `--stage` CLI) run once before any local
+  sequential loop, for the same reason as the cluster path — a missing/`stageable_remote`
+  checkpoint fails the arm, just without losing 14 hours of unrelated compute first.
+- **Recommend a probe before committing to the full sequential run.** Run `prediction_planner`
+  and `predictive_mppi` first (they dominate wall time and are the least certain estimate above)
+  against a small scenario/seed subset — or accept the first native rows from those two arms as
+  the actual timing calibration — before scheduling the remaining 12 arms overnight.
+
+### Local fallback command shape (documented, not executed)
+
+```bash
+# 0. Stage checkpoints once (network required; not run in this session):
+scripts/benchmark/submit_camera_ready_checkpoint_gate.sh \
+  --config configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml \
+  --report-path output/benchmarks/release_v0_0_3_split_plan/checkpoint_staging.json
+
+# 1. Fix the ppo child's predictive_foresight_device: cuda -> cpu (see blocker above),
+#    recompute its sha256, and patch split_manifest.json + re-run `plan` (§1).
+
+# 2. Run arms sequentially, one at a time, reusing the exact packet commands from §1:
+for key in prediction_planner predictive_mppi ppo goal social_force orca socnav_sampling \
+           sacadrl scenario_adaptive_hybrid_orca_v1 \
+           scenario_adaptive_hybrid_orca_v2_collision_guard \
+           hybrid_rule_v3_fast_progress_static_escape \
+           hybrid_rule_v3_fast_progress_static_escape_continuous guarded_ppo risk_dwa; do
+  KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+  uv run python scripts/tools/run_camera_ready_benchmark.py \
+    --config "configs/benchmarks/splits/paper_experiment_matrix_v2_h600_s30_extended/paper_experiment_matrix_v2_h600_s30_extended__arm_${key}.yaml" \
+    --output-root output/benchmarks/release_v0_0_3_arms \
+    --campaign-id "release_0_0_3_h600_s30__arm_${key}" \
+    --mode run --skip-publication-bundle \
+    2>&1 | tee "output/slurm/logs/local-${key}.log"
+done
+
+# 3. Aggregate once all 14 arms have produced campaign_summary.json (§5):
+uv run python scripts/tools/run_split_camera_ready_campaign.py aggregate \
+  --packet output/benchmarks/release_v0_0_3_split_plan/execution_packet.json \
+  --output-dir output/benchmarks/release_v0_0_3_split_plan/aggregate
+```
+
+`workers: 8` is left unchanged in this loop (matching the cluster path) because the same
+process-multiplication risk in §1 applies locally too, arguably more acutely on a 24 GB machine —
+if the human wants a safety margin without editing configs, reducing to `workers: 2`-`4` for the
+5 heavy arms specifically (same mechanism as §1) is the lowest-risk lever before running anything
+overnight unattended.
+
+## Summary for the human operator
+
+(a) **SLURM reachability:** not reachable from this machine (`sbatch`/`sinfo`/`squeue` all
+absent). The cluster is LiCCA, reachable via `ssh licca` per `~/.ssh/config`
+(`licca-li-01.rz.uni-augsburg.de`), documented in `SLURM/Licca/README.md`.
+
+(b) **Exact next command(s):**
+
+- On the LiCCA login node (cluster path): first
+  `scripts/benchmark/submit_camera_ready_checkpoint_gate.sh --config configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml --report-path output/benchmarks/release_v0_0_3_split_plan/checkpoint_staging.json`,
+  confirm `submit_safe: true`, then submit the 14-arm loop in §3 (tier-appropriate `--mem`,
+  `epyc-gpu` for `ppo`, `epyc`/`epyc-mem` for the rest — confirm partition names with `sinfo`
+  first, since this session could not).
+- Locally (fallback path): first override `ppo`'s `predictive_foresight_device` to `cpu` in its
+  split child config and re-`plan`, then run the §6 sequential loop, budgeting **16-36 hours**
+  wall clock with `prediction_planner`/`predictive_mppi` as the dominant, least-certain cost.
+
+(c) **Blockers found:**
+
+1. 4 of 5 checkpoint-bound arms (`prediction_planner`, `ppo`, `guarded_ppo`, `predictive_mppi`)
+   are only `stageable_remote` today — enforced staging (`--stage`) has not been run in this
+   session (network download, out of scope for a planning pass) and must happen before any
+   `sbatch` or local execution.
+2. `ppo`'s algo config hardcodes a CUDA-only foresight device with no CPU fallback in code — it
+   will fail outright on this local Darwin/no-GPU machine without a config edit, and needs a GPU
+   partition on LiCCA.
+3. `run_benchmark_release.py` has no supported way to consume the split-execution `aggregate`
+   output or to resume/report over an existing campaign root — the split-aggregate path and the
+   release-manifest-validated path are not currently connected in code; treating the aggregate as
+   diagnostic-only evidence (not a release bundle) is the only code-supported option today.
+4. `workers: 8` survives the per-arm split unchanged, so each arm's job still fans out to 8
+   OS processes; for the 5 checkpoint-loading arms this multiplies PyTorch/TensorFlow import +
+   checkpoint memory across all 8 workers, which is the actual justification for the 16G heavy
+   tier (not checkpoint file size) — a `workers_override` reduction is available but was not
+   applied, left as an operator decision.
+5. Cluster partition names/QoS are documented in `SLURM/Licca/README.md` but could not be
+   live-verified (`sinfo` unreachable from here); confirm before the first submission.

--- a/robot_sf/benchmark/release_protocol.py
+++ b/robot_sf/benchmark/release_protocol.py
@@ -675,6 +675,18 @@ def parse_release_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="run",
         help="Preflight-only validation or full release execution.",
     )
+    parser.add_argument(
+        "--campaign-id",
+        type=str,
+        default=None,
+        help=(
+            "Optional exact campaign directory id (forwarded to the campaign runner). "
+            "Passing a fixed id makes the release run idempotent: a restart after a "
+            "walltime kill, node failure, or scheduler requeue resumes the existing "
+            "campaign directory through the campaign resume plan instead of starting "
+            "a fresh timestamped one."
+        ),
+    )
     return parser.parse_args(argv)
 
 

--- a/scripts/tools/rebuild_campaign_reports_from_rows.py
+++ b/scripts/tools/rebuild_campaign_reports_from_rows.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Rebuild campaign reports/publication bundle from pre-existing arm rows, without re-simulating.
+
+Context (2026-07-13 release/v0.0.3-h600-s30-extended reconstruction): a 14-arm camera-ready
+campaign ran on a cluster. Run 1 completed 13 arms cleanly (1,440 episodes each) but the ``ppo``
+arm produced 0 rows (unexpected_failure). A resume attempt using the same ``--campaign-id``
+re-ran the 13 already-complete arms and appended duplicate rows onto their ``episodes.jsonl``
+files (see the ``#5392``/``_resume_plan.py`` diagnosis in the accompanying report), while ``ppo``
+produced a clean, fresh 1,440-row run. The cluster job was then cancelled.
+
+This script reconstructs a release-grade campaign root from two clean data snapshots (the 13
+completed arms, deduplicated to 1,440 unique episodes each, plus the freshly-completed ppo arm)
+by driving the *real* release/campaign orchestration code
+(:func:`robot_sf.benchmark.camera_ready_campaign.run_campaign`, mirroring
+``scripts/tools/run_benchmark_release.py``'s ``run`` mode) with one injected collaborator:
+``run_batch`` is replaced by :func:`_native_reuse_run_batch`, which loads each arm's *existing*
+``episodes.jsonl`` (already placed under ``runs/<planner>__<kinematics>/`` before this script
+runs) instead of simulating anything. Preflight, aggregation, SNQI diagnostics, fairness,
+reporting, and publication-bundle export all run for real, exactly as they would for a live
+campaign -- only the (expensive, GPU/CPU-bound) simulation step is skipped because the episode
+data already exists on disk.
+
+Usage:
+    uv run python scripts/tools/rebuild_campaign_reports_from_rows.py \\
+        --manifest configs/benchmarks/releases/paper_experiment_matrix_v2_h600_s30_release_v0_0_3.yaml \\
+        --campaign-id paper_experiment_matrix_v2_h600_s30_extended_release_v0_0_3_final
+
+Preconditions:
+    - ``output/benchmarks/camera_ready/<campaign-id>/runs/<arm>/episodes.jsonl`` must already
+      exist for every enabled planner x kinematics arm, with the full expected episode count and
+      globally-unique ``episode_id`` values (verify with a separate row-count/uniqueness check
+      before running this script -- it does not deduplicate rows itself, it only refuses to
+      fabricate missing ones).
+    - A prior ``summary.json`` should exist alongside each arm's ``episodes.jsonl`` (a normal
+      by-product of any earlier real ``run_batch`` execution for that arm); its non-count fields
+      (``preflight``, ``algorithm_readiness``, ``algorithm_metadata_contract``,
+      ``observation_noise*``, ``tracking_precision*``, ``synthetic_actuation_profile``,
+      ``latency_stress_*``, ``workers``, ``parallel_execution``, ``provenance``) are carried
+      through verbatim; the count fields (``written``, ``total_jobs``, ``failed_jobs``,
+      ``skipped_jobs``, ``successful_jobs``, ``failures``) are recomputed from the actual
+      on-disk row count so a stale/duplicated prior summary can't leak wrong counts forward.
+
+This is a reconstruction tool, not a general resume mechanism: it does not implement any
+new resume/dedup logic, and it deliberately fails closed (raises) rather than simulating when an
+arm's ``episodes.jsonl`` is missing or empty.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from robot_sf.benchmark.aggregate import read_jsonl
+from robot_sf.benchmark.artifact_publication import export_publication_bundle
+from robot_sf.benchmark.camera_ready._config import load_campaign_config
+from robot_sf.benchmark.camera_ready._preflight import prepare_campaign_preflight
+from robot_sf.benchmark.camera_ready._reporting import write_campaign_report
+from robot_sf.benchmark.camera_ready._util import _utc_now
+
+# NOTE: run_campaign is imported from the extracted campaign module directly (not from the
+# robot_sf.benchmark.camera_ready_campaign legacy facade) because the facade's run_campaign
+# hard-binds run_batch=robot_sf.benchmark.runner.run_batch with no override parameter. Only the
+# lower-level robot_sf.benchmark.camera_ready.campaign.run_campaign accepts an injectable
+# run_batch collaborator, which this script relies on to skip simulation entirely.
+from robot_sf.benchmark.camera_ready.campaign import run_campaign
+from robot_sf.benchmark.orca_preflight import OrcaRvo2PreflightError, check_orca_rvo2_preflight
+from robot_sf.benchmark.release_protocol import (
+    build_release_provenance,
+    build_resolved_release_manifest,
+    load_release_manifest,
+    parse_release_args,
+    validate_release_manifest,
+)
+from robot_sf.common.artifact_paths import get_artifact_category_path, get_repository_root
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+# --------------------------------------------------------------------------------------
+# Injected run_batch replacement: reuse existing rows, never simulate.
+# --------------------------------------------------------------------------------------
+
+
+def _native_reuse_run_batch(
+    scenarios: list[dict[str, Any]],
+    *,
+    out_path: str | Path,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    """Return a run_batch-shaped summary for an arm whose episodes.jsonl already exists.
+
+    This is invoked once per enabled planner x kinematics arm by the real
+    ``run_campaign`` orchestrator, in place of ``robot_sf.benchmark.runner.run_batch``.
+    It never simulates: it fails closed if the arm's pre-existing ``episodes.jsonl`` is
+    missing, empty, or contains duplicate ``episode_id`` values, and otherwise returns a
+    summary dict shaped exactly like a real ``run_batch`` return (reusing whatever
+    non-count fields are available from a prior ``summary.json`` alongside the file).
+
+    Returns:
+        A run_batch-contract summary dict with recomputed count fields and a
+        ``reconstruction`` provenance block marking the arm as natively reused (no
+        re-simulation).
+
+    Raises:
+        FileNotFoundError: If the arm's ``episodes.jsonl`` does not exist or is empty.
+        ValueError: If the arm's ``episodes.jsonl`` contains duplicate ``episode_id``
+            values (this script never deduplicates; the campaign root must already be
+            reconciled before this driver runs).
+    """
+    out_path = Path(out_path)
+    arm_dir = out_path.parent
+    if not out_path.is_file() or out_path.stat().st_size == 0:
+        raise FileNotFoundError(
+            f"Reconstruction precondition failed: expected pre-existing episodes at {out_path} "
+            "(this driver never simulates; place the real episodes.jsonl for this arm first)."
+        )
+
+    records = read_jsonl(str(out_path))
+    episode_ids = [str(rec.get("episode_id")) for rec in records]
+    n_rows = len(episode_ids)
+    n_unique = len(set(episode_ids))
+    if n_unique != n_rows:
+        raise ValueError(
+            f"Reconstruction precondition failed: {out_path} has {n_rows} rows but only "
+            f"{n_unique} unique episode_id values (duplicate rows must be deduplicated before "
+            "running this driver)."
+        )
+
+    summary_path = arm_dir / "summary.json"
+    prior_summary: dict[str, Any] = {}
+    if summary_path.is_file():
+        try:
+            loaded = json.loads(summary_path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                prior_summary = loaded
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Could not reuse prior summary.json at {}: {}", summary_path, exc)
+
+    summary: dict[str, Any] = dict(prior_summary)
+    summary.update(
+        {
+            "status": "ok",
+            "out_path": str(out_path),
+            "total_jobs": n_rows,
+            "written": n_rows,
+            "failed_jobs": 0,
+            "skipped_jobs": 0,
+            "successful_jobs": n_rows,
+            "failures": [],
+        }
+    )
+    summary["reconstruction"] = {
+        "mode": "native_reuse_no_resimulation",
+        "reused_at_utc": _utc_now(),
+        "episodes_path": str(out_path),
+        "episode_count": n_rows,
+        "prior_summary_reused": bool(prior_summary),
+        "note": (
+            "Rows were produced by a real run_batch execution outside this reconstruction "
+            "(either the original cluster run or a targeted re-run of a single failed arm); "
+            "this driver only re-ran the reporting/aggregation/publication stages."
+        ),
+    }
+    return summary
+
+
+# --------------------------------------------------------------------------------------
+# The rest mirrors scripts/tools/run_benchmark_release.py's ``run`` mode, with run_batch injected.
+# --------------------------------------------------------------------------------------
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    """Read a JSON object from disk."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object at {path}")
+    return payload
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write a JSON object to disk."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _repo_relative(path: Path) -> str:
+    """Return a repository-relative path string when possible."""
+    resolved = path.resolve()
+    repo_root = get_repository_root().resolve()
+    try:
+        return resolved.relative_to(repo_root).as_posix()
+    except ValueError:
+        return str(resolved)
+
+
+def _merge_release_provenance(campaign_root: Path, release_provenance: dict[str, Any]) -> None:
+    """Inject release provenance into campaign artifacts and refresh the markdown report."""
+    summary_path = campaign_root / "reports" / "campaign_summary.json"
+    report_md_path = campaign_root / "reports" / "campaign_report.md"
+    manifest_path = campaign_root / "campaign_manifest.json"
+    benchmark_manifest_path = campaign_root / "manifest.json"
+    run_meta_path = campaign_root / "run_meta.json"
+
+    summary = _read_json(summary_path)
+    summary["benchmark_release"] = dict(release_provenance)
+    campaign_block = summary.get("campaign")
+    if not isinstance(campaign_block, dict):
+        campaign_block = {}
+        summary["campaign"] = campaign_block
+    campaign_block.update(
+        {
+            "benchmark_protocol_version": release_provenance["benchmark_protocol_version"],
+            "benchmark_release_id": release_provenance["release_id"],
+            "benchmark_release_tag": release_provenance["release_tag"],
+            "benchmark_release_manifest_path": release_provenance["manifest_path"],
+            "benchmark_release_manifest_sha256": release_provenance["manifest_sha256"],
+            "canonical_release_config": release_provenance["canonical_campaign_config"],
+        }
+    )
+    _write_json(summary_path, summary)
+    write_campaign_report(report_md_path, summary)
+
+    for path in (manifest_path, benchmark_manifest_path, run_meta_path):
+        payload = _read_json(path)
+        payload["benchmark_release"] = dict(release_provenance)
+        _write_json(path, payload)
+
+
+def _required_artifacts_missing(campaign_root: Path, required_paths: tuple[str, ...]) -> list[str]:
+    """Return required artifact paths that are missing from the campaign root."""
+    missing: list[str] = []
+    for relative_path in required_paths:
+        candidate = campaign_root / relative_path
+        if not candidate.exists():
+            missing.append(relative_path)
+    return missing
+
+
+def _build_publication_payload(
+    *,
+    campaign_root: Path,
+    release_tag: str,
+    doi: str,
+    repository_url: str,
+) -> dict[str, Any]:
+    """Export a benchmark publication bundle and return a JSON-safe payload."""
+    result = export_publication_bundle(
+        campaign_root,
+        get_artifact_category_path("benchmarks") / "publication",
+        bundle_name=f"{campaign_root.name}_publication_bundle",
+        include_videos=False,
+        repository_url=repository_url,
+        release_tag=release_tag,
+        doi=doi,
+        overwrite=True,
+    )
+    return {
+        "bundle_dir": _repo_relative(result.bundle_dir),
+        "archive_path": _repo_relative(result.archive_path),
+        "manifest_path": _repo_relative(result.manifest_path),
+        "checksums_path": _repo_relative(result.checksums_path),
+        "file_count": result.file_count,
+        "total_bytes": result.total_bytes,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the reconstruction entrypoint and return a POSIX exit code."""
+    raw_argv = list(argv) if argv is not None else list(sys.argv[1:])
+    args = parse_release_args(raw_argv)
+
+    logger.remove()
+    logger.add(sys.stderr, level="INFO")
+
+    invoked_command = shlex.join([sys.executable, str(Path(__file__)), *raw_argv])
+
+    manifest = load_release_manifest(args.manifest)
+    cfg = load_campaign_config(manifest.canonical_campaign_config_path)
+    try:
+        check_orca_rvo2_preflight(cfg)
+    except OrcaRvo2PreflightError as exc:
+        reason = str(exc)
+        result = {
+            "mode": args.mode,
+            "status": "orca_preflight_failed",
+            "status_reason": reason,
+            "benchmark_success": False,
+            "exit_code": 2,
+        }
+        print(json.dumps(result, indent=2))
+        return 2
+    validation = validate_release_manifest(manifest, campaign_config=cfg)
+
+    resolved_manifest = build_resolved_release_manifest(manifest, campaign_config=cfg)
+    if args.mode == "preflight":
+        prepared = prepare_campaign_preflight(
+            cfg,
+            output_root=args.output_root,
+            label=args.label,
+            campaign_id=args.campaign_id,
+            invoked_command=invoked_command,
+        )
+        preflight_payload = {
+            "mode": "preflight",
+            "manifest_validation": validation,
+            "resolved_manifest": resolved_manifest,
+            "campaign_id": prepared["campaign_id"],
+            "campaign_root": str(prepared["campaign_root"]),
+        }
+        print(json.dumps(preflight_payload, indent=2))
+        return 0 if validation["status"] == "valid" else 2
+
+    result: dict[str, Any] = {
+        "mode": "run",
+        "manifest_validation": validation,
+        "resolved_manifest": resolved_manifest,
+    }
+    if validation["status"] != "valid":
+        result["benchmark_success"] = False
+        result["status"] = "invalid_manifest"
+        print(json.dumps(result, indent=2))
+        return 2
+
+    # The only difference from scripts/tools/run_benchmark_release.py: run_batch is replaced
+    # by _native_reuse_run_batch so no simulation happens, only reporting/aggregation/export.
+    run_payload = run_campaign(
+        cfg,
+        output_root=args.output_root,
+        label=args.label,
+        campaign_id=args.campaign_id,
+        skip_publication_bundle=True,
+        invoked_command=invoked_command,
+        run_batch=_native_reuse_run_batch,
+    )
+    result.update(run_payload)
+    campaign_root = Path(str(run_payload["campaign_root"])).resolve()
+
+    release_provenance = build_release_provenance(
+        manifest,
+        campaign_root=campaign_root,
+        invoked_command=invoked_command,
+    )
+    _merge_release_provenance(campaign_root, release_provenance)
+
+    missing = _required_artifacts_missing(campaign_root, manifest.required_artifact_paths)
+    result["required_artifact_paths"] = list(manifest.required_artifact_paths)
+    result["missing_required_artifacts"] = missing
+    result["benchmark_release"] = release_provenance
+
+    release_dir = campaign_root / "release"
+    _write_json(release_dir / "release_manifest.resolved.json", resolved_manifest)
+
+    release_benchmark_success = bool(run_payload.get("benchmark_success")) and not missing
+    result["release_benchmark_success"] = release_benchmark_success
+    if release_benchmark_success:
+        publication_payload = _build_publication_payload(
+            campaign_root=campaign_root,
+            release_tag=manifest.release_tag,
+            doi=manifest.doi,
+            repository_url=manifest.repository_url,
+        )
+        result["publication_bundle"] = publication_payload
+
+        summary_path = campaign_root / "reports" / "campaign_summary.json"
+        summary = _read_json(summary_path)
+        summary["publication_bundle"] = publication_payload
+        _write_json(summary_path, summary)
+        write_campaign_report(campaign_root / "reports" / "campaign_report.md", summary)
+    else:
+        result["publication_bundle"] = None
+
+    result["release_status"] = (
+        "missing_required_artifacts"
+        if missing
+        else (
+            "ok"
+            if release_benchmark_success
+            else str(run_payload.get("status", "benchmark_failed"))
+        )
+    )
+    result["release_status_reason"] = (
+        "release artifacts validated and benchmark campaign was benchmark-success"
+        if release_benchmark_success
+        else (
+            "release is missing required benchmark artifacts"
+            if missing
+            else str(run_payload.get("status_reason", "benchmark release did not succeed"))
+        )
+    )
+    result["release_exit_code"] = (
+        0 if release_benchmark_success else (2 if missing else int(run_payload.get("exit_code", 2)))
+    )
+    _write_json(release_dir / "release_result.json", result)
+
+    print(json.dumps(result, indent=2))
+    return int(result["release_exit_code"])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tools/run_benchmark_release.py
+++ b/scripts/tools/run_benchmark_release.py
@@ -222,6 +222,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         cfg,
         output_root=args.output_root,
         label=args.label,
+        campaign_id=args.campaign_id,
         skip_publication_bundle=True,
         invoked_command=invoked_command,
     )


### PR DESCRIPTION
Merges the 0.0.3 release branch to main so the published release's campaign config, release manifest, sbatch template, `--campaign-id` resume passthrough, and the report-reconstruction driver are reachable from the default branch (the tag itself is already immutable).

- `configs/benchmarks/paper_experiment_matrix_v2_h600_s30_extended.yaml` + release manifest (sha-pinned)
- `run_benchmark_release.py --campaign-id` passthrough (idempotent resume; the resume double-execution regression this exposed is tracked in #5538)
- `SLURM/submit_release_campaign_single_node.sbatch` (per-arm-safe single-node template)
- `scripts/tools/rebuild_campaign_reports_from_rows.py` (row-preserving dedup + report regeneration; used to produce the published 0.0.3 bundle, see release notes)

26 release entrypoint/protocol tests green on the branch; the tag 0.0.3 points at `e2ac534c9` on this branch.