### PR TITLE
feat(benchmark): gate Package B confirmed failures (#3079)

### DIFF
--- a/robot_sf/benchmark/adversarial_package_b_confirmation.py
+++ b/robot_sf/benchmark/adversarial_package_b_confirmation.py
@@ -1,0 +1,881 @@
+"""Fail-closed validation for Package B confirmed-failure evidence.
+
+The Package B report gate validates matrix shape and row arithmetic. This
+second gate validates the stronger discovery boundary from issue #3079:
+certification, deterministic replay, independent-seed confirmation, and stable
+failure-mechanism attribution must all be present before a failure is counted
+as confirmed. It consumes post-run JSON artifacts and never executes a
+campaign or promotes benchmark evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.adversarial_package_b_report import (
+    EXPECTED_BUDGETS,
+    EXPECTED_CLAIM_SCOPE,
+    EXPECTED_SAMPLERS,
+    EXPECTED_SEEDS,
+    REPORT_SCHEMA_VERSION,
+    validate_package_b_report,
+)
+
+SCHEMA_VERSION = "adversarial-package-b-confirmation.v1"
+EXPECTED_ISSUE = 3079
+EXPECTED_ROW_COUNT = len(EXPECTED_BUDGETS) * len(EXPECTED_SEEDS) * len(EXPECTED_SAMPLERS)
+_CONFIRMABLE_FAILURES = frozenset(
+    {"collision", "timeout", "near_miss", "comfort_violation", "incomplete"}
+)
+_REQUIRED_ROW_FIELDS = frozenset(
+    {
+        "sampler",
+        "budget",
+        "seed",
+        "confirmation_status",
+        "certified_failure_count",
+        "confirmed_failure_count",
+        "unconfirmed_certified_failure_count",
+        "time_to_first_confirmed_failure_s",
+        "time_to_first_confirmed_failure_censored",
+        "simulator_seconds",
+        "simulator_seconds_per_confirmed_failure",
+        "evidence",
+    }
+)
+
+
+@dataclass(frozen=True)
+class PackageBConfirmationGate:
+    """Validation result for one Package B confirmation sidecar."""
+
+    report_path: str
+    confirmation_path: str
+    ready: bool
+    status: str
+    errors: tuple[str, ...]
+    blockers: dict[str, tuple[str, ...]]
+    matrix: dict[str, Any]
+    next_empirical_action: str
+    source_report_sha256: str | None
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a stable JSON payload for review and downstream checks."""
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "issue": EXPECTED_ISSUE,
+            "report_path": self.report_path,
+            "confirmation_path": self.confirmation_path,
+            "source_report_sha256": self.source_report_sha256,
+            "ready": self.ready,
+            "status": self.status,
+            "errors": list(self.errors),
+            "blockers": {key: list(value) for key, value in self.blockers.items()},
+            "matrix": self.matrix,
+            "next_empirical_action": self.next_empirical_action,
+            "claim_boundary": (
+                "diagnostic-only confirmation-chain validation; this gate does not promote "
+                "benchmark, paper, or dissertation evidence"
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class _StageValidationContext:
+    """Shared context for one candidate's confirmation-stage checks."""
+
+    prefix: str
+    candidate_index: int
+    report_path: Path
+    artifact_root: Path | None
+    errors: list[str]
+
+
+def validate_package_b_confirmation(
+    report_path: Path,
+    confirmation_path: Path,
+    *,
+    artifact_root: Path | None = None,
+) -> PackageBConfirmationGate:
+    """Validate confirmed-failure evidence against one Package B report.
+
+    The confirmation sidecar must account for every certified failure candidate
+    in every report row. A candidate may be explicitly ``not_confirmed`` and is
+    then excluded from confirmed-failure metrics; silently dropping it is a
+    contract error. Confirmed candidates must reference existing replay,
+    independent-seed, and attribution artifacts.
+
+    Returns:
+        A diagnostic-only gate result. ``ready`` means the sidecar is
+        structurally complete and all referenced artifacts exist; it does not
+        mean the underlying campaign result is benchmark evidence.
+    """
+    base_gate = validate_package_b_report(report_path)
+    report_payload, report_errors = _load_mapping(report_path)
+    confirmation_payload, confirmation_errors = _load_mapping(confirmation_path)
+    errors = list(report_errors) + list(confirmation_errors)
+    if not base_gate.ready:
+        errors.append(f"base Package B report gate is not ready: {base_gate.status}")
+        errors.extend(f"base report: {error}" for error in base_gate.errors)
+
+    source_report_sha256 = _sha256(report_path)
+    _validate_header(
+        confirmation_payload,
+        source_report_sha256=source_report_sha256,
+        errors=errors,
+    )
+
+    base_rows = _index_rows(report_payload.get("rows"), label="base report", errors=errors)
+    row_count, observed_keys, confirmed_count, unconfirmed_count, censored_rows = (
+        _validate_confirmation_rows(
+            confirmation_payload.get("rows"),
+            base_rows=base_rows,
+            report_path=report_path,
+            artifact_root=artifact_root,
+            errors=errors,
+        )
+    )
+
+    expected_keys = {
+        (sampler, budget, seed)
+        for sampler in EXPECTED_SAMPLERS
+        for budget in EXPECTED_BUDGETS
+        for seed in EXPECTED_SEEDS
+    }
+    missing_keys = sorted(expected_keys - observed_keys)
+    if missing_keys:
+        errors.append(f"confirmation rows missing Package B matrix cells: {missing_keys}")
+    if row_count != EXPECTED_ROW_COUNT:
+        errors.append(f"confirmation rows must contain exactly {EXPECTED_ROW_COUNT} matrix cells")
+
+    ready = not errors
+    status = "ready_for_confirmed_failure_review" if ready else "blocked_on_confirmation_contract"
+    return PackageBConfirmationGate(
+        report_path=report_path.as_posix(),
+        confirmation_path=confirmation_path.as_posix(),
+        ready=ready,
+        status=status,
+        errors=tuple(errors),
+        blockers={
+            "remaining": (
+                "The exact Package B campaign and durable artifact review remain external to "
+                "this CPU-only checker.",
+            ),
+            "new": tuple(errors),
+            "intentional": (
+                "not_confirmed candidates are excluded from confirmed-failure counts",
+                "held-out-family yield remains subject to the narrow certified-archive caveat",
+                "learned failure proposal #2921 remains out of scope",
+                "paper-facing and dissertation claims remain forbidden",
+            ),
+        },
+        matrix={
+            "expected_row_count": EXPECTED_ROW_COUNT,
+            "observed_row_count": row_count,
+            "expected_samplers": list(EXPECTED_SAMPLERS),
+            "expected_budgets": list(EXPECTED_BUDGETS),
+            "expected_seeds": list(EXPECTED_SEEDS),
+            "confirmed_failure_count": confirmed_count,
+            "unconfirmed_certified_failure_count": unconfirmed_count,
+            "censored_row_count": censored_rows,
+        },
+        next_empirical_action=(
+            "Run the exact manifest command on an approved compute-capable path, emit one "
+            "confirmation row per report cell, then review the referenced artifacts before "
+            "interpreting any sampler difference."
+        ),
+        source_report_sha256=source_report_sha256,
+    )
+
+
+def _validate_confirmation_rows(
+    rows: Any,
+    *,
+    base_rows: dict[tuple[str, int, int], dict[str, Any]],
+    report_path: Path,
+    artifact_root: Path | None,
+    errors: list[str],
+) -> tuple[int, set[tuple[str, int, int]], int, int, int]:
+    """Validate all sidecar rows and aggregate their derived counts.
+
+    Returns:
+        ``(row_count, observed_keys, confirmed_count, unconfirmed_count,
+        censored_row_count)``.
+    """
+    if not isinstance(rows, list):
+        errors.append("confirmation rows must be a list")
+        return 0, set(), 0, 0, 0
+    observed_keys: set[tuple[str, int, int]] = set()
+    confirmed_count = 0
+    unconfirmed_count = 0
+    censored_rows = 0
+    for row_index, row in enumerate(rows):
+        result = _validate_confirmation_row(
+            row,
+            row_index=row_index,
+            base_rows=base_rows,
+            report_path=report_path,
+            artifact_root=artifact_root,
+            observed_keys=observed_keys,
+            errors=errors,
+        )
+        if result is None:
+            continue
+        row_confirmed, row_unconfirmed, row_censored = result
+        confirmed_count += row_confirmed
+        unconfirmed_count += row_unconfirmed
+        censored_rows += int(row_censored)
+    return len(rows), observed_keys, confirmed_count, unconfirmed_count, censored_rows
+
+
+def _validate_confirmation_row(
+    row: Any,
+    *,
+    row_index: int,
+    base_rows: dict[tuple[str, int, int], dict[str, Any]],
+    report_path: Path,
+    artifact_root: Path | None,
+    observed_keys: set[tuple[str, int, int]],
+    errors: list[str],
+) -> tuple[int, int, bool] | None:
+    """Validate sidecar row shape and delegate a complete row to the contract checker.
+
+    Returns:
+        Derived row counts, or ``None`` when the row cannot be associated with
+        a source-report matrix cell.
+    """
+    if not isinstance(row, dict):
+        errors.append(f"rows[{row_index}] must be a mapping")
+        return None
+    missing = sorted(_REQUIRED_ROW_FIELDS - row.keys())
+    if missing:
+        errors.append(f"rows[{row_index}] missing required fields: {missing}")
+        return None
+    key = _row_key(row)
+    if key is None:
+        errors.append(f"rows[{row_index}] has invalid sampler/budget/seed types")
+        return None
+    if key in observed_keys:
+        errors.append(f"rows[{row_index}] duplicates matrix cell {key!r}")
+    observed_keys.add(key)
+    base_row = base_rows.get(key)
+    if base_row is None:
+        errors.append(f"rows[{row_index}] does not match a base report matrix cell: {key!r}")
+        return None
+    return _validate_row(
+        row,
+        base_row=base_row,
+        row_index=row_index,
+        report_path=report_path,
+        artifact_root=artifact_root,
+        errors=errors,
+    )
+
+
+def _validate_header(
+    payload: dict[str, Any],
+    *,
+    source_report_sha256: str | None,
+    errors: list[str],
+) -> None:
+    """Validate sidecar identity and its binding to the source report."""
+    _check_equal(payload, "schema_version", SCHEMA_VERSION, errors)
+    _check_equal(payload, "issue", EXPECTED_ISSUE, errors)
+    _check_equal(payload, "source_report_schema_version", REPORT_SCHEMA_VERSION, errors)
+    _check_equal(payload, "claim_scope", EXPECTED_CLAIM_SCOPE, errors)
+    if source_report_sha256 is None:
+        errors.append("source report could not be hashed")
+    elif payload.get("source_report_sha256") != source_report_sha256:
+        errors.append("source_report_sha256 does not match the supplied report")
+
+
+def _validate_row(
+    row: dict[str, Any],
+    *,
+    base_row: dict[str, Any],
+    row_index: int,
+    report_path: Path,
+    artifact_root: Path | None,
+    errors: list[str],
+) -> tuple[int, int, bool]:
+    """Validate one sidecar row and return its derived confirmation counts.
+
+    Returns:
+        ``(confirmed_count, unconfirmed_count, is_censored)`` for the row.
+    """
+    prefix = f"rows[{row_index}]"
+    if row.get("confirmation_status") != "complete":
+        errors.append(f"{prefix}.confirmation_status must equal 'complete'")
+
+    certified_candidates = _load_certified_candidates(
+        base_row=base_row,
+        prefix=prefix,
+        report_path=report_path,
+        artifact_root=artifact_root,
+        errors=errors,
+    )
+    expected_certified_count = len(certified_candidates)
+    if expected_certified_count != base_row.get("certified_valid_failure_count"):
+        errors.append(
+            f"{prefix} manifest certified failure count {expected_certified_count} does not "
+            "match base report"
+        )
+    _check_count(row, "certified_failure_count", expected_certified_count, prefix, errors)
+
+    evidence_by_index = _index_evidence(row, prefix=prefix, errors=errors)
+    expected_indices = {index for index, _candidate in certified_candidates}
+    observed_indices = set(evidence_by_index)
+    if observed_indices != expected_indices:
+        errors.append(
+            f"{prefix}.evidence must account for certified candidate indexes "
+            f"{sorted(expected_indices)}; found {sorted(observed_indices)}"
+        )
+
+    confirmed, elapsed_values = _validate_evidence_entries(
+        certified_candidates=certified_candidates,
+        evidence_by_index=evidence_by_index,
+        prefix=prefix,
+        report_path=report_path,
+        artifact_root=artifact_root,
+        errors=errors,
+    )
+
+    _check_count(row, "confirmed_failure_count", confirmed, prefix, errors)
+    unconfirmed = expected_certified_count - confirmed
+    _check_count(row, "unconfirmed_certified_failure_count", unconfirmed, prefix, errors)
+    _validate_row_metrics(
+        row,
+        confirmed=confirmed,
+        elapsed_values=elapsed_values,
+        prefix=prefix,
+        errors=errors,
+    )
+    return confirmed, unconfirmed, not confirmed
+
+
+def _load_certified_candidates(
+    *,
+    base_row: dict[str, Any],
+    prefix: str,
+    report_path: Path,
+    artifact_root: Path | None,
+    errors: list[str],
+) -> list[tuple[int, Any]]:
+    """Load one source manifest and select its certified valid failures.
+
+    Returns:
+        One-based candidate indexes paired with their manifest payloads.
+    """
+    manifest_path = _resolve_existing_path(
+        base_row.get("manifest_path"),
+        report_path=report_path,
+        artifact_root=artifact_root,
+    )
+    if manifest_path is None:
+        errors.append(f"{prefix} base manifest_path does not resolve to an existing file")
+        return []
+    manifest, manifest_errors = _load_mapping(manifest_path)
+    errors.extend(f"{prefix} manifest: {error}" for error in manifest_errors)
+    candidates = manifest.get("candidates")
+    if not isinstance(candidates, list):
+        errors.append(f"{prefix} manifest candidates must be a list")
+        return []
+    if _is_int(base_row.get("num_candidates")) and len(candidates) != base_row["num_candidates"]:
+        errors.append(
+            f"{prefix} manifest candidate count {len(candidates)} does not match "
+            f"base report count {base_row['num_candidates']}"
+        )
+    return [
+        (index, candidate)
+        for index, candidate in enumerate(candidates, start=1)
+        if _is_certified_valid_failure(candidate)
+    ]
+
+
+def _index_evidence(
+    row: dict[str, Any],
+    *,
+    prefix: str,
+    errors: list[str],
+) -> dict[int, dict[str, Any]]:
+    """Index sidecar evidence entries by their one-based candidate index.
+
+    Returns:
+        Validly indexed evidence entries. Malformed entries are omitted after
+        recording a fail-closed error.
+    """
+    evidence = row.get("evidence")
+    if not isinstance(evidence, list):
+        errors.append(f"{prefix}.evidence must be a list")
+        return {}
+    indexed: dict[int, dict[str, Any]] = {}
+    for evidence_index, entry in enumerate(evidence):
+        if not isinstance(entry, dict):
+            errors.append(f"{prefix}.evidence[{evidence_index}] must be a mapping")
+            continue
+        candidate_index = entry.get("candidate_index")
+        if not _is_positive_int(candidate_index):
+            errors.append(f"{prefix}.evidence[{evidence_index}].candidate_index must be positive")
+            continue
+        if candidate_index in indexed:
+            errors.append(f"{prefix}.evidence duplicates candidate index {candidate_index}")
+            continue
+        indexed[candidate_index] = entry
+    return indexed
+
+
+def _validate_evidence_entries(
+    *,
+    certified_candidates: list[tuple[int, Any]],
+    evidence_by_index: dict[int, dict[str, Any]],
+    prefix: str,
+    report_path: Path,
+    artifact_root: Path | None,
+    errors: list[str],
+) -> tuple[int, list[float]]:
+    """Validate each accounted-for failure and return confirmed elapsed times.
+
+    Returns:
+        ``(confirmed_count, elapsed_seconds_for_confirmed_entries)``.
+    """
+    confirmed = 0
+    elapsed_values: list[float] = []
+    for candidate_index, candidate in certified_candidates:
+        entry = evidence_by_index.get(candidate_index)
+        if entry is None:
+            continue
+        status = entry.get("status")
+        if status == "not_confirmed":
+            if not isinstance(entry.get("reason"), str) or not entry["reason"].strip():
+                errors.append(
+                    f"{prefix}.evidence candidate {candidate_index} needs a not_confirmed reason"
+                )
+            continue
+        if status != "confirmed":
+            errors.append(
+                f"{prefix}.evidence candidate {candidate_index}.status must be confirmed or "
+                "not_confirmed"
+            )
+            continue
+        confirmed += 1
+        elapsed = _finite_number(entry.get("simulator_seconds_elapsed"))
+        if elapsed is None or elapsed < 0.0:
+            errors.append(
+                f"{prefix}.evidence candidate {candidate_index}.simulator_seconds_elapsed "
+                "must be a finite non-negative number"
+            )
+        else:
+            elapsed_values.append(elapsed)
+        _validate_confirmed_entry(
+            entry,
+            candidate=candidate,
+            candidate_index=candidate_index,
+            prefix=prefix,
+            report_path=report_path,
+            artifact_root=artifact_root,
+            errors=errors,
+        )
+    return confirmed, elapsed_values
+
+
+def _validate_row_metrics(
+    row: dict[str, Any],
+    *,
+    confirmed: int,
+    elapsed_values: list[float],
+    prefix: str,
+    errors: list[str],
+) -> None:
+    """Validate censored time-to-confirmation and simulator-time rates."""
+    total_seconds = _validated_total_seconds(row, prefix=prefix, errors=errors)
+    _validate_time_to_confirmation(
+        row,
+        confirmed=confirmed,
+        elapsed_values=elapsed_values,
+        total_seconds=total_seconds,
+        prefix=prefix,
+        errors=errors,
+    )
+    _validate_rate(
+        row,
+        confirmed=confirmed,
+        total_seconds=total_seconds,
+        prefix=prefix,
+        errors=errors,
+    )
+
+
+def _validated_total_seconds(row: dict[str, Any], *, prefix: str, errors: list[str]) -> float:
+    """Return the row's simulator-time total after a finite non-negative check."""
+    total_seconds = _finite_number(row.get("simulator_seconds"))
+    if total_seconds is not None and total_seconds >= 0.0:
+        return total_seconds
+    errors.append(f"{prefix}.simulator_seconds must be a finite non-negative number")
+    return 0.0
+
+
+def _validate_time_to_confirmation(
+    row: dict[str, Any],
+    *,
+    confirmed: int,
+    elapsed_values: list[float],
+    total_seconds: float,
+    prefix: str,
+    errors: list[str],
+) -> None:
+    """Validate the first-confirmed time and its right-censoring flag."""
+    if elapsed_values and max(elapsed_values) > total_seconds:
+        errors.append(f"{prefix} confirmation elapsed time exceeds simulator_seconds")
+    reported_time = row.get("time_to_first_confirmed_failure_s")
+    censored = row.get("time_to_first_confirmed_failure_censored")
+    if not isinstance(censored, bool):
+        errors.append(f"{prefix}.time_to_first_confirmed_failure_censored must be boolean")
+    if confirmed:
+        expected_time = min(elapsed_values) if elapsed_values else None
+        if expected_time is None or _finite_number(reported_time) is None:
+            errors.append(f"{prefix} confirmed rows need a finite first-confirmed time")
+        elif not math.isclose(float(reported_time), expected_time, rel_tol=1e-9, abs_tol=1e-9):
+            errors.append(f"{prefix}.time_to_first_confirmed_failure_s disagrees with evidence")
+        if censored is not False:
+            errors.append(f"{prefix} confirmed rows must not be censored")
+    else:
+        if reported_time is not None:
+            errors.append(f"{prefix}.time_to_first_confirmed_failure_s must be null when censored")
+        if censored is not True:
+            errors.append(f"{prefix} rows without confirmed failures must be censored")
+
+
+def _validate_rate(
+    row: dict[str, Any],
+    *,
+    confirmed: int,
+    total_seconds: float,
+    prefix: str,
+    errors: list[str],
+) -> None:
+    """Validate simulator-seconds per confirmed failure against its denominator."""
+    reported_rate = row.get("simulator_seconds_per_confirmed_failure")
+    expected_rate = total_seconds / confirmed if confirmed else None
+    if expected_rate is None:
+        if reported_rate is not None:
+            errors.append(
+                f"{prefix}.simulator_seconds_per_confirmed_failure must be null without "
+                "confirmed failures"
+            )
+    elif _finite_number(reported_rate) is None or not math.isclose(
+        float(reported_rate), expected_rate, rel_tol=1e-9, abs_tol=1e-9
+    ):
+        errors.append(
+            f"{prefix}.simulator_seconds_per_confirmed_failure disagrees with its denominator"
+        )
+
+
+def _validate_confirmed_entry(
+    entry: dict[str, Any],
+    *,
+    candidate: Any,
+    candidate_index: int,
+    prefix: str,
+    report_path: Path,
+    artifact_root: Path | None,
+    errors: list[str],
+) -> None:
+    """Validate the four-stage confirmation chain for one candidate."""
+    candidate_payload = candidate.get("candidate") if isinstance(candidate, dict) else None
+    candidate_seed = (
+        candidate_payload.get("scenario_seed") if isinstance(candidate_payload, dict) else None
+    )
+    failure_attribution = (
+        candidate.get("failure_attribution") if isinstance(candidate, dict) else None
+    )
+    primary_failure = (
+        failure_attribution.get("primary_failure")
+        if isinstance(failure_attribution, dict)
+        else None
+    )
+    if entry.get("candidate_seed") != candidate_seed:
+        errors.append(f"{prefix}.evidence candidate {candidate_index} candidate_seed drifted")
+    if entry.get("primary_failure") != primary_failure:
+        errors.append(f"{prefix}.evidence candidate {candidate_index} primary_failure drifted")
+
+    context = _StageValidationContext(
+        prefix=prefix,
+        candidate_index=candidate_index,
+        report_path=report_path,
+        artifact_root=artifact_root,
+        errors=errors,
+    )
+    _validate_stage(
+        entry,
+        stage_name="replay",
+        expected_status="passed",
+        candidate_seed=candidate_seed,
+        primary_failure=primary_failure,
+        context=context,
+    )
+    _validate_stage(
+        entry,
+        stage_name="independent_seed_confirmation",
+        expected_status="passed",
+        candidate_seed=candidate_seed,
+        primary_failure=primary_failure,
+        context=context,
+    )
+    _validate_stage(
+        entry,
+        stage_name="mechanism_attribution",
+        expected_status="stable",
+        candidate_seed=candidate_seed,
+        primary_failure=primary_failure,
+        context=context,
+    )
+
+
+def _validate_stage(
+    entry: dict[str, Any],
+    *,
+    stage_name: str,
+    expected_status: str,
+    candidate_seed: Any,
+    primary_failure: Any,
+    context: _StageValidationContext,
+) -> None:
+    """Validate one confirmation stage and its artifact reference."""
+    stage = _mapping_field(
+        entry,
+        stage_name,
+        context.prefix,
+        context.candidate_index,
+        context.errors,
+    )
+    if stage is None:
+        return
+    field_context = f"{context.prefix}.evidence candidate {context.candidate_index}.{stage_name}"
+    if stage.get("status") != expected_status:
+        context.errors.append(f"{field_context}.status must equal {expected_status!r}")
+    if stage_name == "replay" and stage.get("deterministic") is not True:
+        context.errors.append(f"{field_context}.deterministic must be true")
+    if stage_name == "independent_seed_confirmation":
+        _validate_independent_fields(
+            stage,
+            candidate_seed=candidate_seed,
+            context=field_context,
+            errors=context.errors,
+        )
+    if stage_name == "mechanism_attribution" and stage.get("primary_failure") != primary_failure:
+        context.errors.append(
+            f"{field_context}.primary_failure does not match the candidate failure"
+        )
+    _require_artifact(
+        stage.get("artifact_path"),
+        field=f"{field_context}.artifact_path",
+        report_path=context.report_path,
+        artifact_root=context.artifact_root,
+        errors=context.errors,
+    )
+
+
+def _validate_independent_fields(
+    stage: dict[str, Any],
+    *,
+    candidate_seed: Any,
+    context: str,
+    errors: list[str],
+) -> None:
+    """Validate independent-seed identity and persistence-rate fields."""
+    seeds = stage.get("seeds")
+    if (
+        not isinstance(seeds, list)
+        or len(seeds) < 2
+        or any(not _is_int(seed) for seed in seeds)
+        or len(set(seeds)) != len(seeds)
+    ):
+        errors.append(f"{context}.seeds needs two distinct integer independent seeds")
+    elif candidate_seed in seeds:
+        errors.append(f"{context}.seeds must not include the search candidate seed")
+    persistence = _finite_number(stage.get("failure_persistence_rate"))
+    if persistence is None or not 0.0 < persistence <= 1.0:
+        errors.append(f"{context}.failure_persistence_rate must be finite and in (0, 1]")
+
+
+def _is_certified_valid_failure(candidate: Any) -> bool:
+    """Return whether a manifest candidate is eligible for confirmation review."""
+    if not isinstance(candidate, dict) or candidate.get("error") is not None:
+        return False
+    certification = candidate.get("certification_status")
+    attribution = candidate.get("failure_attribution")
+    return (
+        isinstance(certification, dict)
+        and certification.get("status") == "passed"
+        and isinstance(attribution, dict)
+        and attribution.get("primary_failure") in _CONFIRMABLE_FAILURES
+    )
+
+
+def _mapping_field(
+    payload: dict[str, Any],
+    field: str,
+    prefix: str,
+    candidate_index: int,
+    errors: list[str],
+) -> dict[str, Any] | None:
+    """Read a required nested mapping and append a contextual error when absent.
+
+    Returns:
+        The nested mapping, or ``None`` after recording a contract error.
+    """
+    value = payload.get(field)
+    if not isinstance(value, dict):
+        errors.append(f"{prefix}.evidence candidate {candidate_index}.{field} must be a mapping")
+        return None
+    return value
+
+
+def _require_artifact(
+    raw_path: Any,
+    *,
+    field: str,
+    report_path: Path,
+    artifact_root: Path | None,
+    errors: list[str],
+) -> None:
+    """Require an artifact path that resolves to an existing file."""
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        errors.append(f"{field} must be a non-empty artifact path")
+        return
+    if (
+        _resolve_existing_path(raw_path, report_path=report_path, artifact_root=artifact_root)
+        is None
+    ):
+        errors.append(f"{field} does not resolve to an existing file")
+
+
+def _index_rows(
+    rows: Any,
+    *,
+    label: str,
+    errors: list[str],
+) -> dict[tuple[str, int, int], dict[str, Any]]:
+    """Index report rows by matrix key without silently accepting duplicates.
+
+    Returns:
+        A mapping from matrix key to its last structurally indexable row.
+    """
+    if not isinstance(rows, list):
+        errors.append(f"{label} rows must be a list")
+        return {}
+    indexed: dict[tuple[str, int, int], dict[str, Any]] = {}
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            errors.append(f"{label} rows[{index}] must be a mapping")
+            continue
+        key = _row_key(row)
+        if key is None:
+            continue
+        if key in indexed:
+            errors.append(f"{label} rows[{index}] duplicates matrix cell {key!r}")
+        indexed[key] = row
+    return indexed
+
+
+def _row_key(row: dict[str, Any]) -> tuple[str, int, int] | None:
+    """Return a matrix key when sampler, budget, and seed have native types."""
+    sampler = row.get("sampler")
+    budget = row.get("budget")
+    seed = row.get("seed")
+    if not isinstance(sampler, str) or not _is_int(budget) or not _is_int(seed):
+        return None
+    return sampler, int(budget), int(seed)
+
+
+def _resolve_existing_path(
+    raw_path: Any,
+    *,
+    report_path: Path,
+    artifact_root: Path | None,
+) -> Path | None:
+    """Resolve a report or artifact path against common post-run roots.
+
+    Returns:
+        The first existing file candidate, or ``None`` when no candidate exists.
+    """
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None
+    path = Path(raw_path)
+    candidates = [path] if path.is_absolute() else []
+    if artifact_root is not None and not path.is_absolute():
+        candidates.append(artifact_root / path)
+    if not path.is_absolute():
+        candidates.extend((Path.cwd() / path, report_path.parent / path))
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _load_mapping(path: Path) -> tuple[dict[str, Any], list[str]]:
+    """Load a JSON object and preserve parse failures as validation errors.
+
+    Returns:
+        ``(mapping, errors)`` where parse or shape failures are represented in
+        the error list instead of raised to the caller.
+    """
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {}, [f"{path} could not be read as JSON: {exc}"]
+    if not isinstance(payload, dict):
+        return {}, [f"{path} JSON payload must be a mapping"]
+    return payload, []
+
+
+def _sha256(path: Path) -> str | None:
+    """Return a file digest or ``None`` when the source is unavailable."""
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _check_equal(payload: dict[str, Any], field: str, expected: Any, errors: list[str]) -> None:
+    """Append an error when a header field drifts."""
+    if payload.get(field) != expected:
+        errors.append(f"{field} must equal {expected!r}; found {payload.get(field)!r}")
+
+
+def _check_count(
+    payload: dict[str, Any],
+    field: str,
+    expected: int,
+    prefix: str,
+    errors: list[str],
+) -> None:
+    """Append an error when a derived count is not represented exactly."""
+    value = payload.get(field)
+    if not _is_int(value) or int(value) < 0:
+        errors.append(f"{prefix}.{field} must be a non-negative integer")
+    elif value != expected:
+        errors.append(f"{prefix}.{field} must equal {expected}; found {value}")
+
+
+def _is_int(value: Any) -> bool:
+    """Return whether a value is a native integer rather than a boolean."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_positive_int(value: Any) -> bool:
+    """Return whether a value is a native positive integer."""
+    return _is_int(value) and value > 0
+
+
+def _finite_number(value: Any) -> float | None:
+    """Return a finite number while rejecting booleans and numeric strings."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    parsed = float(value)
+    return parsed if math.isfinite(parsed) else None

--- a/robot_sf/benchmark/adversarial_package_b_confirmation.py
+++ b/robot_sf/benchmark/adversarial_package_b_confirmation.py
@@ -262,6 +262,7 @@ def _validate_confirmation_row(
         return None
     if key in observed_keys:
         errors.append(f"rows[{row_index}] duplicates matrix cell {key!r}")
+        return None
     observed_keys.add(key)
     base_row = base_rows.get(key)
     if base_row is None:
@@ -807,15 +808,50 @@ def _resolve_existing_path(
     if not isinstance(raw_path, str) or not raw_path.strip():
         return None
     path = Path(raw_path)
-    candidates = [path] if path.is_absolute() else []
-    if artifact_root is not None and not path.is_absolute():
-        candidates.append(artifact_root / path)
-    if not path.is_absolute():
-        candidates.extend((Path.cwd() / path, report_path.parent / path))
+    trusted_roots = _trusted_search_roots(report_path, artifact_root)
+    candidates = [path] if path.is_absolute() else [root / path for root in trusted_roots]
     for candidate in candidates:
-        if candidate.is_file():
-            return candidate
+        resolved = _safe_existing_file(candidate, trusted_roots)
+        if resolved is not None:
+            return resolved
     return None
+
+
+def _trusted_search_roots(report_path: Path, artifact_root: Path | None) -> tuple[Path, ...]:
+    """Return resolved roots allowed for user-supplied artifact references."""
+    roots: list[Path] = []
+    for root in (artifact_root, Path.cwd(), report_path.parent):
+        if root is None:
+            continue
+        try:
+            resolved = root.resolve(strict=True)
+        except (OSError, RuntimeError):
+            continue
+        if resolved not in roots:
+            roots.append(resolved)
+    return tuple(roots)
+
+
+def _safe_existing_file(candidate: Path, trusted_roots: tuple[Path, ...]) -> Path | None:
+    """Resolve a candidate only when it is a regular non-symlink file in a trusted root.
+
+    Returns:
+        The resolved file path, or ``None`` when the candidate is unsafe/unavailable.
+    """
+    try:
+        current = candidate
+        while current != current.parent:
+            if current.is_symlink():
+                return None
+            current = current.parent
+        resolved = candidate.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return None
+    if not resolved.is_file():
+        return None
+    if not any(resolved.is_relative_to(root) for root in trusted_roots):
+        return None
+    return resolved
 
 
 def _load_mapping(path: Path) -> tuple[dict[str, Any], list[str]]:

--- a/scripts/tools/validate_adversarial_package_b_confirmation.py
+++ b/scripts/tools/validate_adversarial_package_b_confirmation.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Validate issue #3079 Package B confirmed-failure evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from robot_sf.benchmark.adversarial_package_b_confirmation import (
+    validate_package_b_confirmation,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", type=Path, help="Generated Package B comparison report JSON.")
+    parser.add_argument(
+        "confirmation",
+        type=Path,
+        help="Post-run Package B confirmation sidecar JSON.",
+    )
+    parser.add_argument(
+        "--artifact-root",
+        type=Path,
+        default=None,
+        help="Optional root used to resolve relative manifest and evidence paths.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path for the compact confirmation-gate JSON payload.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Validate one confirmation sidecar and optionally write its gate payload."""
+    args = parse_args(argv)
+    gate = validate_package_b_confirmation(
+        args.report,
+        args.confirmation,
+        artifact_root=args.artifact_root,
+    )
+    rendered = json.dumps(gate.to_payload(), indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0 if gate.ready else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_adversarial_package_b_confirmation.py
+++ b/tests/benchmark/test_adversarial_package_b_confirmation.py
@@ -305,6 +305,28 @@ def test_confirmation_gate_rejects_manifest_and_evidence_shape_drift(tmp_path: P
     assert any("evidence must be a list" in error for error in gate.errors)
 
 
+def test_confirmation_gate_rejects_untrusted_artifact_paths(tmp_path: Path) -> None:
+    """Traversal, symlink, and directory references cannot satisfy artifact checks."""
+    report, rows = _source_report(tmp_path)
+    sidecar = _confirmation_sidecar(report, rows)
+    outside = tmp_path.parent / "outside-replay.json"
+    outside.write_text("{}\n", encoding="utf-8")
+    symlink = report.parent / "linked-replay.json"
+    symlink.symlink_to(outside)
+
+    for reference in ("../outside-replay.json", "linked-replay.json", "."):
+        payload = json.loads(sidecar.read_text(encoding="utf-8"))
+        payload["rows"][0]["evidence"][0]["replay"]["artifact_path"] = reference
+        sidecar.write_text(json.dumps(payload), encoding="utf-8")
+
+        gate = validate_package_b_confirmation(report, sidecar)
+
+        assert gate.ready is False
+        assert any("replay.artifact_path does not resolve" in error for error in gate.errors)
+
+    assert symlink.is_symlink()
+
+
 def test_confirmation_gate_rejects_stage_and_metric_drift(tmp_path: Path) -> None:
     """Each confirmation stage and derived time metric is independently fail-closed."""
     report, rows = _source_report(tmp_path)

--- a/tests/benchmark/test_adversarial_package_b_confirmation.py
+++ b/tests/benchmark/test_adversarial_package_b_confirmation.py
@@ -244,3 +244,137 @@ def test_confirmation_gate_cli_writes_payload_and_returns_status(tmp_path: Path)
 
     assert main([str(report), str(sidecar), "--output", str(output)]) == 0
     assert json.loads(output.read_text(encoding="utf-8"))["ready"] is True
+
+
+def test_confirmation_gate_fails_closed_for_unreadable_and_malformed_inputs(tmp_path: Path) -> None:
+    """Missing files, scalar JSON, and absent matrix rows remain blocked."""
+    report = tmp_path / "bad-report.json"
+    confirmation = tmp_path / "bad-confirmation.json"
+    report.write_text("{", encoding="utf-8")
+    confirmation.write_text("[]", encoding="utf-8")
+
+    gate = validate_package_b_confirmation(report, confirmation)
+
+    assert gate.ready is False
+    assert any("could not be read as JSON" in error for error in gate.errors)
+    assert any("JSON payload must be a mapping" in error for error in gate.errors)
+    assert any("base Package B report gate is not ready" in error for error in gate.errors)
+    assert any("confirmation rows must be a list" in error for error in gate.errors)
+
+
+def test_confirmation_gate_rejects_row_shape_drift_and_missing_cells(tmp_path: Path) -> None:
+    """Malformed, duplicate, and unknown matrix rows cannot bypass the 27-cell contract."""
+    report, rows = _source_report(tmp_path)
+    sidecar = _confirmation_sidecar(report, rows)
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    valid = dict(payload["rows"][0])
+    invalid_key = dict(valid)
+    invalid_key["budget"] = "16"
+    unknown_key = dict(valid)
+    unknown_key["sampler"] = "unknown"
+    payload["rows"] = ["not-a-row", {}, invalid_key, valid, dict(valid), unknown_key]
+    sidecar.write_text(json.dumps(payload), encoding="utf-8")
+
+    gate = validate_package_b_confirmation(report, sidecar)
+
+    assert gate.ready is False
+    assert any("must be a mapping" in error for error in gate.errors)
+    assert any("missing required fields" in error for error in gate.errors)
+    assert any("invalid sampler/budget/seed types" in error for error in gate.errors)
+    assert any("duplicates matrix cell" in error for error in gate.errors)
+    assert any("does not match a base report matrix cell" in error for error in gate.errors)
+    assert any("missing Package B matrix cells" in error for error in gate.errors)
+
+
+def test_confirmation_gate_rejects_manifest_and_evidence_shape_drift(tmp_path: Path) -> None:
+    """Missing source manifests and malformed evidence lists remain hard blockers."""
+    report, rows = _source_report(tmp_path)
+    sidecar = _confirmation_sidecar(report, rows)
+    report_payload = json.loads(report.read_text(encoding="utf-8"))
+    report_payload["rows"][0]["manifest_path"] = str(tmp_path / "missing-manifest.json")
+    report.write_text(json.dumps(report_payload), encoding="utf-8")
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    payload["source_report_sha256"] = hashlib.sha256(report.read_bytes()).hexdigest()
+    payload["rows"][0]["evidence"] = "not-a-list"
+    sidecar.write_text(json.dumps(payload), encoding="utf-8")
+
+    gate = validate_package_b_confirmation(report, sidecar)
+
+    assert gate.ready is False
+    assert any("base manifest_path does not resolve" in error for error in gate.errors)
+    assert any("evidence must be a list" in error for error in gate.errors)
+
+
+def test_confirmation_gate_rejects_stage_and_metric_drift(tmp_path: Path) -> None:
+    """Each confirmation stage and derived time metric is independently fail-closed."""
+    report, rows = _source_report(tmp_path)
+    sidecar = _confirmation_sidecar(report, rows)
+    pristine = sidecar.read_text(encoding="utf-8")
+    mutations = (
+        (lambda entry: entry.pop("replay"), "replay must be a mapping"),
+        (lambda entry: entry["replay"].update(status="failed"), "status must equal 'passed'"),
+        (lambda entry: entry["replay"].update(deterministic=False), "deterministic must be true"),
+        (
+            lambda entry: entry["independent_seed_confirmation"].update(seeds=[701]),
+            "needs two distinct integer",
+        ),
+        (
+            lambda entry: entry["independent_seed_confirmation"].update(seeds=[901101, 702]),
+            "must not include the search candidate seed",
+        ),
+        (
+            lambda entry: entry["independent_seed_confirmation"].update(
+                failure_persistence_rate=0.0
+            ),
+            "failure_persistence_rate must be finite",
+        ),
+        (
+            lambda entry: entry["mechanism_attribution"].update(primary_failure="timeout"),
+            "primary_failure does not match",
+        ),
+        (lambda entry: entry.update(candidate_seed=1101), "candidate_seed drifted"),
+        (
+            lambda entry: entry["replay"].update(artifact_path=str(tmp_path / "missing.json")),
+            "does not resolve to an existing file",
+        ),
+        (lambda entry: entry.update(simulator_seconds_elapsed=-1.0), "elapsed"),
+    )
+    for mutate, expected_error in mutations:
+        payload = json.loads(pristine)
+        mutate(payload["rows"][0]["evidence"][0])
+        sidecar.write_text(json.dumps(payload), encoding="utf-8")
+        gate = validate_package_b_confirmation(report, sidecar)
+        assert gate.ready is False
+        assert any(expected_error in error for error in gate.errors), expected_error
+
+
+def test_confirmation_gate_rejects_censoring_and_rate_drift(tmp_path: Path) -> None:
+    """Confirmed and censored rows must agree with their time denominators."""
+    report, rows = _source_report(tmp_path)
+    sidecar = _confirmation_sidecar(report, rows)
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    payload["rows"][0]["time_to_first_confirmed_failure_s"] = 4.0
+    payload["rows"][0]["time_to_first_confirmed_failure_censored"] = True
+    payload["rows"][0]["simulator_seconds_per_confirmed_failure"] = 11.0
+    sidecar.write_text(json.dumps(payload), encoding="utf-8")
+
+    gate = validate_package_b_confirmation(report, sidecar)
+
+    assert gate.ready is False
+    assert any("disagrees with evidence" in error for error in gate.errors)
+    assert any("confirmed rows must not be censored" in error for error in gate.errors)
+    assert any("disagrees with its denominator" in error for error in gate.errors)
+
+    censored_sidecar = _confirmation_sidecar(report, rows, confirmed=False)
+    censored_payload = json.loads(censored_sidecar.read_text(encoding="utf-8"))
+    censored_payload["rows"][0]["time_to_first_confirmed_failure_s"] = 1.0
+    censored_payload["rows"][0]["time_to_first_confirmed_failure_censored"] = False
+    censored_payload["rows"][0]["simulator_seconds_per_confirmed_failure"] = 0.0
+    censored_sidecar.write_text(json.dumps(censored_payload), encoding="utf-8")
+
+    censored_gate = validate_package_b_confirmation(report, censored_sidecar)
+
+    assert censored_gate.ready is False
+    assert any("must be null when censored" in error for error in censored_gate.errors)
+    assert any("must be censored" in error for error in censored_gate.errors)
+    assert any("must be null without confirmed failures" in error for error in censored_gate.errors)

--- a/tests/benchmark/test_adversarial_package_b_confirmation.py
+++ b/tests/benchmark/test_adversarial_package_b_confirmation.py
@@ -1,0 +1,246 @@
+"""Tests for the issue #3079 Package B confirmation-chain gate."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.adversarial_package_b_confirmation import (
+    validate_package_b_confirmation,
+)
+from scripts.tools.validate_adversarial_package_b_confirmation import main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _base_row(*, manifest_path: Path, sampler: str, budget: int, seed: int) -> dict[str, Any]:
+    """Build one complete source-report row backed by a synthetic manifest."""
+    return {
+        "objective": "worst_case_snqi",
+        "sampler": sampler,
+        "budget": budget,
+        "seed": seed,
+        "manifest_path": manifest_path.as_posix(),
+        "best_bundle_path": manifest_path.parent.as_posix(),
+        "best_objective_value": 2.0,
+        "best_valid_objective": 2.0,
+        "num_candidates": budget,
+        "num_valid_candidates": budget,
+        "num_invalid_candidates": 0,
+        "num_failed_evaluations": 0,
+        "invalid_candidate_rate": 0.0,
+        "first_failure_iteration": 1,
+        "certified_valid_failure_count": 1,
+        "replayable_valid_failure_count": 1,
+        "replay_success_rate": 1.0,
+        "fallback_candidate_count": 0,
+        "degraded_candidate_count": 0,
+        "held_out_family_yield": None,
+        "held_out_family_status": "not_evaluated_narrow_archive",
+        "caveats": ["diagnostic/local nominal report"],
+    }
+
+
+def _source_report(tmp_path: Path) -> tuple[Path, list[dict[str, Any]]]:
+    """Write a complete 27-cell report and one synthetic manifest per cell."""
+    rows: list[dict[str, Any]] = []
+    for sampler in ("random", "coordinate", "optuna"):
+        for budget in (16, 32, 64):
+            for seed in (1101, 2202, 3303):
+                cell = tmp_path / f"{sampler}-{budget}-{seed}"
+                cell.mkdir()
+                candidates = [
+                    {
+                        "candidate": {"scenario_seed": 901101},
+                        "certification_status": {"status": "passed"},
+                        "objective_value": 2.0,
+                        "failure_attribution": {"primary_failure": "collision"},
+                        "error": None,
+                    }
+                ]
+                candidates.extend(
+                    {
+                        "candidate": {"scenario_seed": 900_000 + seed + index},
+                        "certification_status": {"status": "passed"},
+                        "objective_value": 0.0,
+                        "failure_attribution": {"primary_failure": "success"},
+                        "error": None,
+                    }
+                    for index in range(1, budget)
+                )
+                manifest = cell / "manifest.json"
+                manifest.write_text(
+                    json.dumps(
+                        {
+                            "schema_version": "adversarial-search-manifest.v1",
+                            "candidates": candidates,
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                rows.append(
+                    _base_row(
+                        manifest_path=manifest,
+                        sampler=sampler,
+                        budget=budget,
+                        seed=seed,
+                    )
+                )
+    report = tmp_path / "report.json"
+    report.write_text(
+        json.dumps(
+            {
+                "schema_version": "adversarial-sampler-comparison.v3",
+                "report_status": "diagnostic_local_nominal",
+                "claim_scope": "not_paper_facing_benchmark_evidence",
+                "objectives": ["worst_case_snqi"],
+                "budget_grid": [16, 32, 64],
+                "seeds": [1101, 2202, 3303],
+                "rows": rows,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return report, rows
+
+
+def _confirmation_sidecar(
+    report: Path,
+    rows: list[dict[str, Any]],
+    *,
+    confirmed: bool = True,
+) -> Path:
+    """Write a confirmation sidecar with one reviewed candidate per cell."""
+    evidence_rows: list[dict[str, Any]] = []
+    for row in rows:
+        if confirmed:
+            evidence = [
+                {
+                    "candidate_index": 1,
+                    "candidate_seed": 901101,
+                    "primary_failure": "collision",
+                    "status": "confirmed",
+                    "simulator_seconds_elapsed": 3.0,
+                    "replay": {
+                        "status": "passed",
+                        "deterministic": True,
+                        "artifact_path": str(report.parent / "replay.json"),
+                    },
+                    "independent_seed_confirmation": {
+                        "status": "passed",
+                        "seeds": [701, 702],
+                        "failure_persistence_rate": 1.0,
+                        "artifact_path": str(report.parent / "independent.json"),
+                    },
+                    "mechanism_attribution": {
+                        "status": "stable",
+                        "primary_failure": "collision",
+                        "artifact_path": str(report.parent / "attribution.json"),
+                    },
+                }
+            ]
+            confirmed_count = 1
+            time_to_first = 3.0
+            censored = False
+            per_failure = 10.0
+        else:
+            evidence = [
+                {
+                    "candidate_index": 1,
+                    "status": "not_confirmed",
+                    "reason": "confirmation artifact unavailable",
+                }
+            ]
+            confirmed_count = 0
+            time_to_first = None
+            censored = True
+            per_failure = None
+        evidence_rows.append(
+            {
+                "sampler": row["sampler"],
+                "budget": row["budget"],
+                "seed": row["seed"],
+                "confirmation_status": "complete",
+                "certified_failure_count": 1,
+                "confirmed_failure_count": confirmed_count,
+                "unconfirmed_certified_failure_count": 1 - confirmed_count,
+                "time_to_first_confirmed_failure_s": time_to_first,
+                "time_to_first_confirmed_failure_censored": censored,
+                "simulator_seconds": 10.0,
+                "simulator_seconds_per_confirmed_failure": per_failure,
+                "evidence": evidence,
+            }
+        )
+    for name in ("replay.json", "independent.json", "attribution.json"):
+        path = report.parent / name
+        path.write_text("{}\n", encoding="utf-8")
+    payload = {
+        "schema_version": "adversarial-package-b-confirmation.v1",
+        "issue": 3079,
+        "source_report_schema_version": "adversarial-sampler-comparison.v3",
+        "source_report_sha256": hashlib.sha256(report.read_bytes()).hexdigest(),
+        "claim_scope": "not_paper_facing_benchmark_evidence",
+        "rows": evidence_rows,
+    }
+    sidecar = report.parent / "confirmation.json"
+    sidecar.write_text(json.dumps(payload), encoding="utf-8")
+    return sidecar
+
+
+def test_confirmation_gate_accepts_complete_chain_and_derived_metrics(tmp_path: Path) -> None:
+    """Every certified failure is bound to all required confirmation artifacts."""
+    report, rows = _source_report(tmp_path)
+    sidecar = _confirmation_sidecar(report, rows)
+
+    gate = validate_package_b_confirmation(report, sidecar)
+
+    assert gate.ready is True
+    assert gate.status == "ready_for_confirmed_failure_review"
+    assert gate.matrix["confirmed_failure_count"] == 27
+    assert gate.matrix["unconfirmed_certified_failure_count"] == 0
+    assert gate.matrix["censored_row_count"] == 0
+    assert "dissertation" in gate.to_payload()["claim_boundary"]
+
+
+def test_confirmation_gate_preserves_censored_no_confirmation_rows(tmp_path: Path) -> None:
+    """A reviewed but unconfirmed failure is excluded and remains right-censored."""
+    report, rows = _source_report(tmp_path)
+    sidecar = _confirmation_sidecar(report, rows, confirmed=False)
+
+    gate = validate_package_b_confirmation(report, sidecar)
+
+    assert gate.ready is True
+    assert gate.matrix["confirmed_failure_count"] == 0
+    assert gate.matrix["unconfirmed_certified_failure_count"] == 27
+    assert gate.matrix["censored_row_count"] == 27
+
+
+def test_confirmation_gate_fails_closed_on_missing_artifact_and_seed_drift(tmp_path: Path) -> None:
+    """Artifact absence and reuse of the search seed cannot pass as confirmation."""
+    report, rows = _source_report(tmp_path)
+    sidecar = _confirmation_sidecar(report, rows)
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    payload["rows"][0]["evidence"][0]["candidate_seed"] = 1101
+    payload["rows"][0]["evidence"][0]["replay"]["artifact_path"] = str(
+        tmp_path / "missing-replay.json"
+    )
+    sidecar.write_text(json.dumps(payload), encoding="utf-8")
+
+    gate = validate_package_b_confirmation(report, sidecar)
+
+    assert gate.ready is False
+    assert gate.status == "blocked_on_confirmation_contract"
+    assert any("candidate_seed drifted" in error for error in gate.errors)
+    assert any("does not resolve to an existing file" in error for error in gate.errors)
+
+
+def test_confirmation_gate_cli_writes_payload_and_returns_status(tmp_path: Path) -> None:
+    """The CLI emits and persists the same compact gate payload."""
+    report, rows = _source_report(tmp_path)
+    sidecar = _confirmation_sidecar(report, rows)
+    output = tmp_path / "gate.json"
+
+    assert main([str(report), str(sidecar), "--output", str(output)]) == 0
+    assert json.loads(output.read_text(encoding="utf-8"))["ready"] is True


### PR DESCRIPTION
## Reviewer-critical summary

This PR adds the next bounded evidence-readiness capability for [issue #3079](https://github.com/ll7/robot_sf_ll7/issues/3079): a fail-closed validator for the post-run Package B confirmation sidecar.

- **What changed:** validate every Package B matrix cell against its source manifest, account for every certified failure candidate, and count a candidate as `confirmed` only when deterministic replay, independent-seed confirmation, and stable mechanism attribution each have passing status and existing artifacts.
- **Why now:** the existing [Package B report gate in PR #5534](https://github.com/ll7/robot_sf_ll7/pull/5534) proves matrix completeness and row arithmetic, but intentionally leaves this four-stage discovery boundary to artifact-level review. The live issue's 2026-07 execution spec makes that boundary authoritative.
- **Claim boundary:** diagnostic implementation proof only. The checker emits no campaign result and promotes no benchmark, paper, or dissertation claim. `not_confirmed` candidates are excluded, and rows without a confirmed failure remain explicitly right-censored.
- **Required validation:** focused confirmation tests, adjacent Package B/adversarial tests, Ruff, and committed-HEAD `pr_ready_check` against fresh `origin/main`.
- **Remaining blocker:** the exact 27-cell budget-matched campaign, durable artifacts, and human interpretation still require an approved compute-capable operator; this PR submits no job.

## Contract delta

- Adds `adversarial-package-b-confirmation.v1` with a SHA-256 binding to the existing `adversarial-sampler-comparison.v3` report.
- Adds per-cell confirmation accounting for certified, confirmed, and explicitly unconfirmed failures; censored `time_to_first_confirmed_failure_s`; and `simulator_seconds_per_confirmed_failure` arithmetic.
- Requires each confirmed candidate to reference existing artifacts for deterministic replay, at least two distinct independent seeds not equal to the search seed, and stable mechanism attribution matching the source failure.
- Fails closed on source-report drift, missing/duplicate matrix cells, missing certified-candidate accounting, path absence, stage/status drift, seed reuse, mechanism mismatch, invalid censoring, and denominator arithmetic.
- Compatibility impact: additive checker and CLI only. Existing runner behavior and `adversarial-sampler-comparison.v3` metric semantics are unchanged.

Refs #3079

## Scope and validation

The implementation is limited to the reusable checker, its CLI, and focused contract tests. The synthetic fixtures prove checker behavior and are not benchmark evidence.

Validation on committed HEAD:

```text
uv run ruff check robot_sf/benchmark/adversarial_package_b_confirmation.py scripts/tools/validate_adversarial_package_b_confirmation.py tests/benchmark/test_adversarial_package_b_confirmation.py
result: passed

uv run ruff format --check robot_sf/benchmark/adversarial_package_b_confirmation.py scripts/tools/validate_adversarial_package_b_confirmation.py tests/benchmark/test_adversarial_package_b_confirmation.py
result: passed

uv run pytest tests/benchmark/test_adversarial_package_b_confirmation.py -q
result: 9 passed; focused validator coverage 87.42%

uv run pytest tests/benchmark/test_adversarial_package_b_report.py tests/benchmark/test_adversarial_package_b_preflight.py tests/benchmark/test_adversarial_package_b_gap_packet.py tests/adversarial/test_adversarial_search.py -q
result: 97 passed

PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3079/pr_body.md scripts/dev/pr_ready_check.sh
result: passed — core 2,394 passed/1 skipped; optional 7,260 passed/17 skipped; 3 non-blocking warnings; changed-file coverage 89.5% (80% floor, 100% goal warning); committed-HEAD freshness recorded at 7bfc246cc60083c99c5e59dd7b10b1286824d0cc
```

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No learned failure proposal (#2921), held-out-family expansion, or claim promotion.
- No target-host, queue-routing, or packet-lineage state in tracked files.

<details>
<summary>Research, governance, artifact, and handoff appendix</summary>

### Research result guidance

- **Target blocker:** prevent certified/replayable-but-unconfirmed candidates from being counted as confirmed discoveries under the live #3079 execution spec.
- **Comparator:** the existing #5534 Package B report gate, which checks the 27-cell report matrix but leaves confirmation artifacts for review.
- **Evidence tier:** targeted synthetic contract and adjacent CPU tests; no empirical result.
- **Result classification:** diagnostic blocker-resolution for evidence readiness, not benchmark success.
- **Decision rule:** only `confirmed` candidates with all required stage artifacts may enter confirmed-failure summaries; all other failures remain excluded or censored.
- **Next empirical action:** run the exact manifest command on an approved compute-capable path, emit the confirmation sidecar, run this checker, and review durable artifacts before interpretation.

### Domain-aware approval

- Required for this PR: yes — the checker defines the admission boundary for adversarial failure discoveries.
- Domains reviewed: evidence boundary, experimental comparison, benchmark interpretation.
- Status: self-reviewed and approved for the implementation-level diagnostic gate; maintainer review remains required before any empirical result is interpreted.
- Approver/review source or waiver: Codex self-review against the live #3079 comments, the #5534 report gate, `docs/code_review.md`, the adversarial search/certification surfaces, and the repository fallback/degraded evidence policy.
- Validity checklist:
  - Target claim/hypothesis: only candidates passing certification, deterministic replay, independent-seed confirmation, and stable mechanism attribution may be counted as confirmed.
  - Comparator or split/evidence validity: the sidecar is bound by SHA-256 to the existing fixed 27-cell `adversarial-sampler-comparison.v3` report and each source manifest candidate index.
  - Fallback/degraded exclusions: the checker does not convert fallback/degraded or `not_confirmed` candidates into confirmed failures.
  - Claim boundary: the output is diagnostic-only; no benchmark, paper, dissertation, or sampler-winner claim is promoted.
  - Implementation integrity vs experimental validity: focused synthetic fixtures prove the validator contract; campaign execution, artifact durability, and scientific interpretation remain external.
- Claim status: no metric semantics or paper-facing claim is changed.

### Downstream propagation

- No result store, benchmark report, leaderboard, claim map, context note, or registry entry is updated because no campaign artifact was generated.
- Issue-state propagation is intentionally kept in this PR body: issue/PR comments were not authorized for this run.
- Existing friction issue #5533 already tracks the changed-file proof omission for untracked new files; no duplicate friction issue was filed.

### Artifact handling

- The readiness run created 738 ignored files (112 MiB) under `output/`; these are disposable pytest/coverage/validation artifacts and are not committed or used as durable evidence.
- No raw candidate bundles, episode JSONL, videos, checkpoints, or external datasets were created or promoted.

### Self-review and residual risks

- The new capability is nameably distinct from #5534: it validates the certification → deterministic replay → independent-seed confirmation → stable mechanism-attribution chain and censored simulator-time summaries.
- The checker does not itself rerun simulations or verify the scientific truth of referenced artifacts; durable artifact review and domain interpretation remain required.
- The narrow certified archive caveat for held-out-family yield remains unchanged.
- No new friction issue was filed: the only qualifying friction encountered was already tracked as #5533.

### Late issue guidance

Re-read immediately before PR creation at 2026-07-14T12:28:36Z, including all 11 comments. No maintainer guidance newer than the session start was present. The latest comment (2026-07-14T03:26:50Z, after PR #5534) confirms that the campaign, certified/replayable valid-failure results, durable artifacts, and interpretation remain open; this PR addresses the distinct confirmation-chain checker capability and leaves that empirical work as the remaining blocker.

</details>
