### PR TITLE
Issue #5597: materialize scenario-generator parametrization (cheap-lane worker)

### DIFF
--- a/tests/test_scenario_generator.py
+++ b/tests/test_scenario_generator.py
@@ -350,21 +350,43 @@ _GOAL_TOPOLOGIES = ["point", "swap", "circulate"]
 
 
 def _gen_param_combos():
-    """Yield (density, flow, obstacle, speed_var, goal_topology) combos.
+    """Return materialized (density, flow, obstacle, speed_var, goal_topology) combos.
 
     We generate the full cross-product (3x4x3x2x3 = 216) deliberately:
     the generator is pure Python + numpy and each invocation is < 1 ms.
+
+    The sequence is materialized as a list (not a generator) because pytest 10
+    deprecates passing a non-Collection iterable to parametrize
+    (PytestRemovedIn10Warning). See issue #5597.
     """
+    combos = []
     for d in _DENSITIES:
         for f in _FLOWS:
             for o in _OBSTACLES:
                 for s in _SPEED_VARS:
                     for g in _GOAL_TOPOLOGIES:
-                        yield pytest.param(d, f, o, s, g, id=f"{d}_{f}_{o}_{s}_{g}")
+                        combos.append(pytest.param(d, f, o, s, g, id=f"{d}_{f}_{o}_{s}_{g}"))
+    return combos
 
 
 _DENSITY_EXPECTED = {"low": 10, "med": 25, "high": 40}
 _OBS_EXPECTED = {"open": 0, "bottleneck": 2, "maze": 3}
+
+
+def test_param_combos_are_materialized_collection():
+    """Regression guard for issue #5597.
+
+    pytest 10 deprecates passing a non-Collection (e.g. a generator) to
+    ``parametrize`` (PytestRemovedIn10Warning). The combos feeding
+    ``test_scenario_structural_invariants`` must stay materialized as a list/tuple
+    so collection does not emit that warning. This test fails if the source is
+    ever reverted to a lazy generator.
+    """
+    combos = _gen_param_combos()
+    assert isinstance(combos, (list, tuple)), (
+        f"param combos must be a materialized list/tuple, got {type(combos).__name__}"
+    )
+    assert len(combos) == 216, f"expected 216 combos, got {len(combos)}"
 
 
 @pytest.mark.parametrize("density,flow,obstacle,speed_var,goal_topology", _gen_param_combos())


### PR DESCRIPTION
## What / Why
Issue #5597 reports a `PytestRemovedIn10Warning` during collection of
`tests/test_scenario_generator.py::test_scenario_structural_invariants`: the
parametrization was fed a lazy generator (`_gen_param_combos()` yielded `pytest.param`
instances). pytest 10 deprecates passing a non-Collection iterable to `parametrize`, so
this must be materialized before that upgrade turns the warning into a breakage.

## Change
- `_gen_param_combos()` now materializes the full 216-combo cross-product as a list
  (no behavioral change to the parameter space).
- Added `test_param_combos_are_materialized_collection` as a regression guard: it fails
  if the source is ever reverted to a generator, since a per-test runtime `filterwarnings`
  marker cannot catch a *collection*-phase* warning and a global `error` filter would also
  break the other generator-backed parametrizations in the suite.

## Validation (CPU only)
```
uv run pytest tests/test_scenario_generator.py -q
235 passed in 2.62s

uv run ruff check tests/test_scenario_generator.py
All checks passed!
```
No campaigns, Slurm, or training runs were used.

Closes #5597

This PR was produced by the CommandCode/Tencent-Hy3 cheap implementation lane; the review gate hardens and merges.