### PR TITLE
Issue #5546: preflight source existence before geometry certification (cheap-lane worker)

### DIFF
--- a/scripts/validation/check_issue_5416_sipp_four_geometry_packet.py
+++ b/scripts/validation/check_issue_5416_sipp_four_geometry_packet.py
@@ -4,6 +4,12 @@
 The checker validates the tracked preregistration and runs the repository's
 ``scenario_cert.v1`` geometry/solvability check for the four selected rows. It
 does not run planner episodes, submit compute, or interpret benchmark outcomes.
+
+Every selected scenario source path is preflighted for existence before any
+geometry certification runs, so a missing or misrouted input fails closed with a
+short diagnostic instead of a deep parser or route-planning stack trace. Pass
+``--metadata-only`` (or ``certify_geometry=False``) to validate packet structure
+and source-path existence without invoking map conversion or route planning.
 """
 
 from __future__ import annotations
@@ -99,10 +105,23 @@ def load_packet(path: Path) -> dict[str, Any]:
     return payload
 
 
+def _preflight_source_path(row: dict[str, Any], *, root: Path) -> Path:
+    """Resolve and verify a selected scenario source path exists.
+
+    This runs before any geometry certification so a missing or misrouted input
+    fails closed with a short actionable diagnostic instead of a deep parser or
+    route-planning stack trace.
+    """
+    scenario_id = str(row.get("scenario_id"))
+    source_path = root / _repo_path(row.get("source_path"), f"{scenario_id}.source_path")
+    _require(source_path.is_file(), f"{scenario_id} source missing: {row.get('source_path')}")
+    return source_path
+
+
 def _check_certification(row: dict[str, Any], *, root: Path) -> dict[str, Any]:
     """Certify one selected scenario and return a compact gate result."""
     scenario_id = str(row.get("scenario_id"))
-    source_path = root / _repo_path(row.get("source_path"), f"{scenario_id}.source_path")
+    source_path = _preflight_source_path(row, root=root)
     certificates = certify_scenario_file(source_path, scenario_id=scenario_id)
     _require(len(certificates) == 1, f"{scenario_id} must yield exactly one certificate")
     payload = certificate_to_dict(certificates[0])
@@ -119,8 +138,52 @@ def _check_certification(row: dict[str, Any], *, root: Path) -> dict[str, Any]:
     }
 
 
-def validate_packet(packet: dict[str, Any], *, repo_root: Path | None = None) -> dict[str, Any]:
-    """Validate the preregistration and current geometry gate."""
+def _metadata_only_row(row: dict[str, Any], *, root: Path) -> dict[str, Any]:
+    """Verify a selected scenario's source exists without certifying geometry.
+
+    Returns a compact row shaped like ``_check_certification`` output but with a
+    ``not_certified`` classification/eligibility so callers cannot mistake a
+    metadata-only pass for a geometry gate result.
+    """
+    scenario_id = str(row.get("scenario_id"))
+    _preflight_source_path(row, root=root)
+    return {
+        "scenario_id": scenario_id,
+        "source_path": row["source_path"],
+        "classification": "not_certified",
+        "benchmark_eligibility": "not_certified",
+        "reasons": ["metadata_only_no_geometry_certification"],
+        "route_count": 0,
+        "gate": "metadata_only",
+    }
+
+
+def _certify_rows(
+    rows: list[dict[str, Any]], *, root: Path, certify_geometry: bool
+) -> list[dict[str, Any]]:
+    """Build per-scenario gate rows, certifying geometry unless metadata-only."""
+    if certify_geometry:
+        return [_check_certification(row, root=root) for row in rows]
+    return [_metadata_only_row(row, root=root) for row in rows]
+
+
+def validate_packet(
+    packet: dict[str, Any],
+    *,
+    repo_root: Path | None = None,
+    certify_geometry: bool = True,
+) -> dict[str, Any]:
+    """Validate the preregistration and current geometry gate.
+
+    Args:
+        packet: The tracked preregistration mapping.
+        repo_root: Repository root used to resolve repo-relative paths.
+        certify_geometry: When ``True`` (default), run the ``scenario_cert.v1``
+            geometry/solvability certifier for each selected row. When ``False``,
+            run a metadata-only pass that verifies every selected source path
+            exists without invoking map conversion or route planning, so
+            input/provenance checks stay quiet and fast.
+    """
     root = repo_root or REPO_ROOT
     _walk_for_transient_keys(packet)
     _require(packet.get("schema_version") == SCHEMA_VERSION, "schema_version mismatch")
@@ -177,9 +240,7 @@ def validate_packet(packet: dict[str, Any], *, repo_root: Path | None = None) ->
         "geometry eligibility policy mismatch",
     )
 
-    certification: list[dict[str, Any]] = []
-    for row in rows:
-        certification.append(_check_certification(row, root=root))
+    certification = _certify_rows(rows, root=root, certify_geometry=certify_geometry)
 
     roster = _mapping(packet, "planner_roster")
     planner_rows = roster.get("required")
@@ -252,12 +313,27 @@ def validate_packet(packet: dict[str, Any], *, repo_root: Path | None = None) ->
     ):
         _require(readiness_decision.get(key) is False, f"readiness_decision.{key} must be false")
 
-    blocked_rows = [row["scenario_id"] for row in certification if row["gate"] != "pass"]
+    return _build_result(
+        certification, planner_count=len(planner_rows), certify_geometry=certify_geometry
+    )
+
+
+def _build_result(
+    certification: list[dict[str, Any]], *, planner_count: int, certify_geometry: bool
+) -> dict[str, Any]:
+    """Assemble the compact validation result and derive the gate status."""
+    if certify_geometry:
+        blocked_rows = [row["scenario_id"] for row in certification if row["gate"] != "pass"]
+        status = "ready" if not blocked_rows else "blocked"
+    else:
+        blocked_rows = []
+        status = "metadata_only"
     return {
-        "status": "ready" if not blocked_rows else "blocked",
+        "status": status,
         "issue": 5416,
         "schema_version": SCHEMA_VERSION,
-        "planner_count": len(planner_rows),
+        "geometry_certified": certify_geometry,
+        "planner_count": planner_count,
         "scenario_count": len(certification),
         "certification": certification,
         "blocked_rows": blocked_rows,
@@ -270,9 +346,17 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--packet", type=Path, default=DEFAULT_PACKET)
     parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument(
+        "--metadata-only",
+        action="store_true",
+        help=(
+            "Validate packet metadata and source-path existence only; skip "
+            "geometry/solvability certification and its map-conversion logs."
+        ),
+    )
     args = parser.parse_args(argv)
     try:
-        result = validate_packet(load_packet(args.packet))
+        result = validate_packet(load_packet(args.packet), certify_geometry=not args.metadata_only)
     except (
         OSError,
         PacketError,
@@ -297,7 +381,7 @@ def main(argv: list[str] | None = None) -> int:
             print(
                 f"  {row['gate']}: {row['scenario_id']} ({row['classification']}/{row['benchmark_eligibility']})"
             )
-    return 0 if result["status"] == "ready" else 1
+    return 0 if result["status"] in {"ready", "metadata_only"} else 1
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_check_issue_5416_sipp_four_geometry_packet.py
+++ b/tests/validation/test_check_issue_5416_sipp_four_geometry_packet.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -101,3 +102,64 @@ def test_packet_rejects_excluded_geometry(monkeypatch) -> None:
         "classic_station_platform_medium",
         "classic_merging_low",
     ]
+
+
+def test_metadata_only_mode_skips_geometry_certification(monkeypatch) -> None:
+    """Metadata-only validation must not invoke the geometry certifier."""
+
+    def fail_certify(*_args, **_kwargs):
+        raise AssertionError("geometry certification must not run in metadata-only mode")
+
+    monkeypatch.setattr(checker, "certify_scenario_file", fail_certify)
+
+    result = checker.validate_packet(checker.load_packet(PACKET), certify_geometry=False)
+
+    assert result["status"] == "metadata_only"
+    assert result["geometry_certified"] is False
+    assert result["blocked_rows"] == []
+    assert result["scenario_count"] == 4
+    assert all(row["gate"] == "metadata_only" for row in result["certification"])
+    assert all(row["benchmark_eligibility"] == "not_certified" for row in result["certification"])
+
+
+def test_missing_source_preflights_before_certification(monkeypatch) -> None:
+    """A missing scenario source fails closed before geometry certification runs."""
+
+    def fail_certify(*_args, **_kwargs):
+        raise AssertionError("preflight must fail before geometry certification runs")
+
+    monkeypatch.setattr(checker, "certify_scenario_file", fail_certify)
+
+    packet = checker.load_packet(PACKET)
+    packet["scenario_contract"]["selected_rows"][0]["source_path"] = (
+        "configs/scenarios/archetypes/does_not_exist.yaml"
+    )
+
+    with pytest.raises(checker.PacketError, match="source missing"):
+        checker.validate_packet(packet)
+
+
+def test_metadata_only_reports_missing_source(monkeypatch) -> None:
+    """Metadata-only mode still fails closed on a missing source path."""
+
+    def fail_certify(*_args, **_kwargs):
+        raise AssertionError("geometry certification must not run in metadata-only mode")
+
+    monkeypatch.setattr(checker, "certify_scenario_file", fail_certify)
+
+    packet = checker.load_packet(PACKET)
+    packet["scenario_contract"]["selected_rows"][0]["source_path"] = (
+        "configs/scenarios/archetypes/does_not_exist.yaml"
+    )
+
+    with pytest.raises(checker.PacketError, match="source missing"):
+        checker.validate_packet(packet, certify_geometry=False)
+
+
+def test_cli_metadata_only_returns_success_without_geometry_logs(capsys) -> None:
+    """The --metadata-only CLI path exits 0 and emits the metadata_only status."""
+    exit_code = checker.main(["--metadata-only", "--json"])
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["status"] == "metadata_only"
+    assert payload["geometry_certified"] is False


### PR DESCRIPTION
## What and why

Issue #5546 reports that the issue #5416 four-geometry SIPP analyzer certifies
geometry for all four packet scenarios (emitting verbose
`robot_sf.nav.svg_map_parser` and `classic_global_planner` logs, plus map
conversion and route planning) **before** any missing-input/provenance check.
The reporter hit this on the missing-episode path and had to ignore a wall of
geometry-certification logs to read the final result.

The reporter's transient WIP script name
(`scripts/analysis/analyze_issue_5416_sipp_four_geometry.py`) was never merged.
The surviving, canonical #5416 artifact from PR #5539 is
`scripts/validation/check_issue_5416_sipp_four_geometry_packet.py`, and it
carries the exact friction described: `validate_packet` unconditionally calls
`certify_scenario_file` for every selected row with no input-existence preflight
and no metadata-only mode. This PR fixes that canonical owner rather than
re-deriving a duplicate analyzer.

Implements the issue's suggested change:

- **Input-existence/provenance preflight**: `_preflight_source_path` verifies
  each selected scenario source file exists before geometry certification runs.
  A missing/misrouted source now fails closed with a short
  `"<scenario> source missing: <path>"` diagnostic instead of a deep parser or
  route-planning stack trace.
- **Metadata-only mode**: `validate_packet(..., certify_geometry=False)` and the
  new `--metadata-only` CLI flag validate packet structure and source existence
  without invoking map conversion or route planning, so missing-input checks
  emit no geometry logs.
- Result now reports `geometry_certified` and a `metadata_only` status so a
  metadata-only pass cannot be mistaken for a geometry gate result. The existing
  non-zero blocked exit and geometry gate behavior are preserved.

## Validation output

Focused test file (11 passed, run via shared-venv on CPU):

```
uv run python -m pytest tests/validation/test_check_issue_5416_sipp_four_geometry_packet.py -q
11 passed in 2.73s
```

New tests cover: metadata-only skips certification, missing source preflights
before certification (both default and metadata-only modes), and the
`--metadata-only` CLI exits 0 with `status=metadata_only`.

Metadata-only CLI emits zero geometry logs (grep count of
`svg_map_parser|classic_global_planner` on stderr = `0`):

```
python scripts/validation/check_issue_5416_sipp_four_geometry_packet.py --metadata-only --json
{"status": "metadata_only", "geometry_certified": false, ...}
```

Default (geometry) mode unchanged: `status: ready geometry_certified: True`.

Ruff fix/format on changed files: `All checks passed!`

## Research/benchmark claim

NA — tooling/friction fix to a validation checker. No benchmark, metric, schema,
or paper-facing claim; no campaign, SLURM, or training run. The geometry gate
semantics and blocked exit are preserved.

Closes #5546

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.
