### PR TITLE
fix(baselines): repair PPO exact-repeat dict observation path (#5540)

### DIFF
--- a/robot_sf/baselines/ppo.py
+++ b/robot_sf/baselines/ppo.py
@@ -279,6 +279,12 @@ class PPOPlanner:
 
         # Try model predict
         try:
+            if self._uses_dict_observation():
+                model_obs = self._build_model_obs_dict(self._observation_to_dict(obs))
+                action_vec = self._predict_action(model_obs)
+                if action_vec is None:
+                    raise RuntimeError("PPO model unavailable or prediction failed")
+                return self._action_vec_to_dict_from_array(action_vec)
             action_vec = self._predict_action(obs)
             if action_vec is None:
                 raise RuntimeError("PPO model unavailable or prediction failed")
@@ -318,6 +324,60 @@ class PPOPlanner:
                 return self._fallback_action_dict(obs)
             raise
 
+    def _observation_to_dict(self, obs: Observation) -> dict[str, Any]:
+        """Convert the legacy runner observation into the dict-policy contract.
+
+        Returns:
+            Structured observation mapping compatible with the dict adapter.
+        """
+        robot = dict(obs.robot)
+        robot.setdefault("velocity_xy", robot.get("velocity", [0.0, 0.0]))
+        robot.setdefault("heading", [0.0])
+        robot.setdefault("radius", [0.3])
+        goal = np.asarray(robot.get("goal", [0.0, 0.0]), dtype=np.float32).reshape(-1)[:2]
+
+        positions = np.asarray(
+            [agent.get("position", [0.0, 0.0]) for agent in obs.agents], dtype=np.float32
+        ).reshape(-1, 2)
+        velocities = np.asarray(
+            [agent.get("velocity", [0.0, 0.0]) for agent in obs.agents], dtype=np.float32
+        ).reshape(-1, 2)
+        positions = self._pad_agent_observation(positions, "pedestrians_positions")
+        velocities = self._pad_agent_observation(velocities, "pedestrians_velocities")
+        radius = float(obs.agents[0].get("radius", 0.35)) if obs.agents else 0.35
+
+        return {
+            "robot": robot,
+            "goal": {"current": goal, "next": goal.copy()},
+            "pedestrians": {
+                "positions": positions,
+                "velocities": velocities,
+                "count": np.array([len(obs.agents)], dtype=np.float32),
+                "radius": np.array([radius], dtype=np.float32),
+            },
+            "sim": {"timestep": np.array([obs.dt], dtype=np.float32)},
+        }
+
+    def _pad_agent_observation(self, values: np.ndarray, key: str) -> np.ndarray:
+        """Pad variable-length runner agent arrays to a declared model shape.
+
+        Returns:
+            Agent array with the model-declared row count when available.
+        """
+        if self._model is None:
+            return values
+        spaces = getattr(getattr(self._model, "observation_space", None), "spaces", None)
+        target_space = spaces.get(key) if isinstance(spaces, dict) else None
+        target_shape = getattr(target_space, "shape", None)
+        if target_shape is None or tuple(target_shape) == tuple(values.shape):
+            return values
+        if len(target_shape) != 2 or target_shape[1] != 2:
+            return values
+        padded = np.zeros(tuple(target_shape), dtype=np.float32)
+        rows = min(padded.shape[0], values.shape[0])
+        padded[:rows] = values[:rows]
+        return padded
+
     # --- Helpers -------------------------------------------------------
     def _predict_action(self, model_obs: np.ndarray | dict[str, np.ndarray]) -> np.ndarray | None:
         """Run PPO inference and return the raw action vector.
@@ -347,7 +407,7 @@ class PPOPlanner:
             IndexError,
         ) as exc:  # predict-time errors we can recover from
             # Log at debug level for diagnostics; fall back to goal if enabled
-            logger.debug("PPO model prediction failed: %s", exc, exc_info=True)
+            logger.opt(exception=True).debug("PPO model prediction failed: {}", exc)
             return None
 
     def _build_model_obs_dict(self, obs: dict[str, Any]) -> dict[str, np.ndarray] | np.ndarray:

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -776,7 +776,7 @@ def _create_robot_policy(  # noqa: C901, PLR0915
             metadata["status"] = "policy_step_error_fallback"
             metadata["fallback_reason"] = "policy_step_error"
             timeout_metadata["last_error"] = str(exc)
-            logger.warning("Planner step failed unexpectedly: %s", exc)
+            logger.opt(exception=True).warning("Planner step failed unexpectedly: {}", exc)
             action = {"vx": 0.0, "vy": 0.0}
 
         # Convert action to velocity (handle both action spaces)

--- a/tests/baselines/test_ppo_planner.py
+++ b/tests/baselines/test_ppo_planner.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 import yaml
 from gymnasium import spaces
+from loguru import logger
 
 from robot_sf.baselines.ppo import PPOPlanner, PPOPlannerConfig
 from robot_sf.baselines.social_force import Observation
@@ -343,6 +344,22 @@ def test_predict_action_success_and_error_paths():
         predict=lambda *_args, **_kwargs: (_ for _ in ()).throw(IndexError("bad")),
     )
     assert planner._predict_action(np.array([1.0, 2.0])) is None
+
+
+def test_predict_action_logs_exception_details() -> None:
+    """Prediction failures should retain the exception text in the Loguru message."""
+    planner = PPOPlanner(_planner_config())
+    planner._model = SimpleNamespace(
+        predict=lambda *_args, **_kwargs: (_ for _ in ()).throw(IndexError("bad observation")),
+    )
+    captured: list[str] = []
+    handler = logger.add(lambda message: captured.append(message.record["message"]), level="DEBUG")
+    try:
+        assert planner._predict_action(np.array([1.0, 2.0])) is None
+    finally:
+        logger.remove(handler)
+
+    assert "PPO model prediction failed: bad observation" in captured
 
 
 def test_build_model_obs_image_requires_payload():

--- a/tests/test_baseline_ppo_observation_keys.py
+++ b/tests/test_baseline_ppo_observation_keys.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from gymnasium import spaces as gym_spaces
 
+from robot_sf.baselines.interface import Observation
 from robot_sf.baselines.ppo import PPOPlanner, PPOPlannerConfig
 
 
@@ -130,8 +131,40 @@ def test_ppo_dict_obs_keeps_nested_env_obs_compatible_with_flat_model_space() ->
         "goal_current",
         "pedestrians_positions",
     }
+
+
+def test_ppo_dict_obs_converts_legacy_runner_observation() -> None:
+    """Dict PPO must convert the exact-repeat runner's structured Observation input."""
+    model = _FakePPOModel(
+        gym_spaces.Dict(
+            {
+                "robot_position": _box((2,)),
+                "robot_speed": _box((2,)),
+                "goal_current": _box((2,)),
+                "goal_next": _box((2,)),
+                "pedestrians_positions": _box((2, 2)),
+                "pedestrians_velocities": _box((2, 2)),
+                "pedestrians_count": _box((1,)),
+                "pedestrians_radius": _box((1,)),
+                "sim_timestep": _box((1,)),
+            }
+        )
+    )
+    planner = _planner_with_model(model)
+    observation = Observation(
+        dt=0.1,
+        robot={"position": [1.0, 2.0], "velocity": [0.1, 0.2], "goal": [4.0, 5.0]},
+        agents=[{"position": [2.0, 3.0], "velocity": [0.0, 0.1]}],
+    )
+
+    action = planner.step(observation)
+
+    assert action == {"vx": pytest.approx(0.4), "vy": pytest.approx(-0.2)}
+    assert model.last_obs is not None
     np.testing.assert_allclose(model.last_obs["robot_position"], [1.0, 2.0])
+    np.testing.assert_allclose(model.last_obs["robot_speed"], [0.1, 0.2])
     np.testing.assert_allclose(model.last_obs["goal_current"], [4.0, 5.0])
+    np.testing.assert_allclose(model.last_obs["pedestrians_positions"], [[2.0, 3.0], [0.0, 0.0]])
 
 
 def test_ppo_dict_obs_backfills_missing_leaf_key_with_space_default() -> None:

--- a/tests/test_runner_policy_timeout.py
+++ b/tests/test_runner_policy_timeout.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import numpy as np
 import pytest
+from loguru import logger
 
 from robot_sf import baselines
 from robot_sf.benchmark import runner
@@ -24,6 +25,21 @@ class _SlowPlanner:
         return {"vx": 1.0, "vy": 0.0}
 
     def get_metadata(self) -> dict[str, Any]:
+        return {"algorithm": "random", "status": "ok", "seed": self.seed}
+
+
+class _FailingPlanner:
+    """Planner stub whose worker step raises a diagnostic error."""
+
+    def __init__(self, _config: dict[str, Any], *, seed: int) -> None:
+        self.seed = seed
+
+    def step(self, _obs: Any) -> dict[str, float]:
+        """Raise the worker error that the parent policy wrapper logs."""
+        raise ValueError("bad worker observation")
+
+    def get_metadata(self) -> dict[str, Any]:
+        """Return baseline metadata for the failing planner."""
         return {"algorithm": "random", "status": "ok", "seed": self.seed}
 
 
@@ -89,6 +105,37 @@ def test_planner_step_timeout_fails_fast_and_reports_metadata(
     assert timeout_metadata["step_timeout_s"] == 0.05
     assert timeout_metadata["step_timeouts"] == 1
     assert timeout_metadata["fallback_actions"] == 1
+
+
+@pytest.mark.skipif("fork" not in mp.get_all_start_methods(), reason="requires fork isolation")
+def test_planner_step_error_logs_exception_details(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Worker errors should retain their exception text in the Loguru warning."""
+    monkeypatch.setitem(baselines.BASELINES, "random", _FailingPlanner)
+    captured: list[str] = []
+    handler = logger.add(
+        lambda message: captured.append(message.record["message"]), level="WARNING"
+    )
+    try:
+        policy, metadata = runner._create_robot_policy("random", None, seed=123)
+        velocity = policy(
+            np.array([0.0, 0.0]),
+            np.array([0.0, 0.0]),
+            np.array([1.0, 0.0]),
+            np.empty((0, 2)),
+            0.1,
+        )
+    finally:
+        logger.remove(handler)
+        if "policy" in locals():
+            policy.close()
+
+    assert velocity == pytest.approx(np.array([0.0, 0.0]))
+    assert metadata["status"] == "policy_step_error_fallback"
+    assert any(
+        "Planner step failed unexpectedly: Planner step failed in worker" in message
+        and "bad worker observation" in message
+        for message in captured
+    )
 
 
 @pytest.mark.skipif("fork" not in mp.get_all_start_methods(), reason="requires fork isolation")


### PR DESCRIPTION
## Reviewer-critical summary

Issue: https://github.com/ll7/robot_sf_ll7/issues/5540

- What changed: `PPOPlanner` now converts the legacy `Observation` passed by the exact-repeat runner into the existing dict-policy observation contract before SB3 inference. The PPO and runner failure logs now use Loguru formatting and native exception capture, so the underlying exception remains visible.
- Why now: the exact-repeat path passed an `Observation` dataclass directly to a dict PPO policy, producing `IndexError: only integers, slices (...) are valid indices`; the prior `%s` calls hid that cause.
- Claim boundary: targeted smoke/diagnostic evidence only; this PR does not claim a completed exact-repeat campaign or benchmark result. The one-step CPU probe with the retained PPO configuration returned `{"v": 2.0, "omega": -0.9253}` with planner status `ok`.
- Required validation: focused PPO/runner tests, Ruff, the final readiness gate, and the one-step CPU probe listed below.
- Remaining blocker: the full three-repeat target remains diagnostic-only because predictive foresight revalidates its cached model on every step (the existing overhead class tracked by #867); the separate transient ORCA worker-crash slice remains open.

## Contract delta

- New schema fields: none.
- New fail-closed blockers: none.
- Compatibility impact: dict-mode PPO accepts both the existing mapping input and the legacy runner `Observation`; vector/image paths are unchanged. Variable-length legacy pedestrian arrays are padded to the declared model shape.
- Logging contract: PPO prediction and runner worker failures now interpolate exception text and capture the active traceback through Loguru.

## Scope and acceptance

- [x] Repair the exact-repeat PPO `Observation` → dict-policy handoff.
- [x] Make the swallowed PPO and runner exceptions visible.
- [x] Add regression coverage for both behaviors.
- [ ] Re-run the full PPO exact-repeat cell/campaign after the predictive model-reload overhead is addressed.
- [ ] Resolve the separate transient ORCA worker-crash cells.

This is a partial issue slice, so this PR uses **Refs #5540** rather than closure wording.

<details>
<summary>Validation, evidence, and governance appendix</summary>

### Validation / Proof

- `uv run pytest tests/baselines/test_ppo_planner.py tests/test_baseline_ppo_observation_keys.py tests/test_runner_policy_timeout.py tests/benchmark/test_runner_exception_logging.py -q` — 35 passed, 2 known multiprocessing deprecation warnings.
- `uv run ruff check robot_sf/baselines/ppo.py robot_sf/benchmark/runner.py tests/baselines/test_ppo_planner.py tests/test_baseline_ppo_observation_keys.py tests/test_runner_policy_timeout.py` — passed.
- `uv run ruff format --check robot_sf/baselines/ppo.py robot_sf/benchmark/runner.py tests/baselines/test_ppo_planner.py tests/test_baseline_ppo_observation_keys.py tests/test_runner_policy_timeout.py` — passed.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final PR_READY_PR_BODY_FILE=/tmp/issue-5540/pr-body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` on the committed head — core lane 2,404 passed, 1 skipped; optional lane 7,263 passed, 17 skipped, 1 warning; changed-file coverage warning only for `robot_sf/baselines/ppo.py` (87.9%, minimum 80%).
- CPU probe: one exact-repeat-style `Observation` through the retained PPO dict configuration — passed; planner status `ok`, action emitted, no fallback.
- The attempted three-repeat target is not success evidence: it was stopped after the existing per-step predictive model revalidation overhead exceeded the bounded diagnostic window.

### Research Result Guidance

- Target claim / blocker: remove the deterministic PPO exact-repeat runtime blocker and expose its underlying exception.
- Comparator: `origin/main` behavior, which passed the legacy `Observation` directly to SB3 dict inference.
- Evidence tier: targeted smoke plus diagnostic probe; not nominal benchmark evidence.
- Result classification: blocker-resolution for the PPO path; inconclusive for the full campaign.
- Decision / stop rule: stop campaign interpretation until a complete native repeat cell runs; continue the ORCA follow-up separately.
- Downstream synthesis target: issue #5540; no benchmark report, leaderboard, registry, or paper claim is changed here.

### Domain-Aware Approval

- Required for this PR: yes — the validation is explicitly diagnostic and must not be promoted to benchmark evidence.
- Domains reviewed: fallback/degraded exclusions, benchmark interpretation, implementation integrity.
- Status: waived.
- Approver/review source or waiver: self-waiver under the runtime-only boundary; this PR changes compatibility and logging, not evidence classification, metric semantics, benchmark interpretation, or paper-facing claims.
- Validity checklist:
  - Target claim/hypothesis: remove the PPO exact-repeat runtime blocker and expose the underlying exception.
  - Comparator or split/evidence validity: `origin/main` behavior; no result comparison or split change.
  - Fallback/degraded exclusions: the failed full-cell attempt is excluded; fallback/degraded rows are not evidence.
  - Claim boundary: one CPU action smoke plus regression tests only; no campaign claim.
  - Implementation integrity vs experimental validity: implementation proof is covered by focused tests and readiness gates; experimental validity remains pending a complete native cell.

### Next Empirical Action

- Rerun needed: yes, after the predictive model-reload overhead is addressed.
- Artifact missing: no; the PPO and predictive artifacts were present and checksum-valid after cache hydration.
- Stop / revise / continue: continue with a bounded full-cell rerun once #867’s overhead class is handled; exclude degraded/fallback rows from any claim.

### Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No issue comment was posted because the authorization explicitly forbids `comment_issue_or_pr`; this PR body is the durable status propagation surface for this slice.

### Downstream Propagation

- Parent issue updated: no — PR body carries the slice status; issue comments were not authorized.
- Claim map / benchmark report: NA — no benchmark claim changed.
- Leaderboard / artifact catalog: NA.
- Registry or config index: NA.
- Context index / memory note: NA.
- Follow-up issue: existing #867 covers the observed predictive model-reload overhead class.

### Risks / Rollout

- The legacy runner still lacks the rich occupancy-grid inputs expected by the checkpoint; missing declared fields continue through the existing explicit default/backfill path and must not be treated as faithful benchmark evidence without a complete campaign review.
- A rollback is the one-commit revert; vector/image behavior is unchanged.

### Friction

No new friction issue was filed: the observed repeated predictive model/cache validation is already tracked by #867.

</details>
