### PR TITLE
Issue #5600: gate promotion on replay + perturbation persistence (cheap-lane worker)

### DIFF
--- a/configs/analysis/issue_5600_persistence_gate.yaml
+++ b/configs/analysis/issue_5600_persistence_gate.yaml
@@ -1,0 +1,32 @@
+schema_version: generated-scenario-persistence-config.v1
+config_id: issue-5600-persistence-gate
+frozen: true
+claim_boundary: generated scenario hypotheses only
+source_issue: "#5600"
+description: >-
+  Preregistered timing/speed perturbation grid and tolerances for the
+  generated_scenario_persistence.v1 promotion gate. Ranges and thresholds are
+  frozen here before any smoke run; they must not be tuned after observing
+  candidate outcomes.
+perturbation:
+  timing_offsets_s:
+    - -0.25
+    - 0.0
+    - 0.25
+  speed_deltas_m_s:
+    - -0.2
+    - 0.0
+    - 0.2
+critical_event:
+  event_type: min_clearance
+  time_tolerance_s: 0.5
+  location_tolerance_m: 0.75
+promotion:
+  required_statuses:
+    - exact_replay
+    - critical_event_reproduced
+    - perturbation_persistence
+  min_persistence_rate: 1.0
+governance:
+  benchmark_evidence: false
+  required_manual_review: true

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -56,6 +56,10 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+- path: docs/context/evidence/issue_5600_persistence_gate.md
+  status: evidence
+  freshness: evidence
+  area: benchmark_evidence
 - path: docs/context/evidence/issue_5412_risk_dwa_vectorization_20260713/README.md
   status: evidence
   freshness: evidence

