### PR TITLE
Issue #5541: cross-issue merged-coverage revalidation (cheap-lane worker)

### DIFF
--- a/.agents/skills/gh-issue-autopilot/SKILL.md
+++ b/.agents/skills/gh-issue-autopilot/SKILL.md
@@ -56,14 +56,26 @@ unless the user explicitly chooses a stacked-PR route.
 
 ### Exact merged-fix stale-evidence guard
 
-Before auto-admitting a ready candidate, search recently merged PR titles and bodies, then verify
-the candidate's failure signature, named symbol, and failing file/line against current
-`origin/main` history and code. Classify the issue as `covered_by_pr` and stop before claim or
-branch only when an exact merged fix implements the stated boundary and its regression proof covers
-the reported failure. Record the covering PR rather than treating a loose keyword, a change in the
-same file, or historical failure output alone as duplicate evidence. The #5145 / PR #4958
-`PosixPath` serialization regression is the required fixture: it was stale because current main
-already replaced `json.dumps(asdict(arm_params))` with the tested subprocess-boundary serializer.
+Before auto-admitting a ready candidate, revalidate it against current `origin/main` history using
+the issue's named symbol, failing test, and error signature — not issue-number references alone.
+Search recently merged PR titles and bodies, and when a fix is named only by issue number, map its
+merge commits back to the covering PR through the commit-to-pulls API so a fix filed under a
+different issue number is still found. Then verify the candidate's failure signature, named symbol,
+and failing file/line against current `origin/main` history and code. Classify the issue as
+`covered_by_pr` and stop before claim or branch only when an exact merged fix implements the stated
+boundary and its regression proof covers the reported failure. Record the covering PR rather than
+treating a loose keyword, a change in the same file, or historical failure output alone as duplicate
+evidence.
+
+Two regression fixtures are required:
+- #5145 / PR #4958 `PosixPath` serialization: stale because current main already replaced
+  `json.dumps(asdict(arm_params))` with the tested subprocess-boundary serializer.
+- #5480 / PR #5486 `_run_batch_sequential` 3-tuple return: #5480 was dispatched after PR #5486
+  merged under #5482 (not #5480), so an issue-number-only merged-PR search missed it; the covering
+  PR is found only by mapping the named failing test
+  `test_run_batch_sequential_worker_failure_logs_warning` and its
+  `too many values to unpack (expected 2)` signature to current `origin/main`, and the expected
+  outcome is `covered/stale` with PR #5486 linked and no implementation worker admitted.
 
 Delegated queue-scout output is only route evidence until verified by the main agent in the target
 repository. Before using a scout recommendation to select, claim, or branch for an issue, run:

--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -34,14 +34,26 @@ validation, and delegation failure recovery across the loop.
 
 ## Exact merged-fix stale-evidence guard
 
-Before this loop auto-admits or delegates a ready candidate, search recently merged PR titles and
-bodies, then verify the candidate's failure signature, named symbol, and failing file/line against
-current `origin/main` history and code. Classify the issue as `covered_by_pr` and stop before claim
-or branch only when an exact merged fix implements the stated boundary and its regression proof
-covers the reported failure. Record the covering PR rather than treating a loose keyword, a change
-in the same file, or historical failure output alone as duplicate evidence. The #5145 / PR #4958
-`PosixPath` serialization regression is the required fixture: it was stale because current main
-already replaced `json.dumps(asdict(arm_params))` with the tested subprocess-boundary serializer.
+Before this loop auto-admits or delegates a ready candidate, revalidate it against current
+`origin/main` history using the issue's named symbol, failing test, and error signature — not
+issue-number references alone. Search recently merged PR titles and bodies, and when a fix is named
+only by issue number, map its merge commits back to the covering PR through the commit-to-pulls API
+so a fix filed under a different issue number is still found. Then verify the candidate's failure
+signature, named symbol, and failing file/line against current `origin/main` history and code.
+Classify the issue as `covered_by_pr` and stop before claim or branch only when an exact merged fix
+implements the stated boundary and its regression proof covers the reported failure. Record the
+covering PR rather than treating a loose keyword, a change in the same file, or historical failure
+output alone as duplicate evidence.
+
+Two regression fixtures are required:
+- #5145 / PR #4958 `PosixPath` serialization: stale because current main already replaced
+  `json.dumps(asdict(arm_params))` with the tested subprocess-boundary serializer.
+- #5480 / PR #5486 `_run_batch_sequential` 3-tuple return: #5480 was dispatched after PR #5486
+  merged under #5482 (not #5480), so an issue-number-only merged-PR search missed it; the covering
+  PR is found only by mapping the named failing test
+  `test_run_batch_sequential_worker_failure_logs_warning` and its
+  `too many values to unpack (expected2)` signature to current `origin/main`, and the expected
+  outcome is `covered/stale` with PR #5486 linked and no implementation worker admitted.
 
 ## Default Token-Efficient Mode
 

--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -130,14 +130,26 @@ blocked/unavailable for clean-main work with the unblock condition "source PR me
 
 ### Exact merged-fix stale-evidence guard
 
