### PR TITLE
Issue #5594: reap orphaned DRL-VO pytest worker (cheap-lane worker)

### DIFF
--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -316,6 +316,38 @@ fi
 "$SCRIPT_DIR/check_docstring_todos_ratchet.sh"
 uv run python "$SCRIPT_DIR/../validation/check_broad_exceptions.py"
 
+# Orphan guard for issue #5594: the readiness command must leave no worktree-owned
+# pytest worker behind. A leaked planner-step worker (or any pytest descendant) that
+# outlives the controller and its parents becomes reparented to PID 1 while still
+# holding host resources; that orphans the shared host. We scan for reparented
+# (parent PID 1) pytest processes whose cwd/cmdline ties them to this worktree.
+check_no_orphaned_pytest_workers() {
+  local worktree_root
+  worktree_root="$(git rev-parse --show-toplevel 2>/dev/null)" || return 0
+  local orphaned=0
+  local pid ppid cmdline cwd_link
+  for proc_dir in /proc/[0-9]*; do
+    pid="${proc_dir#/proc/}"
+    [[ "$pid" =~ ^[0-9]+$ ]] || continue
+    ppid=$(awk '{print $4}' "/proc/$pid/stat" 2>/dev/null) || continue
+    [[ "$ppid" == "1" ]] || continue
+    cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) || continue
+    [[ "$cmdline" == *"pytest"* ]] || continue
+    cwd_link=$(readlink "/proc/$pid/cwd" 2>/dev/null) || continue
+    if [[ "$cwd_link" == "$worktree_root"* || "$cmdline" == *"$worktree_root"* ]]; then
+      printf 'Orphaned pytest worker still attached to this worktree: PID %s (cwd=%s cmdline=%s)\n' \
+        "$pid" "$cwd_link" "$cmdline" >&2
+      orphaned=1
+    fi
+  done
+  if (( orphaned )); then
+    printf 'Readiness left an orphaned pytest worker on the shared host (issue #5594).\n' >&2
+    printf 'Terminate the listed PID(s) and fix the leaking test/worker before reporting success.\n' >&2
+    return 1
+  fi
+  return 0
+}
+
 freshness_args=(write --base-ref "$BASE_REF")
 if [[ "$pr_ready_final" == "1" ]]; then
   freshness_args+=(--require-clean-tree)
@@ -325,3 +357,8 @@ elif [[ "$(worktree_state)" != "clean" ]]; then
   printf 'Use PR_READY_MODE=final BASE_REF=%q %q for final committed-HEAD PR proof.\n' "$BASE_REF" "$0" >&2
 fi
 uv run python "$SCRIPT_DIR/pr_ready_freshness.py" "${freshness_args[@]}"
+
+# Final orphan guard (issue #5594): after all lanes exit, assert no worktree-owned
+# pytest worker survived the controller. A leaked planner-step worker reparented to
+# PID 1 would otherwise sit orphaned on the shared host.
+check_no_orphaned_pytest_workers

--- a/tests/planner/test_drl_vo.py
+++ b/tests/planner/test_drl_vo.py
@@ -172,21 +172,31 @@ def test_drl_vo_predict_passes_deterministic_flag() -> None:
 
 
 def test_drl_vo_runner_integration_policy() -> None:
-    """The benchmark runner should be able to instantiate and execute a DRL-VO policy."""
-    policy_fn, metadata = _create_robot_policy("drl_vo", None, seed=1)
-    assert callable(policy_fn)
-    assert metadata["algorithm"] == "drl_vo"
+    """The benchmark runner should be able to instantiate and execute a DRL-VO policy.
 
-    velocity = policy_fn(
-        np.array([0.0, 0.0], dtype=float),
-        np.array([0.0, 0.0], dtype=float),
-        np.array([2.0, 0.0], dtype=float),
-        np.zeros((0, 2), dtype=float),
-        0.1,
-    )
-    assert isinstance(velocity, np.ndarray)
-    assert velocity.shape == (2,)
-    assert velocity[0] >= 0.0
+    The policy spawns a forked planner-step worker (Unix-stream pipe); closing it
+    reaps that worker so the readiness runner leaves no orphaned pytest-xdist child
+    behind (issue #5594).
+    """
+    policy_fn, metadata = _create_robot_policy("drl_vo", None, seed=1)
+    try:
+        assert callable(policy_fn)
+        assert metadata["algorithm"] == "drl_vo"
+
+        velocity = policy_fn(
+            np.array([0.0, 0.0], dtype=float),
+            np.array([0.0, 0.0], dtype=float),
+            np.array([2.0, 0.0], dtype=float),
+            np.zeros((0, 2), dtype=float),
+            0.1,
+        )
+        assert isinstance(velocity, np.ndarray)
+        assert velocity.shape == (2,)
+        assert velocity[0] >= 0.0
+    finally:
+        runner_close = getattr(policy_fn, "close", None)
+        if callable(runner_close):
+            runner_close()
 
 
 def test_drl_vo_missing_model_path_falls_back(tmp_path) -> None:

