### PR TITLE
feat(validation): freeze VecEnv throughput acceptance (#4981)

### DIFF
--- a/configs/training/lidar/issue_4981_vecenv_throughput_acceptance.yaml
+++ b/configs/training/lidar/issue_4981_vecenv_throughput_acceptance.yaml
@@ -1,0 +1,40 @@
+schema: issue_4981_vecenv_throughput_acceptance_profile.v1
+issue: 4981
+
+# This is the reversible definition of "sufficiently long standard-config measurement" used by
+# the issue acceptance runner. It is intentionally 100x longer than the comparator's 100-step
+# diagnostic default while remaining a bounded local CPU workload.
+standard_workload:
+  config_path: configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml
+  num_envs: 4
+  modes:
+    - dummy
+    - subproc
+    - threaded
+    - threaded_lidar_batch
+  repetitions: 5
+  base_seed: 4981
+  warmup_steps: 1000
+  measure_steps: 10000
+
+acceptance:
+  source_schema: vecenv_throughput_comparator.v2
+  source_claim_boundary: diagnostic_only_not_benchmark_evidence
+  baseline_mode: dummy
+  baseline_num_envs: 1
+  candidate_modes:
+    - threaded
+    - threaded_lidar_batch
+  speedup_statistic: median_transitions_per_second_ratio
+  minimum_speedup_exclusive: 3.0
+
+required_pytest_nodes:
+  - tests/sensor/test_batched_lidar_kernel.py::test_single_environment_batch_uses_bit_identical_scalar_fallback
+  - tests/training/test_train_expert_ppo_contract.py::test_resolve_worker_mode_accepts_threaded_and_keeps_single_env_fallback
+  - tests/training/test_train_expert_ppo_contract.py::test_threaded_lidar_batch_mode_uses_dummy_single_environment_fallback
+  - tests/training/test_threaded_vec_env.py::test_threaded_vec_env_batches_real_lidar_without_changing_observations
+
+claim_boundary: >-
+  Host-specific CPU implementation-performance acceptance for issue #4981 only; this does not
+  establish training quality, navigation-benchmark performance, cross-host speedup, GPU speedup,
+  or any paper/dissertation claim.

--- a/docs/dev/issues/4981-vectorized-rollouts/design.md
+++ b/docs/dev/issues/4981-vectorized-rollouts/design.md
@@ -55,5 +55,31 @@ uv run python scripts/validation/run_vecenv_worker_mode_throughput.py \
 
 The JSON records repeated throughput samples, median speedup against a separately measured
 one-environment dummy fallback, failures, and config/scenario/commit/host provenance. Its explicit
-claim boundary is diagnostic-only. The issue's >3x claim may only be promoted after a reviewed,
-sufficiently long standard-config measurement supports it; a bounded smoke is not that evidence.
+claim boundary is diagnostic-only. A bounded smoke is not acceptance evidence.
+
+The issue acceptance workload and strict `>3x` decision are frozen separately in
+`configs/training/lidar/issue_4981_vecenv_throughput_acceptance.yaml`. Inspect the exact local CPU
+command without running it:
+
+```bash
+uv run python scripts/validation/run_issue_4981_vecenv_throughput_acceptance.py \
+  --dry-run
+```
+
+When an uncontended host is available, run the full profile explicitly with `--run`. The wrapper
+requires a clean current commit, executes the single-environment fallback and LiDAR-equivalence
+tests, then runs five repetitions with 1,000 warmup and 10,000 measured steps per mode. It emits a
+machine-readable decision with three states:
+
+- `met`: a predeclared in-process candidate (`threaded` or `threaded_lidar_batch`) has median
+  throughput strictly greater than `3x` the one-environment dummy baseline;
+- `not_met`: the complete valid measurement ran, but the strict threshold was not exceeded;
+- `blocked`: inputs, provenance, required tests, mode rows, repetitions, or failures do not satisfy
+  the profile.
+
+The reversible assumption is that the already documented
+`lidar_ppo_mlp_smoke_issue_1662.yaml` workload is the standard config for this engineering gate and
+that a 100-times-longer step window plus five repetitions is sufficient for review. The decision
+remains host-specific implementation-performance evidence; it does not establish training quality,
+navigation-benchmark performance, cross-host speedup, or a paper/dissertation claim. This change
+does not run or promote the acceptance measurement itself.

--- a/docs/training/vectorized_env_support.md
+++ b/docs/training/vectorized_env_support.md
@@ -65,3 +65,21 @@ resolves the one-environment worker mode to `DummyVecEnv` before constructing a 
 Multi-environment tests require complete LiDAR observations to be bit-identical to scalar threaded
 execution. These checks establish compatibility and rollout integration only; the standard-config
 throughput comparison required by issue #4981 remains separate.
+
+## Issue #4981 throughput acceptance
+
+The tracked vectorized-environment (VecEnv) acceptance profile
+`configs/training/lidar/issue_4981_vecenv_throughput_acceptance.yaml` fixes the standard workload,
+environment count, worker modes, seeds, warmup, measurement length, repetitions, and strict `>3x`
+decision rule for the in-process `threaded` candidates. `subproc` remains a measured comparator,
+not an acceptance candidate. Preview the exact local CPU command without launching the measurement:
+
+```bash
+uv run python scripts/validation/run_issue_4981_vecenv_throughput_acceptance.py --dry-run
+```
+
+Use `--run` only for the reviewed acceptance measurement. The wrapper fails closed unless the
+tracked tree is clean, the single-environment fallback and LiDAR-equivalence tests pass, and the
+comparator JSON exactly matches the profile and current commit. Its `met`, `not_met`, and `blocked`
+states apply only to host-specific rollout throughput; they are not training-quality, navigation
+benchmark, cross-host, GPU, or paper/dissertation evidence.

--- a/scripts/validation/run_issue_4981_vecenv_throughput_acceptance.py
+++ b/scripts/validation/run_issue_4981_vecenv_throughput_acceptance.py
@@ -1,0 +1,654 @@
+#!/usr/bin/env python3
+"""Run or adjudicate the issue #4981 VecEnv throughput acceptance workload.
+
+The four-mode comparator remains a diagnostic measurement tool. This wrapper derives its command
+from a tracked profile, requires the single-environment fallback/equivalence tests, and reports
+``met``, ``not_met``, or ``blocked`` without promoting incomplete evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import math
+import re
+import statistics
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.validation.run_vecenv_worker_mode_throughput import (  # noqa: E402
+    _git_commit,
+    _load_yaml_raw,
+    _provenance_path,
+    _resolve_scenario_path,
+    _sha256_file,
+)
+
+PROFILE_SCHEMA = "issue_4981_vecenv_throughput_acceptance_profile.v1"
+REPORT_SCHEMA = "issue_4981_vecenv_throughput_acceptance.v1"
+SOURCE_SCHEMA = "vecenv_throughput_comparator.v2"
+SOURCE_CLAIM_BOUNDARY = "diagnostic_only_not_benchmark_evidence"
+DEFAULT_PROFILE = _REPO_ROOT / "configs/training/lidar/issue_4981_vecenv_throughput_acceptance.yaml"
+DEFAULT_OUTPUT_DIR = _REPO_ROOT / "output/issue_4981_vecenv_throughput_acceptance"
+_COMPARATOR = _REPO_ROOT / "scripts/validation/run_vecenv_worker_mode_throughput.py"
+_STANDARD_CONFIG = Path("configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml")
+_SUPPORTED_MODES = ("dummy", "subproc", "threaded", "threaded_lidar_batch")
+_SPEEDUP_STATISTIC = "median_transitions_per_second_ratio"
+_CLAIM_BOUNDARY = (
+    "Host-specific CPU implementation-performance acceptance for issue #4981 only; this does not "
+    "establish training quality, navigation-benchmark performance, cross-host speedup, GPU speedup, "
+    "or any paper/dissertation claim."
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class AcceptanceProfile:
+    """Validated parameters for one issue #4981 acceptance decision."""
+
+    path: Path
+    config_path: Path
+    num_envs: int
+    modes: tuple[str, ...]
+    repetitions: int
+    base_seed: int
+    warmup_steps: int
+    measure_steps: int
+    candidate_modes: tuple[str, ...]
+    minimum_speedup_exclusive: float
+    required_pytest_nodes: tuple[str, ...]
+    claim_boundary: str
+
+
+def _mapping(value: object, field: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be a mapping")
+    return dict(value)
+
+
+def _strings(value: object, field: str) -> tuple[str, ...]:
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise ValueError(f"{field} must be a non-empty sequence of strings")
+    resolved = tuple(item.strip() for item in value if isinstance(item, str))
+    if len(resolved) != len(value) or not resolved or any(not item for item in resolved):
+        raise ValueError(f"{field} must be a non-empty sequence of strings")
+    if len(set(resolved)) != len(resolved):
+        raise ValueError(f"{field} must not contain duplicates")
+    return resolved
+
+
+def _integer(value: object, field: str, *, minimum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise ValueError(f"{field} must be an integer >= {minimum}")
+    return value
+
+
+def _strict_threshold(value: object) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int | float)
+        or not math.isfinite(float(value))
+        or float(value) != 3.0
+    ):
+        raise ValueError("acceptance.minimum_speedup_exclusive must be exactly 3.0")
+    return float(value)
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise ValueError(f"could not load profile {path}: {exc}") from exc
+    return _mapping(payload, "profile")
+
+
+def _repository_file(value: object, field: str) -> Path:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a repository-relative path")
+    path = Path(value)
+    if path.is_absolute() or ".." in path.parts or not (_REPO_ROOT / path).is_file():
+        raise ValueError(f"{field} must name an existing repository file")
+    return path
+
+
+def _required_test_nodes(root: Mapping[str, Any]) -> tuple[str, ...]:
+    nodes = _strings(root.get("required_pytest_nodes"), "required_pytest_nodes")
+    for node in nodes:
+        test_path = Path(node.split("::", maxsplit=1)[0])
+        if (
+            "::" not in node
+            or test_path.is_absolute()
+            or not str(test_path).startswith("tests/")
+            or not (_REPO_ROOT / test_path).is_file()
+        ):
+            raise ValueError(f"invalid required pytest node: {node!r}")
+    return nodes
+
+
+def load_profile(path: Path) -> AcceptanceProfile:
+    """Load the tracked profile and fail closed on unsupported acceptance semantics."""
+    profile_path = path.resolve()
+    root = _load_yaml_mapping(profile_path)
+    workload = _mapping(root.get("standard_workload"), "standard_workload")
+    acceptance = _mapping(root.get("acceptance"), "acceptance")
+    modes = _strings(workload.get("modes"), "standard_workload.modes")
+    candidates = _strings(acceptance.get("candidate_modes"), "acceptance.candidate_modes")
+    threshold = _strict_threshold(acceptance.get("minimum_speedup_exclusive"))
+    claim_boundary = str(root.get("claim_boundary", "")).strip()
+    config_path = _repository_file(workload.get("config_path"), "standard_workload.config_path")
+    num_envs = _integer(workload.get("num_envs"), "standard_workload.num_envs", minimum=2)
+    repetitions = _integer(workload.get("repetitions"), "standard_workload.repetitions", minimum=5)
+    warmup_steps = _integer(
+        workload.get("warmup_steps"), "standard_workload.warmup_steps", minimum=1000
+    )
+    measure_steps = _integer(
+        workload.get("measure_steps"), "standard_workload.measure_steps", minimum=10000
+    )
+
+    if root.get("schema") != PROFILE_SCHEMA or root.get("issue") != 4981:
+        raise ValueError(f"profile must use {PROFILE_SCHEMA!r} for issue 4981")
+    if modes != _SUPPORTED_MODES:
+        raise ValueError(f"standard_workload.modes must be {_SUPPORTED_MODES!r}")
+    if config_path != _STANDARD_CONFIG or num_envs != 4:
+        raise ValueError("standard workload must use the reviewed issue #1662 config with 4 envs")
+    if any(mode not in {"threaded", "threaded_lidar_batch"} for mode in candidates):
+        raise ValueError("candidate modes must be in-process threaded modes")
+    if acceptance.get("source_schema") != SOURCE_SCHEMA:
+        raise ValueError(f"acceptance.source_schema must be {SOURCE_SCHEMA!r}")
+    if acceptance.get("source_claim_boundary") != SOURCE_CLAIM_BOUNDARY:
+        raise ValueError("acceptance.source_claim_boundary must preserve the diagnostic boundary")
+    expected_acceptance = {
+        "baseline_mode": "dummy",
+        "baseline_num_envs": 1,
+        "speedup_statistic": _SPEEDUP_STATISTIC,
+    }
+    for field, expected in expected_acceptance.items():
+        if acceptance.get(field) != expected:
+            raise ValueError(f"acceptance.{field} must be {expected!r}")
+    if claim_boundary != _CLAIM_BOUNDARY:
+        raise ValueError("claim_boundary must match the host-specific non-transfer boundary")
+
+    return AcceptanceProfile(
+        path=profile_path,
+        config_path=config_path,
+        num_envs=num_envs,
+        modes=modes,
+        repetitions=repetitions,
+        base_seed=_integer(workload.get("base_seed"), "standard_workload.base_seed", minimum=0),
+        warmup_steps=warmup_steps,
+        measure_steps=measure_steps,
+        candidate_modes=candidates,
+        minimum_speedup_exclusive=threshold,
+        required_pytest_nodes=_required_test_nodes(root),
+        claim_boundary=claim_boundary,
+    )
+
+
+def expected_source_provenance(profile: AcceptanceProfile) -> dict[str, str]:
+    """Return the config/scenario paths and hashes required from source evidence."""
+    config_path = (_REPO_ROOT / profile.config_path).resolve()
+    scenario_path = _resolve_scenario_path(_load_yaml_raw(config_path), config_path)
+    if not scenario_path.is_file():
+        raise ValueError(f"standard workload scenario does not exist: {scenario_path}")
+    return {
+        "config_path": _provenance_path(config_path),
+        "config_sha256": _sha256_file(config_path),
+        "scenario_path": _provenance_path(scenario_path),
+        "scenario_sha256": _sha256_file(scenario_path),
+    }
+
+
+def build_comparator_command(
+    profile: AcceptanceProfile,
+    evidence_path: Path,
+    *,
+    python_executable: str = sys.executable,
+) -> list[str]:
+    """Derive the comparator command entirely from the tracked profile."""
+    return [
+        python_executable,
+        str(_COMPARATOR),
+        "--config",
+        str((_REPO_ROOT / profile.config_path).resolve()),
+        "--num-envs",
+        str(profile.num_envs),
+        "--repetitions",
+        str(profile.repetitions),
+        "--base-seed",
+        str(profile.base_seed),
+        "--warmup-steps",
+        str(profile.warmup_steps),
+        "--measure-steps",
+        str(profile.measure_steps),
+        "--modes",
+        *profile.modes,
+        "--output",
+        str(evidence_path.resolve()),
+    ]
+
+
+def _number(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    resolved = float(value)
+    return resolved if math.isfinite(resolved) else None
+
+
+class _EvidenceValidator:
+    """Validate comparator JSON against the frozen profile while collecting every blocker."""
+
+    def __init__(
+        self,
+        profile: AcceptanceProfile,
+        evidence: Mapping[str, Any],
+        current_commit: str,
+        preflight: Mapping[str, Any],
+    ) -> None:
+        self.profile = profile
+        self.evidence = evidence
+        self.current_commit = current_commit
+        self.preflight = preflight
+        self.blockers: list[str] = []
+
+    def _expect(self, field: str, expected: object) -> None:
+        actual = self.evidence.get(field)
+        if actual != expected:
+            self.blockers.append(f"{field} must be {expected!r}, got {actual!r}")
+
+    def _summary(self, record: object, *, label: str, mode: str) -> float | None:
+        if not isinstance(record, Mapping):
+            self.blockers.append(f"{label} must be a mapping")
+            return None
+        for field, expected in {"mode": mode, "status": "ok", "error": None}.items():
+            if record.get(field) != expected:
+                self.blockers.append(f"{label}.{field} must be {expected!r}")
+        aggregate = _number(record.get("transitions_per_second"))
+        if aggregate is None or aggregate <= 0:
+            self.blockers.append(f"{label}.transitions_per_second must be positive and finite")
+            aggregate = None
+
+        samples = record.get("repetition_results")
+        if not isinstance(samples, list) or len(samples) != self.profile.repetitions:
+            self.blockers.append(
+                f"{label}.repetition_results must contain exactly {self.profile.repetitions} rows"
+            )
+            return aggregate
+        throughputs = self._repetition_throughputs(samples, label=label, mode=mode)
+        if aggregate is not None and len(throughputs) == self.profile.repetitions:
+            expected_median = round(statistics.median(throughputs), 2)
+            if not math.isclose(aggregate, expected_median, rel_tol=0.0, abs_tol=0.011):
+                self.blockers.append(
+                    f"{label}.transitions_per_second must equal median repetition throughput "
+                    f"{expected_median}, got {aggregate}"
+                )
+        return aggregate
+
+    def _repetition_throughputs(
+        self,
+        samples: list[object],
+        *,
+        label: str,
+        mode: str,
+    ) -> list[float]:
+        """Validate retained repetitions and return their positive throughputs."""
+        throughputs: list[float] = []
+        for index, sample in enumerate(samples):
+            sample_label = f"{label}.repetition_results[{index}]"
+            if not isinstance(sample, Mapping):
+                self.blockers.append(f"{sample_label} must be a mapping")
+                continue
+            expected_fields = {
+                "mode": mode,
+                "repetition": index,
+                "status": "ok",
+                "error": None,
+            }
+            for field, expected in expected_fields.items():
+                if sample.get(field) != expected:
+                    self.blockers.append(f"{sample_label}.{field} must be {expected!r}")
+            throughput = _number(sample.get("transitions_per_second"))
+            if throughput is None or throughput <= 0:
+                self.blockers.append(
+                    f"{sample_label}.transitions_per_second must be positive and finite"
+                )
+            else:
+                throughputs.append(throughput)
+        return throughputs
+
+    def _validate_source_contract(self) -> None:
+        expected_fields: dict[str, object] = {
+            "schema": SOURCE_SCHEMA,
+            **expected_source_provenance(self.profile),
+            "num_envs": self.profile.num_envs,
+            "repetitions": self.profile.repetitions,
+            "base_seed": self.profile.base_seed,
+            "warmup_steps": self.profile.warmup_steps,
+            "measure_steps": self.profile.measure_steps,
+            "modes": list(self.profile.modes),
+            "baseline_mode": "dummy",
+            "baseline_num_envs": 1,
+            "claim_boundary": SOURCE_CLAIM_BOUNDARY,
+            "scenario_selection": {"strategy": "first", "index": 0},
+            "failures": [],
+        }
+        for field, expected in expected_fields.items():
+            self._expect(field, expected)
+        if self.evidence.get("status") != "ok":
+            self.blockers.append(f"source status must be 'ok', got {self.evidence.get('status')!r}")
+        if self.evidence.get("commit") != self.current_commit:
+            self.blockers.append(
+                f"source commit must match current HEAD {self.current_commit!r}, "
+                f"got {self.evidence.get('commit')!r}"
+            )
+        if not re.fullmatch(r"[0-9a-f]{40}", self.current_commit):
+            self.blockers.append(
+                f"current HEAD must be a full Git commit, got {self.current_commit!r}"
+            )
+        for field in ("host", "python", "platform"):
+            value = self.evidence.get(field)
+            if not isinstance(value, str) or not value.strip():
+                self.blockers.append(f"{field} must be a non-empty provenance string")
+        if self.preflight.get("status") != "passed":
+            self.blockers.append(
+                f"required fallback/equivalence preflight failed: {self.preflight!r}"
+            )
+
+    def validate(self) -> tuple[float | None, list[dict[str, Any]]]:
+        """Return validated baseline throughput and in-process candidate speedups."""
+        self._validate_source_contract()
+        baseline = self._summary(self.evidence.get("baseline"), label="baseline", mode="dummy")
+        results = self.evidence.get("results")
+        if not isinstance(results, list) or any(not isinstance(row, Mapping) for row in results):
+            self.blockers.append("results must be a list of mappings")
+            return baseline, []
+        modes = [row.get("mode") for row in results]
+        if modes != list(self.profile.modes):
+            self.blockers.append(
+                f"result mode order must be {list(self.profile.modes)!r}, got {modes!r}"
+            )
+
+        candidate_speedups = []
+        for mode, row in zip(self.profile.modes, results, strict=False):
+            throughput = self._summary(row, label=f"results[{mode}]", mode=mode)
+            if baseline is None or throughput is None:
+                continue
+            speedup = round(throughput / baseline, 3)
+            reported = _number(row.get("speedup_vs_baseline"))
+            if reported is None or not math.isclose(reported, speedup, rel_tol=0.0, abs_tol=0.0011):
+                self.blockers.append(
+                    f"results[{mode}].speedup_vs_baseline must equal {speedup}, got {reported!r}"
+                )
+            if mode in self.profile.candidate_modes:
+                candidate_speedups.append(
+                    {
+                        "mode": mode,
+                        "transitions_per_second": throughput,
+                        "speedup_vs_baseline": speedup,
+                        "threshold_met": speedup > self.profile.minimum_speedup_exclusive,
+                    }
+                )
+        if baseline is not None:
+            reported = _number(
+                self.evidence.get("baseline", {}).get("speedup_vs_baseline")
+                if isinstance(self.evidence.get("baseline"), Mapping)
+                else None
+            )
+            if reported != 1.0:
+                self.blockers.append("baseline.speedup_vs_baseline must equal 1.0")
+        if not candidate_speedups:
+            self.blockers.append("no valid candidate-mode speedups were available")
+        return baseline, candidate_speedups
+
+
+def adjudicate(
+    profile: AcceptanceProfile,
+    evidence: Mapping[str, Any],
+    *,
+    evidence_path: Path,
+    current_commit: str,
+    preflight: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate one comparator artifact and classify the issue throughput criterion."""
+    validator = _EvidenceValidator(profile, evidence, current_commit, preflight)
+    baseline, speedups = validator.validate()
+    best = max(speedups, key=lambda row: row["speedup_vs_baseline"], default=None)
+    acceptance_met = (
+        None
+        if validator.blockers
+        else bool(best and best["speedup_vs_baseline"] > profile.minimum_speedup_exclusive)
+    )
+    status = "blocked" if validator.blockers else "met" if acceptance_met else "not_met"
+    return {
+        "schema": REPORT_SCHEMA,
+        "issue": 4981,
+        "status": status,
+        "acceptance_met": acceptance_met,
+        "evidence_status": (
+            "blocked_invalid_or_incomplete_evidence"
+            if validator.blockers
+            else "host_specific_implementation_performance_acceptance"
+        ),
+        "claim_boundary": profile.claim_boundary,
+        "profile_path": _provenance_path(profile.path),
+        "profile_sha256": _sha256_file(profile.path),
+        "source_evidence_path": _provenance_path(evidence_path),
+        "source_evidence_sha256": _sha256_file(evidence_path) if evidence_path.is_file() else None,
+        "source_commit": evidence.get("commit"),
+        "source_host": evidence.get("host"),
+        "source_platform": evidence.get("platform"),
+        "preflight": dict(preflight),
+        "decision_rule": {
+            "statistic": _SPEEDUP_STATISTIC,
+            "baseline_mode": "dummy",
+            "baseline_num_envs": 1,
+            "candidate_modes": list(profile.candidate_modes),
+            "minimum_speedup_exclusive": profile.minimum_speedup_exclusive,
+            "required_repetitions": profile.repetitions,
+            "warmup_steps_per_repetition": profile.warmup_steps,
+            "measure_steps_per_repetition": profile.measure_steps,
+        },
+        "baseline_transitions_per_second": baseline,
+        "mode_speedups": speedups,
+        "best_mode": best["mode"] if best else None,
+        "best_speedup_vs_baseline": best["speedup_vs_baseline"] if best else None,
+        "blockers": validator.blockers,
+        "residual_risks": [
+            "The decision is specific to the recorded CPU host and current commit.",
+            "It does not measure policy learning quality or navigation benchmark outcomes.",
+        ],
+    }
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _clean_tracked_tree() -> tuple[bool, str]:
+    try:
+        output = subprocess.check_output(
+            ["git", "status", "--porcelain", "--untracked-files=no"],
+            cwd=_REPO_ROOT,
+            text=True,
+            stderr=subprocess.STDOUT,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError) as exc:
+        return False, f"could not inspect tracked worktree state: {exc}"
+    return not output, output
+
+
+def _run_required_tests(profile: AcceptanceProfile, output_dir: Path) -> dict[str, Any]:
+    command = [sys.executable, "-m", "pytest", "-q", *profile.required_pytest_nodes]
+    completed = subprocess.run(command, cwd=_REPO_ROOT, text=True, capture_output=True, check=False)
+    log_path = output_dir / "fallback_preflight.log"
+    log_path.write_text(completed.stdout + completed.stderr, encoding="utf-8")
+    return {
+        "status": "passed" if completed.returncode == 0 else "failed",
+        "command": command,
+        "exit_code": completed.returncode,
+        "pytest_nodes": list(profile.required_pytest_nodes),
+        "log_path": _provenance_path(log_path),
+    }
+
+
+def _blocked_report(
+    profile: AcceptanceProfile,
+    blocker: str,
+    preflight: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema": REPORT_SCHEMA,
+        "issue": 4981,
+        "status": "blocked",
+        "acceptance_met": None,
+        "evidence_status": "blocked_before_measurement",
+        "claim_boundary": profile.claim_boundary,
+        "profile_path": _provenance_path(profile.path),
+        "profile_sha256": _sha256_file(profile.path),
+        "preflight": dict(preflight),
+        "blockers": [blocker],
+    }
+
+
+def _read_evidence(path: Path) -> tuple[Mapping[str, Any] | None, str | None]:
+    if not path.is_file():
+        return None, f"comparator evidence does not exist: {path}"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"could not read comparator evidence: {exc}"
+    if not isinstance(payload, Mapping):
+        return None, "comparator evidence root must be a JSON object"
+    return payload, None
+
+
+def _execute(
+    args: argparse.Namespace,
+    profile: AcceptanceProfile,
+    output_dir: Path,
+    command: list[str],
+) -> tuple[dict[str, Any], int]:
+    """Run required proof, optionally measure, and return a decision plus exit code."""
+    clean, detail = _clean_tracked_tree()
+    if not clean:
+        report = _blocked_report(
+            profile,
+            "tracked worktree must be clean before acceptance measurement/adjudication",
+            {"status": "failed", "tracked_tree": detail},
+        )
+        return report, 3
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    preflight = _run_required_tests(profile, output_dir)
+    if preflight["status"] != "passed":
+        report = _blocked_report(
+            profile,
+            "required single-environment fallback/equivalence tests failed",
+            preflight,
+        )
+        return report, 3
+
+    evidence_path = args.evidence.resolve() if args.evidence else output_dir / "comparison.json"
+    comparator_exit_code = None
+    if args.run:
+        completed = subprocess.run(
+            command,
+            cwd=_REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        comparator_exit_code = completed.returncode
+        log_path = output_dir / "comparator.log"
+        log_path.write_text(completed.stdout + completed.stderr, encoding="utf-8")
+        preflight.update(
+            {
+                "comparator_exit_code": comparator_exit_code,
+                "comparator_log_path": _provenance_path(log_path),
+            }
+        )
+
+    evidence, blocker = _read_evidence(evidence_path)
+    if evidence is None:
+        return _blocked_report(profile, blocker or "could not load evidence", preflight), 3
+    report = adjudicate(
+        profile,
+        evidence,
+        evidence_path=evidence_path,
+        current_commit=_git_commit(_REPO_ROOT),
+        preflight=preflight,
+    )
+    if comparator_exit_code not in {None, 0}:
+        report["blockers"].append(f"comparator exited with code {comparator_exit_code}")
+        report.update(
+            status="blocked",
+            acceptance_met=None,
+            evidence_status="blocked_invalid_or_incomplete_evidence",
+        )
+    return report, {"met": 0, "not_met": 2}.get(str(report["status"]), 3)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the explicit preview/run/existing-evidence interface."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument("--dry-run", action="store_true", help="Write the exact command only.")
+    action.add_argument("--run", action="store_true", help="Run and adjudicate the profile.")
+    action.add_argument("--evidence", type=Path, help="Adjudicate existing current-HEAD JSON.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the requested phase and return zero only for preview-ready or met outcomes."""
+    args = build_arg_parser().parse_args(argv)
+    output_dir = args.output_dir.resolve()
+    decision_path = output_dir / "decision.json"
+    try:
+        profile = load_profile(DEFAULT_PROFILE)
+        expected_source_provenance(profile)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    command = build_comparator_command(profile, output_dir / "comparison.json")
+
+    if args.dry_run:
+        report = {
+            "schema": REPORT_SCHEMA,
+            "issue": 4981,
+            "status": "dry_run_ready",
+            "acceptance_met": None,
+            "evidence_status": "preflight_only_not_performance_evidence",
+            "claim_boundary": (
+                "Preflight only; no throughput measurement ran and no issue, benchmark, or "
+                "paper/dissertation claim is supported."
+            ),
+            "profile_path": _provenance_path(profile.path),
+            "profile_sha256": _sha256_file(profile.path),
+            "comparator_command": command,
+            "required_pytest_nodes": list(profile.required_pytest_nodes),
+            "blockers": [],
+        }
+        exit_code = 0
+    else:
+        report, exit_code = _execute(args, profile, output_dir, command)
+
+    _write_json(decision_path, report)
+    print(
+        f"status={report['status']} best_mode={report.get('best_mode')} "
+        f"best_speedup={report.get('best_speedup_vs_baseline')} decision={decision_path}"
+    )
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/validation/test_run_issue_4981_vecenv_throughput_acceptance.py
+++ b/tests/validation/test_run_issue_4981_vecenv_throughput_acceptance.py
@@ -1,0 +1,249 @@
+"""Contract tests for the issue #4981 VecEnv throughput acceptance runner."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
+sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.validation.run_issue_4981_vecenv_throughput_acceptance import (  # noqa: E402
+    DEFAULT_PROFILE,
+    REPORT_SCHEMA,
+    SOURCE_CLAIM_BOUNDARY,
+    SOURCE_SCHEMA,
+    adjudicate,
+    build_comparator_command,
+    expected_source_provenance,
+    load_profile,
+    main,
+)
+
+
+def _repetitions(mode: str, count: int, tps: float) -> list[dict[str, object]]:
+    return [
+        {
+            "mode": mode,
+            "transitions_per_second": tps,
+            "speedup_vs_baseline": None,
+            "status": "ok",
+            "error": None,
+            "repetition": index,
+        }
+        for index in range(count)
+    ]
+
+
+def _evidence(
+    *,
+    current_commit: str,
+    speedups: dict[str, float] | None = None,
+) -> dict[str, object]:
+    profile = load_profile(DEFAULT_PROFILE)
+    provenance = expected_source_provenance(profile)
+    baseline_tps = 100.0
+    resolved_speedups = {
+        "dummy": 1.05,
+        "subproc": 2.8,
+        "threaded": 3.1,
+        "threaded_lidar_batch": 2.9,
+        **(speedups or {}),
+    }
+    results = []
+    for mode in profile.modes:
+        speedup = resolved_speedups[mode]
+        tps = round(baseline_tps * speedup, 2)
+        results.append(
+            {
+                "mode": mode,
+                "transitions_per_second": tps,
+                "speedup_vs_baseline": round(speedup, 3),
+                "status": "ok",
+                "error": None,
+                "repetition_results": _repetitions(mode, profile.repetitions, tps),
+            }
+        )
+    return {
+        "schema": SOURCE_SCHEMA,
+        "status": "ok",
+        **provenance,
+        "scenario_selection": {"strategy": "first", "index": 0},
+        "commit": current_commit,
+        "host": "test-host",
+        "python": "3.13.0",
+        "platform": "test-platform",
+        "num_envs": profile.num_envs,
+        "repetitions": profile.repetitions,
+        "base_seed": profile.base_seed,
+        "warmup_steps": profile.warmup_steps,
+        "measure_steps": profile.measure_steps,
+        "modes": list(profile.modes),
+        "baseline_mode": "dummy",
+        "baseline_num_envs": 1,
+        "baseline": {
+            "mode": "dummy",
+            "transitions_per_second": baseline_tps,
+            "speedup_vs_baseline": 1.0,
+            "status": "ok",
+            "error": None,
+            "repetition_results": _repetitions("dummy", profile.repetitions, baseline_tps),
+        },
+        "results": results,
+        "failures": [],
+        "claim_boundary": SOURCE_CLAIM_BOUNDARY,
+    }
+
+
+def _adjudicate(evidence: dict[str, object], current_commit: str) -> dict[str, object]:
+    profile = load_profile(DEFAULT_PROFILE)
+    return adjudicate(
+        profile,
+        evidence,
+        evidence_path=Path("output/comparison.json"),
+        current_commit=current_commit,
+        preflight={"status": "passed", "pytest_nodes": list(profile.required_pytest_nodes)},
+    )
+
+
+def test_profile_freezes_the_standard_workload_and_strict_threshold() -> None:
+    """The tracked profile makes the formerly vague acceptance workload reviewable."""
+    profile = load_profile(DEFAULT_PROFILE)
+
+    assert profile.num_envs == 4
+    assert profile.modes == ("dummy", "subproc", "threaded", "threaded_lidar_batch")
+    assert profile.repetitions == 5
+    assert profile.warmup_steps == 1000
+    assert profile.measure_steps == 10000
+    assert profile.candidate_modes == ("threaded", "threaded_lidar_batch")
+    assert profile.minimum_speedup_exclusive == pytest.approx(3.0)
+    assert "paper/dissertation" in profile.claim_boundary
+
+
+def test_comparator_command_is_derived_only_from_the_profile(tmp_path: Path) -> None:
+    """The acceptance measurement cannot silently drift through ad-hoc CLI overrides."""
+    profile = load_profile(DEFAULT_PROFILE)
+
+    command = build_comparator_command(
+        profile,
+        tmp_path / "comparison.json",
+        python_executable="python-under-test",
+    )
+
+    assert command[:2] == [
+        "python-under-test",
+        str(_REPO_ROOT / "scripts/validation/run_vecenv_worker_mode_throughput.py"),
+    ]
+    assert command[command.index("--config") + 1] == str(_REPO_ROOT / profile.config_path)
+    assert command[command.index("--num-envs") + 1] == "4"
+    assert command[command.index("--repetitions") + 1] == "5"
+    assert command[command.index("--warmup-steps") + 1] == "1000"
+    assert command[command.index("--measure-steps") + 1] == "10000"
+    modes_index = command.index("--modes")
+    assert command[modes_index + 1 : modes_index + 5] == list(profile.modes)
+
+
+def test_adjudicator_marks_strictly_greater_than_three_speedup_met() -> None:
+    """A complete current-head artifact with a 3.1x candidate meets the engineering gate."""
+    current_commit = "a" * 40
+
+    report = _adjudicate(_evidence(current_commit=current_commit), current_commit)
+
+    assert report["schema"] == REPORT_SCHEMA
+    assert report["status"] == "met"
+    assert report["acceptance_met"] is True
+    assert report["best_mode"] == "threaded"
+    assert report["best_speedup_vs_baseline"] == pytest.approx(3.1)
+    assert report["blockers"] == []
+    assert "paper/dissertation" in report["claim_boundary"]
+
+
+def test_exactly_three_speedup_does_not_satisfy_greater_than_gate() -> None:
+    """The issue says greater than 3x, so equality must remain a valid not-met result."""
+    current_commit = "b" * 40
+    evidence = _evidence(
+        current_commit=current_commit,
+        speedups={"subproc": 2.8, "threaded": 3.0, "threaded_lidar_batch": 2.9},
+    )
+
+    report = _adjudicate(evidence, current_commit)
+
+    assert report["status"] == "not_met"
+    assert report["acceptance_met"] is False
+    assert report["best_speedup_vs_baseline"] == pytest.approx(3.0)
+    assert report["blockers"] == []
+
+
+def test_subproc_speedup_is_comparison_only_not_acceptance() -> None:
+    """The existing process-per-environment mode cannot satisfy the in-process issue goal."""
+    current_commit = "c" * 40
+    evidence = _evidence(
+        current_commit=current_commit,
+        speedups={"subproc": 3.5, "threaded": 2.9, "threaded_lidar_batch": 2.8},
+    )
+
+    report = _adjudicate(evidence, current_commit)
+
+    assert report["status"] == "not_met"
+    assert report["acceptance_met"] is False
+    assert {row["mode"] for row in report["mode_speedups"]} == {
+        "threaded",
+        "threaded_lidar_batch",
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_blocker"),
+    [
+        (lambda data: data.__setitem__("measure_steps", 9999), "measure_steps"),
+        (lambda data: data.__setitem__("commit", "c" * 40), "current HEAD"),
+        (lambda data: data.__setitem__("config_sha256", "0" * 64), "config_sha256"),
+        (lambda data: data.__setitem__("status", "failed"), "source status"),
+        (lambda data: data.__setitem__("failures", [{"scope": "mode"}]), "failures"),
+    ],
+)
+def test_incomplete_or_stale_evidence_blocks_claim_promotion(mutation, expected_blocker) -> None:
+    """Short, stale, failed, or provenance-mismatched artifacts stay blocked."""
+    current_commit = "d" * 40
+    evidence = _evidence(current_commit=current_commit)
+    mutation(evidence)
+
+    report = _adjudicate(evidence, current_commit)
+
+    assert report["status"] == "blocked"
+    assert report["acceptance_met"] is None
+    assert any(expected_blocker in blocker for blocker in report["blockers"])
+
+
+def test_aggregate_throughput_must_match_retained_repetitions() -> None:
+    """A hand-edited headline speedup cannot override the retained sample records."""
+    current_commit = "e" * 40
+    evidence = _evidence(current_commit=current_commit)
+    threaded = next(row for row in evidence["results"] if row["mode"] == "threaded")
+    for repetition in threaded["repetition_results"]:
+        repetition["transitions_per_second"] = 999.0
+
+    report = _adjudicate(evidence, current_commit)
+
+    assert report["status"] == "blocked"
+    assert any("median repetition throughput" in blocker for blocker in report["blockers"])
+
+
+def test_dry_run_writes_a_non_evidence_preflight_without_running_commands(tmp_path: Path) -> None:
+    """Reviewers can validate the frozen command without launching the long CPU measurement."""
+    with patch(
+        "scripts.validation.run_issue_4981_vecenv_throughput_acceptance.subprocess.run"
+    ) as run:
+        exit_code = main(["--dry-run", "--output-dir", str(tmp_path)])
+
+    assert exit_code == 0
+    run.assert_not_called()
+    report = json.loads((tmp_path / "decision.json").read_text(encoding="utf-8"))
+    assert report["status"] == "dry_run_ready"
+    assert report["acceptance_met"] is None
+    assert report["claim_boundary"].startswith("Preflight only")
+    assert report["comparator_command"]


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** adds a tracked issue #4981 throughput-acceptance profile plus a fail-closed
  runner that invokes the merged four-mode comparator, proves the single-environment fallback, and
  classifies complete evidence as `met`, `not_met`, or `blocked`.
- **Why now:** merged PR #5183 supplied diagnostic comparator v2, but the issue still lacked a
  reviewable definition of “sufficiently long” and an adjudication boundary for its strict `>3x`
  criterion.
- **Claim boundary:** host-specific central processing unit (CPU) implementation throughput only.
  This PR does not establish training quality, navigation-benchmark performance, cross-host or GPU
  speedup, or any paper/dissertation claim.
- **Required validation:** focused profile/adjudicator/comparator/fallback tests, one real profile run
  on `auxme-imech036`, and the repository final PR-readiness gate.
- **Remaining blocker:** the current real profile run was valid but `not_met`; `threaded` was the best
  in-process candidate at `0.902x`, so optimization and a current-commit rerun remain before #4981
  can close.

## Contract delta

- **New tracked contract:**
  `configs/training/lidar/issue_4981_vecenv_throughput_acceptance.yaml` freezes the standard config,
  4 environments, all four comparison modes, seed 4981, 5 repetitions, 1,000 warmup steps, 10,000
  measured steps, in-process candidates, and a strict `>3.0` decision.
- **New report contract:** `issue_4981_vecenv_throughput_acceptance.v1` records the profile and source
  hashes, current commit and host, retained candidate medians, exact decision rule, preflight, and
  blockers.
- **New fail-closed blockers:** stale or shortened evidence, provenance/hash drift, failed or missing
  fallback tests, incomplete repetitions, failed modes, altered aggregate medians, non-current
  commits, and malformed source fields cannot become a performance result.
- **Compatibility:** no training or environment runtime defaults change. `subproc` remains in the
  four-mode comparison but cannot satisfy acceptance because it still uses one process per
  environment. Single-environment `threaded` modes still resolve to `DummyVecEnv`.

Issue: https://github.com/ll7/robot_sf_ll7/issues/4981

Refs #4981

This is a progression capability: a predeclared, executable, fail-closed VecEnv throughput
acceptance path. It consumes comparator v2 from #5183 and does not duplicate the earlier
implementation or comparator slices. The fragmentation guard did not trigger: no #4981 guardrail,
checker, or packet-refresh PR merged in the preceding 24 hours.

### Scope and assumptions

The reversible assumption is that the already-documented issue #1662 LiDAR PPO smoke config is the
standard training workload and that a 100-times-longer measurement window than comparator defaults,
with five repetitions, is sufficiently long for this host-specific engineering gate. Confidence is
approximately 80%; a reviewer requirement for another standard config, uncertainty interval, or
longer steady-state window would change the profile before acceptance is promoted.

Late-guidance refresh immediately before PR creation found no issue comments newer than the
2026-07-14 13:23:30 UTC session start and no open PR covering #4981 or the exact rollout scope.

Out of scope: **no full benchmark campaign run, no Slurm/GPU submission, and no
paper/dissertation claim edits**. One bounded local CPU comparator run was performed as
representative validation; it is not a navigation benchmark campaign.

### Validation result

The representative profile run used branch commit `ae463b40f4226e22e5a67632d153814fc6d673ff`
on `auxme-imech036`. Required fallback/equivalence tests passed, comparator exit was 0, all five
repetitions completed for every mode, and `failures=[]`.

| mode | median transitions/s | speedup vs 1-env dummy | acceptance candidate |
| --- | ---: | ---: | --- |
| 1-env dummy baseline | 3,238.30 | 1.000x | baseline |
| 4-env dummy | 4,254.85 | 1.314x | no |
| 4-env subproc | 8,604.36 | 2.657x | no; process-per-environment comparator |
| 4-env threaded | 2,921.88 | 0.902x | yes; threshold not met |
| 4-env threaded + LiDAR batch | 1,193.13 | 0.368x | yes; threshold not met |

Decision: `not_met`; no fallback or degraded execution was counted as success. The raw local
`output/` files are ignored, disposable validation artifacts; the command, source commit, workload,
decision, and retained medians are summarized here for durable review.

<details>
<summary>Implementation, research-boundary, validation, and governance details</summary>

## Summary

Freeze and enforce the missing issue #4981 acceptance boundary on top of the existing VecEnv
comparator, while preserving all runtime defaults.

## Linked Issues

- Refs #4981.
- Friction follow-up: #5613.

## Stack / Dependency

- Base dependency: `main` including merged PR #5183.
- Required prior PRs: #5017, #5102, #5123, #5183 are already merged.
- Stack follow-up issues: #4981.
- Safe to review independently: yes.
- Review dependency reason: the new runner imports provenance helpers and invokes comparator v2.

## What Changed

- Added the canonical YAML workload and acceptance decision.
- Added a compact runner with `--dry-run`, `--run`, and `--evidence` actions.
- Added contract tests for met/not-met/blocked cases, strict-threshold behavior, provenance drift,
  aggregate tampering, and exclusion of `subproc` from acceptance.
- Updated the issue design and vectorized-environment training documentation.

## Why It Matters

- Added value: turns a vague remaining measurement into one reviewable and reproducible command.
- Expected impact: invalid, stale, short, or fallback evidence cannot close the performance gate.
- Why merge now: the actual run shows the gate is not met, making the optimization remainder
  concrete rather than allowing a short smoke to be over-interpreted.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: issue #4981's strict `>3x` in-process
  rollout-throughput criterion and the previously undefined sufficiently-long workload.
- Comparator or baseline, if applicable: current-commit one-environment `DummyVecEnv`; four-env
  dummy and subproc are context rows; only four-env threaded modes are candidates.
- Evidence tier: diagnostic probe - host-specific CPU implementation-performance measurement, not
  navigation benchmark evidence.
- Result classification: negative - the complete representative run was valid but did not meet the
  strict threshold.
- Decision or stop rule, if applicable: leave #4981 open; do not promote the throughput claim unless
  an in-process candidate is strictly above `3.0x` in a blocker-free report.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #4981; this PR
  body is the durable result handoff because issue/PR comment authorization was not granted.
- New research/benchmark/metric/paper-facing analysis tool, if any: representative use is recorded
  above on the versioned profile and branch commit; #4981 carries the optimization/rerun decision.

## Domain-Aware Approval

- Required for this PR: yes - it defines comparison methodology and an evidence-classification
  boundary.
- Domains reviewed: evidence classification, experimental comparison, benchmark interpretation,
  paper-facing claim exclusion.
- Status: approved for this bounded fail-closed boundary; independent merge-gate review remains
  required.
- Approver/review source or waiver: author self-review against the live #4981 contract, merged
  comparator v2 contract, retained five-repetition result, and repository benchmark-safety rules.
- Validity checklist:
  - Target claim/hypothesis: strict `>3x` in-process rollout throughput, not training quality.
  - Comparator or split/evidence validity: one-env dummy baseline and fixed first scenario/config;
    all modes share seed, warmup, steps, repetitions, and current commit.
  - Fallback/degraded exclusions: incomplete/failed/fallback evidence is blocked; `subproc` cannot
    satisfy the in-process goal.
  - Claim boundary: host-specific CPU implementation throughput only; no benchmark, cross-host,
    GPU, training-quality, or paper/dissertation transfer.
  - Implementation integrity vs experimental validity: tests prove enforcement; the negative local
    result informs optimization but does not establish general performance.

## Falsification / Non-Transfer Check

- Did the mechanism activate? yes; both in-process modes completed all retained repetitions.
- Did the intervention change command source, selected command, trajectory, or route progress? yes;
  the worker mode changed while the config/scenario/seed matrix remained fixed.
- Did the scenario actually contain the targeted failure mode? NA - this measures rollout
  throughput, not a navigation-failure scenario.
- Result route: revise; profile the in-process path before rerunning.
- Follow-up question or issue for weak, negative, or non-transfer results: #4981 remains the
  canonical optimization and rerun issue.

## Next Empirical Action

- Rerun needed: yes, after a nameable in-process optimization.
- Extractor or analysis tool needed: likely profiler/call-count evidence before changing runtime;
  avoid another acceptance wrapper.
- Artifact missing or unavailable: no artifact was missing; the missing outcome is a `>3x`
  blocker-free result.
- Stop / revise / continue decision: revise implementation, then continue with this same profile.
- Proposed child issue or existing follow-up: existing #4981.

## Validation / Proof

- Commands run:
  - `uv run ruff check scripts/validation/run_issue_4981_vecenv_throughput_acceptance.py tests/validation/test_run_issue_4981_vecenv_throughput_acceptance.py`
  - `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests/validation/test_run_issue_4981_vecenv_throughput_acceptance.py tests/validation/test_run_vecenv_worker_mode_throughput.py tests/training/test_threaded_vec_env.py tests/sensor/test_batched_lidar_kernel.py::test_single_environment_batch_uses_bit_identical_scalar_fallback tests/training/test_train_expert_ppo_contract.py::test_resolve_worker_mode_accepts_threaded_and_keeps_single_env_fallback tests/training/test_train_expert_ppo_contract.py::test_threaded_lidar_batch_mode_uses_dummy_single_environment_fallback -q`
  - `uv run python scripts/validation/run_issue_4981_vecenv_throughput_acceptance.py --dry-run --output-dir output/issue_4981_acceptance_dry_run_final`
  - `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run python scripts/validation/run_issue_4981_vecenv_throughput_acceptance.py --run --output-dir output/issue_4981_acceptance_run_d8655475`
  - `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=<private-body-file> PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` - passed: 2,394 core tests, 1 skipped; changed-coverage, docstring, broad-exception, formatting, and freshness gates passed.
- Evidence that the change works here: 48 focused tests passed; dry-run status was
  `dry_run_ready`; real preflight/comparator succeeded and produced a blocker-free `not_met`
  decision rather than promoting the result.
- Benchmarks or smoke tests, if applicable: bounded local CPU implementation-throughput profile
  only; no full benchmark campaign.

## Risks / Rollout

- Compatibility risks: none to runtime defaults; the new command is opt-in.
- Failure modes: host contention and workload choice can affect throughput; current-commit,
  repetition, hash, and failure checks block common provenance drift but do not make one host
  representative of another.
- Rollback or fallback plan: remove the additive profile/runner; existing comparator and worker
  modes remain unchanged.

## Docs / Provenance

- Updated docs: `docs/dev/issues/4981-vectorized-rollouts/design.md` and
  `docs/training/vectorized_env_support.md`.
- Relevant design or provenance notes: the tracked profile and report contain config/scenario/profile
  hashes plus commit/host lineage.
- Assumptions to preserve: in-process candidates only; strict `>3.0`; no transfer beyond the
  recorded CPU host/current commit.

## Downstream Propagation

- Parent issue updated: no comment; authorization disallowed issue/PR comments, so this PR body is
  the single durable handoff.
- Claim map / benchmark report updated: NA; the result is not benchmark evidence.
- Leaderboard / artifact catalog updated: NA; no eligible benchmark artifact was produced.
- Registry or config index updated: NA; this is one issue-owned validation profile.
- Context index / memory note updated: NA; the existing issue design remains the canonical doc.
- Follow-up issue opened for deferred propagation: no; parent #4981 already owns the remainder.
- Not applicable because: no claim promotion or benchmark result occurred.

## Follow-Up Issues

- Deferred work: profile and optimize the in-process rollout hot path, then rerun the same
  current-commit acceptance profile and adjudicate the strict gate.
- Issues opened for follow-up: #4981 owns the functional remainder; #5613 tracks comparator log
  noise encountered during this work.

## Reviewer Notes

- Verify closely that the selected “standard” config and 5 x 10,000-step window are adequate; this
  is the main reversible judgment in the PR.
- Verify that `subproc` remains comparison-only and cannot cause `met`.
- Known limitation: the retained negative result is specific to `auxme-imech036` and source commit
  `ae463b40f4226e22e5a67632d153814fc6d673ff`.
- Shared-helper migration: inapplicable; the runner consumes existing comparator provenance helpers
  but does not migrate or change their call sites or return contracts.

</details>

Remaining checklist for #4981:

- [x] Freeze a standard workload and fail-closed strict acceptance decision.
- [x] Prove bit-identical/single-environment fallback before measurement.
- [x] Execute and review one sufficiently long candidate measurement without fallback/degraded rows.
- [ ] Profile and optimize an in-process candidate; the current best is `0.902x`.
- [ ] Rerun on the current candidate commit and obtain a blocker-free result strictly above `3.0x`.