-Before auto-admitting a ready candidate, search recently merged PR titles and bodies, then verify
-the candidate's failure signature, named symbol, and failing file/line against current
-`origin/main` history and code. Classify the issue as `covered_by_pr` and stop before claim or
-branch only when an exact merged fix implements the stated boundary and its regression proof covers
-the reported failure. Record the covering PR rather than treating a loose keyword, a change in the
-same file, or historical failure output alone as duplicate evidence. The #5145 / PR #4958
-`PosixPath` serialization regression is the required fixture: it was stale because current main
-already replaced `json.dumps(asdict(arm_params))` with the tested subprocess-boundary serializer.
+Before auto-admitting a ready candidate, revalidate it against current `origin/main` history using
+the issue's named symbol, failing test, and error signature — not issue-number references alone.
+Search recently merged PR titles and bodies, and when a fix is named only by issue number, map its
+merge commits back to the covering PR through the commit-to-pulls API so a fix filed under a
+different issue number is still found. Then verify the candidate's failure signature, named symbol,
+and failing file/line against current `origin/main` history and code. Classify the issue as
+`covered_by_pr` and stop before claim or branch only when an exact merged fix implements the stated
+boundary and its regression proof covers the reported failure. Record the covering PR rather than
+treating a loose keyword, a change in the same file, or historical failure output alone as duplicate
+evidence.
+
+Two regression fixtures are required:
+- #5145 / PR #4958 `PosixPath` serialization: stale because current main already replaced
+  `json.dumps(asdict(arm_params))` with the tested subprocess-boundary serializer.
+- #5480 / PR #5486 `_run_batch_sequential` 3-tuple return: #5480 was dispatched after PR #5486
+  merged under #5482 (not #5480), so an issue-number-only merged-PR search missed it; the covering
+  PR is found only by mapping the named failing test
+  `test_run_batch_sequential_worker_failure_logs_warning` and its
+  `too many values to unpack (expected2)` signature to current `origin/main`, and the expected
+  outcome is `covered/stale` with PR #5486 linked and no implementation worker admitted.
 
 For token-efficient orientation, collect a compact snapshot before broad parent reads:
 

--- a/tests/test_ai_prompt_surfaces.py
+++ b/tests/test_ai_prompt_surfaces.py
@@ -244,20 +244,26 @@ def test_ready_queue_skills_use_issue_thread_rest_fallback() -> None:
 def test_ready_queue_skills_reject_stale_evidence_after_an_exact_merged_fix() -> None:
     """Ready-queue admission must distinguish an exact merged fix from loose similarity.
 
-    Issue #5172: #5145 was auto-admitted from a pre-fix `PosixPath` serialization failure even
-    though PR #4958 had already replaced the failing call, restored the subprocess-boundary
-    contract, and added regression proof. The admission-capable skill surfaces therefore need all
-    three anchors before they skip work: the failure signature, named symbol, and failing file/line
-    checked against current main and a merged PR.
+    Issue #5172 / #5541: #5145 was auto-admitted from a pre-fix `PosixPath` serialization failure
+    even though PR #4958 had already replaced the failing call; and #5480 was dispatched after PR
+    #5486 merged under #5482 (not #5480), so an issue-number-only merged-PR search missed the exact
+    covering fix. The admission-capable skill surfaces therefore need to revalidate by named symbol,
+    failing test, and error signature against current main, and map merge commits back to the
+    covering PR through the commit-to-pulls API so a fix filed under a different issue number is
+    still found.
     """
 
     required_fragments = (
         "Exact merged-fix stale-evidence guard",
         "recently merged PR titles and bodies",
+        "commit-to-pulls API",
+        "issue-number references alone",
         "failure signature, named symbol, and failing file/line",
         "`origin/main` history and code",
         "covered_by_pr",
         "#5145 / PR #4958",
+        "#5480 / PR #5486",
+        "test_run_batch_sequential_worker_failure_logs_warning",
     )
     for skill_name in MERGED_FIX_GUARD_SKILLS:
         skill_path = SKILL_DIR / skill_name / "SKILL.md"


### PR DESCRIPTION
## What / Why

Ready-queue admission guard (added in #5177 for #5172) only searched **issue-number references** in
merged PR titles/bodies. That missed PR #5486, which merged under **#5482** (not #5480) and fixed the
exact failing symbol (`runner._run_batch_sequential` 3-tuple return) and regression test
(`test_run_batch_sequential_worker_failure_logs_warning`) that #5480 named. #5480 was therefore
auto-dispatched against already-fixed `origin/main` and conflicted on the already-fixed unpacking line.

## Change

Hardened the Exact merged-fix stale-evidence guard in the three admission-capable skills
(`gh-issue-autopilot`, `goal-issue-implementation`, `goal-autopilot`) to revalidate a ready candidate
against current `origin/main` using its **named symbol, failing test, and error signature** — not
issue-number references alone — and to map merge commits back to the covering PR through the
commit-to-pulls API so a fix filed under a different issue number is still found. Added the #5480 /
PR #5486 cross-issue fixture alongside the existing #5145 / PR #4958 fixture, with expected outcome
`covered/stale` and the covering PR linked, no worker admitted.

Artifacts produced: updated guard text in 3 SKILL.md files + extended regression test in
`tests/test_ai_prompt_surfaces.py::test_ready_queue_skills_reject_stale_evidence_after_an_exact_merged_fix`.

## Validation

- `uv run pytest tests/test_ai_prompt_surfaces.py -q` — 7 passed.
- `uv run ruff check tests/test_ai_prompt_surfaces.py` — All checks passed.
- `uv run ruff format --check tests/test_ai_prompt_surfaces.py` — already formatted.
- `uv run pytest tests/benchmark/test_runner_exception_logging.py tests/benchmark/test_runner_circuit_breaker.py -q` — 19 passed (confirms the named covering fix still holds on current main).

CPU-only validation; no campaigns/training/benchmark runs. Claim tier: NA (workflow/skill contract only).

Closes #5541

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Strengthened validation for ready-queue admission after merged fixes.
  - Added coverage ensuring stale evidence is rejected and current branch state is revalidated.
  - Improved checks for mapping merge commits to their covering pull requests.
  - Added safeguards against relying solely on issue-number references when routing skills.
  - Expanded regression coverage for sequential worker failure warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->