--- a/tests/test_runner_policy_timeout.py
+++ b/tests/test_runner_policy_timeout.py
@@ -100,3 +100,40 @@ def test_planner_step_process_reports_eof_between_poll_and_recv() -> None:
 
     with pytest.raises(RuntimeError, match="exited before returning an action"):
         step_process.step({"obs": "value"})
+
+
+@pytest.mark.skipif("fork" not in mp.get_all_start_methods(), reason="requires fork isolation")
+def test_planner_step_worker_is_reaped_on_policy_close() -> None:
+    """Closing a runner policy must terminate its forked planner-step worker.
+
+    Regression for issue #5594: a leaked worker kept pytest-xdist's gateway fds
+    open and was reparented to PID 1 after the readiness command exited, so the
+    shared host was left with an orphaned ``[pytest-xdist running]`` process.
+    """
+    psutil = pytest.importorskip("psutil")
+    policy, _ = runner._create_robot_policy("random", None, seed=7)
+
+    try:
+        before_pids = {p.pid for p in psutil.Process().children()}
+
+        velocity = policy(
+            np.array([0.0, 0.0]),
+            np.array([0.0, 0.0]),
+            np.array([1.0, 0.0]),
+            np.empty((0, 2)),
+            0.1,
+        )
+        assert velocity.shape == (2,)
+
+        after_step_pids = {p.pid for p in psutil.Process().children()}
+        worker_pids = after_step_pids - before_pids
+        # Exactly one forked planner-step worker should be running after a step.
+        assert len(worker_pids) == 1
+    finally:
+        policy.close()  # type: ignore[attr-defined]
+
+    # The worker process must be reaped, not orphaned under PID 1.
+    remaining_pids = {p.pid for p in psutil.Process().children()}
+    assert not worker_pids.issubset(remaining_pids)
+    for pid in worker_pids:
+        assert not psutil.pid_exists(pid)


### PR DESCRIPTION
## What / Why

Issue #5594 reports that `PR_READY_MODE=final scripts/dev/pr_ready_check.sh` exited 0
but left an orphaned `[pytest-xdist running] tests/planner/test_drl_vo.py::test_drl_vo_runner_integration_policy`
process attached to the worktree (parent PID 1).

**Root cause:** `test_drl_vo_runner_integration_policy` calls `_create_robot_policy("drl_vo", ...)`
which (under the fork-based policy-step-isolation path) lazily forks a `_PlannerStepProcess`
worker holding a Unix-stream pipe. The test never called `policy_fn.close()`, so the worker
leaked. Because it inherited pytest-xdist's gateway fds, the xdist worker could not tear down
its gateway connection and was reparented to PID 1 after the readiness command exited.

The production path (`run_episode`) already closes the policy in a `finally` block, so the fix
belongs in the test and in a readiness-level guard.

## Changes

- `tests/planner/test_drl_vo.py`: `test_drl_vo_runner_integration_policy` now closes the
  policy's planner-step worker in a `finally` block, reaping the forked child.
- `tests/test_runner_policy_timeout.py`: added `test_planner_step_worker_is_reaped_on_policy_close`,
  a regression test (needs psutil) asserting exactly one forked worker runs after a step and that
  `policy.close()` reaps it (not orphaned under PID 1).
- `scripts/dev/pr_ready_check.sh`: added `check_no_orphaned_pytest_workers`, a final fail-closed
  gate that scans for reparented (ppid 1) pytest processes whose cwd/cmdline ties them to this
  worktree and exits non-zero if any survive after all lanes finish.

## Validation

- `uv run pytest tests/planner/test_drl_vo.py::test_drl_vo_runner_integration_policy tests/test_runner_policy_timeout.py -v` → **4 passed** (including the new regression test).
- `uv run ruff check tests/planner/test_drl_vo.py tests/test_runner_policy_timeout.py` → clean.
- `bash -n scripts/dev/pr_ready_check.sh` → syntax OK.
- Verified the new orphan guard detects a genuine PID-1 pytest orphan (returns exit 1) and
  passes when none exist.

This is a complete fix (code + tests + CPU validation); no campaigns/Slurm/training involved.

Closes #5594

This PR was produced by the CommandCode/Tencent-Hy3 cheap implementation lane; the review gate hardens and merges.