### PR TITLE
Issue #5598: remove reflected-set Numba warning from Theta-star LOS (cheap-lane worker)

### DIFF
--- a/robot_sf/planner/theta_star_v2.py
+++ b/robot_sf/planner/theta_star_v2.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from types import MethodType
 from typing import TYPE_CHECKING
 
+import numpy as np
 from loguru import logger
 from python_motion_planning.common import TYPES
 from python_motion_planning.path_planner import ThetaStar
@@ -37,6 +38,26 @@ if TYPE_CHECKING:
     from python_motion_planning.common import Grid
 
 
+if njit:
+
+    @njit(cache=True)
+    def _contains_free(free_vals, value) -> bool:
+        """Return whether a typed array of free cell values contains value."""
+        for i in range(free_vals.shape[0]):
+            if free_vals[i] == value:
+                return True
+        return False
+
+else:
+
+    def _contains_free(free_vals, value) -> bool:
+        """Return whether a typed int64 array of free cell values contains value."""
+        for i in range(free_vals.shape[0]):
+            if free_vals[i] == value:
+                return True
+        return False
+
+
 def _python_los_blocks(type_map, x0, y0, x1, y1, free_vals) -> bool:
     """Pure-Python Bresenham line traversal.
 
@@ -46,7 +67,7 @@ def _python_los_blocks(type_map, x0, y0, x1, y1, free_vals) -> bool:
         y0: Start Y index.
         x1: End X index.
         y1: End Y index.
-        free_vals: Set of cell values considered traversable.
+        free_vals: Int64 array of cell values considered traversable.
 
     Returns:
         True when an obstacle is encountered along the segment, else False.
@@ -57,9 +78,9 @@ def _python_los_blocks(type_map, x0, y0, x1, y1, free_vals) -> bool:
     if not (0 <= x1 < width and 0 <= y1 < height):
         return True
 
-    if type_map[x0, y0] not in free_vals:
+    if not _contains_free(free_vals, type_map[x0, y0]):
         return True
-    if type_map[x1, y1] not in free_vals:
+    if not _contains_free(free_vals, type_map[x1, y1]):
         return True
 
     dx = abs(x1 - x0)
@@ -69,7 +90,7 @@ def _python_los_blocks(type_map, x0, y0, x1, y1, free_vals) -> bool:
     err = dx - dy
 
     while True:
-        if type_map[x0, y0] not in free_vals:
+        if not _contains_free(free_vals, type_map[x0, y0]):
             return True
         if x0 == x1 and y0 == y1:
             return False
@@ -96,10 +117,10 @@ if njit:
             return True
 
         v0 = type_map[x0, y0]
-        if v0 not in free_vals:
+        if not _contains_free(free_vals, v0):
             return True
         v1 = type_map[x1, y1]
-        if v1 not in free_vals:
+        if not _contains_free(free_vals, v1):
             return True
 
         dx = abs(x1 - x0)
@@ -110,7 +131,7 @@ if njit:
 
         while True:
             v = type_map[x0, y0]
-            if v not in free_vals:
+            if not _contains_free(free_vals, v):
                 return True
             if x0 == x1 and y0 == y1:
                 return False
@@ -128,7 +149,7 @@ def _bind_fast_in_collision(grid: Grid) -> None:
 
     The bound method uses either the Numba-accelerated LOS or a Python fallback.
     """
-    free_vals = {TYPES.FREE, TYPES.START, TYPES.GOAL}
+    free_vals = np.array([TYPES.FREE, TYPES.START, TYPES.GOAL], dtype=np.int64)
     if njit:
 
         def fast_in_collision(self, p1, p2):

--- a/tests/test_planner/test_theta_star_v2.py
+++ b/tests/test_planner/test_theta_star_v2.py
@@ -3,10 +3,32 @@
 from __future__ import annotations
 
 import types
+import warnings
 
 import numpy as np
 
 from robot_sf.planner.theta_star_v2 import HighPerformanceThetaStar, _bind_fast_in_collision
+
+
+def test_fast_in_collision_emits_no_reflected_set_numba_warning():
+    """The Numba LOS path must not emit reflected-set deprecation warnings.
+
+    Issue #5598: the njit LOS previously received a reflected Python ``set`` for
+    ``free_vals``, raising NumbaPendingDeprecationWarning. The free-cell set is
+    now a typed int64 array, so exercising the bound collision check must pass
+    cleanly even when deprecation warnings are escalated to errors.
+    """
+    arr = np.zeros((3, 3), dtype=np.int8)
+    grid = DummyGrid(arr)
+    _bind_fast_in_collision(grid)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        warnings.simplefilter("error", PendingDeprecationWarning)
+        # Force the Numba (or Python) LOS path to actually run.
+        assert grid.in_collision((0, 0), (2, 2)) is False
+        grid.type_map.array[1, 1] = 1
+        assert grid.in_collision((0, 0), (2, 2)) is True
 
 
 class DummyGrid:


### PR DESCRIPTION
## What changed
Issue #5598 reports a `NumbaPendingDeprecationWarning` ("use of a type scheduled for deprecation: type 'reflected set'") raised for `free_vals` of `_numba_los_blocks` in `robot_sf/planner/theta_star_v2.py` when the feasibility-oracle suite exercises the Theta* LOS path.

The fix replaces the reflected Python `set` passed into the njit LOS function with a Numba-supported typed `np.int64` array, plus an njit-compatible `_contains_free` membership helper (used by both the JIT and pure-Python LOS paths). Behavior is unchanged: the traversable set is still `{TYPES.FREE, TYPES.START, TYPES.GOAL}`.

## Why now
This is a `friction:`-flagged warning (found during #5247) that should not be silently tolerated. Removing it keeps the canonical PR readiness gate warning-clean without changing planner semantics.

## Validation
- `pytest tests/test_planner/test_theta_star_v2.py -W error::DeprecationWarning -W error::PendingDeprecationWarning` → **3 passed** (includes the new `test_fast_in_collision_emits_no_reflected_set_numba_warning`).
- `pytest tests/scenario_certification/test_feasibility_oracle.py -W error::DeprecationWarning -W error::PendingDeprecationWarning` → **30 passed** (previously emitted the warning at `test_envelope_sweep_blocks_when_a_reduced_probe_is_unobserved`).
- `ruff check` and `ruff format --check` on both changed files → **all passed**.

CPU-only validation; no campaigns, Slurm, training, or benchmark/paper claims.

## Successor statement
This PR FULLY resolves issue #5598 (no prior merged slices of #5598 exist; the only related past PR was #5599 for the unrelated #5247 analysis runner). It adds the missing regression test and closes the warning, so no successor slice is required.

Closes #5598

This PR was produced by the CommandCode/Tencent-Hy3 cheap implementation lane; the review gate hardens and merges.