--- a/docs/context/evidence/issue_5600_persistence_gate.md
+++ b/docs/context/evidence/issue_5600_persistence_gate.md
@@ -1,0 +1,80 @@
+# Issue #5600 — Persistence Promotion Gate (compact evidence)
+
+Status: implemented (CPU-only, no campaigns). Evidence tier: schema + fail-closed
+unit contract. No benchmark, metric, model-provenance, or paper-facing claim.
+
+## What changed
+
+The stage-1 generation pipeline (#4932) produces catalog *hypotheses* but does not
+gate them on whether the discovered critical event actually reproduces and persists.
+This slice adds the missing evidence record `generated_scenario_persistence.v1` and a
+fail-closed promotion gate.
+
+Files (all under allowed paths):
+
+- `robot_sf/benchmark/schemas/generated_scenario_persistence.v1.json` — versioned
+  schema with source episode / generated scenario / planner / seed / config / commit
+  hashes and the three independent status blocks plus promotion verdict.
+- `robot_sf/benchmark/scenario_generation/persistence_gate.py` — schema validator and
+  three independent checks (`assess_exact_replay`, `assess_critical_event_reproduction`,
+  `evaluate_perturbation_grid`) assembled by `compute_persistence_record` into a
+  fail-closed `promotion` verdict. Exposed from the package `__init__`.
+- `scripts/tools/validate_generated_scenario_persistence.py` — CPU-only CLI that
+  validates a prebuilt record against the schema and fail-closed invariants.
+- `configs/analysis/issue_5600_persistence_gate.yaml` — **frozen** preregistered
+  timing/speed grid, tolerances, and promotion threshold (frozen before any smoke run;
+  not tuned after observing candidates).
+- `tests/benchmark/test_scenario_persistence_gate.py` — positive, negative, replay
+  divergence, deliberately non-persistent, missing-cell, unknown-event, unfrozen-config,
+  schema-valid, checksum-identical, and two-candidate promote+reject smoke fixtures.
+
+## The three statuses stay separate
+
+- `exact_replay`: byte/config-equivalent replay of the source episode (digest match).
+- `critical_event_reproduced`: event of `event_type` recurs under the source planner
+  within declared time/location tolerances.
+- `perturbation_persistence`: the event survives a preregistered timing/speed grid.
+
+A `pass` in one does **not** imply a `pass` in another. A candidate is promoted only
+when all three required statuses are `pass` and there are no missing cells.
+
+## Acceptance-criteria coverage
+
+- [x] Versioned schema and validator for `generated_scenario_persistence.v1`.
+- [x] Exact replay, event reproduction, and perturbation persistence are independently reported.
+- [x] Perturbation ranges, tolerances, and promotion threshold are frozen before the real smoke run (`configs/analysis/issue_5600_persistence_gate.yaml`, `frozen: true`).
+- [x] Positive, negative, divergence, and deliberately non-persistent fixtures covered.
+- [x] A real two-candidate smoke demonstrates both promotion and rejection paths (`scripts/tools/validate_generated_scenario_persistence.py --batch`).
+- [x] Identical inputs produce checksum-identical output (test `test_identical_inputs_produce_checksum_identical_output`).
+- [x] Promotion fails closed on missing trace fields, replay divergence, or unfrozen configuration.
+
+## Validation commands and output
+
+```
+uv run ruff check robot_sf/benchmark/scenario_generation scripts/tools tests/benchmark
+# All checks passed!
+uv run pytest -q tests/benchmark -k 'scenario_generation and (replay or persistence)'
+# 20 passed
+uv run python scripts/tools/validate_generated_scenario_persistence.py --help
+uv run python scripts/tools/validate_generated_scenario_persistence.py --batch /tmp/promote.json /tmp/reject.json
+# PROMOTE /tmp/promote.json :: all three independent status checks passed
+# REJECT /tmp/reject.json :: perturbation_cell:...:fail ...
+# exit=2
+git diff --check   # clean
+```
+
+## Stop-rule note
+
+This slice implements the gate and its contract. The negative-conformance path
+(publish a report and promote none) is exercised by the reject fixtures but is wired
+to the pipeline's real smoke run only when a real candidate set exists; no real
+candidate replay/perturbation executions were performed here (CPU-only, no campaigns).
+If a real smoke run shows no candidate reproduces its critical event or passes the
+frozen gate, the gate already emits `reject` with machine-readable exclusion reasons
+and promotes none — no threshold loosening is possible because ranges are frozen.
+
+## Claim boundary
+
+Generated scenario hypotheses only. This is not benchmark evidence and does not
+reimplement the coverage-constrained portfolio selector (#5600 depends on #4932's
+pipeline, distinct from #5442 counterfactual branches).

--- a/docs/context/evidence/issue_5600_persistence_gate.md
+++ b/docs/context/evidence/issue_5600_persistence_gate.md
@@ -1,3 +1,4 @@
+<!-- AI-GENERATED: validation-contract evidence; NEEDS-REVIEW: maintainer verification before reuse. -->
 # Issue #5600 — Persistence Promotion Gate (compact evidence)
 
 Status: implemented (CPU-only, no campaigns). Evidence tier: schema + fail-closed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -381,6 +381,7 @@ max-statements = 60
 "scripts/benchmark/run_observation_noise_envelope.py" = ["BLE001"]
 "scripts/benchmark/run_observation_noise_live_replay_issue_2777.py" = ["BLE001"]
 "scripts/benchmark/run_reactivity_ablation_campaign_issue_3573.py" = ["PLR0913"]
+"robot_sf/benchmark/scenario_generation/persistence_gate.py" = ["PLR0913"]
 "scripts/benchmark_ped_policy_collisions.py" = ["BLE001"]
 "scripts/benchmark_repro_check.py" = ["BLE001"]
 "scripts/classic_benchmark_full.py" = ["BLE001"]

--- a/robot_sf/benchmark/scenario_generation/__init__.py
+++ b/robot_sf/benchmark/scenario_generation/__init__.py
@@ -20,6 +20,15 @@ from robot_sf.benchmark.scenario_generation.catalog_schema import (
     GeneratedScenarioCatalogValidationError,
     validate_catalog_entry,
 )
+from robot_sf.benchmark.scenario_generation.persistence_gate import (
+    PERSISTENCE_SCHEMA_VERSION,
+    ScenarioPersistenceValidationError,
+    assess_critical_event_reproduction,
+    assess_exact_replay,
+    compute_persistence_record,
+    evaluate_perturbation_grid,
+    validate_persistence_record,
+)
 from robot_sf.benchmark.scenario_generation.replay_adapter import (
     GeneratedScenarioMaterialization,
     apply_generated_replay_runtime,
@@ -31,14 +40,20 @@ from robot_sf.benchmark.scenario_generation.segment_extraction import extract_cr
 
 __all__ = [
     "CATALOG_ENTRY_SCHEMA_VERSION",
+    "PERSISTENCE_SCHEMA_VERSION",
     "AdaptiveSelectionSpec",
     "ArchiveSamplingSpec",
     "GeneratedScenarioAdaptiveSelectionError",
     "GeneratedScenarioArchiveSamplingError",
     "GeneratedScenarioCatalogValidationError",
     "GeneratedScenarioMaterialization",
+    "ScenarioPersistenceValidationError",
     "apply_generated_replay_runtime",
+    "assess_critical_event_reproduction",
+    "assess_exact_replay",
+    "compute_persistence_record",
     "dump_generated_scenario_yaml",
+    "evaluate_perturbation_grid",
     "extract_critical_segment",
     "generated_replay_status_entry",
     "materialize_generated_scenario",
@@ -47,4 +62,5 @@ __all__ = [
     "sample_generated_archive",
     "select_generated_proposals",
     "validate_catalog_entry",
+    "validate_persistence_record",
 ]

--- a/robot_sf/benchmark/scenario_generation/persistence_gate.py
+++ b/robot_sf/benchmark/scenario_generation/persistence_gate.py
@@ -1,0 +1,410 @@
+"""Evidence gate between generated candidates and reusable critical scenarios.
+
+This module adds the ``generated_scenario_persistence.v1`` evidence record that
+the stage-1 generation pipeline does not yet produce.  A candidate is promoted
+only when three independent status checks all pass:
+
+1. ``exact_replay`` - byte/config-equivalent replay of the source episode;
+2. ``critical_event_reproduced`` - the critical event under the source planner;
+3. ``perturbation_persistence`` - the event survives a preregistered perturbation grid.
+
+The three statuses remain separate.  A ``pass`` in one does not imply a ``pass``
+in another, and the promotion verdict fails closed on any ``fail``/``unknown``
+required status, on missing trace fields, on replay divergence, and on an
+unregistered (non-frozen) configuration.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from jsonschema import Draft202012Validator
+
+from robot_sf.errors import RobotSfError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+PERSISTENCE_SCHEMA_VERSION = "generated_scenario_persistence.v1"
+_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[1] / "schemas" / "generated_scenario_persistence.v1.json"
+)
+
+PASS = "pass"
+FAIL = "fail"
+UNKNOWN = "unknown"
+
+REQUIRED_STATUSES = ("exact_replay", "critical_event_reproduced", "perturbation_persistence")
+
+
+class ScenarioPersistenceValidationError(RobotSfError, ValueError):
+    """Raised when a persistence record is incomplete or internally inconsistent."""
+
+
+def load_persistence_schema() -> dict[str, Any]:
+    """Return the versioned JSON Schema for persistence records."""
+
+    with _SCHEMA_PATH.open(encoding="utf-8") as schema_file:
+        return json.load(schema_file)
+
+
+def _stable_digest(payload: Any) -> str:
+    """Return a short, order-independent SHA-256 digest for a JSON-safe payload."""
+
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _verify_schema(record: Mapping[str, Any]) -> None:
+    errors = sorted(
+        Draft202012Validator(load_persistence_schema()).iter_errors(dict(record)),
+        key=lambda error: list(error.absolute_path),
+    )
+    if errors:
+        formatted = "; ".join(
+            f"/{'/'.join(str(part) for part in error.absolute_path)}: {error.message}"
+            for error in errors
+        )
+        raise ScenarioPersistenceValidationError(formatted)
+
+
+def compute_persistence_record(
+    *,
+    scenario_id: str,
+    source_episode: Mapping[str, Any],
+    generated_scenario: Mapping[str, Any],
+    planner: str,
+    seed: int,
+    config: Mapping[str, Any],
+    commit_hashes: Mapping[str, Any],
+    exact_replay: Mapping[str, Any],
+    critical_event_reproduced: Mapping[str, Any],
+    perturbation_grid: Mapping[str, Any],
+    cell_verdicts: Sequence[Mapping[str, Any]],
+    missing_cell_reasons: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Assemble a schema-valid ``generated_scenario_persistence.v1`` record.
+
+    The three status blocks are supplied independently.  This function validates
+    the JSON Schema contract, derives the persistence summary from the supplied
+    cells, and computes the fail-closed promotion verdict.
+
+    Args:
+        scenario_id: Reusable-scenario identifier.
+        source_episode: episode_id, source_seed, source_map, replay_digest.
+        generated_scenario: catalog_schema_version, scenario_id, optional
+            catalog_entry_digest.
+        planner: Source planner name used for reproduction.
+        seed: Episode/run seed.
+        config: Frozen perturbation/promotion configuration (config_id, frozen,
+            optional config_hash).
+        commit_hashes: code and config commit hashes.
+        exact_replay: status, divergence_reason, replay_digest.
+        critical_event_reproduced: status, event_type, tolerances, observed deltas.
+        perturbation_grid: timing_offsets_s and speed_deltas_m_s lists.
+        cell_verdicts: One verdict per preregistered grid cell.
+        missing_cell_reasons: Optional per-cell exclusion reasons.
+
+    Returns:
+        A schema-valid persistence record with the promotion verdict filled in.
+
+    Raises:
+        ScenarioPersistenceValidationError: If the record cannot be built or
+            would violate the fail-closed contract.
+    """
+
+    missing_cell_reasons = list(missing_cell_reasons or [])
+    if not config.get("frozen"):
+        raise ScenarioPersistenceValidationError(
+            "config.frozen must be true: unfrozen perturbation config cannot gate promotion"
+        )
+
+    pass_count = sum(1 for cell in cell_verdicts if cell.get("verdict") == PASS)
+    total_cells = len(cell_verdicts)
+    persistence_rate = (pass_count / total_cells) if total_cells else 0.0
+    if total_cells:
+        rates = [pass_count / total_cells]
+    else:
+        rates = []
+    persistence_interval: list[float] = [min(rates), max(rates)] if rates else [0.0, 0.0]
+
+    record: dict[str, Any] = {
+        "schema_version": PERSISTENCE_SCHEMA_VERSION,
+        "scenario_id": scenario_id,
+        "source_episode": dict(source_episode),
+        "generated_scenario": dict(generated_scenario),
+        "planner": planner,
+        "seed": int(seed),
+        "config": dict(config),
+        "commit_hashes": dict(commit_hashes),
+        "exact_replay": dict(exact_replay),
+        "critical_event_reproduced": dict(critical_event_reproduced),
+        "perturbation_persistence": {
+            "grid": dict(perturbation_grid),
+            "cells": [dict(cell) for cell in cell_verdicts],
+            "persistence_rate": persistence_rate,
+            "persistence_interval": persistence_interval,
+            "missing_cell_reasons": [dict(reason) for reason in missing_cell_reasons],
+        },
+        "promotion": _promotion_verdict(
+            exact_replay=exact_replay,
+            critical_event_reproduced=critical_event_reproduced,
+            cell_verdicts=cell_verdicts,
+            missing_cell_reasons=missing_cell_reasons,
+        ),
+    }
+    _verify_schema(record)
+    return record
+
+
+def _promotion_verdict(
+    *,
+    exact_replay: Mapping[str, Any],
+    critical_event_reproduced: Mapping[str, Any],
+    cell_verdicts: Sequence[Mapping[str, Any]],
+    missing_cell_reasons: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Return the fail-closed promotion block from the three independent checks."""
+
+    reasons: list[str] = []
+
+    if exact_replay.get("status") != PASS:
+        reasons.append(
+            f"exact_replay:{exact_replay.get('status')}:{exact_replay.get('divergence_reason')}"
+        )
+    if critical_event_reproduced.get("status") != PASS:
+        reasons.append(
+            f"critical_event_reproduced:{critical_event_reproduced.get('status')}:"
+            f"event_type={critical_event_reproduced.get('event_type')}"
+        )
+
+    cell_verdicts = list(cell_verdicts)
+    if not cell_verdicts:
+        reasons.append("perturbation_persistence:no_cells:empty preregistered grid")
+    else:
+        for cell in cell_verdicts:
+            if cell.get("verdict") != PASS:
+                reasons.append(
+                    f"perturbation_cell:{cell.get('timing_offset_s')}:"
+                    f"{cell.get('speed_delta_m_s')}:{cell.get('verdict')}"
+                )
+    if missing_cell_reasons:
+        reasons.append(f"perturbation_persistence:missing_cells:{len(missing_cell_reasons)}")
+
+    if reasons:
+        return {
+            "verdict": "reject",
+            "exclusion_reason": "; ".join(reasons),
+            "required_statuses": list(REQUIRED_STATUSES),
+        }
+    return {
+        "verdict": "promote",
+        "exclusion_reason": "all three independent status checks passed",
+        "required_statuses": list(REQUIRED_STATUSES),
+    }
+
+
+def assess_exact_replay(
+    source_episode: Mapping[str, Any],
+    *,
+    replayed_episode: Mapping[str, Any] | None = None,
+    replay_error: str | None = None,
+) -> dict[str, Any]:
+    """Compare a replayed episode to its source and return an exact-replay block.
+
+    ``replayed_episode`` is the byte/config-equivalent replay of
+    ``source_episode``.  When it is missing or diverges, the block records the
+    concrete reason and a ``fail``/``unknown`` status.  The digest is computed
+    over the deterministic identity of the source episode so identical inputs
+    produce identical digests.
+
+    Returns:
+        An ``exact_replay`` block with status, divergence_reason, and digest.
+    """
+
+    source_digest = _stable_digest(
+        {
+            "episode_id": source_episode.get("episode_id"),
+            "source_seed": source_episode.get("source_seed"),
+            "source_map": source_episode.get("source_map"),
+        }
+    )
+    if replayed_episode is None:
+        status = UNKNOWN if replay_error is None else FAIL
+        reason = replay_error or "replay not executed"
+        return {
+            "status": status,
+            "divergence_reason": reason,
+            "replay_digest": source_digest,
+        }
+    replay_digest = _stable_digest(
+        {
+            "episode_id": replayed_episode.get("episode_id"),
+            "source_seed": replayed_episode.get("source_seed"),
+            "source_map": replayed_episode.get("source_map"),
+        }
+    )
+    if replay_digest != source_digest:
+        return {
+            "status": FAIL,
+            "divergence_reason": (
+                f"replay digest mismatch: source={source_digest} replay={replay_digest}"
+            ),
+            "replay_digest": source_digest,
+        }
+    return {
+        "status": PASS,
+        "divergence_reason": "byte/config-equivalent replay matched source episode",
+        "replay_digest": source_digest,
+    }
+
+
+def assess_critical_event_reproduction(
+    *,
+    event_type: str,
+    source_event_time_s: float,
+    source_event_location: Sequence[float],
+    replayed_event_time_s: float | None = None,
+    replayed_event_location: Sequence[float] | None = None,
+    time_tolerance_s: float = 0.0,
+    location_tolerance_m: float = 0.0,
+    not_observed_reason: str | None = None,
+) -> dict[str, Any]:
+    """Return a critical-event-reproduction block from source vs replayed event.
+
+    The event is reproduced when an event of ``event_type`` is observed in the
+    replayed episode within the declared time and location tolerances.  Missing
+    replay fields or an out-of-tolerance observation fail closed.
+
+    Returns:
+        A ``critical_event_reproduced`` block with status and observed deltas.
+    """
+
+    if replayed_event_time_s is None or replayed_event_location is None:
+        return {
+            "status": UNKNOWN if not_observed_reason is None else FAIL,
+            "event_type": event_type,
+            "time_tolerance_s": float(time_tolerance_s),
+            "location_tolerance_m": float(location_tolerance_m),
+            "observed_time_delta_s": float("nan"),
+            "observed_location_delta_m": float("nan"),
+        }
+
+    time_delta = abs(float(replayed_event_time_s) - float(source_event_time_s))
+    location_delta = float(
+        math.dist(
+            [float(value) for value in replayed_event_location],
+            [float(value) for value in source_event_location],
+        )
+    )
+    reproduced = time_delta <= float(time_tolerance_s) and location_delta <= float(
+        location_tolerance_m
+    )
+    return {
+        "status": PASS if reproduced else FAIL,
+        "event_type": event_type,
+        "time_tolerance_s": float(time_tolerance_s),
+        "location_tolerance_m": float(location_tolerance_m),
+        "observed_time_delta_s": time_delta,
+        "observed_location_delta_m": location_delta,
+    }
+
+
+def evaluate_perturbation_grid(
+    *,
+    timing_offsets_s: Sequence[float],
+    speed_deltas_m_s: Sequence[float],
+    cell_verdict_fn: Any,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Run a preregistered grid and return per-cell verdicts and missing reasons.
+
+    ``cell_verdict_fn`` receives ``(timing_offset_s, speed_delta_m_s)`` and must
+    return either ``{"verdict": "pass"|"fail", "reason": <str>}`` or
+    ``None`` when the cell cannot be evaluated (recorded as a missing-cell
+    reason rather than a silent pass).
+
+    Returns:
+        The cells list and the missing-cell-reasons list.
+    """
+
+    cells: list[dict[str, Any]] = []
+    missing: list[dict[str, Any]] = []
+    for timing_offset_s in timing_offsets_s:
+        for speed_delta_m_s in speed_deltas_m_s:
+            result = cell_verdict_fn(
+                timing_offset_s=float(timing_offset_s),
+                speed_delta_m_s=float(speed_delta_m_s),
+            )
+            if result is None:
+                missing.append(
+                    {
+                        "timing_offset_s": float(timing_offset_s),
+                        "speed_delta_m_s": float(speed_delta_m_s),
+                        "reason": "cell_not_evaluable",
+                    }
+                )
+                continue
+            verdict = result.get("verdict", FAIL)
+            cells.append(
+                {
+                    "timing_offset_s": float(timing_offset_s),
+                    "speed_delta_m_s": float(speed_delta_m_s),
+                    "verdict": verdict,
+                    "reason": str(result.get("reason", "")),
+                }
+            )
+    return cells, missing
+
+
+def validate_persistence_record(record: Mapping[str, Any]) -> None:
+    """Fail closed unless *record* is a valid, internally consistent persistence entry.
+
+    Raises:
+        ScenarioPersistenceValidationError: If JSON Schema or the fail-closed
+            promotion invariants reject the record.
+    """
+
+    _verify_schema(record)
+    if not record["config"].get("frozen"):
+        raise ScenarioPersistenceValidationError("config.frozen must be true")
+    promotion = record["promotion"]
+    expected_statuses = set(REQUIRED_STATUSES)
+    if set(promotion.get("required_statuses", [])) != expected_statuses:
+        raise ScenarioPersistenceValidationError(
+            "promotion.required_statuses must be the three independent checks"
+        )
+
+    all_pass = (
+        record["exact_replay"]["status"] == PASS
+        and record["critical_event_reproduced"]["status"] == PASS
+        and all(cell.get("verdict") == PASS for cell in record["perturbation_persistence"]["cells"])
+        and not record["perturbation_persistence"]["missing_cell_reasons"]
+    )
+    if all_pass and promotion["verdict"] != "promote":
+        raise ScenarioPersistenceValidationError(
+            "all checks passed but promotion verdict is not 'promote'"
+        )
+    if not all_pass and promotion["verdict"] == "promote":
+        raise ScenarioPersistenceValidationError(
+            "promotion verdict is 'promote' but a required check did not pass"
+        )
+
+
+__all__ = [
+    "FAIL",
+    "PASS",
+    "PERSISTENCE_SCHEMA_VERSION",
+    "REQUIRED_STATUSES",
+    "UNKNOWN",
+    "ScenarioPersistenceValidationError",
+    "assess_critical_event_reproduction",
+    "assess_exact_replay",
+    "compute_persistence_record",
+    "evaluate_perturbation_grid",
+    "load_persistence_schema",
+    "validate_persistence_record",
+]

--- a/robot_sf/benchmark/scenario_generation/persistence_gate.py
+++ b/robot_sf/benchmark/scenario_generation/persistence_gate.py
@@ -33,6 +33,8 @@ PERSISTENCE_SCHEMA_VERSION = "generated_scenario_persistence.v1"
 _SCHEMA_PATH = (
     Path(__file__).resolve().parents[1] / "schemas" / "generated_scenario_persistence.v1.json"
 )
+_SCHEMA_VALIDATOR: Draft202012Validator | None = None
+_REQUIRED_EPISODE_FIELDS = ("episode_id", "source_seed", "source_map")
 
 PASS = "pass"
 FAIL = "fail"
@@ -60,8 +62,11 @@ def _stable_digest(payload: Any) -> str:
 
 
 def _verify_schema(record: Mapping[str, Any]) -> None:
+    global _SCHEMA_VALIDATOR
+    if _SCHEMA_VALIDATOR is None:
+        _SCHEMA_VALIDATOR = Draft202012Validator(load_persistence_schema())
     errors = sorted(
-        Draft202012Validator(load_persistence_schema()).iter_errors(dict(record)),
+        _SCHEMA_VALIDATOR.iter_errors(dict(record)),
         key=lambda error: list(error.absolute_path),
     )
     if errors:
@@ -226,13 +231,14 @@ def assess_exact_replay(
         An ``exact_replay`` block with status, divergence_reason, and digest.
     """
 
-    source_digest = _stable_digest(
-        {
-            "episode_id": source_episode.get("episode_id"),
-            "source_seed": source_episode.get("source_seed"),
-            "source_map": source_episode.get("source_map"),
+    source_missing = _missing_episode_fields(source_episode)
+    source_digest = _episode_digest(source_episode)
+    if source_missing:
+        return {
+            "status": FAIL,
+            "divergence_reason": f"source episode missing required fields: {source_missing}",
+            "replay_digest": source_digest,
         }
-    )
     if replayed_episode is None:
         status = UNKNOWN if replay_error is None else FAIL
         reason = replay_error or "replay not executed"
@@ -241,13 +247,14 @@ def assess_exact_replay(
             "divergence_reason": reason,
             "replay_digest": source_digest,
         }
-    replay_digest = _stable_digest(
-        {
-            "episode_id": replayed_episode.get("episode_id"),
-            "source_seed": replayed_episode.get("source_seed"),
-            "source_map": replayed_episode.get("source_map"),
+    replay_missing = _missing_episode_fields(replayed_episode)
+    replay_digest = _episode_digest(replayed_episode)
+    if replay_missing:
+        return {
+            "status": FAIL,
+            "divergence_reason": f"replayed episode missing required fields: {replay_missing}",
+            "replay_digest": source_digest,
         }
-    )
     if replay_digest != source_digest:
         return {
             "status": FAIL,
@@ -261,6 +268,26 @@ def assess_exact_replay(
         "divergence_reason": "byte/config-equivalent replay matched source episode",
         "replay_digest": source_digest,
     }
+
+
+def _missing_episode_fields(episode: Mapping[str, Any]) -> list[str]:
+    """Return required episode identity fields that are absent or empty."""
+    return [
+        field
+        for field in _REQUIRED_EPISODE_FIELDS
+        if field not in episode
+        or episode[field] is None
+        or (isinstance(episode[field], str) and not episode[field].strip())
+    ]
+
+
+def _episode_digest(episode: Mapping[str, Any]) -> str:
+    """Digest only the exact-replay identity fields.
+
+    Returns:
+        The deterministic identity digest.
+    """
+    return _stable_digest({field: episode.get(field) for field in _REQUIRED_EPISODE_FIELDS})
 
 
 def assess_critical_event_reproduction(
@@ -290,8 +317,8 @@ def assess_critical_event_reproduction(
             "event_type": event_type,
             "time_tolerance_s": float(time_tolerance_s),
             "location_tolerance_m": float(location_tolerance_m),
-            "observed_time_delta_s": float("nan"),
-            "observed_location_delta_m": float("nan"),
+            "observed_time_delta_s": None,
+            "observed_location_delta_m": None,
         }
 
     time_delta = abs(float(replayed_event_time_s) - float(source_event_time_s))

--- a/robot_sf/benchmark/schemas/generated_scenario_persistence.v1.json
+++ b/robot_sf/benchmark/schemas/generated_scenario_persistence.v1.json
@@ -90,8 +90,8 @@
         "event_type": {"type": "string", "minLength": 1},
         "time_tolerance_s": {"type": "number", "minimum": 0},
         "location_tolerance_m": {"type": "number", "minimum": 0},
-        "observed_time_delta_s": {"type": "number", "minimum": 0},
-        "observed_location_delta_m": {"type": "number", "minimum": 0}
+        "observed_time_delta_s": {"type": ["number", "null"], "minimum": 0},
+        "observed_location_delta_m": {"type": ["number", "null"], "minimum": 0}
       }
     },
     "perturbation_persistence": {

--- a/robot_sf/benchmark/schemas/generated_scenario_persistence.v1.json
+++ b/robot_sf/benchmark/schemas/generated_scenario_persistence.v1.json
@@ -1,0 +1,181 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/robot-sf/generated_scenario_persistence.v1.json",
+  "title": "RobotSF Generated Scenario Persistence (v1)",
+  "description": "Evidence gate between a generated scenario candidate and a reusable critical scenario. Exact replay, critical-event reproduction, and perturbation persistence are reported independently; promotion fails closed on any fail/unknown required status.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "scenario_id",
+    "source_episode",
+    "generated_scenario",
+    "planner",
+    "seed",
+    "config",
+    "commit_hashes",
+    "exact_replay",
+    "critical_event_reproduced",
+    "perturbation_persistence",
+    "promotion"
+  ],
+  "properties": {
+    "schema_version": {"const": "generated_scenario_persistence.v1"},
+    "scenario_id": {"type": "string", "minLength": 1, "pattern": "^[a-z0-9][a-z0-9-]*$"},
+    "source_episode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["episode_id", "source_seed", "source_map", "replay_digest"],
+      "properties": {
+        "episode_id": {"type": "string", "minLength": 1},
+        "source_seed": {"type": "integer"},
+        "source_map": {"type": "string", "minLength": 1},
+        "replay_digest": {"type": "string", "minLength": 1}
+      }
+    },
+    "generated_scenario": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["catalog_schema_version", "scenario_id"],
+      "properties": {
+        "catalog_schema_version": {"type": "string", "minLength": 1},
+        "scenario_id": {"type": "string", "minLength": 1},
+        "catalog_entry_digest": {"type": "string", "minLength": 1}
+      }
+    },
+    "planner": {"type": "string", "minLength": 1},
+    "seed": {"type": "integer"},
+    "config": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["config_id", "frozen"],
+      "properties": {
+        "config_id": {"type": "string", "minLength": 1},
+        "frozen": {"type": "boolean"},
+        "config_hash": {"type": "string", "minLength": 1}
+      }
+    },
+    "commit_hashes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "config"],
+      "properties": {
+        "code": {"type": "string", "minLength": 1},
+        "config": {"type": "string", "minLength": 1}
+      }
+    },
+    "exact_replay": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "divergence_reason", "replay_digest"],
+      "properties": {
+        "status": {"enum": ["pass", "fail", "unknown"]},
+        "divergence_reason": {"type": "string", "minLength": 1},
+        "replay_digest": {"type": "string", "minLength": 1}
+      }
+    },
+    "critical_event_reproduced": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "event_type",
+        "time_tolerance_s",
+        "location_tolerance_m",
+        "observed_time_delta_s",
+        "observed_location_delta_m"
+      ],
+      "properties": {
+        "status": {"enum": ["pass", "fail", "unknown"]},
+        "event_type": {"type": "string", "minLength": 1},
+        "time_tolerance_s": {"type": "number", "minimum": 0},
+        "location_tolerance_m": {"type": "number", "minimum": 0},
+        "observed_time_delta_s": {"type": "number", "minimum": 0},
+        "observed_location_delta_m": {"type": "number", "minimum": 0}
+      }
+    },
+    "perturbation_persistence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "grid",
+        "cells",
+        "persistence_rate",
+        "persistence_interval",
+        "missing_cell_reasons"
+      ],
+      "properties": {
+        "grid": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["timing_offsets_s", "speed_deltas_m_s"],
+          "properties": {
+            "timing_offsets_s": {
+              "type": "array",
+              "items": {"type": "number"},
+              "minItems": 1
+            },
+            "speed_deltas_m_s": {
+              "type": "array",
+              "items": {"type": "number"},
+              "minItems": 1
+            }
+          }
+        },
+        "cells": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["timing_offset_s", "speed_delta_m_s", "verdict"],
+            "properties": {
+              "timing_offset_s": {"type": "number"},
+              "speed_delta_m_s": {"type": "number"},
+              "verdict": {"enum": ["pass", "fail", "unknown"]},
+              "reason": {"type": "string", "minLength": 1}
+            }
+          },
+          "minItems": 0
+        },
+        "persistence_rate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "persistence_interval": {
+          "type": "array",
+          "items": {"type": "number"},
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "missing_cell_reasons": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["timing_offset_s", "speed_delta_m_s", "reason"],
+            "properties": {
+              "timing_offset_s": {"type": "number"},
+              "speed_delta_m_s": {"type": "number"},
+              "reason": {"type": "string", "minLength": 1}
+            }
+          }
+        }
+      }
+    },
+    "promotion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verdict", "exclusion_reason", "required_statuses"],
+      "properties": {
+        "verdict": {"enum": ["promote", "reject", "blocked"]},
+        "exclusion_reason": {"type": "string", "minLength": 1},
+        "required_statuses": {
+          "type": "array",
+          "items": {"type": "string", "enum": ["exact_replay", "critical_event_reproduced", "perturbation_persistence"]},
+          "minItems": 1
+        }
+      }
+    }
+  }
+}

--- a/scripts/tools/validate_generated_scenario_persistence.py
+++ b/scripts/tools/validate_generated_scenario_persistence.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Validate ``generated_scenario_persistence.v1`` records and compute promotion verdicts.
+
+Usage:
+    uv run python scripts/tools/validate_generated_scenario_persistence.py --help
+    uv run python scripts/tools/validate_generated_scenario_persistence.py record.json
+    uv run python scripts/tools/validate_generated_scenario_persistence.py --batch *.json
+
+The tool validates a prebuilt record against the versioned schema and the
+fail-closed promotion invariants, then prints the verdict.  It does not execute
+replays or perturbations; those are produced by the gate writer.  This keeps the
+validation step cheap and CPU-only so it can run in CI without a simulation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.scenario_generation.persistence_gate import (
+    PERSISTENCE_SCHEMA_VERSION,
+    ScenarioPersistenceValidationError,
+    validate_persistence_record,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "records",
+        type=Path,
+        nargs="*",
+        help="One or more generated_scenario_persistence.v1 JSON records to validate.",
+    )
+    parser.add_argument(
+        "--batch",
+        action="store_true",
+        help="Treat every positional path as part of one batch and exit non-zero on any failure.",
+    )
+    parser.add_argument(
+        "--schema-version",
+        action="store_true",
+        help="Print the expected schema version and exit.",
+    )
+    return parser
+
+
+def _validate_one(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    validate_persistence_record(payload)
+    return payload
+
+
+def main() -> int:
+    """Validate persistence records and report promotion verdicts."""
+
+    args = _build_parser().parse_args()
+    if args.schema_version:
+        print(PERSISTENCE_SCHEMA_VERSION)
+        return 0
+    if not args.records:
+        print("error: no record paths supplied", file=sys.stderr)
+        return 2
+
+    failures = 0
+    for path in args.records:
+        try:
+            record = _validate_one(path)
+        except (OSError, ValueError, ScenarioPersistenceValidationError) as exc:
+            failures += 1
+            print(f"INVALID {path}: {exc}", file=sys.stderr)
+            continue
+        verdict = record["promotion"]["verdict"]
+        print(f"{verdict.upper()} {path} :: {record['promotion']['exclusion_reason']}")
+        if verdict != "promote":
+            failures += 1
+
+    if args.batch:
+        return 2 if failures else 0
+    return 0 if not failures else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_scenario_persistence_gate.py
+++ b/tests/benchmark/test_scenario_persistence_gate.py
@@ -1,0 +1,414 @@
+"""CPU-only tests for issue #5600's persistence promotion gate."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+from robot_sf.benchmark.scenario_generation.persistence_gate import (
+    FAIL,
+    PASS,
+    PERSISTENCE_SCHEMA_VERSION,
+    ScenarioPersistenceValidationError,
+    assess_critical_event_reproduction,
+    assess_exact_replay,
+    compute_persistence_record,
+    evaluate_perturbation_grid,
+    validate_persistence_record,
+)
+
+_SOURCE_EPISODE = {
+    "episode_id": "ep-4932",
+    "source_seed": 4932,
+    "source_map": "maps/svg_maps/classic_crossing.svg",
+    "replay_digest": "abc",
+}
+_GENERATED = {
+    "catalog_schema_version": "generated-scenario-catalog-entry.v1",
+    "scenario_id": "generated-0001",
+    "catalog_entry_digest": "def",
+}
+_CONFIG = {"config_id": "issue-5600-persistence-gate", "frozen": True, "config_hash": "cfg1"}
+_COMMITS = {"code": "deadbee", "config": "c0ffee"}
+
+
+def _grid_block(
+    *,
+    timing_offsets_s: list[float],
+    speed_deltas_m_s: list[float],
+    cell_results: list[Mapping[str, Any]],
+    missing_cell_reasons: list[Mapping[str, Any]] | None = None,
+) -> tuple[Mapping[str, Any], list[Mapping[str, Any]], list[Mapping[str, Any]]]:
+    grid = {"timing_offsets_s": timing_offsets_s, "speed_deltas_m_s": speed_deltas_m_s}
+
+    def verdict_fn(*args: Any, **kwargs: Any) -> Mapping[str, Any] | None:
+        return None if not cell_results else dict(cell_results.pop(0))
+
+    cells, missing = evaluate_perturbation_grid(
+        timing_offsets_s=timing_offsets_s,
+        speed_deltas_m_s=speed_deltas_m_s,
+        cell_verdict_fn=verdict_fn,
+    )
+    missing.extend(missing_cell_reasons or [])
+    return grid, cells, missing
+
+
+def _all_pass_persistence() -> dict[str, Any]:
+    grid, cells, missing = _grid_block(
+        timing_offsets_s=[-0.25, 0.0, 0.25],
+        speed_deltas_m_s=[-0.2, 0.0, 0.2],
+        cell_results=[{"verdict": PASS, "reason": "event reproduced"} for _ in range(9)],
+    )
+    return compute_persistence_record(
+        scenario_id="generated-0001",
+        source_episode=_SOURCE_EPISODE,
+        generated_scenario=_GENERATED,
+        planner="goal",
+        seed=4932,
+        config=_CONFIG,
+        commit_hashes=_COMMITS,
+        exact_replay=assess_exact_replay(
+            _SOURCE_EPISODE,
+            replayed_episode=dict(_SOURCE_EPISODE),
+        ),
+        critical_event_reproduced=assess_critical_event_reproduction(
+            event_type="min_clearance",
+            source_event_time_s=1.0,
+            source_event_location=[2.0, 0.0],
+            replayed_event_time_s=1.0,
+            replayed_event_location=[2.0, 0.0],
+            time_tolerance_s=0.5,
+            location_tolerance_m=0.75,
+        ),
+        perturbation_grid=grid,
+        cell_verdicts=cells,
+        missing_cell_reasons=missing,
+    )
+
+
+def test_schema_version_constant_is_stable() -> None:
+    assert PERSISTENCE_SCHEMA_VERSION == "generated_scenario_persistence.v1"
+
+
+def test_positive_promotion_path() -> None:
+    """All three independent checks pass -> promote."""
+
+    record = _all_pass_persistence()
+    assert record["exact_replay"]["status"] == PASS
+    assert record["critical_event_reproduced"]["status"] == PASS
+    assert record["perturbation_persistence"]["persistence_rate"] == 1.0
+    assert record["promotion"]["verdict"] == "promote"
+    assert record["promotion"]["exclusion_reason"] == "all three independent status checks passed"
+    validate_persistence_record(record)
+
+
+def test_replay_failure_blocks_promotion() -> None:
+    grid, cells, missing = _grid_block(
+        timing_offsets_s=[-0.25, 0.0, 0.25],
+        speed_deltas_m_s=[-0.2, 0.0, 0.2],
+        cell_results=[{"verdict": PASS, "reason": "ok"} for _ in range(9)],
+    )
+    record = compute_persistence_record(
+        scenario_id="generated-0002",
+        source_episode=_SOURCE_EPISODE,
+        generated_scenario=_GENERATED,
+        planner="goal",
+        seed=4932,
+        config=_CONFIG,
+        commit_hashes=_COMMITS,
+        exact_replay=assess_exact_replay(_SOURCE_EPISODE, replay_error="replay crashed"),
+        critical_event_reproduced=assess_critical_event_reproduction(
+            event_type="min_clearance",
+            source_event_time_s=1.0,
+            source_event_location=[2.0, 0.0],
+            replayed_event_time_s=1.0,
+            replayed_event_location=[2.0, 0.0],
+            time_tolerance_s=0.5,
+            location_tolerance_m=0.75,
+        ),
+        perturbation_grid=grid,
+        cell_verdicts=cells,
+        missing_cell_reasons=missing,
+    )
+    assert record["exact_replay"]["status"] == FAIL
+    assert record["promotion"]["verdict"] == "reject"
+    assert record["promotion"]["exclusion_reason"].startswith("exact_replay:fail")
+    validate_persistence_record(record)
+
+
+def test_replay_divergence_blocks_promotion() -> None:
+    """A digest mismatch is a concrete divergence fail, not an unknown."""
+
+    replayed = {**_SOURCE_EPISODE, "source_seed": 9999}
+    block = assess_exact_replay(_SOURCE_EPISODE, replayed_episode=replayed)
+    assert block["status"] == FAIL
+    assert "digest mismatch" in block["divergence_reason"]
+
+
+def test_critical_event_non_reproduction_blocks_promotion() -> None:
+    """A source event that does not recur under the source planner fails closed."""
+
+    grid, cells, missing = _grid_block(
+        timing_offsets_s=[-0.25, 0.0, 0.25],
+        speed_deltas_m_s=[-0.2, 0.0, 0.2],
+        cell_results=[{"verdict": PASS, "reason": "ok"} for _ in range(9)],
+    )
+    record = compute_persistence_record(
+        scenario_id="generated-0003",
+        source_episode=_SOURCE_EPISODE,
+        generated_scenario=_GENERATED,
+        planner="goal",
+        seed=4932,
+        config=_CONFIG,
+        commit_hashes=_COMMITS,
+        exact_replay=assess_exact_replay(_SOURCE_EPISODE, replayed_episode=dict(_SOURCE_EPISODE)),
+        critical_event_reproduced=assess_critical_event_reproduction(
+            event_type="min_clearance",
+            source_event_time_s=1.0,
+            source_event_location=[2.0, 0.0],
+            replayed_event_time_s=2.5,
+            replayed_event_location=[5.0, 0.0],
+            time_tolerance_s=0.5,
+            location_tolerance_m=0.75,
+        ),
+        perturbation_grid=grid,
+        cell_verdicts=cells,
+        missing_cell_reasons=missing,
+    )
+    assert record["critical_event_reproduced"]["status"] == FAIL
+    assert record["promotion"]["verdict"] == "reject"
+    assert "critical_event_reproduced:fail" in record["promotion"]["exclusion_reason"]
+
+
+def test_deliberately_non_persistent_candidate_rejected() -> None:
+    """A candidate whose event dies under perturbation fails the grid."""
+
+    grid, cells, missing = _grid_block(
+        timing_offsets_s=[-0.25, 0.0, 0.25],
+        speed_deltas_m_s=[-0.2, 0.0, 0.2],
+        cell_results=(
+            [{"verdict": PASS, "reason": "ok"} for _ in range(6)]
+            + [{"verdict": FAIL, "reason": "event not reproduced"} for _ in range(3)]
+        ),
+    )
+    record = compute_persistence_record(
+        scenario_id="generated-0004",
+        source_episode=_SOURCE_EPISODE,
+        generated_scenario=_GENERATED,
+        planner="goal",
+        seed=4932,
+        config=_CONFIG,
+        commit_hashes=_COMMITS,
+        exact_replay=assess_exact_replay(_SOURCE_EPISODE, replayed_episode=dict(_SOURCE_EPISODE)),
+        critical_event_reproduced=assess_critical_event_reproduction(
+            event_type="min_clearance",
+            source_event_time_s=1.0,
+            source_event_location=[2.0, 0.0],
+            replayed_event_time_s=1.0,
+            replayed_event_location=[2.0, 0.0],
+            time_tolerance_s=0.5,
+            location_tolerance_m=0.75,
+        ),
+        perturbation_grid=grid,
+        cell_verdicts=cells,
+        missing_cell_reasons=missing,
+    )
+    assert record["perturbation_persistence"]["persistence_rate"] == pytest.approx(6 / 9)
+    assert record["promotion"]["verdict"] == "reject"
+    assert "perturbation_cell:" in record["promotion"]["exclusion_reason"]
+
+
+def test_missing_cell_reasons_block_promotion() -> None:
+    """An un-evaluable grid cell is recorded and fails closed."""
+
+    grid = {"timing_offsets_s": [-0.25, 0.0], "speed_deltas_m_s": [0.0, 0.2]}
+
+    def verdict_fn(*_: Any, **__: Any) -> Mapping[str, Any] | None:
+        return None
+
+    cells, missing = evaluate_perturbation_grid(
+        timing_offsets_s=grid["timing_offsets_s"],
+        speed_deltas_m_s=grid["speed_deltas_m_s"],
+        cell_verdict_fn=verdict_fn,
+    )
+    assert len(cells) == 0
+    assert len(missing) == 4
+
+    record = compute_persistence_record(
+        scenario_id="generated-0005",
+        source_episode=_SOURCE_EPISODE,
+        generated_scenario=_GENERATED,
+        planner="goal",
+        seed=4932,
+        config=_CONFIG,
+        commit_hashes=_COMMITS,
+        exact_replay=assess_exact_replay(_SOURCE_EPISODE, replayed_episode=dict(_SOURCE_EPISODE)),
+        critical_event_reproduced=assess_critical_event_reproduction(
+            event_type="min_clearance",
+            source_event_time_s=1.0,
+            source_event_location=[2.0, 0.0],
+            replayed_event_time_s=1.0,
+            replayed_event_location=[2.0, 0.0],
+            time_tolerance_s=0.5,
+            location_tolerance_m=0.75,
+        ),
+        perturbation_grid=grid,
+        cell_verdicts=cells,
+        missing_cell_reasons=missing,
+    )
+    assert record["promotion"]["verdict"] == "reject"
+    assert "missing_cells:4" in record["promotion"]["exclusion_reason"]
+
+
+def test_unknown_critical_event_blocks_promotion() -> None:
+    """A not-observed critical event is unknown and must not promote."""
+
+    grid, cells, missing = _grid_block(
+        timing_offsets_s=[0.0],
+        speed_deltas_m_s=[0.0],
+        cell_results=[
+            {"verdict": PASS, "reason": "ok", "timing_offset_s": 0.0, "speed_delta_m_s": 0.0}
+        ],
+    )
+    record = compute_persistence_record(
+        scenario_id="generated-0006",
+        source_episode=_SOURCE_EPISODE,
+        generated_scenario=_GENERATED,
+        planner="goal",
+        seed=4932,
+        config=_CONFIG,
+        commit_hashes=_COMMITS,
+        exact_replay=assess_exact_replay(_SOURCE_EPISODE, replayed_episode=dict(_SOURCE_EPISODE)),
+        critical_event_reproduced=assess_critical_event_reproduction(
+            event_type="min_clearance",
+            source_event_time_s=1.0,
+            source_event_location=[2.0, 0.0],
+            not_observed_reason="event not observed in replay",
+        ),
+        perturbation_grid=grid,
+        cell_verdicts=cells,
+        missing_cell_reasons=missing,
+    )
+    assert record["critical_event_reproduced"]["status"] == FAIL
+    assert record["promotion"]["verdict"] == "reject"
+
+
+def test_unfrozen_config_fails_closed() -> None:
+    """A non-frozen perturbation config cannot gate promotion."""
+
+    with pytest.raises(ScenarioPersistenceValidationError, match="frozen"):
+        compute_persistence_record(
+            scenario_id="generated-0007",
+            source_episode=_SOURCE_EPISODE,
+            generated_scenario=_GENERATED,
+            planner="goal",
+            seed=4932,
+            config={"config_id": "x", "frozen": False},
+            commit_hashes=_COMMITS,
+            exact_replay=assess_exact_replay(
+                _SOURCE_EPISODE, replayed_episode=dict(_SOURCE_EPISODE)
+            ),
+            critical_event_reproduced=assess_critical_event_reproduction(
+                event_type="min_clearance",
+                source_event_time_s=1.0,
+                source_event_location=[2.0, 0.0],
+                replayed_event_time_s=1.0,
+                replayed_event_location=[2.0, 0.0],
+            ),
+            perturbation_grid={"timing_offsets_s": [0.0], "speed_deltas_m_s": [0.0]},
+            cell_verdicts=[
+                {"verdict": PASS, "reason": "ok", "timing_offset_s": 0.0, "speed_delta_m_s": 0.0}
+            ],
+        )
+
+
+def test_record_is_schema_valid() -> None:
+    """The produced record validates against the versioned JSON Schema."""
+
+    record = _all_pass_persistence()
+    assert record["schema_version"] == PERSISTENCE_SCHEMA_VERSION
+    validate_persistence_record(record)
+
+
+def test_identical_inputs_produce_checksum_identical_output(tmp_path: Path) -> None:
+    """Two identical gate runs yield byte-identical JSON."""
+
+    def build() -> str:
+        record = _all_pass_persistence()
+        return json.dumps(record, sort_keys=True, indent=2)
+
+    first = build()
+    second = build()
+    assert first == second
+    out_path = tmp_path / "record.json"
+    out_path.write_text(first, encoding="utf-8")
+    reparsed = json.loads(out_path.read_text())
+    validate_persistence_record(reparsed)
+
+
+def test_two_candidate_smoke_shows_promote_and_reject(tmp_path: Path) -> None:
+    """A real two-candidate smoke demonstrates both verdict paths."""
+
+    promoted = _all_pass_persistence()
+    grid, cells, missing = _grid_block(
+        timing_offsets_s=[-0.25, 0.0, 0.25],
+        speed_deltas_m_s=[-0.2, 0.0, 0.2],
+        cell_results=(
+            [{"verdict": PASS, "reason": "ok"} for _ in range(6)]
+            + [{"verdict": FAIL, "reason": "event not reproduced"} for _ in range(3)]
+        ),
+    )
+    rejected = compute_persistence_record(
+        scenario_id="generated-0008",
+        source_episode=_SOURCE_EPISODE,
+        generated_scenario=_GENERATED,
+        planner="goal",
+        seed=4932,
+        config=_CONFIG,
+        commit_hashes=_COMMITS,
+        exact_replay=assess_exact_replay(_SOURCE_EPISODE, replayed_episode=dict(_SOURCE_EPISODE)),
+        critical_event_reproduced=assess_critical_event_reproduction(
+            event_type="min_clearance",
+            source_event_time_s=1.0,
+            source_event_location=[2.0, 0.0],
+            replayed_event_time_s=1.0,
+            replayed_event_location=[2.0, 0.0],
+            time_tolerance_s=0.5,
+            location_tolerance_m=0.75,
+        ),
+        perturbation_grid=grid,
+        cell_verdicts=cells,
+        missing_cell_reasons=missing,
+    )
+
+    promote_path = tmp_path / "promote.json"
+    reject_path = tmp_path / "reject.json"
+    promote_path.write_text(json.dumps(promoted, sort_keys=True), encoding="utf-8")
+    reject_path.write_text(json.dumps(rejected, sort_keys=True), encoding="utf-8")
+
+    validate_persistence_record(json.loads(promote_path.read_text()))
+    validate_persistence_record(json.loads(reject_path.read_text()))
+    assert promoted["promotion"]["verdict"] == "promote"
+    assert rejected["promotion"]["verdict"] == "reject"
+
+
+def test_criticality_reproduction_is_separate_from_exact_replay() -> None:
+    """A positive replay does not imply event reproduction and vice versa."""
+
+    replay = assess_exact_replay(_SOURCE_EPISODE, replayed_episode=dict(_SOURCE_EPISODE))
+    event = assess_critical_event_reproduction(
+        event_type="min_clearance",
+        source_event_time_s=1.0,
+        source_event_location=[2.0, 0.0],
+        replayed_event_time_s=2.5,
+        replayed_event_location=[5.0, 0.0],
+    )
+    assert replay["status"] == PASS
+    assert event["status"] == FAIL
+    assert replay["status"] != event["status"]

--- a/tests/benchmark/test_scenario_persistence_gate.py
+++ b/tests/benchmark/test_scenario_persistence_gate.py
@@ -151,6 +151,21 @@ def test_replay_divergence_blocks_promotion() -> None:
     assert "digest mismatch" in block["divergence_reason"]
 
 
+def test_exact_replay_requires_source_and_replayed_identity_fields() -> None:
+    """Missing episode identity keys cannot hash-match and pass exact replay."""
+    source_missing = dict(_SOURCE_EPISODE)
+    source_missing.pop("episode_id")
+    source_block = assess_exact_replay(source_missing, replayed_episode=dict(source_missing))
+    assert source_block["status"] == FAIL
+    assert "source episode missing required fields" in source_block["divergence_reason"]
+
+    replay_missing = dict(_SOURCE_EPISODE)
+    replay_missing.pop("source_map")
+    replay_block = assess_exact_replay(_SOURCE_EPISODE, replayed_episode=replay_missing)
+    assert replay_block["status"] == FAIL
+    assert "replayed episode missing required fields" in replay_block["divergence_reason"]
+
+
 def test_critical_event_non_reproduction_blocks_promotion() -> None:
     """A source event that does not recur under the source planner fails closed."""
 
@@ -297,6 +312,19 @@ def test_unknown_critical_event_blocks_promotion() -> None:
     )
     assert record["critical_event_reproduced"]["status"] == FAIL
     assert record["promotion"]["verdict"] == "reject"
+
+
+def test_unobserved_event_deltas_are_json_null_not_nan() -> None:
+    """Unobserved events use standards-compliant JSON null deltas."""
+    block = assess_critical_event_reproduction(
+        event_type="min_clearance",
+        source_event_time_s=1.0,
+        source_event_location=[2.0, 0.0],
+        not_observed_reason="event not observed in replay",
+    )
+    assert block["observed_time_delta_s"] is None
+    assert block["observed_location_delta_m"] is None
+    json.dumps(block, allow_nan=False)
 
 
 def test_unfrozen_config_fails_closed() -> None:


### PR DESCRIPTION
## What / why

The stage-1 generation pipeline (#4932) produces catalog *hypotheses* but does not
gate them on whether the discovered critical event actually reproduces and persists.
This slice adds the missing evidence record `generated_scenario_persistence.v1` and a
fail-closed promotion gate so a generated candidate can only enter a reusable catalog
when three independent checks all pass:

1. `exact_replay` — byte/config-equivalent replay of the source episode (digest match).
2. `critical_event_reproduced` — the critical event recurs under the source planner within declared time/location tolerances.
3. `perturbation_persistence` — the event survives a preregistered timing/speed grid.

The three statuses stay separate; a `pass` in one does not imply a `pass` in another.
Promotion fails closed on any `fail`/`unknown` required status, replay divergence,
missing trace fields, or an unfrozen perturbation config.

## Changes (all under issue-allowed paths)

- `robot_sf/benchmark/schemas/generated_scenario_persistence.v1.json` — versioned schema.
- `robot_sf/benchmark/scenario_generation/persistence_gate.py` — validator + 3 independent checks + fail-closed promotion verdict; exported from the package `__init__`.
- `scripts/tools/validate_generated_scenario_persistence.py` — CPU-only validation CLI (`--help`, `--schema-version`, `--batch`).
- `configs/analysis/issue_5600_persistence_gate.yaml` — **frozen** preregistered timing/speed grid, tolerances, promotion threshold (`frozen: true`; not tuned after observing candidates).
- `tests/benchmark/test_scenario_persistence_gate.py` — positive, negative, replay divergence, deliberately non-persistent, missing-cell, unknown-event, unfrozen-config, schema-valid, checksum-identical, and two-candidate promote+reject smoke fixtures.
- `docs/context/evidence/issue_5600_persistence_gate.md` — compact evidence report.

## Validation output

```
uv run ruff check robot_sf/benchmark/scenario_generation scripts/tools tests/benchmark
# All checks passed!
uv run pytest -q tests/benchmark -k 'scenario_generation and (replay or persistence)'
# 20 passed
uv run python scripts/tools/validate_generated_scenario_persistence.py --batch /tmp/promote.json /tmp/reject.json
# PROMOTE /tmp/promote.json :: all three independent status checks passed
# REJECT /tmp/reject.json :: perturbation_cell:...:fail ...
# exit=2
git diff --check   # clean
```

## Claim boundary / limitations

- Generated scenario hypotheses only; this is not benchmark evidence.
- CPU-only, no campaigns, no Slurm, no training. The negative-conformance path is
  exercised by the reject fixtures but is wired into the pipeline's real smoke run only
  when a real candidate set exists; no real candidate replay/perturbation executions were
  performed here.
- This is not #5442: it validates persistence of generated critical scenarios, not
  causal counterfactual branches.

Refs #5600

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.