### PR TITLE
fix(ci): unbreak main doctest after #5537 (#5560)

### DIFF
--- a/robot_sf/nav/occupancy_grid_rasterization.py
+++ b/robot_sf/nav/occupancy_grid_rasterization.py
@@ -67,7 +67,7 @@ def rasterize_line_segment(
         >>> grid = np.zeros((100, 100))
         >>> config = GridConfig(resolution=0.1, width=10.0, height=10.0)
         >>> line = ((1.0, 1.0), (9.0, 9.0))
-        >>> rasterize_line_segment(line, grid, config)
+        >>> _ = rasterize_line_segment(line, grid, config)
         >>> int(np.sum(grid > 0))  # Count occupied cells
         81
     """


### PR DESCRIPTION
## Reviewer-critical summary

This PR addresses [#5560](https://github.com/ll7/robot_sf_ll7/issues/5560) by repairing the first breaking merge in the current red-main chain. PR #5537 changed `rasterize_line_segment` to return a boolean, but its existing doctest still expected the call to produce no displayed result; the exact `fast-feedback` doctest then failed on the post-#5537 run and again on later merges. The example now explicitly discards the status value.

- Claim boundary: this is a documentation/doctest compatibility repair only; rasterization behavior, occupancy values, metrics, planners, and public research claims are unchanged.
- Required validation: the focused doctest, occupancy helper tests, Ruff/format checks, and final `pr_ready_check` must pass.
- Remaining blocker: none in the issue's implementation scope; after merge, the normal main CI runs must provide the issue's requested consecutive-green confirmation.

## Contract delta

- New schema fields: none.
- New fail-closed blockers: none.
- Compatibility impact: none to runtime callers; the doctest now matches the existing boolean return contract introduced by PR #5537.
- Assumption: the boolean return is intentional and should remain observable to callers; the example does not need to assert it because the following assertion already verifies the rasterized grid.

<details>
<summary>Validation and governance details</summary>

### Issue and diagnosis

- Issue: [#5560](https://github.com/ll7/robot_sf_ll7/issues/5560).
- Breaking merge: [PR #5537](https://github.com/ll7/robot_sf_ll7/pull/5537), merge commit `9420967`; it changed the helper from `None` to `bool` and added the return documentation without updating the doctest expression.
- Direct evidence: [failed main CI run](https://github.com/ll7/robot_sf_ll7/actions/runs/29300961817) reports `Expected nothing` / `Got: True` for this exact example. Later failing runs #5554 and #5552 reproduced the same latent failure.

### Validation

- `.venv/bin/pytest -q tests/docs/test_module_doctests.py -k occupancy_grid_rasterization` — **passed** (1 passed, 10 deselected).
- `.venv/bin/pytest -q tests/test_occupancy_grid_helpers.py` — **passed** (8 passed).
- `.venv/bin/ruff check robot_sf/nav/occupancy_grid_rasterization.py` — **passed**.
- `.venv/bin/ruff format --check robot_sf/nav/occupancy_grid_rasterization.py` — **passed**.
- `git diff --check` — **passed**.
- `PR_READY_MODE=final PR_READY_PR_BODY_FILE=/tmp/issue-5560/pr_body.md PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — **passed** (2,377 passed, 1 skipped, 1 warning; all readiness ratchets passed; clean committed-HEAD freshness stamp recorded).

### Scope and artifact handling

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No generated benchmark artifacts; no `output/` artifact promotion is needed.
- No friction issue opened: the `gh issue view --comments` readout problem is already tracked by closed issues #5148 and #5344.

### Research result guidance

- Target claim / hypothesis / blocker: restore the main CI contract after the #5537 doctest regression.
- Comparator or baseline: `origin/main` before this one-line change.
- Evidence tier: docs-only
- Result classification: NA - no research result; this repairs an executable documentation example
- Decision or stop rule: stop after the focused doctest and final readiness gate pass; no benchmark interpretation is involved.
- Parent issue, claim map, registry, or context note: parent issue #5560; no research surface changes.

### Domain-aware approval

- Required for this PR: no — docs/doctest compatibility only; no evidence classification change.
- Domains reviewed: NA.
- Status: not required.

### Downstream propagation

- Parent issue updated: no — issue/PR comments are outside this run's authorization (`comment_issue_or_pr: false`); this PR body is the durable implementation handoff.
- Claim map / benchmark report: NA.
- Leaderboard / artifact catalog: NA.
- Registry or config index: NA.
- Context index / memory note: NA.
- Follow-up issue: no; no implementation work remains after the post-merge green-run confirmation.
- Not applicable because: this PR changes only an executable documentation example and has no evidence-producing downstream consumer.

### Follow-up issues

- Deferred work: NA - only the requested post-merge consecutive-green CI confirmation remains
- Issues opened for follow-up: none - no follow-up issue is needed

### Reviewer notes

- Verify the doctest now intentionally assigns the boolean return while retaining the occupied-cell assertion.
- Rollback: revert this one-line documentation change; no runtime fallback or degraded benchmark mode is involved.

</details>

Refs #5560


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a code example for clearer handling of the function’s return value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
