### PR TITLE
chore: adopt shared evidence writers and guard (#4921)

### DIFF
--- a/robot_sf/evidence/writers.py
+++ b/robot_sf/evidence/writers.py
@@ -137,11 +137,15 @@ def write_text(
         marker = review_marker(issue_ref, marker_date=marker_date)
         if not content.startswith(marker):
             content = f"{marker}\n{content}"
-    elif not (
-        content.startswith(("<!-- AI-GENERATED", "# AI-GENERATED"))
-        and "NEEDS-REVIEW" in content.splitlines()[0]
-    ):
-        raise ValueError(f"generated evidence text must start with an AI-GENERATED marker: {path}")
+    else:
+        first_line = content.splitlines()[0] if content else ""
+        if not (
+            content.startswith(("<!-- AI-GENERATED", "# AI-GENERATED"))
+            and "NEEDS-REVIEW" in first_line
+        ):
+            raise ValueError(
+                f"generated evidence text must start with an AI-GENERATED marker: {path}"
+            )
     path.write_text(content, encoding="utf-8")
 
 

--- a/robot_sf/evidence/writers.py
+++ b/robot_sf/evidence/writers.py
@@ -118,6 +118,33 @@ def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         writer.writerows(rows)
 
 
+def write_text(
+    path: Path,
+    content: str,
+    *,
+    issue_ref: str | None = None,
+    marker_date: str | None = None,
+) -> None:
+    """Write marked Markdown/text evidence.
+
+    Callers may provide ``issue_ref`` to have the shared writer prepend the
+    canonical HTML marker. Existing generated text may omit ``issue_ref`` only
+    when it already starts with an AI-GENERATED / NEEDS-REVIEW marker. This
+    keeps marker ownership in one module while preserving pinned marker dates
+    and byte-stable reruns.
+    """
+    if issue_ref is not None:
+        marker = review_marker(issue_ref, marker_date=marker_date)
+        if not content.startswith(marker):
+            content = f"{marker}\n{content}"
+    elif not (
+        content.startswith(("<!-- AI-GENERATED", "# AI-GENERATED"))
+        and "NEEDS-REVIEW" in content.splitlines()[0]
+    ):
+        raise ValueError(f"generated evidence text must start with an AI-GENERATED marker: {path}")
+    path.write_text(content, encoding="utf-8")
+
+
 def write_distance_series_csv(
     path: Path,
     rows: list[dict[str, Any]],

--- a/scripts/ci/check_evidence_writer_usage.py
+++ b/scripts/ci/check_evidence_writer_usage.py
@@ -1,0 +1,168 @@
+"""Guard changed Python files against unmarked evidence-tree writers."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+EVIDENCE_PATH_FRAGMENT = "docs/context/evidence"
+EXEMPTION_PATTERN = re.compile(r"#\s*evidence-writer-exempt:\s*(.*)$", re.IGNORECASE)
+WRITE_METHODS = frozenset({"write_bytes", "write_text"})
+
+
+def _has_write_mode(call: ast.Call) -> bool:
+    """Return whether an ``open`` call requests a write-capable mode."""
+    mode: ast.expr | None = None
+    if len(call.args) >= 2:
+        mode = call.args[1]
+    for keyword in call.keywords:
+        if keyword.arg == "mode":
+            mode = keyword.value
+            break
+    if isinstance(mode, ast.Constant) and isinstance(mode.value, str):
+        return any(flag in mode.value for flag in ("w", "a", "x", "+"))
+    return False
+
+
+class _DirectWriterVisitor(ast.NodeVisitor):
+    """Find calls that can write generated output without the shared module."""
+
+    def __init__(self) -> None:
+        self.violations: list[tuple[int, str]] = []
+
+    def _record(self, node: ast.Call, operation: str) -> None:
+        self.violations.append((node.lineno, operation))
+
+    def visit_Call(self, node: ast.Call) -> None:
+        function = node.func
+        if isinstance(function, ast.Attribute):
+            if function.attr in WRITE_METHODS:
+                self._record(node, f".{function.attr}()")
+            elif function.attr == "open" and _has_write_mode(node):
+                self._record(node, ".open(..., write mode)")
+            elif function.attr == "DictWriter":
+                self._record(node, "csv.DictWriter()")
+            elif function.attr == "dump" and isinstance(function.value, ast.Name):
+                if function.value.id == "json":
+                    self._record(node, "json.dump()")
+            elif function.attr in {"_write_sha256sums", "write_sha256sums"}:
+                if not (isinstance(function.value, ast.Name) and function.value.id == "writers"):
+                    self._record(node, f"{function.attr}()")
+        elif isinstance(function, ast.Name) and function.id == "open" and _has_write_mode(node):
+            self._record(node, "open(..., write mode)")
+        self.generic_visit(node)
+
+
+def _exemption(source: str) -> tuple[bool, str | None]:
+    """Return whether source has a valid file-level exemption."""
+    for line_number, line in enumerate(source.splitlines(), start=1):
+        match = EXEMPTION_PATTERN.search(line)
+        if match is None:
+            continue
+        reason = match.group(1).strip()
+        if not reason:
+            return True, f"line {line_number} has an empty evidence-writer exemption reason"
+        return True, None
+    return False, None
+
+
+def check_file(path: str | Path) -> list[str]:
+    """Return fail-closed guard messages for one changed Python file."""
+    source_path = Path(path)
+    if source_path.suffix != ".py" or not source_path.is_file():
+        return []
+    try:
+        source = source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"BLOCKER: could not read changed Python file '{source_path}': {exc}"]
+
+    has_exemption, exemption_error = _exemption(source)
+    if exemption_error is not None:
+        return [f"BLOCKER: evidence-writer exemption in '{source_path}' {exemption_error}"]
+    if has_exemption:
+        return []
+    if EVIDENCE_PATH_FRAGMENT not in source:
+        return []
+
+    try:
+        tree = ast.parse(source, filename=str(source_path))
+    except SyntaxError as exc:
+        return [f"BLOCKER: cannot parse changed Python file '{source_path}': {exc}"]
+
+    visitor = _DirectWriterVisitor()
+    visitor.visit(tree)
+    return [
+        f"BLOCKER: '{source_path}:{line}' directly uses {operation} in a file that writes "
+        "generated evidence. Use robot_sf.evidence.writers.write_json/write_csv/write_text/"
+        "write_sha256sums, or add a justified '# evidence-writer-exempt: <reason>' comment."
+        for line, operation in visitor.violations
+    ]
+
+
+def _is_changed_from_base(path: str | Path, base_ref: str) -> bool:
+    """Return whether a repository file differs from ``base_ref``.
+
+    Historical PR regression checks replay old file lists against the current
+    checkout. Skipping files that are no longer changed avoids re-linting those
+    old paths; an unavailable base is treated as changed so the guard fails
+    closed in CI.
+    """
+    source_path = Path(path)
+    try:
+        repo_root = Path(
+            subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+        )
+        relative_path = source_path.resolve().relative_to(repo_root.resolve())
+    except (OSError, subprocess.CalledProcessError, ValueError):
+        return True
+    result = subprocess.run(
+        ["git", "diff", "--quiet", base_ref, "--", relative_path.as_posix()],
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode != 0
+
+
+def check_changed_files(changed_files: list[str], base_ref: str = "origin/main") -> list[str]:
+    """Check only changed Python files, preserving the PR contract boundary."""
+    blockers: list[str] = []
+    for path in changed_files:
+        if not _is_changed_from_base(path, base_ref):
+            continue
+        blockers.extend(check_file(path))
+    return blockers
+
+
+def main() -> int:
+    """Run the changed-file evidence-writer guard."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--changed-files-file",
+        type=Path,
+        required=True,
+        help="newline-delimited changed-file paths",
+    )
+    parser.add_argument("--base-ref", default="origin/main", help="git base ref")
+    args = parser.parse_args()
+    changed_files = [
+        line.strip()
+        for line in args.changed_files_file.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    blockers = check_changed_files(changed_files, args.base_ref)
+    for blocker in blockers:
+        print(blocker)
+    return 1 if blockers else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_evidence_writer_usage.py
+++ b/scripts/ci/check_evidence_writer_usage.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import argparse
 import ast
+import io
 import re
 import subprocess
 import sys
+import tokenize
 from pathlib import Path
 
 EVIDENCE_PATH_FRAGMENT = "docs/context/evidence"
@@ -28,11 +30,45 @@ def _has_write_mode(call: ast.Call) -> bool:
     return False
 
 
-class _DirectWriterVisitor(ast.NodeVisitor):
-    """Find calls that can write generated output without the shared module."""
+def _expr_mentions_evidence(expr: ast.AST, evidence_names: set[str]) -> bool:
+    """Return whether an expression resolves to an evidence-tree path."""
+    if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
+        return EVIDENCE_PATH_FRAGMENT in expr.value
+    if isinstance(expr, ast.Name):
+        return expr.id in evidence_names
+    return any(
+        _expr_mentions_evidence(child, evidence_names) for child in ast.iter_child_nodes(expr)
+    )
 
-    def __init__(self) -> None:
+
+def _evidence_path_names(tree: ast.AST) -> set[str]:
+    """Collect simple names assigned from expressions containing the evidence path."""
+    evidence_names: set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                targets = node.targets
+            elif isinstance(node, ast.AnnAssign):
+                targets = [node.target]
+            else:
+                continue
+            if node.value is None or not _expr_mentions_evidence(node.value, evidence_names):
+                continue
+            for target in targets:
+                if isinstance(target, ast.Name) and target.id not in evidence_names:
+                    evidence_names.add(target.id)
+                    changed = True
+    return evidence_names
+
+
+class _DirectWriterVisitor(ast.NodeVisitor):
+    """Find direct writes whose target resolves to the evidence tree."""
+
+    def __init__(self, evidence_names: set[str]) -> None:
         self.violations: list[tuple[int, str]] = []
+        self.evidence_names = evidence_names
 
     def _record(self, node: ast.Call, operation: str) -> None:
         self.violations.append((node.lineno, operation))
@@ -40,33 +76,62 @@ class _DirectWriterVisitor(ast.NodeVisitor):
     def visit_Call(self, node: ast.Call) -> None:
         function = node.func
         if isinstance(function, ast.Attribute):
-            if function.attr in WRITE_METHODS:
+            if function.attr in WRITE_METHODS and _expr_mentions_evidence(
+                function.value, self.evidence_names
+            ):
                 self._record(node, f".{function.attr}()")
-            elif function.attr == "open" and _has_write_mode(node):
+            elif (
+                function.attr == "open"
+                and _has_write_mode(node)
+                and _expr_mentions_evidence(function.value, self.evidence_names)
+            ):
                 self._record(node, ".open(..., write mode)")
-            elif function.attr == "DictWriter":
+            elif (
+                function.attr == "DictWriter"
+                and node.args
+                and _expr_mentions_evidence(node.args[0], self.evidence_names)
+            ):
                 self._record(node, "csv.DictWriter()")
-            elif function.attr == "dump" and isinstance(function.value, ast.Name):
-                if function.value.id == "json":
-                    self._record(node, "json.dump()")
-            elif function.attr in {"_write_sha256sums", "write_sha256sums"}:
+            elif (
+                function.attr == "dump"
+                and len(node.args) >= 2
+                and _expr_mentions_evidence(node.args[1], self.evidence_names)
+            ):
+                self._record(node, "json.dump()")
+            elif function.attr in {"_write_sha256sums", "write_sha256sums"} and any(
+                _expr_mentions_evidence(argument, self.evidence_names) for argument in node.args
+            ):
                 if not (isinstance(function.value, ast.Name) and function.value.id == "writers"):
                     self._record(node, f"{function.attr}()")
-        elif isinstance(function, ast.Name) and function.id == "open" and _has_write_mode(node):
+        elif (
+            isinstance(function, ast.Name)
+            and function.id == "open"
+            and _has_write_mode(node)
+            and node.args
+            and _expr_mentions_evidence(node.args[0], self.evidence_names)
+        ):
             self._record(node, "open(..., write mode)")
         self.generic_visit(node)
 
 
 def _exemption(source: str) -> tuple[bool, str | None]:
     """Return whether source has a valid file-level exemption."""
-    for line_number, line in enumerate(source.splitlines(), start=1):
-        match = EXEMPTION_PATTERN.search(line)
-        if match is None:
-            continue
-        reason = match.group(1).strip()
-        if not reason:
-            return True, f"line {line_number} has an empty evidence-writer exemption reason"
-        return True, None
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(source).readline)
+        comment_tokens = (token for token in tokens if token.type == tokenize.COMMENT)
+        for token in comment_tokens:
+            if token.start[1] != 0:
+                continue
+            match = EXEMPTION_PATTERN.match(token.string)
+            if match is None:
+                continue
+            reason = match.group(1).strip()
+            if not reason:
+                return True, f"line {token.start[0]} has an empty evidence-writer exemption reason"
+            return True, None
+    except (IndentationError, tokenize.TokenError):
+        # Let ast.parse below report malformed source as a fail-closed blocker.
+        return False, None
     return False, None
 
 
@@ -85,15 +150,12 @@ def check_file(path: str | Path) -> list[str]:
         return [f"BLOCKER: evidence-writer exemption in '{source_path}' {exemption_error}"]
     if has_exemption:
         return []
-    if EVIDENCE_PATH_FRAGMENT not in source:
-        return []
-
     try:
         tree = ast.parse(source, filename=str(source_path))
     except SyntaxError as exc:
         return [f"BLOCKER: cannot parse changed Python file '{source_path}': {exc}"]
 
-    visitor = _DirectWriterVisitor()
+    visitor = _DirectWriterVisitor(_evidence_path_names(tree))
     visitor.visit(tree)
     return [
         f"BLOCKER: '{source_path}:{line}' directly uses {operation} in a file that writes "

--- a/scripts/ci/pr_contract_check.py
+++ b/scripts/ci/pr_contract_check.py
@@ -29,6 +29,9 @@ from robot_sf.evidence.distance_convention import (  # noqa: E402
     has_distance_like_columns,
     is_distance_like_filename,
 )
+from scripts.ci.check_evidence_writer_usage import (  # noqa: E402
+    check_changed_files as check_evidence_writer_usage,
+)
 
 # Match keywords followed by #N or a GitHub issue URL
 CLOSING_PATTERN = re.compile(
@@ -530,7 +533,7 @@ def run_all_checks(
     pr_number: str | None,
     added_files: set[str] | None = None,
 ) -> tuple[list[str], list[str], list[str]]:
-    """Run all 6 contract checks."""
+    """Run all 7 contract checks."""
     blockers = []
     warnings = []
     infos = []
@@ -551,11 +554,14 @@ def run_all_checks(
     evidence_blockers = check_evidence_tree_hygiene(changed_files, base_ref, added_files)
     blockers.extend(evidence_blockers)
 
-    # 5. Successor discipline
+    # 5. Evidence writer adoption
+    blockers.extend(check_evidence_writer_usage(changed_files, base_ref))
+
+    # 6. Successor discipline
     successor_warnings = check_successor_discipline(title, body, repo)
     warnings.extend(successor_warnings)
 
-    # 6. Worker-lane provenance
+    # 7. Worker-lane provenance
     lane_info, _ = check_worker_lane_provenance(body, pr_number, repo)
     infos.append(lane_info)
 
@@ -586,12 +592,15 @@ def build_comment_body(
         f"| 4. Evidence hygiene | {get_status_str(any('evidence' in b.lower() for b in blockers))} | Checks markers and provenance fields |"
     )
     rows.append(
-        f"| 5. Successor discipline | {get_status_str(any('successor' in w.lower() for w in warnings), is_blocker=False)} | Require successor statement on multi-PR issues |"
+        f"| 5. Evidence writer usage | {get_status_str(any('evidence-writer' in b.lower() for b in blockers))} | Require the shared marked writer path |"
+    )
+    rows.append(
+        f"| 6. Successor discipline | {get_status_str(any('successor' in w.lower() for w in warnings), is_blocker=False)} | Require successor statement on multi-PR issues |"
     )
 
     lane_detected = "Added 'cheap-lane' label" in "".join(infos)
     rows.append(
-        f"| 6. Worker-lane label | {'🏷️ cheap-lane' if lane_detected else '⚪ None'} | Label PRs from cheap worker lane |"
+        f"| 7. Worker-lane label | {'🏷️ cheap-lane' if lane_detected else '⚪ None'} | Label PRs from cheap worker lane |"
     )
 
     comment = [

--- a/scripts/export_issue_4268_trace_episode.py
+++ b/scripts/export_issue_4268_trace_episode.py
@@ -9,8 +9,6 @@ not benchmark evidence.
 from __future__ import annotations
 
 import argparse
-import csv
-import hashlib
 import json
 import math
 import subprocess
@@ -24,6 +22,15 @@ from robot_sf.benchmark.map_runner import _run_map_episode
 from robot_sf.evidence.distance_convention import (
     DISTANCE_CONVENTION_FIELD,
     DistanceConvention,
+)
+from robot_sf.evidence.writers import (
+    extract_marker_date,
+    sha256_file,
+    write_csv,
+    write_distance_series_csv,
+    write_json,
+    write_sha256sums,
+    write_text,
 )
 
 DEFAULT_OUTPUT_DIR = Path("docs/context/evidence/issue_4253_trace_episode_2026-07")
@@ -69,16 +76,6 @@ def _git_commit() -> str:
     except (OSError, subprocess.CalledProcessError):
         return "unknown"
     return result.stdout.strip()
-
-
-def sha256_file(path: Path) -> str:
-    """Compute a SHA-256 hex digest for ``path``."""
-
-    hasher = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1 << 16), b""):
-            hasher.update(chunk)
-    return hasher.hexdigest()
 
 
 def _min_distance(
@@ -187,14 +184,8 @@ def derive_trace_rows(record: dict[str, Any]) -> TraceRows:
 
 
 def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
-    """Write CSV rows with stable column ordering."""
-
-    if not rows:
-        raise ValueError(f"cannot write empty CSV: {path}")
-    with path.open("w", newline="", encoding="utf-8") as handle:
-        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()), lineterminator="\n")
-        writer.writeheader()
-        writer.writerows(rows)
+    """Compatibility wrapper around the shared CSV evidence writer."""
+    write_csv(path, rows)
 
 
 def _write_distance_csv(
@@ -203,24 +194,18 @@ def _write_distance_csv(
     *,
     convention: DistanceConvention,
 ) -> None:
-    """Write a distance-like series CSV with an explicit convention header.
-
-    Issue #5141: distance-like series must declare their convention so a
-    center-to-center value is not misread as surface clearance.
-    """
-    if not rows:
-        raise ValueError(f"cannot write empty CSV: {path}")
-    with path.open("w", newline="", encoding="utf-8") as handle:
-        handle.write(f"# {DISTANCE_CONVENTION_FIELD}: {convention.value}\n")
-        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()), lineterminator="\n")
-        writer.writeheader()
-        writer.writerows(rows)
+    """Compatibility wrapper around the shared distance-series writer."""
+    write_distance_series_csv(path, rows, convention=convention)
 
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
-    """Write deterministic JSON."""
+    """Compatibility wrapper around the shared JSON evidence writer."""
+    write_json(path, payload)
 
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+def _write_sha256sums(output_dir: Path) -> None:
+    """Compatibility wrapper around the shared checksum writer."""
+    write_sha256sums(output_dir)
 
 
 def write_bundle(
@@ -291,16 +276,16 @@ def write_bundle(
         "derived_rows": derived.trace_rows,
     }
 
-    _write_json(output_dir / "metadata.json", metadata)
-    _write_json(output_dir / "trace_series.json", trace_payload)
-    _write_csv(output_dir / "trace_timeseries.csv", derived.trace_rows)
-    _write_distance_csv(
+    write_json(output_dir / "metadata.json", metadata)
+    write_json(output_dir / "trace_series.json", trace_payload)
+    write_csv(output_dir / "trace_timeseries.csv", derived.trace_rows)
+    write_distance_series_csv(
         output_dir / "min_distance_series.csv",
         derived.min_distance_rows,
         convention=DistanceConvention.CENTER_CENTER,
     )
     _write_readme(output_dir, metadata)
-    _write_sha256sums(output_dir)
+    write_sha256sums(output_dir)
     return metadata
 
 
@@ -346,28 +331,12 @@ This bundle is `analysis_workbench_only` style evidence for one illustrative epi
 used as a trace-level worked example input only. It is not a full benchmark campaign, not a Slurm or
 GPU result, and not a statistical comparison.
 """
-    (output_dir / "README.md").write_text(readme, encoding="utf-8")
-
-
-def _write_sha256sums(output_dir: Path) -> None:
-    """Write SHA256SUMS for all generated bundle files except itself."""
-
-    files = sorted(
-        path for path in output_dir.iterdir() if path.is_file() and path.name != "SHA256SUMS"
+    write_text(
+        output_dir / "README.md",
+        readme,
+        issue_ref="robot_sf#4268",
+        marker_date=extract_marker_date(metadata),
     )
-    # Use repository-relative paths so the docs-evidence-integrity checker resolves
-    # each entry against this bundle rather than a same-named repo-root file (e.g. README.md).
-    # Fall back to the bare filename when the bundle lives outside the repo (e.g. test tmpdirs).
-    lines = [f"{sha256_file(path)}  {_manifest_label(path)}" for path in files]
-    (output_dir / "SHA256SUMS").write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-
-def _manifest_label(path: Path) -> str:
-    """Return the SHA256SUMS entry label for a bundle file (repo-relative when possible)."""
-    try:
-        return path.resolve().relative_to(_repo_root()).as_posix()
-    except ValueError:
-        return path.name
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/scripts/export_issue_4848_group_crossing_exemplars.py
+++ b/scripts/export_issue_4848_group_crossing_exemplars.py
@@ -26,6 +26,7 @@ from robot_sf.evidence.writers import (
     write_distance_series_csv,
     write_json,
     write_sha256sums,
+    write_text,
 )
 
 # Target planners for exemplar selection (classical + social navigation diversity)
@@ -375,7 +376,7 @@ benchmark campaign, not a Slurm or GPU result, and not a statistical comparison.
 
 <!-- /AI-GENERATED -->
 """
-    (output_dir / "README.md").write_text(readme, encoding="utf-8")
+    write_text(output_dir / "README.md", readme)
 
 
 def write_selection_report(
@@ -445,9 +446,7 @@ def write_selection_report(
         ]
     )
 
-    (output_dir / "SELECTION_REPORT.md").write_text(
-        "\n".join(report_lines) + "\n", encoding="utf-8"
-    )
+    write_text(output_dir / "SELECTION_REPORT.md", "\n".join(report_lines) + "\n")
 
 
 def _process_planner(

--- a/scripts/export_issue_4891_head_on_corridor_exemplars.py
+++ b/scripts/export_issue_4891_head_on_corridor_exemplars.py
@@ -26,6 +26,7 @@ from robot_sf.evidence.writers import (
     write_distance_series_csv,
     write_json,
     write_sha256sums,
+    write_text,
 )
 
 # Back-compat alias for the shared helper (kept for the module-attribute tests).
@@ -428,7 +429,7 @@ benchmark campaign, not a Slurm or GPU result, and not a statistical comparison.
 
 <!-- /AI-GENERATED -->
 """
-    (output_dir / "README.md").write_text(readme, encoding="utf-8")
+    write_text(output_dir / "README.md", readme)
 
 
 def write_selection_report(
@@ -506,9 +507,7 @@ def write_selection_report(
         ]
     )
 
-    (output_dir / "SELECTION_REPORT.md").write_text(
-        "\n".join(report_lines) + "\n", encoding="utf-8"
-    )
+    write_text(output_dir / "SELECTION_REPORT.md", "\n".join(report_lines) + "\n")
 
 
 def _process_planner(

--- a/tests/ci/test_evidence_writer_usage_guard.py
+++ b/tests/ci/test_evidence_writer_usage_guard.py
@@ -1,0 +1,103 @@
+"""Tests for the changed-file evidence-writer adoption guard."""
+
+# evidence-writer-exempt: tests intentionally write temporary fixture files while testing the guard.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from scripts.ci.check_evidence_writer_usage import check_changed_files, check_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_fixture(tmp_path: Path, source: str, name: str = "fixture.py") -> Path:
+    """Write a synthetic changed Python file for guard tests."""
+    path = tmp_path / name
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def test_markerless_direct_writer_is_caught(tmp_path: Path) -> None:
+    """A direct evidence-tree write must fail with an actionable message."""
+    path = _write_fixture(
+        tmp_path,
+        """
+from pathlib import Path
+OUTPUT = Path('docs/context/evidence/example')
+OUTPUT.joinpath('report.md').write_text('# report', encoding='utf-8')
+""",
+    )
+    blockers = check_file(path)
+    assert len(blockers) == 1
+    assert "write_text" in blockers[0]
+    assert "robot_sf.evidence.writers" in blockers[0]
+
+
+def test_shared_writer_usage_passes(tmp_path: Path) -> None:
+    """A generated evidence file written by the shared module passes."""
+    path = _write_fixture(
+        tmp_path,
+        """
+from pathlib import Path
+from robot_sf.evidence.writers import write_json
+OUTPUT = Path('docs/context/evidence/example')
+write_json(OUTPUT / 'report.json', {'status': 'diagnostic-only'})
+""",
+    )
+    assert check_file(path) == []
+
+
+def test_handwritten_evidence_markdown_is_ignored(tmp_path: Path) -> None:
+    """The Python-only guard does not classify a handwritten Markdown file."""
+    path = tmp_path / "docs/context/evidence/README.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("# Handwritten context\n", encoding="utf-8")
+    assert check_changed_files([str(path)]) == []
+
+
+def test_binary_sidecar_exemption_with_reason_passes(tmp_path: Path) -> None:
+    """A justified binary sidecar exemption is accepted."""
+    path = _write_fixture(
+        tmp_path,
+        """
+# evidence-writer-exempt: binary PNG output cannot carry a text marker; SHA256SUMS is emitted by the shared writer.
+from pathlib import Path
+OUTPUT = Path('docs/context/evidence/example')
+OUTPUT.joinpath('trace.png').write_bytes(b'png')
+""",
+    )
+    assert check_file(path) == []
+
+
+def test_exemption_without_reason_fails(tmp_path: Path) -> None:
+    """An empty exemption cannot silence the guard."""
+    path = _write_fixture(
+        tmp_path,
+        """
+# evidence-writer-exempt:
+from pathlib import Path
+OUTPUT = Path('docs/context/evidence/example')
+OUTPUT.joinpath('report.md').write_text('# report', encoding='utf-8')
+""",
+    )
+    blockers = check_file(path)
+    assert len(blockers) == 1
+    assert "empty evidence-writer exemption reason" in blockers[0]
+
+
+def test_pr_contract_check_reports_guard_violation(tmp_path: Path) -> None:
+    """The parent PR contract check exposes the same guard blocker."""
+    path = _write_fixture(
+        tmp_path,
+        """
+from pathlib import Path
+OUTPUT = Path('docs/context/evidence/example')
+OUTPUT.joinpath('report.md').write_text('# report', encoding='utf-8')
+""",
+    )
+    from scripts.ci.pr_contract_check import run_all_checks
+
+    blockers, _, _ = run_all_checks("", "", [str(path)], "ll7/robot_sf_ll7", "origin/main", None)
+    assert any("evidence-writer" in blocker for blocker in blockers)

--- a/tests/ci/test_evidence_writer_usage_guard.py
+++ b/tests/ci/test_evidence_writer_usage_guard.py
@@ -49,6 +49,55 @@ write_json(OUTPUT / 'report.json', {'status': 'diagnostic-only'})
     assert check_file(path) == []
 
 
+def test_exemption_text_in_string_does_not_bypass_guard(tmp_path: Path) -> None:
+    """A string containing the exemption text is not a file-level comment."""
+    path = _write_fixture(
+        tmp_path,
+        """
+EXEMPTION_TEXT = "# evidence-writer-exempt: not a comment"
+from pathlib import Path
+OUTPUT = Path("docs/context/evidence/example")
+OUTPUT.joinpath("report.md").write_text("# report", encoding="utf-8")
+""",
+    )
+    blockers = check_file(path)
+    assert len(blockers) == 1
+    assert "write_text" in blockers[0]
+
+
+def test_indented_exemption_comment_does_not_bypass_guard(tmp_path: Path) -> None:
+    """An indented exemption comment is not a file-level exemption."""
+    path = _write_fixture(
+        tmp_path,
+        """
+if True:
+    # evidence-writer-exempt: not file-level
+    pass
+from pathlib import Path
+OUTPUT = Path("docs/context/evidence/example")
+OUTPUT.joinpath("report.md").write_text("# report", encoding="utf-8")
+""",
+    )
+    blockers = check_file(path)
+    assert len(blockers) == 1
+    assert "write_text" in blockers[0]
+
+
+def test_evidence_path_read_does_not_classify_tmp_writes(tmp_path: Path) -> None:
+    """Reading an evidence fixture does not make unrelated temporary writes blockers."""
+    path = _write_fixture(
+        tmp_path,
+        """
+from pathlib import Path
+FIXTURE = Path("docs/context/evidence/example/report.json")
+manifest_path = tmp_path / "manifest.json"
+manifest_path.write_text("{}", encoding="utf-8")
+FIXTURE.read_text(encoding="utf-8")
+""",
+    )
+    assert check_file(path) == []
+
+
 def test_handwritten_evidence_markdown_is_ignored(tmp_path: Path) -> None:
     """The Python-only guard does not classify a handwritten Markdown file."""
     path = tmp_path / "docs/context/evidence/README.md"

--- a/tests/test_evidence_writers.py
+++ b/tests/test_evidence_writers.py
@@ -153,6 +153,15 @@ class TestWriteText:
         else:
             raise AssertionError("unmarked evidence text should be rejected")
 
+    def test_rejects_empty_unmarked_text_with_value_error(self, tmp_path: Path) -> None:
+        path = tmp_path / "README.md"
+        try:
+            write_text(path, "")
+        except ValueError as exc:
+            assert "AI-GENERATED" in str(exc)
+        else:
+            raise AssertionError("empty unmarked evidence text should be rejected")
+
     def test_preserves_existing_pinned_marker(self, tmp_path: Path) -> None:
         path = tmp_path / "README.md"
         content = "<!-- AI-GENERATED (robot_sf#4921, 2026-07-14) - NEEDS-REVIEW -->\n# Report\n"

--- a/tests/test_evidence_writers.py
+++ b/tests/test_evidence_writers.py
@@ -13,6 +13,7 @@ from robot_sf.evidence.writers import (
     write_csv,
     write_json,
     write_sha256sums,
+    write_text,
 )
 
 if TYPE_CHECKING:
@@ -131,3 +132,29 @@ class TestWriteSha256sums:
         sha_file = tmp_path / "SHA256SUMS"
         content = sha_file.read_text(encoding="utf-8")
         assert "SHA256SUMS" not in content.split("\n", 1)[1]
+
+
+class TestWriteText:
+    """Test marker enforcement for Markdown/text evidence."""
+
+    def test_prepends_issue_marker(self, tmp_path: Path) -> None:
+        path = tmp_path / "README.md"
+        write_text(path, "# Report\n", issue_ref="robot_sf#4921", marker_date="2026-07-14")
+        assert path.read_text(encoding="utf-8") == (
+            "<!-- AI-GENERATED (robot_sf#4921, 2026-07-14) - NEEDS-REVIEW -->\n# Report\n"
+        )
+
+    def test_rejects_unmarked_text_without_issue(self, tmp_path: Path) -> None:
+        path = tmp_path / "README.md"
+        try:
+            write_text(path, "# Report\n")
+        except ValueError as exc:
+            assert "AI-GENERATED" in str(exc)
+        else:
+            raise AssertionError("unmarked evidence text should be rejected")
+
+    def test_preserves_existing_pinned_marker(self, tmp_path: Path) -> None:
+        path = tmp_path / "README.md"
+        content = "<!-- AI-GENERATED (robot_sf#4921, 2026-07-14) - NEEDS-REVIEW -->\n# Report\n"
+        write_text(path, content)
+        assert path.read_text(encoding="utf-8") == content

--- a/tests/tools/test_export_issue_4268_trace_episode.py
+++ b/tests/tools/test_export_issue_4268_trace_episode.py
@@ -113,6 +113,7 @@ def test_csv_and_checksum_outputs_are_stable(tmp_path: Path) -> None:
     exporter._write_sha256sums(tmp_path)
 
     with csv_path.open(newline="", encoding="utf-8") as handle:
+        assert handle.readline() == "# AI-GENERATED NEEDS-REVIEW\n"
         rows = list(csv.DictReader(handle))
 
     assert rows[0]["step"] == "0"


### PR DESCRIPTION
## Reviewer-critical summary

This progression slice for [issue #4921](https://github.com/ll7/robot_sf_ll7/issues/4921) centralizes the remaining text writes in the three highest-priority trace exporters and adds the requested fail-closed changed-file guard. It is needed now because the shared writer API from [#4910](https://github.com/ll7/robot_sf_ll7/pull/4910) is merged and the issue's former gate is retired.

- Changed: added marker-enforcing `write_text`, migrated #4268 fully, and migrated the residual README/selection-report writes in #4848/#4891.
- Guard: new `scripts/ci/check_evidence_writer_usage.py` is integrated into `pr_contract_check`; direct writes in changed Python files are blocked unless they use the shared writers or carry a reasoned exemption.
- Claim boundary: this proves writer routing, marker/provenance behavior, and guard behavior only. It is not benchmark evidence, a campaign result, or a paper-facing claim (confidence 97% for the code contract; no claim about unreviewed historical writers).
- Required validation: focused writer/guard/contract/exporter tests and the repository readiness lane are green; the final clean-HEAD readiness run is required after commit.
- Remaining blocker: the conservative repository inventory still contains historical packet/report generators outside this bounded trace-exporter slice; they need migration or explicit exemptions in follow-up slices, so this PR uses `Refs #4921`. This is a successor slice and does not duplicate the merged #4910 shared-module introduction.

## Contract delta

- `robot_sf.evidence.writers.write_text(...)` now owns Markdown/text marker enforcement. It prepends an issue/date-pinned marker when given `issue_ref`, and rejects text without an existing marker otherwise.
- `scripts/ci/check_evidence_writer_usage.py` scans changed `.py` files for direct evidence-tree writes (`write_text`, `write_bytes`, write-mode `open`, `json.dump`, `csv.DictWriter`, and local checksum writers). A file-level `# evidence-writer-exempt: <reason>` is allowed; an empty exemption is a blocker.
- `scripts/ci/pr_contract_check.py` reports the guard as a contract blocker. Historical regression inputs are compared with `origin/main` before scanning; an unavailable base remains fail-closed.
- Compatibility: #4268 now emits the shared review marker in JSON/CSV/text/checksum outputs; CSV consumers must skip the marker comment. Its former private helper names remain as thin compatibility delegates. Existing pinned markers in #4848/#4891 are preserved byte-for-byte.

## Scope and inventory

The inventory command was run against `scripts`, `robot_sf`, `tests`, and `docs` with the issue's path/write patterns. The conservative Python candidate set is 101 files; the table below records the current disposition for this slice and the staged remainder.

| candidate set | writes generated evidence? | disposition | reason / next action |
| --- | --- | --- | --- |
| `scripts/export_issue_4268_trace_episode.py` | yes | migrated | Full JSON/CSV/text/checksum path now uses shared writers; private helper names delegate for compatibility. |
| `scripts/export_issue_4848_group_crossing_exemplars.py` | yes | migrated | Existing JSON/CSV/checksum adoption completed with shared text writes. |
| `scripts/export_issue_4891_head_on_corridor_exemplars.py` | yes | migrated | Existing JSON/CSV/checksum adoption completed with shared text writes. |
| `scripts/validation/build_issue_5149_emergent_phenomena_demo.py`; `scripts/benchmark/trace_dwa_decisions_issue_5298.py`; `scripts/benchmark/trace_dwa_global_route_probe_issue_5331.py`; `scripts/benchmark/trace_dwa_route_rescue_issue_5319.py` | mixed | existing shared adoption / follow-up | These already use shared writers for selected evidence outputs; residual direct text or non-evidence output needs separate classification. |
| `scripts/analysis/{assemble_release_claim_matrix_issue_3294,audit_issue_4013_acceptance,audit_issue_4016_acceptance,build_issue_2910_publication_suite_certification_report,build_issue_4195_h600_aggregation_artifact,build_issue_5138_h600_family_breakdown_export,build_research_v1_failure_pack_issue_2159,build_snqi_governance_disposition_issue_3800,compare_scenario_priors_issue_2919,compare_trace_vs_live_replay_issue_2790}.py` | yes / likely | follow-up migration | Analysis packet/report writers; migrate in the analysis-packet slice without changing metrics or claims. |
| `scripts/benchmark/{build_fidelity_sensitivity_smoke_report,build_heterogeneous_pedestrian_smoke_report,build_heterogeneous_population_ablation_report,build_horizon_timestep_ablation_report,build_horizon_timestep_denominator_report,build_hybrid_global_rl_diagnostic_issue_4183,build_issue3465_topology_gate_paired_decision,build_pedestrian_archetype_report,promote_reactivity_replay_rank_study_issue_3637,run_cv_forecast_eval,run_dense_stress_observation_envelope,run_fidelity_sensitivity_campaign,run_observation_noise_envelope,run_observation_noise_live_replay_issue_2777,run_rare_event_estimation_issue_4163}.py` | yes / likely | follow-up migration | Benchmark/smoke packet writers; preserve fallback/degraded and claim boundaries while adopting shared outputs. |
| `scripts/tools/{analyze_issue_1462_h500_failure_modes,classify_observation_noise_mechanisms,generate_benchmark_table_candidates,generate_mixed_scenario_matrix,generate_signalized_runtime_metrics_report}.py` | yes / likely | follow-up migration | Tool-generated evidence reports; migrate only outputs under the evidence tree and document arbitrary-output cases. |
| `scripts/validation/{build_issue_2557_seed_variance_report,build_issue_4206_policy_structure_mechanism_crosscut,build_issue_4232_uncertainty_envelope_evidence,build_issue_4242_h600_mechanism_exposure_sidecars,close_issue_3556_seed_sufficiency,evaluate_issue_4328_h600_seed_sufficiency_candidates,run_uncertainty_representation_generalization_issue_3557,run_uncertainty_source_generalization_issue_3557}.py` | yes / likely | follow-up migration | Validation packet/report writers; migrate in the validation-packet slice with checksum and marker tests. |
| remaining conservative grep candidates under `scripts/analysis`, `scripts/benchmark`, `scripts/tools`, `scripts/training`, and `scripts/validation` | no / reads evidence or writes arbitrary caller paths | explicit exemption or no-op classification required | Includes catalog, registry, checker, launch-packet, and verifier scripts. The guard scans only changed Python files and permits a reasoned exemption; no historical file is silently promoted by this PR. |

The remaining work is intentionally not a blanket rewrite: it is the next two named slices from the issue plan (analysis packets, then validation/benchmark packets), with each row either migrated or given an inline reasoned exemption and a focused test.

## Validation

- `uv run ruff check robot_sf/evidence/writers.py scripts/ci/check_evidence_writer_usage.py scripts/ci/pr_contract_check.py scripts/export_issue_4268_trace_episode.py scripts/export_issue_4848_group_crossing_exemplars.py scripts/export_issue_4891_head_on_corridor_exemplars.py tests/test_evidence_writers.py tests/ci/test_evidence_writer_usage_guard.py tests/tools/test_export_issue_4268_trace_episode.py` — passed.
- `uv run ruff format --check ...` on all changed Python files — passed.
- `uv run pytest -q tests/test_evidence_writers.py tests/ci/test_evidence_writer_usage_guard.py tests/validation/test_pr_contract_check.py tests/test_export_issue_4848.py tests/test_export_issue_4891.py tests/tools/test_export_issue_4268_trace_episode.py` — 121 passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` after staging — 2,377 passed, 1 skipped, 1 warning; the interim wrapper correctly excluded dirty paths, so final clean-HEAD readiness will be rerun after commit.
- `uv run python scripts/ci/pr_contract_check.py --help` — passed.

## Domain-Aware Approval

- Required for this PR: yes - evidence-writer contract review; no benchmark metric, scenario, model-provenance, or paper-facing claim semantics change.
- Domains reviewed: evidence marker/provenance routing, changed-file guard behavior, claim-boundary hygiene.
- Status: waived
- Approver/review source or waiver: maintainer-directed waiver for an implementation-only progression slice; no result validity is asserted.
- Validity checklist:
  - Target claim/hypothesis: changed generated-evidence writers route through one marker/checksum contract and future bypasses fail closed.
  - Comparator or split/evidence validity: compared with `origin/main`; this is a contract/implementation slice, not a benchmark split or statistical comparison.
  - Fallback/degraded exclusions: no campaign rows were run or counted; fallback/degraded execution is excluded from this PR's evidence.
  - Claim boundary: tests prove writer plumbing and guard behavior only; they do not establish benchmark, human-subject, simulator-validity, or paper-facing claims.
  - Implementation integrity vs experimental validity: implementation integrity is supported by the focused tests and readiness lane; experimental validity is intentionally not assessed here.
- Review obligation: verify the shared marker/checksum contract, changed-file guard false-positive boundary, and the explicitly listed remaining writer inventory before treating the parent issue as complete.
- Evidence status: smoke/contract evidence only; no generated bundle or benchmark result is promoted by this PR.

## Governance appendix

<details>
<summary>Scope, propagation, and exclusions</summary>

- Refs [#4921](https://github.com/ll7/robot_sf_ll7/issues/4921), [#4903](https://github.com/ll7/robot_sf_ll7/issues/4903), and [#4910](https://github.com/ll7/robot_sf_ll7/pull/4910).
- State propagation: no issue comment was posted because the authorization explicitly forbids issue/PR comments; this PR body is the canonical handoff surface.
- No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.
- No generated evidence bundle was regenerated or committed; `output/` remains disposable worktree-local output.
- No target-host, packet-lineage, or transient queue-routing state was added to tracked files.
- No friction issue was filed: the only observed readiness friction was the already-tracked untracked-file limitation reported as issue #5533, and the implementation proceeded after staging the new files.

</details>
