### PR TITLE
Issue #5602: benchmark scenario-evidence crosswalk v1 (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/scenario_evidence_crosswalk.py
+++ b/robot_sf/benchmark/scenario_evidence_crosswalk.py
@@ -1,0 +1,736 @@
+"""Versioned scenario-evidence crosswalk (issue #5602).
+
+A single deterministic join that downstream benchmark reports and exemplar
+selectors can query instead of reconstructing taxonomy, predicate availability,
+and trace/example availability manually.
+
+The crosswalk stops at **benchmark-evidence metadata**. It must not encode
+private manuscript claims and must not imply a causal failure mechanism from
+geometry alone. Two contract rules from the issue are load-bearing:
+
+1. Geometry groups and *validated* mechanisms live in **separate fields** with
+   **separate provenance**. Geometry is descriptive only; a trace-verified
+   mechanism is never derived from geometry (see
+   :mod:`robot_sf.benchmark.failure_mechanism_taxonomy`).
+2. Predicate availability is consumed from the #5593 predicate-export lane when
+   present; until that lane lands, predicate fields are explicit ``unavailable``
+   and taxonomy-motivated predicates are listed as ``motivated_not_exported``
+   rather than re-derived from motivation text (issue stop rule).
+
+The builder is fail-closed: duplicate scenario ids, empty/stale config hashes,
+unknown predicate schema versions, broken artifact references, and
+provenance-incomplete eligibility are all rejected rather than silently patched.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import subprocess
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from robot_sf.benchmark.utils import _config_hash
+from robot_sf.common.json_pointer import json_pointer as _render_json_pointer
+
+SCHEMA_VERSION = "scenario_evidence_crosswalk.v1"
+
+#: Predicate schema tags motivated by the failure taxonomy (#5593 lane). These
+#: are the only predicate versions the crosswalk recognizes; any other version
+#: in a supplied export is rejected as an unknown predicate version.
+KNOWN_PREDICATE_SCHEMAS: dict[str, str] = {
+    "oscillatory_control": "safety_predicate.oscillatory_control.v1",
+    "late_evasive": "safety_predicate.late_evasive.v2",
+    "occlusion_near_miss": "safety_predicate.occlusion_near_miss.v1",
+}
+
+PREDICATE_EXPORT_SCHEMA_VERSION = "trace_predicate_export.v1"
+
+EXCLUSION_REASON_PREDICATE_UNAVAILABLE = "predicate_export_unavailable"
+EXCLUSION_REASON_NO_EVIDENCE_BUNDLE = "no_evidence_bundle_provided"
+
+SCHEMA_FILE = Path(__file__).with_name("schemas") / "scenario_evidence_crosswalk.v1.json"
+
+
+class ScenarioEvidenceCrosswalkError(ValueError):
+    """Raised when a defensible crosswalk cannot be built or validated."""
+
+
+def _git_sha_short(length: int = 7) -> str:
+    """Return short git SHA for the current HEAD, or ``unknown``."""
+    try:
+        sha = (
+            subprocess.check_output(
+                ["git", "rev-parse", f"--short={length}", "HEAD"],
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+            )
+            .decode("utf-8")
+            .strip()
+        )
+        return sha or "unknown"
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+        OSError,
+    ):
+        return "unknown"
+
+
+def _scenario_id(scenario: Mapping[str, Any], index: int) -> str:
+    """Return the stable scenario identifier used across benchmark views.
+
+    Returns:
+        The scenario id string, or a deterministic fallback like ``scenario_NNN``.
+    """
+    for field in ("name", "id", "scenario_id"):
+        value = scenario.get(field)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return f"scenario_{index:03d}"
+
+
+def _metadata(scenario: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a shallow metadata mapping for a scenario."""
+    value = scenario.get("metadata")
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _first_nonempty_str(*values: Any) -> str | None:
+    """Return the first non-empty string among ``values`` or ``None``."""
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _scenario_family(scenario: Mapping[str, Any]) -> str:
+    """Return the scenario family, preferring explicit family fields."""
+    meta = _metadata(scenario)
+    return (
+        _first_nonempty_str(
+            meta.get("scenario_family"),
+            scenario.get("scenario_family"),
+            meta.get("family"),
+            meta.get("archetype"),
+        )
+        or "unknown"
+    )
+
+
+def _interaction_class(scenario: Mapping[str, Any]) -> str:
+    """Return the interaction class when explicitly declared, else ``unknown``."""
+    meta = _metadata(scenario)
+    return (
+        _first_nonempty_str(meta.get("interaction_class"), scenario.get("interaction_class"))
+        or "unknown"
+    )
+
+
+def _geometry_group(scenario: Mapping[str, Any]) -> str:
+    """Return a *descriptive* geometry/topology group label.
+
+    Geometry groups are descriptive topology labels only; they never substitute
+    for a trace-verified mechanism. Prefer an explicit ``geometry_group`` field,
+    otherwise fall back to the archetype as a topology hint.
+    """
+    meta = _metadata(scenario)
+    return (
+        _first_nonempty_str(
+            meta.get("geometry_group"), scenario.get("geometry_group"), meta.get("archetype")
+        )
+        or "unknown"
+    )
+
+
+_HAZARD_SOURCE_KEYS = (
+    "expected_failure_modes",
+    "target_failure_mode",
+    "primary_capability",
+    "capability_tags",
+    "hazard_classes",
+)
+
+
+def _hazard_tags(scenario: Mapping[str, Any]) -> list[str]:
+    """Collect declared hazard/capability/stress tags from scenario metadata.
+
+    Returns:
+        Sorted unique tag strings.
+    """
+    meta = _metadata(scenario)
+    tags: list[str] = []
+    for key in _HAZARD_SOURCE_KEYS:
+        value = meta.get(key)
+        if isinstance(value, str) and value.strip():
+            tags.append(value.strip())
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            for item in value:
+                if isinstance(item, str) and item.strip():
+                    tags.append(item.strip())
+    # Platform semantics hazard regions (descriptive only).
+    regions = scenario.get("platform_semantics", {})
+    if isinstance(regions, Mapping):
+        for region in regions.get("regions", []) or []:
+            if isinstance(region, Mapping) and region.get("kind") == "hazard":
+                rid = region.get("id")
+                if isinstance(rid, str) and rid.strip():
+                    tags.append(f"platform:{rid.strip()}")
+    return sorted(set(tags))
+
+
+def _source_config_hash(scenario: Mapping[str, Any]) -> str:
+    """Return a stable deterministic hash of the scenario config source."""
+    return _config_hash(dict(scenario))
+
+
+def _seeds(scenario: Mapping[str, Any]) -> list[int]:
+    """Return the deterministic seed list for a scenario."""
+    raw = scenario.get("seeds")
+    if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes)):
+        seeds = [int(s) for s in raw if isinstance(s, (int, float))]
+        if seeds:
+            return seeds
+    return []
+
+
+def _normalize_predicate_export(export: Mapping[str, Any] | None) -> dict[str, dict[str, Any]]:
+    """Normalize a #5593 predicate-export manifest into a per-scenario map.
+
+    Returns:
+        Mapping from scenario id to a record with ``exported`` (name -> schema
+        version) and ``predicate_status`` (name -> status string).
+    """
+    if export is None:
+        return {}
+    if not isinstance(export, Mapping):
+        raise ScenarioEvidenceCrosswalkError("predicate export must be a mapping")
+    schema = export.get("schema_version")
+    if schema is not None and schema != PREDICATE_EXPORT_SCHEMA_VERSION:
+        raise ScenarioEvidenceCrosswalkError(
+            f"predicate export schema mismatch: expected {PREDICATE_EXPORT_SCHEMA_VERSION!r}, "
+            f"got {schema!r}"
+        )
+    per_scenario: dict[str, dict[str, Any]] = {}
+    rows = export.get("rows")
+    if not isinstance(rows, list):
+        return per_scenario
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        sid = _first_nonempty_str(row.get("scenario_id"), row.get("scenario"))
+        if sid is None:
+            continue
+        entry = per_scenario.setdefault(sid, {"exported": {}, "predicate_status": {}})
+        _absorb_predicate_row(row, entry)
+    return per_scenario
+
+
+def _absorb_predicate_row(row: Mapping[str, Any], entry: dict[str, Any]) -> None:
+    """Fold one predicate-export row's predicates into ``entry`` dicts."""
+    for pred in row.get("predicates", []) or []:
+        if not isinstance(pred, Mapping):
+            continue
+        name = pred.get("predicate")
+        if not isinstance(name, str) or not name:
+            continue
+        entry["exported"][name] = pred.get("schema_version")
+        entry["predicate_status"][name] = pred.get("status", "ok")
+
+
+def _predicate_section(
+    scenario_id: str,
+    export: Mapping[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Build the predicate availability section for one scenario.
+
+    Consumes a #5593 export when supplied; otherwise marks everything explicit
+    ``unavailable`` and lists taxonomy-motivated predicates as
+    ``motivated_not_exported`` (never inferred from motivation text).
+
+    Returns:
+        Predicate availability section dict.
+    """
+    exported: list[dict[str, Any]] = []
+    missing_degraded: list[dict[str, Any]] = []
+    motivated_not_exported: list[dict[str, Any]] = []
+
+    entry = export.get(scenario_id)
+    if entry is None:
+        for name, version in KNOWN_PREDICATE_SCHEMAS.items():
+            motivated_not_exported.append(
+                {
+                    "predicate": name,
+                    "motivated_by": "failure_taxonomy",
+                    "schema_version": version,
+                    "status": "motivated_not_exported",
+                }
+            )
+        return {
+            "export_status": "unavailable",
+            "export_status_reason": EXCLUSION_REASON_PREDICATE_UNAVAILABLE,
+            "exported_predicates": exported,
+            "missing_or_degraded_predicates": missing_degraded,
+            "motivated_not_exported_predicates": motivated_not_exported,
+        }
+
+    for name, version in entry["exported"].items():
+        if version is not None and version not in KNOWN_PREDICATE_SCHEMAS.values():
+            raise ScenarioEvidenceCrosswalkError(
+                f"scenario {scenario_id}: unknown predicate schema version {version!r} for "
+                f"predicate {name!r}"
+            )
+        status = entry["predicate_status"].get(name, "ok")
+        record = {"predicate": name, "schema_version": version}
+        if status in {"degraded", "missing", "unavailable", "fallback"}:
+            record["status"] = status
+            missing_degraded.append(record)
+        else:
+            exported.append(record)
+
+    exported_names = {record["predicate"] for record in exported}
+    for name, version in KNOWN_PREDICATE_SCHEMAS.items():
+        if name not in exported_names and name not in {m["predicate"] for m in missing_degraded}:
+            motivated_not_exported.append(
+                {
+                    "predicate": name,
+                    "motivated_by": "failure_taxonomy",
+                    "schema_version": version,
+                    "status": "motivated_not_exported",
+                }
+            )
+
+    return {
+        "export_status": "available",
+        "export_status_reason": None,
+        "exported_predicates": exported,
+        "missing_or_degraded_predicates": missing_degraded,
+        "motivated_not_exported_predicates": motivated_not_exported,
+    }
+
+
+def _evidence_section(
+    scenario_id: str,
+    evidence_catalog: Mapping[str, Any] | None,
+    *,
+    artifact_root: Path | None = None,
+) -> dict[str, Any]:
+    """Build the evidence/replay eligibility section for one scenario.
+
+    Fails closed: without a supplied evidence catalog, eligibility is
+    ``excluded`` with a concrete reason rather than fabricated ids.
+
+    Returns:
+        Evidence section dict (eligibility, exclusion reason, and artifact ids).
+    """
+    if evidence_catalog is None:
+        return {
+            "eligibility": "excluded",
+            "exclusion_reason": EXCLUSION_REASON_NO_EVIDENCE_BUNDLE,
+            "validated_mechanism": None,
+            "validated_mechanism_provenance": None,
+            "trace_ids": [],
+            "replay_ids": [],
+            "generated_candidate_ids": [],
+            "case_capsule_ids": [],
+        }
+
+    entry = evidence_catalog.get(scenario_id)
+    if not isinstance(entry, Mapping):
+        return {
+            "eligibility": "excluded",
+            "exclusion_reason": "scenario_absent_from_evidence_catalog",
+            "validated_mechanism": None,
+            "validated_mechanism_provenance": None,
+            "trace_ids": [],
+            "replay_ids": [],
+            "generated_candidate_ids": [],
+            "case_capsule_ids": [],
+        }
+
+    eligibility = entry.get("eligibility", "excluded")
+    exclusion_reason = entry.get("exclusion_reason")
+    if eligibility != "eligible":
+        if not exclusion_reason:
+            raise ScenarioEvidenceCrosswalkError(
+                f"scenario {scenario_id}: non-eligible evidence must carry an exclusion_reason"
+            )
+
+    validated = entry.get("validated_mechanism")
+    if validated is not None:
+        raise ScenarioEvidenceCrosswalkError(
+            f"scenario {scenario_id}: validated_mechanism must be supplied by a validated causal "
+            f"report, not the scenario crosswalk (geometry-only rejection)"
+        )
+
+    ids_fields = ("trace_ids", "replay_ids", "generated_candidate_ids", "case_capsule_ids")
+    resolved = _resolve_evidence_ids(scenario_id, entry, ids_fields, artifact_root)
+
+    return {
+        "eligibility": eligibility,
+        "exclusion_reason": exclusion_reason if eligibility != "eligible" else None,
+        "validated_mechanism": None,
+        "validated_mechanism_provenance": None,
+        "trace_ids": resolved["trace_ids"],
+        "replay_ids": resolved["replay_ids"],
+        "generated_candidate_ids": resolved["generated_candidate_ids"],
+        "case_capsule_ids": resolved["case_capsule_ids"],
+    }
+
+
+def _resolve_evidence_ids(
+    scenario_id: str,
+    entry: Mapping[str, Any],
+    ids_fields: Sequence[str],
+    artifact_root: Path | None,
+) -> dict[str, list[str]]:
+    """Normalize evidence artifact id lists and fail-closed on broken refs.
+
+    Returns:
+        Mapping from each id field to its list of string references.
+    """
+    resolved: dict[str, list[str]] = {}
+    for field in ids_fields:
+        values = entry.get(field, []) or []
+        if not isinstance(values, list):
+            raise ScenarioEvidenceCrosswalkError(
+                f"scenario {scenario_id}: {field} must be a list when present"
+            )
+        resolved[field] = [str(v) for v in values]
+
+    if artifact_root is not None:
+        for field, ids in resolved.items():
+            for ref in ids:
+                if not (artifact_root / ref).exists():
+                    raise ScenarioEvidenceCrosswalkError(
+                        f"scenario {scenario_id}: {field} references missing artifact {ref!r} "
+                        f"(broken artifact reference)"
+                    )
+    return resolved
+
+
+def build_scenario_evidence_crosswalk(
+    scenarios: Sequence[Mapping[str, Any]],
+    *,
+    source: str,
+    predicate_export: Mapping[str, Any] | None = None,
+    evidence_catalog: Mapping[str, Any] | None = None,
+    artifact_root: Path | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic scenario-evidence crosswalk from canonical scenarios.
+
+    Args:
+        scenarios: Canonical scenario dicts (one per release cell).
+        source: Human-readable source identifier (matrix path).
+        predicate_export: Optional #5593 predicate-export manifest.
+        evidence_catalog: Optional mapping from scenario id to evidence/eligibility.
+        artifact_root: Optional root used to fail-closed on broken artifact refs.
+
+    Returns:
+        A schema-versioned crosswalk dict.
+
+    Raises:
+        ScenarioEvidenceCrosswalkError: On duplicate ids, empty config hashes,
+            unknown predicate versions, or broken artifact references.
+    """
+    if not scenarios:
+        raise ScenarioEvidenceCrosswalkError("crosswalk requires at least one scenario")
+
+    export = _normalize_predicate_export(predicate_export)
+    scenario_entries = [dict(scenario) for scenario in scenarios]
+
+    seen: dict[str, int] = {}
+    rows: list[dict[str, Any]] = []
+    for index, scenario in enumerate(scenario_entries):
+        scenario_id = _scenario_id(scenario, index)
+        if scenario_id in seen:
+            raise ScenarioEvidenceCrosswalkError(
+                f"duplicate scenario id {scenario_id!r} at indices {seen[scenario_id]} and {index}"
+            )
+        seen[scenario_id] = index
+
+        source_hash = _source_config_hash(scenario)
+        if not source_hash or source_hash == "0" * len(source_hash):
+            raise ScenarioEvidenceCrosswalkError(
+                f"scenario {scenario_id}: empty/stale source config hash"
+            )
+
+        family = _scenario_family(scenario)
+        geometry = _geometry_group(scenario)
+        if geometry == family:
+            # Defensive guard: geometry group must not silently equal the family
+            # in a way that implies a mechanism; keep them labelled separately.
+            geometry = f"{geometry} (geometry_only)"
+
+        row = {
+            "scenario_id": scenario_id,
+            "source_config_hash": source_hash,
+            "scenario_family": family,
+            "interaction_class": _interaction_class(scenario),
+            "map_id": _first_nonempty_str(
+                scenario.get("map_id"), scenario.get("map_file"), scenario.get("map")
+            )
+            or "unknown",
+            "geometry_group": geometry,
+            "geometry_group_provenance": "config_metadata",
+            "geometry_group_note": "descriptive topology label; not a causal mechanism",
+            "hazard_tags": _hazard_tags(scenario),
+            "hazard_tag_source": "config_metadata",
+            "seeds": _seeds(scenario),
+            "predicate_availability": _predicate_section(scenario_id, export),
+            "evidence": _evidence_section(
+                scenario_id, evidence_catalog, artifact_root=artifact_root
+            ),
+        }
+        rows.append(row)
+
+    rows.sort(key=lambda r: r["scenario_id"])
+
+    json_text = json.dumps(
+        {"schema_version": SCHEMA_VERSION, "rows": rows},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    content_sha256 = hashlib.sha256(json_text.encode("utf-8")).hexdigest()
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source": source,
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "repo_commit": _git_sha_short(),
+        "claim_boundary": (
+            "Benchmark-evidence metadata join only. Geometry groups are descriptive topology "
+            "labels and never imply a causal failure mechanism; predicate availability is "
+            "consumed from the #5593 export lane when present and is explicit 'unavailable' "
+            "otherwise; validated mechanisms require a validated causal report and are not "
+            "derived here. No private manuscript claims are encoded."
+        ),
+        "predicate_export_consumed": predicate_export is not None,
+        "evidence_catalog_consumed": evidence_catalog is not None,
+        "summary": {
+            "scenario_count": len(rows),
+            "eligible_scenarios": sum(
+                1 for r in rows if r["evidence"]["eligibility"] == "eligible"
+            ),
+            "excluded_scenarios": sum(
+                1 for r in rows if r["evidence"]["eligibility"] != "eligible"
+            ),
+            "predicate_export_available": sum(
+                1 for r in rows if r["predicate_availability"]["export_status"] == "available"
+            ),
+            "predicate_unavailable": sum(
+                1 for r in rows if r["predicate_availability"]["export_status"] == "unavailable"
+            ),
+        },
+        "content_sha256": content_sha256,
+        "rows": rows,
+    }
+
+
+def _load_schema() -> dict[str, Any]:
+    """Load the crosswalk JSON Schema.
+
+    Returns:
+        Parsed JSON Schema dictionary.
+    """
+    return json.loads(SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
+def validate_scenario_evidence_crosswalk(crosswalk: Mapping[str, Any]) -> list[str]:
+    """Validate a crosswalk against its JSON Schema and semantic gates.
+
+    Returns:
+        List of validation error strings; empty when valid.
+    """
+    errors: list[str] = []
+    validator = Draft202012Validator(_load_schema())
+    errors.extend(
+        f"{json_pointer(list(err.absolute_path))}: {err.message}"
+        for err in sorted(
+            validator.iter_errors(dict(crosswalk)), key=lambda e: list(e.absolute_path)
+        )
+    )
+    if crosswalk.get("schema_version") != SCHEMA_VERSION:
+        errors.append(
+            f"schema_version mismatch: expected {SCHEMA_VERSION!r}, "
+            f"got {crosswalk.get('schema_version')!r}"
+        )
+
+    rows = crosswalk.get("rows")
+    if not isinstance(rows, list):
+        errors.append("crosswalk.rows must be a list")
+        return errors
+
+    seen_ids: dict[str, int] = {}
+    for index, row in enumerate(rows):
+        if not isinstance(row, Mapping):
+            errors.append(f"rows[{index}]: not a mapping")
+            continue
+        sid = row.get("scenario_id")
+        if sid in seen_ids:
+            errors.append(f"rows[{index}]: duplicate scenario_id {sid!r}")
+        seen_ids[sid] = index
+        _validate_crosswalk_row(row, index, sid, errors)
+
+    return errors
+
+
+def _validate_crosswalk_row(
+    row: Mapping[str, Any],
+    index: int,
+    sid: object,
+    errors: list[str],
+) -> None:
+    """Append semantic-validation errors for a single crosswalk row."""
+    if not row.get("source_config_hash"):
+        errors.append(f"rows[{index}] ({sid}): empty source_config_hash")
+
+    pred = row.get("predicate_availability")
+    if isinstance(pred, Mapping):
+        for rec in pred.get("exported_predicates", []) or []:
+            version = rec.get("schema_version")
+            if version is not None and version not in KNOWN_PREDICATE_SCHEMAS.values():
+                errors.append(
+                    f"rows[{index}] ({sid}): unknown predicate schema_version {version!r}"
+                )
+
+    evidence = row.get("evidence")
+    if isinstance(evidence, Mapping):
+        if evidence.get("eligibility") != "eligible" and not evidence.get("exclusion_reason"):
+            errors.append(f"rows[{index}] ({sid}): non-eligible evidence missing exclusion_reason")
+        if evidence.get("validated_mechanism") is not None:
+            errors.append(
+                f"rows[{index}] ({sid}): validated_mechanism must not be set in crosswalk"
+            )
+
+
+def json_pointer(parts: Sequence[Any]) -> str:
+    """Render a JSON-path list as a slash-prefixed pointer (or '' for root).
+
+    Returns:
+        The RFC6901 JSON pointer string, or ``""`` for the root path.
+    """
+    return _render_json_pointer(parts)
+
+
+def crosswalk_markdown(crosswalk: Mapping[str, Any]) -> str:
+    """Render a compact Markdown coverage report for the crosswalk.
+
+    Returns:
+        Markdown report body.
+    """
+    summary = crosswalk.get("summary", {})
+    lines = [
+        "# Scenario-Evidence Crosswalk",
+        "",
+        f"- Source: `{crosswalk.get('source', '')}`",
+        f"- Schema: `{crosswalk.get('schema_version', SCHEMA_VERSION)}`",
+        f"- Repo commit: `{crosswalk.get('repo_commit', 'unknown')}`",
+        f"- Content SHA-256: `{crosswalk.get('content_sha256', '')}`",
+        "",
+        "## Summary",
+        "",
+        f"- Scenarios: {int(summary.get('scenario_count', 0))}",
+        f"- Eligible (evidence): {int(summary.get('eligible_scenarios', 0))}",
+        f"- Excluded (evidence): {int(summary.get('excluded_scenarios', 0))}",
+        f"- Predicate export available: {int(summary.get('predicate_export_available', 0))}",
+        f"- Predicate unavailable: {int(summary.get('predicate_unavailable', 0))}",
+        "",
+        "## Rows",
+        "",
+        "| Scenario | Family | Geometry (descriptive) | Interaction | Predicate export | Evidence |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in crosswalk.get("rows", []) or []:
+        pred = row.get("predicate_availability", {})
+        pred_status = pred.get("export_status", "unknown")
+        evidence = row.get("evidence", {})
+        eligibility = evidence.get("eligibility", "unknown")
+        lines.append(
+            "| "
+            f"{row.get('scenario_id', '')} | "
+            f"{row.get('scenario_family', '')} | "
+            f"{row.get('geometry_group', '')} | "
+            f"{row.get('interaction_class', '')} | "
+            f"{pred_status} | "
+            f"{eligibility} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_scenario_evidence_crosswalk(
+    crosswalk: Mapping[str, Any],
+    *,
+    json_path: Path | None = None,
+    markdown_path: Path | None = None,
+    csv_path: Path | None = None,
+) -> None:
+    """Write crosswalk artifacts (JSON, Markdown, CSV) when paths are given."""
+    if json_path is not None:
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(
+            json.dumps(crosswalk, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    if markdown_path is not None:
+        markdown_path.parent.mkdir(parents=True, exist_ok=True)
+        markdown_path.write_text(crosswalk_markdown(crosswalk), encoding="utf-8")
+    if csv_path is not None:
+        csv_path.parent.mkdir(parents=True, exist_ok=True)
+        with csv_path.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.writer(handle)
+            writer.writerow(
+                [
+                    "scenario_id",
+                    "source_config_hash",
+                    "scenario_family",
+                    "interaction_class",
+                    "geometry_group",
+                    "geometry_group_provenance",
+                    "hazard_tags",
+                    "predicate_export_status",
+                    "evidence_eligibility",
+                    "exclusion_reason",
+                    "validated_mechanism",
+                    "trace_ids",
+                    "replay_ids",
+                ]
+            )
+            for row in crosswalk.get("rows", []) or []:
+                pred = row.get("predicate_availability", {})
+                evidence = row.get("evidence", {})
+                writer.writerow(
+                    [
+                        row.get("scenario_id", ""),
+                        row.get("source_config_hash", ""),
+                        row.get("scenario_family", ""),
+                        row.get("interaction_class", ""),
+                        row.get("geometry_group", ""),
+                        row.get("geometry_group_provenance", ""),
+                        ";".join(row.get("hazard_tags", []) or []),
+                        pred.get("export_status", ""),
+                        evidence.get("eligibility", ""),
+                        evidence.get("exclusion_reason") or "",
+                        evidence.get("validated_mechanism") or "",
+                        ";".join(evidence.get("trace_ids", []) or []),
+                        ";".join(evidence.get("replay_ids", []) or []),
+                    ]
+                )
+
+
+__all__ = [
+    "KNOWN_PREDICATE_SCHEMAS",
+    "PREDICATE_EXPORT_SCHEMA_VERSION",
+    "SCHEMA_VERSION",
+    "ScenarioEvidenceCrosswalkError",
+    "build_scenario_evidence_crosswalk",
+    "crosswalk_markdown",
+    "json_pointer",
+    "validate_scenario_evidence_crosswalk",
+    "write_scenario_evidence_crosswalk",
+]

--- a/robot_sf/benchmark/scenario_evidence_crosswalk.py
+++ b/robot_sf/benchmark/scenario_evidence_crosswalk.py
@@ -53,6 +53,7 @@ PREDICATE_EXPORT_SCHEMA_VERSION = "trace_predicate_export.v1"
 
 EXCLUSION_REASON_PREDICATE_UNAVAILABLE = "predicate_export_unavailable"
 EXCLUSION_REASON_NO_EVIDENCE_BUNDLE = "no_evidence_bundle_provided"
+EXCLUSION_REASON_UNREADABLE_EPISODE_ARTIFACT = "unreadable_episode_artifact"
 
 SCHEMA_FILE = Path(__file__).with_name("schemas") / "scenario_evidence_crosswalk.v1.json"
 
@@ -190,11 +191,18 @@ def _source_config_hash(scenario: Mapping[str, Any]) -> str:
     return _config_hash(dict(scenario))
 
 
+def _strict_int(value: Any) -> int | None:
+    """Return an integer seed only when the input is exactly an integer."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
 def _seeds(scenario: Mapping[str, Any]) -> list[int]:
     """Return the deterministic seed list for a scenario."""
     raw = scenario.get("seeds")
     if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes)):
-        seeds = [int(s) for s in raw if isinstance(s, (int, float))]
+        seeds = [seed for value in raw if (seed := _strict_int(value)) is not None]
         if seeds:
             return seeds
     return []
@@ -405,14 +413,69 @@ def _resolve_evidence_ids(
         resolved[field] = [str(v) for v in values]
 
     if artifact_root is not None:
+        trusted_root = _trusted_artifact_root(scenario_id, artifact_root)
         for field, ids in resolved.items():
             for ref in ids:
-                if not (artifact_root / ref).exists():
-                    raise ScenarioEvidenceCrosswalkError(
-                        f"scenario {scenario_id}: {field} references missing artifact {ref!r} "
-                        f"(broken artifact reference)"
-                    )
+                _validate_artifact_reference(
+                    scenario_id,
+                    field,
+                    ref,
+                    artifact_root=artifact_root,
+                    trusted_root=trusted_root,
+                )
     return resolved
+
+
+def _trusted_artifact_root(scenario_id: str, artifact_root: Path) -> Path:
+    """Resolve the trusted artifact root or raise a structured blocker.
+
+    Returns:
+        The resolved trusted artifact root.
+    """
+    try:
+        return artifact_root.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise ScenarioEvidenceCrosswalkError(
+            f"scenario {scenario_id}: {EXCLUSION_REASON_UNREADABLE_EPISODE_ARTIFACT} "
+            f"(broken artifact reference): trusted root {str(artifact_root)!r} is unreadable"
+        ) from exc
+
+
+def _validate_artifact_reference(
+    scenario_id: str,
+    field: str,
+    ref: str,
+    *,
+    artifact_root: Path,
+    trusted_root: Path,
+) -> None:
+    """Reject unsafe artifact references before they can be consumed."""
+    ref_path = Path(ref)
+    reason: str | None = None
+    if ref_path.is_absolute() or ".." in ref_path.parts:
+        reason = "absolute or parent traversal"
+    else:
+        candidate = artifact_root / ref_path
+        current = artifact_root
+        try:
+            for part in ref_path.parts:
+                current /= part
+                if current.is_symlink():
+                    reason = "symlink component"
+                    break
+            resolved_candidate = candidate.resolve(strict=False)
+        except (OSError, RuntimeError):
+            reason = reason or "path resolution failed"
+        else:
+            if reason is None and not resolved_candidate.is_relative_to(trusted_root):
+                reason = "outside trusted root"
+            if reason is None and not resolved_candidate.is_file():
+                reason = "not a regular file"
+    if reason is not None:
+        raise ScenarioEvidenceCrosswalkError(
+            f"scenario {scenario_id}: {EXCLUSION_REASON_UNREADABLE_EPISODE_ARTIFACT} "
+            f"(broken artifact reference) for {field} {ref!r}: {reason}"
+        )
 
 
 def build_scenario_evidence_crosswalk(
@@ -699,6 +762,8 @@ def write_scenario_evidence_crosswalk(
                     "validated_mechanism",
                     "trace_ids",
                     "replay_ids",
+                    "generated_candidate_ids",
+                    "case_capsule_ids",
                 ]
             )
             for row in crosswalk.get("rows", []) or []:
@@ -719,6 +784,8 @@ def write_scenario_evidence_crosswalk(
                         evidence.get("validated_mechanism") or "",
                         ";".join(evidence.get("trace_ids", []) or []),
                         ";".join(evidence.get("replay_ids", []) or []),
+                        ";".join(evidence.get("generated_candidate_ids", []) or []),
+                        ";".join(evidence.get("case_capsule_ids", []) or []),
                     ]
                 )
 

--- a/robot_sf/benchmark/schemas/scenario_evidence_crosswalk.v1.json
+++ b/robot_sf/benchmark/schemas/scenario_evidence_crosswalk.v1.json
@@ -1,0 +1,297 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/robot-sf/scenario_evidence_crosswalk.v1.json",
+  "title": "RobotSF Scenario-Evidence Crosswalk (v1)",
+  "description": "Deterministic join of scenario taxonomy, predicate availability, and evidence/replay eligibility. Benchmark-evidence metadata only: geometry groups are descriptive and never imply a causal mechanism; validated mechanisms are supplied by a validated causal report and must be null here.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "source",
+    "generated_at_utc",
+    "repo_commit",
+    "claim_boundary",
+    "predicate_export_consumed",
+    "evidence_catalog_consumed",
+    "summary",
+    "content_sha256",
+    "rows"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "scenario_evidence_crosswalk.v1"
+    },
+    "source": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at_utc": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repo_commit": {
+      "type": "string",
+      "minLength": 1
+    },
+    "claim_boundary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "predicate_export_consumed": {
+      "type": "boolean"
+    },
+    "evidence_catalog_consumed": {
+      "type": "boolean"
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scenario_count",
+        "eligible_scenarios",
+        "excluded_scenarios",
+        "predicate_export_available",
+        "predicate_unavailable"
+      ],
+      "properties": {
+        "scenario_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "eligible_scenarios": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "excluded_scenarios": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "predicate_export_available": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "predicate_unavailable": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "content_sha256": {
+      "type": "string",
+      "minLength": 64,
+      "maxLength": 64,
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "rows": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/crosswalk_row"
+      }
+    }
+  },
+  "$defs": {
+    "string_or_null": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "optional_string_list": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "predicate_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "predicate",
+        "schema_version"
+      ],
+      "properties": {
+        "predicate": {
+          "type": "string",
+          "minLength": 1
+        },
+        "schema_version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "minLength": 1
+        },
+        "motivated_by": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "predicate_availability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "export_status",
+        "exported_predicates",
+        "missing_or_degraded_predicates",
+        "motivated_not_exported_predicates"
+      ],
+      "properties": {
+        "export_status": {
+          "type": "string",
+          "enum": [
+            "available",
+            "unavailable"
+          ]
+        },
+        "export_status_reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "exported_predicates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/predicate_record"
+          }
+        },
+        "missing_or_degraded_predicates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/predicate_record"
+          }
+        },
+        "motivated_not_exported_predicates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/predicate_record"
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "eligibility",
+        "validated_mechanism",
+        "validated_mechanism_provenance",
+        "trace_ids",
+        "replay_ids",
+        "generated_candidate_ids",
+        "case_capsule_ids"
+      ],
+      "properties": {
+        "eligibility": {
+          "type": "string",
+          "enum": [
+            "eligible",
+            "excluded",
+            "degraded",
+            "unavailable"
+          ]
+        },
+        "exclusion_reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "validated_mechanism": {
+          "const": null
+        },
+        "validated_mechanism_provenance": {
+          "const": null
+        },
+        "trace_ids": {
+          "$ref": "#/$defs/optional_string_list"
+        },
+        "replay_ids": {
+          "$ref": "#/$defs/optional_string_list"
+        },
+        "generated_candidate_ids": {
+          "$ref": "#/$defs/optional_string_list"
+        },
+        "case_capsule_ids": {
+          "$ref": "#/$defs/optional_string_list"
+        }
+      }
+    },
+    "crosswalk_row": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scenario_id",
+        "source_config_hash",
+        "scenario_family",
+        "interaction_class",
+        "map_id",
+        "geometry_group",
+        "geometry_group_provenance",
+        "geometry_group_note",
+        "hazard_tags",
+        "hazard_tag_source",
+        "seeds",
+        "predicate_availability",
+        "evidence"
+      ],
+      "properties": {
+        "scenario_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_config_hash": {
+          "type": "string",
+          "minLength": 1
+        },
+        "scenario_family": {
+          "type": "string",
+          "minLength": 1
+        },
+        "interaction_class": {
+          "type": "string",
+          "minLength": 1
+        },
+        "map_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "geometry_group": {
+          "type": "string",
+          "minLength": 1
+        },
+        "geometry_group_provenance": {
+          "type": "string",
+          "minLength": 1
+        },
+        "geometry_group_note": {
+          "type": "string",
+          "minLength": 1
+        },
+        "hazard_tags": {
+          "$ref": "#/$defs/optional_string_list"
+        },
+        "hazard_tag_source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "seeds": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "predicate_availability": {
+          "$ref": "#/$defs/predicate_availability"
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        }
+      }
+    }
+  }
+}

--- a/scripts/tools/export_scenario_evidence_crosswalk.py
+++ b/scripts/tools/export_scenario_evidence_crosswalk.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Export a versioned scenario-evidence crosswalk for coverage and exemplar selection.
+
+Joins canonical scenario taxonomy, #5593 predicate-export availability, and an
+optional evidence/eligibility catalog into one deterministic
+``scenario_evidence_crosswalk.v1`` artifact plus a compact Markdown coverage
+report and a CSV summary.
+
+Consumes #5593's predicate export when available; until that lane lands,
+predicate fields are explicit ``unavailable`` (never inferred from motivation
+text). Geometry groups and validated mechanisms are emitted as separate fields
+with separate provenance -- geometry never implies a causal mechanism.
+
+Usage:
+    python scripts/tools/export_scenario_evidence_crosswalk.py \
+        configs/scenarios/nominal_v1.yaml \
+        --output-json output/crosswalk.json \
+        --output-markdown output/crosswalk.md \
+        --output-csv output/crosswalk.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.benchmark.scenario_evidence_crosswalk import (
+    SCHEMA_VERSION,
+    build_scenario_evidence_crosswalk,
+    validate_scenario_evidence_crosswalk,
+    write_scenario_evidence_crosswalk,
+)
+from robot_sf.training.scenario_loader import load_scenarios
+from robot_sf.training.task_bundles import is_task_bundle_reference
+
+
+def load_scenario_matrix(path: str | Path) -> list[dict]:
+    """Load scenario rows without importing benchmark runtime planners."""
+    import yaml
+
+    scenario_path = Path(path)
+    if is_task_bundle_reference(scenario_path):
+        return [dict(scenario) for scenario in load_scenarios(scenario_path)]
+
+    with scenario_path.open("r", encoding="utf-8") as handle:
+        raw_docs = list(yaml.safe_load_all(handle))
+    docs = [doc for doc in raw_docs if doc is not None]
+    if not docs:
+        raise ValueError(f"Scenario matrix '{scenario_path}' is empty.")
+    if len(raw_docs) > 1:
+        invalid_docs = [
+            index for index, scenario in enumerate(docs) if not isinstance(scenario, dict)
+        ]
+        if invalid_docs:
+            raise ValueError(
+                f"Scenario matrix '{scenario_path}' contains non-object YAML documents: "
+                f"{invalid_docs}"
+            )
+        return [dict(scenario) for scenario in docs]
+    return [dict(scenario) for scenario in load_scenarios(scenario_path, base_dir=scenario_path)]
+
+
+def _load_json(path: Path | None) -> dict[str, object] | None:
+    """Load an optional JSON manifest; return ``None`` when not provided."""
+    if path is None:
+        return None
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("matrix", type=Path, help="Canonical scenario matrix YAML file.")
+    parser.add_argument("--output-json", type=Path, help="Output crosswalk JSON path.")
+    parser.add_argument("--output-markdown", type=Path, help="Output Markdown report path.")
+    parser.add_argument("--output-csv", type=Path, help="Output CSV summary path.")
+    parser.add_argument(
+        "--predicate-export",
+        type=Path,
+        help="Optional #5593 predicate-export manifest (JSON).",
+    )
+    parser.add_argument(
+        "--evidence-catalog",
+        type=Path,
+        help="Optional evidence/eligibility catalog (JSON: scenario id -> record).",
+    )
+    parser.add_argument(
+        "--artifact-root",
+        type=Path,
+        help="Optional root to fail-closed on missing referenced artifacts.",
+    )
+    parser.add_argument(
+        "--no-validate",
+        action="store_true",
+        help="Skip JSON Schema validation (not recommended).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the crosswalk export and write artifacts."""
+    args = parse_args()
+
+    scenarios = load_scenario_matrix(args.matrix)
+    predicate_export = _load_json(args.predicate_export)
+    evidence_catalog = _load_json(args.evidence_catalog)
+    artifact_root = Path(args.artifact_root) if args.artifact_root else None
+
+    crosswalk = build_scenario_evidence_crosswalk(
+        scenarios,
+        source=str(args.matrix),
+        predicate_export=predicate_export,
+        evidence_catalog=evidence_catalog,
+        artifact_root=artifact_root,
+    )
+
+    if not args.no_validate:
+        errors = validate_scenario_evidence_crosswalk(crosswalk)
+        if errors:
+            print("Crosswalk validation failed:", file=sys.stderr)
+            for error in errors:
+                print(f"  - {error}", file=sys.stderr)
+            return 1
+
+    write_scenario_evidence_crosswalk(
+        crosswalk,
+        json_path=args.output_json,
+        markdown_path=args.output_markdown,
+        csv_path=args.output_csv,
+    )
+
+    summary = crosswalk["summary"]
+    print(
+        json.dumps(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "source": crosswalk["source"],
+                "scenario_count": summary["scenario_count"],
+                "eligible_scenarios": summary["eligible_scenarios"],
+                "predicate_export_available": summary["predicate_export_available"],
+                "predicate_unavailable": summary["predicate_unavailable"],
+                "content_sha256": crosswalk["content_sha256"],
+                "output_json": str(args.output_json) if args.output_json else None,
+                "output_markdown": str(args.output_markdown) if args.output_markdown else None,
+                "output_csv": str(args.output_csv) if args.output_csv else None,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tools/export_scenario_evidence_crosswalk.py
+++ b/scripts/tools/export_scenario_evidence_crosswalk.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 from robot_sf.benchmark.scenario_evidence_crosswalk import (
     SCHEMA_VERSION,
+    ScenarioEvidenceCrosswalkError,
     build_scenario_evidence_crosswalk,
     validate_scenario_evidence_crosswalk,
     write_scenario_evidence_crosswalk,
@@ -148,33 +149,37 @@ def main() -> int:
     """Run the crosswalk export and write artifacts."""
     args = parse_args()
 
-    scenarios = load_scenario_matrix(args.matrix)
-    predicate_export = _load_json(args.predicate_export)
-    evidence_catalog = _load_json(args.evidence_catalog)
-    artifact_root = Path(args.artifact_root) if args.artifact_root else None
+    try:
+        scenarios = load_scenario_matrix(args.matrix)
+        predicate_export = _load_json(args.predicate_export)
+        evidence_catalog = _load_json(args.evidence_catalog)
+        artifact_root = Path(args.artifact_root) if args.artifact_root else None
 
-    crosswalk = build_scenario_evidence_crosswalk(
-        scenarios,
-        source=str(args.matrix),
-        predicate_export=predicate_export,
-        evidence_catalog=evidence_catalog,
-        artifact_root=artifact_root,
-    )
+        crosswalk = build_scenario_evidence_crosswalk(
+            scenarios,
+            source=str(args.matrix),
+            predicate_export=predicate_export,
+            evidence_catalog=evidence_catalog,
+            artifact_root=artifact_root,
+        )
 
-    if not args.no_validate:
-        errors = validate_scenario_evidence_crosswalk(crosswalk)
-        if errors:
-            print("Crosswalk validation failed:", file=sys.stderr)
-            for error in errors:
-                print(f"  - {error}", file=sys.stderr)
-            return 1
+        if not args.no_validate:
+            errors = validate_scenario_evidence_crosswalk(crosswalk)
+            if errors:
+                print("Crosswalk validation failed:", file=sys.stderr)
+                for error in errors:
+                    print(f"  - {error}", file=sys.stderr)
+                return 1
 
-    write_scenario_evidence_crosswalk(
-        crosswalk,
-        json_path=args.output_json,
-        markdown_path=args.output_markdown,
-        csv_path=args.output_csv,
-    )
+        write_scenario_evidence_crosswalk(
+            crosswalk,
+            json_path=args.output_json,
+            markdown_path=args.output_markdown,
+            csv_path=args.output_csv,
+        )
+    except (ScenarioEvidenceCrosswalkError, ValueError, OSError) as exc:
+        print(f"Crosswalk export failed: {exc}", file=sys.stderr)
+        return 1
 
     summary = crosswalk["summary"]
     print(

--- a/scripts/tools/export_scenario_evidence_crosswalk.py
+++ b/scripts/tools/export_scenario_evidence_crosswalk.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 
 from robot_sf.benchmark.scenario_evidence_crosswalk import (
@@ -51,7 +52,9 @@ def load_scenario_matrix(path: str | Path) -> list[dict]:
         raise ValueError(f"Scenario matrix '{scenario_path}' is empty.")
     if len(raw_docs) > 1:
         invalid_docs = [
-            index for index, scenario in enumerate(docs) if not isinstance(scenario, dict)
+            index
+            for index, scenario in enumerate(raw_docs)
+            if scenario is not None and not isinstance(scenario, Mapping)
         ]
         if invalid_docs:
             raise ValueError(
@@ -59,6 +62,48 @@ def load_scenario_matrix(path: str | Path) -> list[dict]:
                 f"{invalid_docs}"
             )
         return [dict(scenario) for scenario in docs]
+    return _load_single_document(scenario_path, docs[0])
+
+
+def _is_abstract_scenario(scenario: Mapping[str, object]) -> bool:
+    """Return whether an entry has no manifest/map-loader identity fields."""
+    return not any(key in scenario for key in ("name", "scenario_id", "map_file", "map_id"))
+
+
+def _load_single_document(scenario_path: Path, single_doc: object) -> list[dict]:
+    """Load one parsed YAML document without reparsing direct abstract matrices."""
+    if isinstance(single_doc, list):
+        if not single_doc or any(not isinstance(scenario, Mapping) for scenario in single_doc):
+            raise ValueError(
+                f"Scenario matrix '{scenario_path}' single-document lists must contain mappings."
+            )
+        if all(_is_abstract_scenario(scenario) for scenario in single_doc):
+            return [dict(scenario) for scenario in single_doc]
+    elif isinstance(single_doc, Mapping) and "scenarios" in single_doc:
+        manifest_keys = frozenset(
+            {
+                "includes",
+                "include",
+                "scenario_files",
+                "select_scenarios",
+                "scenario_overrides",
+                "scenario_overrides_by_name",
+                "map_search_paths",
+            }
+        )
+        scenario_entries = single_doc["scenarios"]
+        if (
+            not manifest_keys & single_doc.keys()
+            and isinstance(scenario_entries, list)
+            and scenario_entries
+            and all(isinstance(scenario, Mapping) for scenario in scenario_entries)
+            and all(_is_abstract_scenario(scenario) for scenario in scenario_entries)
+        ):
+            return [dict(scenario) for scenario in scenario_entries]
+    elif not isinstance(single_doc, Mapping):
+        raise ValueError(
+            f"Scenario matrix '{scenario_path}' single YAML document must be a mapping or list."
+        )
     return [dict(scenario) for scenario in load_scenarios(scenario_path, base_dir=scenario_path)]
 
 

--- a/tests/benchmark/test_scenario_evidence_crosswalk.py
+++ b/tests/benchmark/test_scenario_evidence_crosswalk.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -19,6 +20,7 @@ from robot_sf.benchmark.scenario_evidence_crosswalk import (
     write_scenario_evidence_crosswalk,
 )
 from scripts.tools.export_scenario_evidence_crosswalk import load_scenario_matrix
+from scripts.tools.export_scenario_evidence_crosswalk import main as export_main
 
 
 def _scenario(
@@ -304,6 +306,18 @@ def test_exporter_rejects_scalar_single_document(tmp_path: Path) -> None:
     matrix.write_text("just-a-scalar\n", encoding="utf-8")
     with pytest.raises(ValueError, match="mapping or list"):
         load_scenario_matrix(matrix)
+
+
+def test_exporter_reports_input_errors_without_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CLI input failures use the clean error path and nonzero status."""
+    matrix = tmp_path / "scalar.yaml"
+    matrix.write_text("just-a-scalar\n", encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["export_scenario_evidence_crosswalk.py", str(matrix)])
+
+    assert export_main() == 1
+    assert "Crosswalk export failed:" in capsys.readouterr().err
 
 
 def test_markdown_labels_geometry_as_descriptive_not_causal() -> None:

--- a/tests/benchmark/test_scenario_evidence_crosswalk.py
+++ b/tests/benchmark/test_scenario_evidence_crosswalk.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 import json
 from pathlib import Path
 
@@ -17,6 +18,7 @@ from robot_sf.benchmark.scenario_evidence_crosswalk import (
     validate_scenario_evidence_crosswalk,
     write_scenario_evidence_crosswalk,
 )
+from scripts.tools.export_scenario_evidence_crosswalk import load_scenario_matrix
 
 
 def _scenario(
@@ -177,8 +179,44 @@ def test_broken_artifact_reference_fails_closed() -> None:
             scenarios,
             source="fixture.yaml",
             evidence_catalog=evidence_catalog,
-            artifact_root=Path("/tmp/robot_sf_cw_artifacts"),
+            artifact_root=Path(__file__).resolve().parents[2] / "does-not-exist",
         )
+
+
+def test_unsafe_artifact_reference_is_structured_and_regular_file_only(tmp_path: Path) -> None:
+    """Traversal, symlinks, and directories cannot enter the trusted artifact root."""
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    (artifact_root / "episode.json").write_text("{}", encoding="utf-8")
+    (artifact_root / "subdir").mkdir()
+    (artifact_root / "subdir" / "episode.json").write_text("{}", encoding="utf-8")
+    outside = tmp_path / "outside.json"
+    outside.write_text("{}", encoding="utf-8")
+    symlink = artifact_root / "symlink.json"
+    symlink.symlink_to(outside)
+
+    for reference in ("../outside.json", str(outside), "symlink.json", "subdir"):
+        evidence_catalog = {
+            "doorway_low": {"eligibility": "eligible", "trace_ids": [reference]}
+        }
+        with pytest.raises(
+            ScenarioEvidenceCrosswalkError,
+            match="unreadable_episode_artifact",
+        ):
+            build_scenario_evidence_crosswalk(
+                [_scenario("doorway_low")],
+                source="fixture.yaml",
+                evidence_catalog=evidence_catalog,
+                artifact_root=artifact_root,
+            )
+
+
+def test_seed_coercion_accepts_only_strict_integers() -> None:
+    """Boolean, float, and string seed values are not silently coerced."""
+    crosswalk = build_scenario_evidence_crosswalk(
+        [_scenario("doorway_low", seeds=[1, True, 2.0, "3", 4])], source="fixture.yaml"
+    )
+    assert crosswalk["rows"][0]["seeds"] == [1, 4]
 
 
 def test_duplicate_scenario_ids_are_rejected() -> None:
@@ -237,6 +275,35 @@ def test_writers_emit_json_markdown_csv(tmp_path: Path) -> None:
     csv_text = csv_path.read_text(encoding="utf-8")
     assert "doorway_low" in csv_text
     assert "collision;near_miss" in csv_text
+
+
+def test_csv_preserves_generated_and_case_capsule_ids(tmp_path: Path) -> None:
+    """CSV output must retain all evidence-id fields in the versioned schema."""
+    crosswalk = build_scenario_evidence_crosswalk(
+        [_scenario("doorway_low")],
+        source="fixture.yaml",
+        evidence_catalog={
+            "doorway_low": {
+                "eligibility": "eligible",
+                "trace_ids": [],
+                "generated_candidate_ids": ["candidate_1"],
+                "case_capsule_ids": ["capsule_1"],
+            }
+        },
+    )
+    csv_path = tmp_path / "cw.csv"
+    write_scenario_evidence_crosswalk(crosswalk, csv_path=csv_path)
+    rows = list(csv.DictReader(csv_path.read_text(encoding="utf-8").splitlines()))
+    assert rows[0]["generated_candidate_ids"] == "candidate_1"
+    assert rows[0]["case_capsule_ids"] == "capsule_1"
+
+
+def test_exporter_rejects_scalar_single_document(tmp_path: Path) -> None:
+    """The exporter must reject a scalar YAML document before scenario loading."""
+    matrix = tmp_path / "scalar.yaml"
+    matrix.write_text("just-a-scalar\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="mapping or list"):
+        load_scenario_matrix(matrix)
 
 
 def test_markdown_labels_geometry_as_descriptive_not_causal() -> None:

--- a/tests/benchmark/test_scenario_evidence_crosswalk.py
+++ b/tests/benchmark/test_scenario_evidence_crosswalk.py
@@ -1,0 +1,250 @@
+"""Tests for the scenario-evidence crosswalk (issue #5602)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.scenario_evidence_crosswalk import (
+    KNOWN_PREDICATE_SCHEMAS,
+    PREDICATE_EXPORT_SCHEMA_VERSION,
+    SCHEMA_VERSION,
+    ScenarioEvidenceCrosswalkError,
+    build_scenario_evidence_crosswalk,
+    crosswalk_markdown,
+    validate_scenario_evidence_crosswalk,
+    write_scenario_evidence_crosswalk,
+)
+
+
+def _scenario(
+    name: str,
+    *,
+    scenario_family: str = "doorway",
+    geometry_group: str = "doorway",
+    interaction_class: str | None = None,
+    hazard_tags: list[str] | None = None,
+    seeds: list[int] | None = None,
+    map_id: str = "classic_doorway",
+) -> dict[str, object]:
+    """Return a compact scenario fixture for crosswalk tests."""
+    metadata: dict[str, object] = {
+        "scenario_family": scenario_family,
+        "archetype": geometry_group,
+    }
+    if interaction_class is not None:
+        metadata["interaction_class"] = interaction_class
+    if hazard_tags is not None:
+        metadata["expected_failure_modes"] = hazard_tags
+    return {
+        "name": name,
+        "map_id": map_id,
+        "metadata": metadata,
+        "seeds": seeds if seeds is not None else [1, 2, 3],
+    }
+
+
+def test_crosswalk_schema_version_and_one_row_per_scenario() -> None:
+    """Exactly one row per canonical scenario, with stable schema version."""
+    scenarios = [
+        _scenario("doorway_low", scenario_family="doorway", geometry_group="doorway"),
+        _scenario("bottleneck_low", scenario_family="bottleneck", geometry_group="bottleneck"),
+    ]
+
+    crosswalk = build_scenario_evidence_crosswalk(scenarios, source="fixture.yaml")
+
+    assert crosswalk["schema_version"] == SCHEMA_VERSION
+    assert crosswalk["summary"]["scenario_count"] == 2
+    assert [r["scenario_id"] for r in crosswalk["rows"]] == [
+        "bottleneck_low",
+        "doorway_low",
+    ]
+    errors = validate_scenario_evidence_crosswalk(crosswalk)
+    assert errors == []
+
+
+def test_predicate_fields_unavailable_when_export_absent() -> None:
+    """Without #5593 export, predicate fields are explicit unavailable, not inferred."""
+    scenarios = [_scenario("doorway_low")]
+
+    crosswalk = build_scenario_evidence_crosswalk(scenarios, source="fixture.yaml")
+    pred = crosswalk["rows"][0]["predicate_availability"]
+
+    assert pred["export_status"] == "unavailable"
+    assert pred["export_status_reason"] == "predicate_export_unavailable"
+    assert pred["exported_predicates"] == []
+    motivated = {m["predicate"] for m in pred["motivated_not_exported_predicates"]}
+    assert motivated == set(KNOWN_PREDICATE_SCHEMAS)
+
+
+def test_predicate_export_is_consumed_when_present() -> None:
+    """A supplied #5593 export populates exported predicates and drops motivated-only."""
+    scenarios = [_scenario("doorway_low")]
+    export = {
+        "schema_version": PREDICATE_EXPORT_SCHEMA_VERSION,
+        "rows": [
+            {
+                "scenario_id": "doorway_low",
+                "predicates": [
+                    {
+                        "predicate": "oscillatory_control",
+                        "schema_version": KNOWN_PREDICATE_SCHEMAS["oscillatory_control"],
+                        "status": "ok",
+                    }
+                ],
+            }
+        ],
+    }
+
+    crosswalk = build_scenario_evidence_crosswalk(
+        scenarios, source="fixture.yaml", predicate_export=export
+    )
+    row = crosswalk["rows"][0]
+    assert row["predicate_availability"]["export_status"] == "available"
+    assert {p["predicate"] for p in row["predicate_availability"]["exported_predicates"]} == {
+        "oscillatory_control"
+    }
+    motivated = {
+        m["predicate"] for m in row["predicate_availability"]["motivated_not_exported_predicates"]
+    }
+    assert "oscillatory_control" not in motivated
+
+
+def test_geometry_group_and_validated_mechanism_are_separate_fields() -> None:
+    """Geometry group is a descriptive label; validated_mechanism stays null in crosswalk."""
+    scenarios = [_scenario("doorway_low", geometry_group="doorway_geometry")]
+    evidence_catalog = {
+        "doorway_low": {
+            "eligibility": "eligible",
+            "trace_ids": ["trace_1"],
+            "replay_ids": ["replay_1"],
+        }
+    }
+
+    crosswalk = build_scenario_evidence_crosswalk(
+        scenarios, source="fixture.yaml", evidence_catalog=evidence_catalog
+    )
+    row = crosswalk["rows"][0]
+    assert row["geometry_group"] == "doorway_geometry"
+    assert row["geometry_group_provenance"] == "config_metadata"
+    assert row["evidence"]["validated_mechanism"] is None
+    assert row["evidence"]["validated_mechanism_provenance"] is None
+    assert row["evidence"]["trace_ids"] == ["trace_1"]
+    assert row["evidence"]["eligibility"] == "eligible"
+
+
+def test_non_eligible_evidence_requires_exclusion_reason() -> None:
+    """Fail closed: a non-eligible evidence entry without a reason is rejected."""
+    scenarios = [_scenario("doorway_low")]
+    evidence_catalog = {"doorway_low": {"eligibility": "excluded", "trace_ids": []}}
+
+    with pytest.raises(ScenarioEvidenceCrosswalkError, match="exclusion_reason"):
+        build_scenario_evidence_crosswalk(
+            scenarios, source="fixture.yaml", evidence_catalog=evidence_catalog
+        )
+
+
+def test_validated_mechanism_must_not_be_supplied_by_crosswalk() -> None:
+    """Crosswalk must not encode a mechanism; such input is rejected."""
+    scenarios = [_scenario("doorway_low")]
+    evidence_catalog = {
+        "doorway_low": {
+            "eligibility": "eligible",
+            "validated_mechanism": "static_deadlock_or_local_minimum",
+        }
+    }
+
+    with pytest.raises(ScenarioEvidenceCrosswalkError, match="validated_mechanism"):
+        build_scenario_evidence_crosswalk(
+            scenarios, source="fixture.yaml", evidence_catalog=evidence_catalog
+        )
+
+
+def test_broken_artifact_reference_fails_closed() -> None:
+    """Referenced evidence artifacts that are missing raise rather than pass."""
+    scenarios = [_scenario("doorway_low")]
+    evidence_catalog = {
+        "doorway_low": {
+            "eligibility": "eligible",
+            "trace_ids": ["does_not_exist.jsonl"],
+        }
+    }
+
+    with pytest.raises(ScenarioEvidenceCrosswalkError, match="broken artifact reference"):
+        build_scenario_evidence_crosswalk(
+            scenarios,
+            source="fixture.yaml",
+            evidence_catalog=evidence_catalog,
+            artifact_root=Path("/tmp/robot_sf_cw_artifacts"),
+        )
+
+
+def test_duplicate_scenario_ids_are_rejected() -> None:
+    """Duplicate scenario ids must fail rather than produce ambiguous rows."""
+    scenarios = [_scenario("same"), _scenario("same")]
+
+    with pytest.raises(ScenarioEvidenceCrosswalkError, match="duplicate scenario id"):
+        build_scenario_evidence_crosswalk(scenarios, source="dupes.yaml")
+
+
+def test_unknown_predicate_schema_version_fails_validation() -> None:
+    """An export carrying an unrecognized predicate schema version is rejected."""
+    scenarios = [_scenario("doorway_low")]
+    export = {
+        "schema_version": PREDICATE_EXPORT_SCHEMA_VERSION,
+        "rows": [
+            {
+                "scenario_id": "doorway_low",
+                "predicates": [
+                    {
+                        "predicate": "oscillatory_control",
+                        "schema_version": "safety_predicate.oscillatory_control.v9",
+                    }
+                ],
+            }
+        ],
+    }
+
+    with pytest.raises(ScenarioEvidenceCrosswalkError, match="unknown predicate schema version"):
+        build_scenario_evidence_crosswalk(scenarios, source="fixture.yaml", predicate_export=export)
+
+
+def test_output_is_deterministic_checksum_identical() -> None:
+    """Same inputs produce checksum-identical content JSON."""
+    scenarios = [_scenario("doorway_low"), _scenario("bottleneck_low")]
+
+    first = build_scenario_evidence_crosswalk(scenarios, source="fixture.yaml")
+    second = build_scenario_evidence_crosswalk(scenarios, source="fixture.yaml")
+    assert first["content_sha256"] == second["content_sha256"]
+
+
+def test_writers_emit_json_markdown_csv(tmp_path: Path) -> None:
+    """JSON, Markdown, and CSV artifacts are written and pass validation."""
+    scenarios = [_scenario("doorway_low", hazard_tags=["near_miss", "collision"])]
+    crosswalk = build_scenario_evidence_crosswalk(scenarios, source="fixture.yaml")
+
+    json_path = tmp_path / "cw.json"
+    md_path = tmp_path / "cw.md"
+    csv_path = tmp_path / "cw.csv"
+    write_scenario_evidence_crosswalk(
+        crosswalk, json_path=json_path, markdown_path=md_path, csv_path=csv_path
+    )
+
+    assert json.loads(json_path.read_text(encoding="utf-8"))["schema_version"] == SCHEMA_VERSION
+    assert "Scenario-Evidence Crosswalk" in md_path.read_text(encoding="utf-8")
+    csv_text = csv_path.read_text(encoding="utf-8")
+    assert "doorway_low" in csv_text
+    assert "collision;near_miss" in csv_text
+
+
+def test_markdown_labels_geometry_as_descriptive_not_causal() -> None:
+    """The report must separate geometry (descriptive) from evidence eligibility."""
+    scenarios = [_scenario("doorway_low")]
+    crosswalk = build_scenario_evidence_crosswalk(scenarios, source="fixture.yaml")
+    md = crosswalk_markdown(crosswalk)
+
+    assert "Geometry (descriptive)" in md
+    assert "Evidence" in md
+    assert "doorway_low" in md

--- a/tests/benchmark/test_scenario_evidence_crosswalk.py
+++ b/tests/benchmark/test_scenario_evidence_crosswalk.py
@@ -198,9 +198,7 @@ def test_unsafe_artifact_reference_is_structured_and_regular_file_only(tmp_path:
     symlink.symlink_to(outside)
 
     for reference in ("../outside.json", str(outside), "symlink.json", "subdir"):
-        evidence_catalog = {
-            "doorway_low": {"eligibility": "eligible", "trace_ids": [reference]}
-        }
+        evidence_catalog = {"doorway_low": {"eligibility": "eligible", "trace_ids": [reference]}}
         with pytest.raises(
             ScenarioEvidenceCrosswalkError,
             match="unreadable_episode_artifact",


### PR DESCRIPTION
## What / Why

Implements the full `scenario_evidence_crosswalk.v1` as specified in #5602: a versioned, deterministic join that maps every canonical release scenario/cell to its taxonomy, geometry group, predicate availability, and evidence eligibility — all in one machine-readable artifact.

Downstream benchmark reports and exemplar selectors can query this single artifact instead of reconstructing taxonomy and predicate availability from multiple manifests.

### Key contract rules enforced

1. **Geometry groups are descriptive only** — labelled `(geometry_only)` when they match the family; never imply a causal mechanism.
2. **Predicate fields are explicit `unavailable`** until #5593 predicate-export lane lands; taxonomy-motivated predicates are listed as `motivated_not_exported` (never inferred from motivation text).
3. **Validated mechanisms must be null** in crosswalk; the crosswalk does not encode causal claims.
4. **Non-eligible evidence requires an exclusion reason**; broken artifact references fail closed.
5. **Deterministic output**: same inputs produce checksum-identical JSON.

### Files changed

- `robot_sf/benchmark/schemas/scenario_evidence_crosswalk.v1.json` — JSON Schema defining the v1 crosswalk artifact
- `robot_sf/benchmark/scenario_evidence_crosswalk.py` — core module: builder, validator, Markdown report, CSV/JSON writers
- `scripts/tools/export_scenario_evidence_crosswalk.py` — deterministic export CLI
- `tests/benchmark/test_scenario_evidence_crosswalk.py` — 12 fixture-backed tests

### Validation output

```
uv run ruff check robot_sf/benchmark scripts/tools tests/benchmark tests/tools
All checks passed!

uv run pytest -q tests/benchmark/test_scenario_evidence_crosswalk.py -v
12 passed in 1.05s

uv run python scripts/tools/export_scenario_evidence_crosswalk.py --help
(help output shown; CLI works)

uv run python scripts/tools/export_scenario_evidence_crosswalk.py \
    configs/scenarios/classic_interactions_francis2023.yaml \
    --output-json output/crosswalk.json \
    --output-markdown output/crosswalk.md \
    --output-csv output/crosswalk.csv
scenario_count=48, eligible=0, predicate_export_available=0, predicate_unavailable=48

git diff --check
(no whitespace errors)
```

### End-to-end test (real scenario matrix, 48 canonical scenarios)

```
$ uv run python scripts/tools/export_scenario_evidence_crosswalk.py \
    configs/scenarios/classic_interactions_francis2023.yaml \
    --output-json output/5602-tests/crosswalk.json

Output: schema_version=scenario_evidence_crosswalk.v1, 48 rows
- scenario_family: bottleneck, cross_trap, doorway, overtaking, t_intersection, etc.
- geometry_group: correctly labelled with (geometry_only) provenance
- predicate_availability: all unavailable (no #5593 export), with motivated_not_exported list
- evidence: all excluded (no evidence catalog), with explicit exclusion_reason
- content_sha256: deterministic

See output/5602-tests/ for the JSON, Markdown, and CSV artifacts.
```

### Notes

- Predicate fields are `unavailable` because #5593 is not yet merged (per issue stop rule: "predicate fields must be explicit `unavailable`, never inferred from motivation text.") — the export_cli accepts `--predicate-export` and will consume #5593 output automatically when available.
- No new predicate computation, campaign execution, causal labels, or private claims.
- No downstream benchmark runs; CPU-level validation only.

Closes #5602

This PR was produced by the Pi-harness/SAIA-DeepSeek-v4-Flash cheap implementation lane; the review gate hardens and merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a versioned scenario-to-evidence crosswalk builder with deterministic `schema_version`/`content_sha256`.
  * Produces scenario rows with explicit predicate-availability and fail-closed evidence eligibility semantics.
  * Supports generating JSON plus optional Markdown and CSV reports.
  * Introduced a CLI exporter that loads scenario matrices/manifests, validates outputs (unless disabled), and prints summary stats.
* **Documentation**
  * Added a JSON Schema (`scenario_evidence_crosswalk.v1`) defining the crosswalk format and validation rules.
* **Tests**
  * Added end-to-end tests for determinism, ordering, predicate/evidence rules, validation failures, artifact-root safety, and writer/CLI integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->