### PR TITLE
Issue #5571: add --json machine-readable output to main_ci_is_green.py (cheap-lane worker)

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -1636,6 +1636,25 @@ run never counts as green or red. Only PRs that fix the breakage (title-prefixed
 the cure and must land. Reviewing a PR while main is red is fine — only the
 merge is held.
 
+For automated gates, emit the machine-readable signal instead of parsing the
+human line (issue #5571). The `--json` flag prints the `main_ci_is_green.v1`
+schema and still exits 0 (green) / 1 (not green), so the gate contract is
+satisfied without text scraping:
+
+```bash
+uv run python scripts/dev/main_ci_is_green.py --json
+# -> {"schema_version": "main_ci_is_green.v1", "is_green": true, "status": "green",
+#     "repo": "ll7/robot_sf_ll7", "workflow": "CI",
+#     "deciding_run": {"databaseId": ..., "conclusion": "success", "status": "completed",
+#                      "headSha": "...", "createdAt": "..."}}
+```
+
+`status` is one of `green` / `red` / `stale`. A `stale` verdict (no decisive
+completed run in the window) still fails closed to not green, but is reported
+distinctly so the gate can hold for a *fresh run* rather than treat it as a main
+regression. The `--quiet` flag suppresses the human line; the existing
+exit-code contract is unchanged.
+
 ## CI Performance Monitoring
 The CI pipeline separates fast feedback from the heavier smoke/artifact tail:
 

--- a/scripts/dev/main_ci_is_green.py
+++ b/scripts/dev/main_ci_is_green.py
@@ -17,7 +17,10 @@ pure decision function filters defensively on top so the rule is unit-tested.
 
 Exit code: 0 == green (latest completed CI run on main concluded ``success``),
 1 == not green (red, or no completed run to judge from). Prints the run id and
-conclusion it decided from.
+conclusion it decided from. The ``--json`` flag emits the machine-readable
+main-signal schema (``main_ci_is_green.v1``) with the same green/red/stale
+classification the gate contract consumes, so the gate need not parse the
+human line.
 """
 
 from __future__ import annotations
@@ -112,6 +115,43 @@ def decide(runs: list[Any]) -> tuple[bool, dict[str, Any] | None]:
     return classify(run.get("conclusion")) == "green", run
 
 
+# The main-signal schema consumed by the red-main merge-hold gate (issue #5571).
+# ``status`` is one of green / red / stale, matching :func:`classify`; a stale
+# verdict (no decisive completed run in the window) still fails closed to not
+# green but is reported distinctly so the gate can hold for a *fresh run* rather
+# than treat it as a main regression.
+SIGNAL_SCHEMA_VERSION = "main_ci_is_green.v1"
+
+
+def build_signal(
+    is_green: bool,
+    run: dict[str, Any] | None,
+    repo: str = DEFAULT_REPO,
+    workflow: str = DEFAULT_WORKFLOW,
+) -> dict[str, Any]:
+    """Build the machine-readable main-signal payload (the ``--json`` contract)."""
+    if run is None:
+        status = "stale"
+        deciding_run = None
+    else:
+        status = classify(run.get("conclusion"))
+        deciding_run = {
+            "databaseId": run.get("databaseId"),
+            "conclusion": run.get("conclusion"),
+            "status": run.get("status"),
+            "headSha": run.get("headSha"),
+            "createdAt": run.get("createdAt"),
+        }
+    return {
+        "schema_version": SIGNAL_SCHEMA_VERSION,
+        "is_green": is_green,
+        "status": status,
+        "repo": repo,
+        "workflow": workflow,
+        "deciding_run": deciding_run,
+    }
+
+
 def fetch_runs(
     repo: str = DEFAULT_REPO, workflow: str = DEFAULT_WORKFLOW, limit: int = 5
 ) -> list[dict[str, Any]]:
@@ -143,12 +183,24 @@ def fetch_runs(
 
 
 def main() -> int:
-    """CLI entry: exit 0 if main CI is green, 1 otherwise."""
+    """CLI entry: exit 0 if main CI is green, 1 otherwise.
+
+    Default and ``--quiet`` modes print the human-readable line (and use the
+    exit code) so the gate's existing human fallback keeps working. ``--json``
+    emits the machine-readable main-signal schema (issue #5571) and still exits
+    0/1, so the gate contract can be satisfied without parsing text.
+    """
     ap = argparse.ArgumentParser(description="Is main CI green (latest completed run)?")
     ap.add_argument("--repo", default=DEFAULT_REPO)
     ap.add_argument("--workflow", default=DEFAULT_WORKFLOW)
     ap.add_argument("--limit", type=int, default=5)
     ap.add_argument("--quiet", action="store_true", help="suppress the human line")
+    ap.add_argument(
+        "--json",
+        dest="as_json",
+        action="store_true",
+        help="emit the machine-readable main-signal JSON (green/red/stale schema)",
+    )
     args = ap.parse_args()
 
     try:
@@ -156,12 +208,30 @@ def main() -> int:
     except (RuntimeError, json.JSONDecodeError) as exc:
         # Fail closed: an unreadable signal is treated as NOT green so a merge
         # hold errs toward holding, never toward merging on unknown state.
+        if args.as_json:
+            # A stale schema_version + is_green=false lets the gate fail closed
+            # without a traceback; the human UNKNOWN line still goes to stderr.
+            print(
+                json.dumps(
+                    {
+                        "schema_version": SIGNAL_SCHEMA_VERSION,
+                        "is_green": False,
+                        "status": "stale",
+                        "repo": args.repo,
+                        "workflow": args.workflow,
+                        "deciding_run": None,
+                        "error": f"fetch failed: {exc}",
+                    }
+                )
+            )
         if not args.quiet:
             print(f"main CI status UNKNOWN ({exc}) -> treated as not-green", file=sys.stderr)
         return 1
 
     is_green, run = decide(runs)
-    if not args.quiet:
+    if args.as_json:
+        print(json.dumps(build_signal(is_green, run, args.repo, args.workflow)))
+    elif not args.quiet:
         if run is None:
             print("main CI: no completed run found -> not green")
         else:

--- a/tests/dev/test_main_ci_is_green.py
+++ b/tests/dev/test_main_ci_is_green.py
@@ -14,6 +14,7 @@ import pytest
 
 from scripts.dev import main_ci_is_green
 from scripts.dev.main_ci_is_green import (
+    build_signal,
     classify,
     decide,
     fetch_runs,
@@ -183,3 +184,86 @@ def test_gh_oserror_becomes_a_failed_process(monkeypatch: pytest.MonkeyPatch) ->
 
     assert proc.returncode == 127
     assert "not executable" in proc.stderr
+
+
+def test_build_signal_green_schema() -> None:
+    """build_signal encodes a green decisive run with the machine-readable schema."""
+    runs = [_run(3, "completed", "success", "2026-07-12T12:00:00Z")]
+    is_green, run = decide(runs)
+    signal = build_signal(is_green, run)
+
+    assert signal["schema_version"] == "main_ci_is_green.v1"
+    assert signal["is_green"] is True
+    assert signal["status"] == "green"
+    assert signal["deciding_run"]["databaseId"] == 3
+    assert signal["deciding_run"]["conclusion"] == "success"
+    assert signal["deciding_run"]["status"] == "completed"
+
+
+def test_build_signal_red_schema() -> None:
+    """build_signal encodes a red decisive run; is_green False, status red."""
+    runs = [_run(2, "completed", "failure", "2026-07-12T12:00:00Z")]
+    is_green, run = decide(runs)
+    signal = build_signal(is_green, run)
+
+    assert signal["is_green"] is False
+    assert signal["status"] == "red"
+    assert signal["deciding_run"]["conclusion"] == "failure"
+
+
+def test_build_signal_stale_when_no_deciding_run() -> None:
+    """A stale-only window yields status=stale, deciding_run=None, is_green False."""
+    is_green, run = decide([_run(1, "completed", "cancelled", "2026-07-12T12:00:00Z")])
+    signal = build_signal(is_green, run)
+
+    assert is_green is False
+    assert signal["is_green"] is False
+    assert signal["status"] == "stale"
+    assert signal["deciding_run"] is None
+
+
+def test_json_output_matches_schema_and_exit_code(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    """The --json CLI path emits valid schema JSON and preserves the exit code.
+
+    This is the exact gate contract from issue #5571 that previously failed with
+    an argparse error: ``uv run python scripts/dev/main_ci_is_green.py --json``.
+    """
+    import json as _json
+
+    sample = [_run(7, "completed", "success", "2026-07-12T12:00:00Z")]
+    monkeypatch.setattr(main_ci_is_green, "fetch_runs", lambda *a, **k: sample)
+    monkeypatch.setattr(main_ci_is_green.sys, "argv", ["main_ci_is_green.py", "--json"])
+
+    rc = main_ci_is_green.main()
+
+    captured = capsys.readouterr()
+    payload = _json.loads(captured.out)
+    assert rc == 0
+    assert payload["is_green"] is True
+    assert payload["status"] == "green"
+    assert payload["schema_version"] == "main_ci_is_green.v1"
+    assert payload["deciding_run"]["databaseId"] == 7
+
+
+def test_json_fetch_failure_is_machine_readable_stale(
+    monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """A fetch failure under --json still exits 1 but emits a stale JSON signal."""
+    import json as _json
+
+    monkeypatch.setattr(
+        main_ci_is_green,
+        "fetch_runs",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("gh run list failed: boom")),
+    )
+    monkeypatch.setattr(main_ci_is_green.sys, "argv", ["main_ci_is_green.py", "--json"])
+
+    rc = main_ci_is_green.main()
+    captured = capsys.readouterr()
+    payload = _json.loads(captured.out)
+
+    assert rc == 1
+    assert payload["status"] == "stale"
+    assert payload["is_green"] is False
+    assert payload["deciding_run"] is None
+    assert "error" in payload


### PR DESCRIPTION
## What / Why

Issue #5571 (friction): the red-main merge-hold gate contract requires
`uv run python scripts/dev/main_ci_is_green.py --json`, but the helper rejected
`--json` with an argparse error and only supported human-readable output plus
`--quiet`. That forced the gate to scrape the human line, weakening the
machine-readable red/green/stale contract.

This PR adds the documented, tested `--json` mode:

- New `--json` flag on the CLI that emits the `main_ci_is_green.v1` schema:
  `schema_version`, `is_green`, `status` (one of `green`/`red`/`stale`),
  `repo`, `workflow`, and `deciding_run` (the latest decisive completed run with
  `databaseId`/`conclusion`/`status`/`headSha`/`createdAt`).
- New pure `build_signal(is_green, run, repo, workflow)` function producing the
  payload, unit-tested directly.
- The `--json` path preserves the existing exit-code contract (0 green, 1 not
  green) and the human-readable fallback path is untouched. A fetch failure under
  `--json` still fails closed: exits 1 and emits a `stale` JSON signal with an
  `error` field instead of a traceback.

## Acceptance (from #5571)

- [x] Documented, tested `--json` output mode added.
- [x] Main-signal schema includes green/red/stale classification.
- [x] Existing human-readable mode and exit-code behavior preserved.
- [x] Helper tests aligned (new `build_signal` + `--json` CLI tests).
- [x] Gate documentation in `docs/dev_guide.md` updated to show the `--json` contract.

## Validation

```text
uv run ruff check scripts/dev/main_ci_is_green.py tests/dev/test_main_ci_is_green.py
  -> All checks passed!
uv run ruff format --check scripts/dev/main_ci_is_green.py tests/dev/test_main_ci_is_green.py
  -> clean (after format)
uv run pytest tests/dev/test_main_ci_is_green.py -q
  -> 19 passed
uv run python -c "scripts.dev.main_ci_is_green smoke via --json (mocked fetch)"
  -> {"schema_version": "main_ci_is_green.v1", "is_green": true, "status": "green",
      "repo": "ll7/robot_sf_ll7", "workflow": "CI",
      "deciding_run": {"databaseId": 7, "conclusion": "success", "status": "completed",
                       "headSha": "aaaa...", "createdAt": "2026-07-12T12:00:00Z"}}
  -> rc=0
```

No campaigns, Slurm, training runs, or benchmark/paper claims. CPU-only,
deterministic unit + CLI smoke tests.

Closes #5571

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.
