### PR TITLE
ci(deps): group dependabot updates (actions as one PR; python minor/patch grouped, majors individual)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "deps"
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "uv"
     directory: "/fast-pysf"
@@ -28,5 +33,9 @@ updates:
       day: "tuesday"
       time: "07:00"
     open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: "deps"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,5 +37,8 @@ updates:
       actions:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "deps"


### PR DESCRIPTION
Reduces dependency-PR shower: #5561/#5562 were one logical CodeQL upgrade split in two. Majors (e.g. torch #5553) stay individual per the deliberate-validation policy. Config-only; yaml validated. Refs the 2026-07-14 review's staged-upgrade guidance.