### PR TITLE
feat(benchmark): preserve empirical replay entry flows (#4975)

### DIFF
--- a/docs/datasets/eth-ucy.md
+++ b/docs/datasets/eth-ucy.md
@@ -37,7 +37,17 @@ scorecard = run_realism_validation_from_staged_dataset(
 )
 ```
 
-The plan exposes existing `SinglePedestrianDefinition` replay seeds, padded observed-position bounds, and a conservative entry/exit flow summary. A non-empty plan is always `partial`: ETH/UCY trajectory files do not provide static scene geometry, obstacle semantics, or a scene-faithful benchmark map. Missing or incomplete provenance produces a `not_available` scorecard; it is never success evidence. Re-run the registry staging/provenance commands when the local bytes change because the loader checks manifest readiness but does not rehash the local tree.
+The plan exposes existing `SinglePedestrianDefinition` replay seeds, padded observed-position
+bounds, and a conservative entry/exit flow summary. Each replay seed preserves its relative entry
+time as `start_delay_s` and carries the observed entry/exit record in `plan.entry_exit_flows`; the
+waypoint list still does not preserve per-waypoint timestamps.
+
+A non-empty plan is always `partial`: ETH/UCY trajectory files do not provide static scene
+geometry, obstacle semantics, or a scene-faithful benchmark map. Missing or incomplete provenance
+produces a `not_available` scorecard; it is never success evidence. Scorecard JSON separates metric
+availability (`status`) from the evidence boundary (`evidence_status`) and includes a content-light
+`reconstruction` readiness summary. Re-run the registry staging/provenance commands when the local
+bytes change because the loader checks manifest readiness but does not rehash the local tree.
 
 ## Sources And Citations
 

--- a/robot_sf/benchmark/pedestrian_realism_validation.py
+++ b/robot_sf/benchmark/pedestrian_realism_validation.py
@@ -61,6 +61,7 @@ __all__ = [
     "RECONSTRUCTION_CLAIM_BOUNDARY",
     "RECONSTRUCTION_SCHEMA_VERSION",
     "RealismCrowdInputs",
+    "RealismEntryExitFlow",
     "RealismMetricConfig",
     "RealismReconstructionPlan",
     "RealismScorecard",
@@ -98,6 +99,7 @@ RECONSTRUCTION_CLAIM_BOUNDARY = (
 STATUS_NOT_AVAILABLE = "not_available"
 STATUS_OK = "ok"
 STATUS_EMPTY = "empty"
+EVIDENCE_STATUS_DIAGNOSTIC_ONLY = "diagnostic-only"
 
 
 @dataclass(frozen=True)
@@ -155,6 +157,42 @@ class RealismTrackPair:
 
 
 @dataclass(frozen=True)
+class RealismEntryExitFlow:
+    """Observed entry/exit timing and displacement for one real track.
+
+    This record preserves the source track's temporal admission information for a replay
+    planner. It is not a scene annotation: the entry and exit points are observed trajectory
+    endpoints, and the flow direction is inferred from the dominant displacement axis.
+    """
+
+    pedestrian_id: int
+    entry_time_s: float
+    exit_time_s: float
+    entry_position: tuple[float, float]
+    exit_position: tuple[float, float]
+    flow_direction: str
+
+    @property
+    def observed_duration_s(self) -> float:
+        """Return the observed duration between the first and last samples."""
+
+        return float(self.exit_time_s - self.entry_time_s)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe representation for caller-owned decision packets."""
+
+        return {
+            "pedestrian_id": int(self.pedestrian_id),
+            "entry_time_s": float(self.entry_time_s),
+            "exit_time_s": float(self.exit_time_s),
+            "entry_position": [float(value) for value in self.entry_position],
+            "exit_position": [float(value) for value in self.exit_position],
+            "flow_direction": self.flow_direction,
+            "observed_duration_s": self.observed_duration_s,
+        }
+
+
+@dataclass(frozen=True)
 class RealismCrowdInputs:
     """Matched simulation/real crowd arrays for distribution-metric comparison.
 
@@ -187,6 +225,9 @@ class RealismScorecard:
         config: JSON-safe metric configuration used.
         reference_source: Provenance note for the real reference data.
         notes: Caveat and limitation notes.
+        reconstruction: Content-light reconstruction readiness summary, when a parsed
+            trajectory set was supplied. The serialized scorecard derives an explicit
+            diagnostic-only or unavailable evidence boundary from ``status``.
     """
 
     dataset_id: str
@@ -195,6 +236,7 @@ class RealismScorecard:
     config: dict[str, Any] = field(default_factory=dict)
     reference_source: str = ""
     notes: list[str] = field(default_factory=list)
+    reconstruction: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-safe mapping representation of the scorecard."""
@@ -204,10 +246,16 @@ class RealismScorecard:
             "claim_boundary": REALISM_CLAIM_BOUNDARY,
             "dataset_id": self.dataset_id,
             "status": self.status,
+            "evidence_status": (
+                EVIDENCE_STATUS_DIAGNOSTIC_ONLY
+                if self.status == STATUS_OK
+                else STATUS_NOT_AVAILABLE
+            ),
             "metrics": self.metrics,
             "config": self.config,
             "reference_source": self.reference_source,
             "notes": list(self.notes),
+            "reconstruction": self.reconstruction,
         }
 
 
@@ -231,6 +279,8 @@ class RealismReconstructionPlan:
     flow_direction_counts: dict[str, int]
     total_sample_count: int
     blockers: tuple[str, ...]
+    entry_exit_flows: tuple[RealismEntryExitFlow, ...] = ()
+    timing_status: str = "unavailable"
 
     def summary_dict(self) -> dict[str, Any]:
         """Return a content-light JSON-safe summary without trajectory coordinates."""
@@ -244,6 +294,9 @@ class RealismReconstructionPlan:
             "geometry_status": self.geometry_status,
             "flow_axis": self.flow_axis,
             "flow_direction_counts": dict(self.flow_direction_counts),
+            "entry_exit_flow_count": len(self.entry_exit_flows),
+            "timing_status": self.timing_status,
+            "entry_exit_time_span_s": _entry_exit_time_span(self.entry_exit_flows),
             "pedestrian_count": len(self.pedestrians),
             "total_sample_count": self.total_sample_count,
             "blockers": list(self.blockers),
@@ -613,6 +666,7 @@ def build_dataset_scorecard(
     lane_formation: dict[str, Any] | None,
     reference_source: str,
     notes: Sequence[str] | None = None,
+    reconstruction: dict[str, Any] | None = None,
 ) -> RealismScorecard:
     """Aggregate per-metric results into a per-dataset scorecard.
 
@@ -624,6 +678,7 @@ def build_dataset_scorecard(
         lane_formation: Lane-formation comparison mapping (or ``None``).
         reference_source: Provenance note for the real reference data.
         notes: Caveat notes.
+        reconstruction: Content-light reconstruction readiness summary.
 
     Returns:
         A :class:`RealismScorecard` with aggregated statistics.
@@ -674,10 +729,11 @@ def build_dataset_scorecard(
         config=_config_to_dict(config),
         reference_source=reference_source,
         notes=list(notes or []),
+        reconstruction=reconstruction,
     )
 
 
-def run_realism_validation(
+def run_realism_validation(  # noqa: PLR0913 - metric inputs are explicit for callers
     *,
     dataset_id: str,
     crowds: RealismCrowdInputs | None = None,
@@ -685,6 +741,7 @@ def run_realism_validation(
     rmse_pairs: Sequence[RealismTrackPair] | None = None,
     reference_source: str = "",
     notes: Sequence[str] | None = None,
+    reconstruction: dict[str, Any] | None = None,
     movement_axis: int = 0,
     lateral_axis: int = 1,
 ) -> RealismScorecard:
@@ -701,6 +758,9 @@ def run_realism_validation(
     corresponding distribution metric degrade to ``empty`` (fail-closed), so a
     partial run still produces a labeled scorecard. A missing real reference is
     never reported as a passing realism result.
+
+    The optional ``reconstruction`` mapping is serialized as a content-light readiness
+    summary; it does not change any metric computation or promote benchmark evidence.
 
     Returns:
         A :class:`RealismScorecard` aggregating all computed metrics.
@@ -738,6 +798,7 @@ def run_realism_validation(
         lane_formation=lane,
         reference_source=reference_source,
         notes=notes,
+        reconstruction=reconstruction,
     )
 
 
@@ -755,7 +816,7 @@ def build_track_reconstruction_plan(
     derived from observed positions and padded only to keep a replay container
     non-degenerate. This is an explicit partial reconstruction: the track parser
     does not provide static obstacles, scene semantics, or entry/exit geometry
-    beyond the observed first/last positions.
+    beyond the observed first/last positions and relative entry times.
 
     Args:
         track_set: Parsed real track set, or ``None`` when the asset is not staged.
@@ -781,14 +842,20 @@ def build_track_reconstruction_plan(
         "Static scene geometry is not encoded in ETH/UCY trajectory tracks; "
         "trajectory bounds are diagnostic-only and cannot seed a scene-faithful benchmark."
     )
+    timing_blocker = (
+        "Replay preserves relative entry delays but not per-waypoint timestamps; a simulator "
+        "trace adapter is required for time-faithful trajectory comparison."
+    )
     if track_set is None or not track_set.tracks:
         return _empty_reconstruction_plan(
             dataset_id=resolved_dataset_id,
             split=split,
             geometry_blocker=geometry_blocker,
+            timing_blocker=timing_blocker,
         )
 
     track_arrays = _validated_track_arrays(track_set)
+    replay_start_time_s = min(float(times[0]) for times, _positions in track_arrays)
 
     all_positions = np.concatenate([positions for _times, positions in track_arrays], axis=0)
     min_xy = np.min(all_positions, axis=0) - float(padding_m)
@@ -805,11 +872,12 @@ def build_track_reconstruction_plan(
     if float(np.max(axis_magnitudes)) > direction_epsilon_m:
         flow_axis_index = int(np.argmax(axis_magnitudes))
     flow_axis = None if flow_axis_index is None else ("x" if flow_axis_index == 0 else "y")
-    pedestrians, direction_counts = _build_reconstruction_pedestrians(
+    pedestrians, direction_counts, entry_exit_flows = _build_reconstruction_pedestrians(
         track_set,
         track_arrays,
         flow_axis_index=flow_axis_index,
         direction_epsilon_m=direction_epsilon_m,
+        replay_start_time_s=replay_start_time_s,
     )
 
     return RealismReconstructionPlan(
@@ -822,7 +890,9 @@ def build_track_reconstruction_plan(
         flow_axis=flow_axis,
         flow_direction_counts=direction_counts,
         total_sample_count=sum(times.shape[0] for times, _positions in track_arrays),
-        blockers=(geometry_blocker,),
+        blockers=(geometry_blocker, timing_blocker),
+        entry_exit_flows=tuple(entry_exit_flows),
+        timing_status="entry_delay_only",
     )
 
 
@@ -831,6 +901,7 @@ def _empty_reconstruction_plan(
     dataset_id: str,
     split: str,
     geometry_blocker: str,
+    timing_blocker: str,
 ) -> RealismReconstructionPlan:
     """Build the fail-closed plan used when no parsed tracks are available.
 
@@ -856,7 +927,10 @@ def _empty_reconstruction_plan(
         blockers=(
             "No parsed real tracks are available; stage the dataset and rerun the parser.",
             geometry_blocker,
+            timing_blocker,
         ),
+        entry_exit_flows=(),
+        timing_status="unavailable",
     )
 
 
@@ -880,6 +954,8 @@ def _validated_track_arrays(
             )
         if not np.all(np.isfinite(times)) or not np.all(np.isfinite(positions)):
             raise ValueError(f"track {track.pedestrian_id} contains non-finite values")
+        if not np.all(np.diff(times) > 0.0):
+            raise ValueError(f"track {track.pedestrian_id} times must be strictly increasing")
         arrays.append((times, positions))
     return arrays
 
@@ -890,22 +966,47 @@ def _build_reconstruction_pedestrians(
     *,
     flow_axis_index: int | None,
     direction_epsilon_m: float,
-) -> tuple[list[SinglePedestrianDefinition], dict[str, int]]:
+    replay_start_time_s: float,
+) -> tuple[
+    list[SinglePedestrianDefinition],
+    dict[str, int],
+    list[RealismEntryExitFlow],
+]:
     """Convert tracks to simulator definitions and count inferred directions.
 
     Returns:
-        A pair containing replay definitions and conservative flow-direction counts.
+        A triple containing replay definitions, conservative flow-direction counts, and
+        observed entry/exit flow records.
     """
 
     direction_counts = {"positive": 0, "negative": 0, "stationary": 0, "off_axis": 0}
     pedestrians: list[SinglePedestrianDefinition] = []
+    entry_exit_flows: list[RealismEntryExitFlow] = []
     for track, (times, positions) in zip(track_set.tracks, track_arrays, strict=True):
         waypoints = _trajectory_waypoints(positions)
+        entry_delay_s = float(times[0] - replay_start_time_s)
+        flow_direction = _increment_direction_count(
+            direction_counts,
+            positions[-1] - positions[0],
+            flow_axis_index=flow_axis_index,
+            direction_epsilon_m=direction_epsilon_m,
+        )
+        entry_exit_flows.append(
+            RealismEntryExitFlow(
+                pedestrian_id=int(track.pedestrian_id),
+                entry_time_s=float(times[0]),
+                exit_time_s=float(times[-1]),
+                entry_position=(float(positions[0, 0]), float(positions[0, 1])),
+                exit_position=(float(positions[-1, 0]), float(positions[-1, 1])),
+                flow_direction=flow_direction,
+            )
+        )
         pedestrians.append(
             SinglePedestrianDefinition(
                 id=f"{track_set.split}_p{track.pedestrian_id}",
                 start=(float(positions[0, 0]), float(positions[0, 1])),
                 trajectory=waypoints,
+                start_delay_s=entry_delay_s,
                 metadata={
                     "reconstruction_mode": "trajectory_waypoint_replay",
                     "source_asset_id": track_set.asset_id,
@@ -913,17 +1014,18 @@ def _build_reconstruction_pedestrians(
                     "source_pedestrian_id": int(track.pedestrian_id),
                     "observed_sample_count": int(times.shape[0]),
                     "observed_duration_s": float(times[-1] - times[0]),
+                    "entry_time_s": float(times[0]),
+                    "exit_time_s": float(times[-1]),
+                    "entry_delay_s": entry_delay_s,
+                    "entry_position": [float(value) for value in positions[0]],
+                    "exit_position": [float(value) for value in positions[-1]],
+                    "flow_direction": flow_direction,
+                    "timing_status": "entry_delay_only",
                     "claim_boundary": RECONSTRUCTION_CLAIM_BOUNDARY,
                 },
             )
         )
-        _increment_direction_count(
-            direction_counts,
-            positions[-1] - positions[0],
-            flow_axis_index=flow_axis_index,
-            direction_epsilon_m=direction_epsilon_m,
-        )
-    return pedestrians, direction_counts
+    return pedestrians, direction_counts, entry_exit_flows
 
 
 def _trajectory_waypoints(positions: np.ndarray) -> list[tuple[float, float]]:
@@ -947,18 +1049,24 @@ def _increment_direction_count(
     *,
     flow_axis_index: int | None,
     direction_epsilon_m: float,
-) -> None:
-    """Increment one conservative direction category for a track displacement."""
+) -> str:
+    """Increment and return one conservative direction category for a displacement.
+
+    Returns:
+        The direction bucket used in ``counts``.
+    """
 
     displacement_norm = float(np.linalg.norm(displacement))
     if displacement_norm <= direction_epsilon_m:
-        counts["stationary"] += 1
+        direction = "stationary"
     elif flow_axis_index is None or abs(displacement[flow_axis_index]) <= direction_epsilon_m:
-        counts["off_axis"] += 1
+        direction = "off_axis"
     elif displacement[flow_axis_index] > 0.0:
-        counts["positive"] += 1
+        direction = "positive"
     else:
-        counts["negative"] += 1
+        direction = "negative"
+    counts[direction] += 1
+    return direction
 
 
 def _require_non_negative_finite(value: float, name: str) -> None:
@@ -1018,6 +1126,7 @@ def run_realism_validation_from_track_set(
 
     cfg = config or RealismMetricConfig()
     base_notes = list(notes or [])
+    reconstruction = build_track_reconstruction_plan(track_set, dataset_id=dataset_id)
     if track_set is None or not track_set.tracks:
         return build_dataset_scorecard(
             dataset_id=dataset_id,
@@ -1036,6 +1145,7 @@ def run_realism_validation_from_track_set(
                 "This is not success evidence (fail-closed). Stage the dataset per "
                 "docs/datasets/eth-ucy.md and re-run."
             ],
+            reconstruction=reconstruction.summary_dict(),
         )
 
     real_positions, real_velocities = _gridded_crowd_from_tracks(track_set, cfg)
@@ -1060,6 +1170,7 @@ def run_realism_validation_from_track_set(
             f"Real reference gridded from {len(track_set.tracks)} parsed pedestrians; "
             "velocities finite-differenced on the common grid."
         ],
+        reconstruction=reconstruction.summary_dict(),
         movement_axis=movement_axis,
         lateral_axis=1,
     )
@@ -1100,6 +1211,7 @@ def run_realism_validation_from_staged_dataset(
             provenance_manifest=dataset.provenance_manifest,
         )
     except EthUcyDataError as exc:
+        reconstruction = build_track_reconstruction_plan(None, dataset_id=dataset_id)
         return build_dataset_scorecard(
             dataset_id=dataset_id,
             config=cfg,
@@ -1113,6 +1225,7 @@ def run_realism_validation_from_staged_dataset(
                 "This is not success evidence (fail-closed); complete acquisition and provenance "
                 "staging before rerunning.",
             ],
+            reconstruction=reconstruction.summary_dict(),
         )
 
     reconstruction = build_track_reconstruction_plan(track_set, dataset_id=dataset_id)
@@ -1175,11 +1288,23 @@ def render_scorecard_markdown(scorecard: RealismScorecard) -> str:
         "",
         f"Claim boundary: {sc['claim_boundary']}.",
         "",
-        f"**Status: `{sc['status']}`**  |  schema `{sc['schema_version']}`",
+        f"**Status: `{sc['status']}`**  |  evidence status: `{sc['evidence_status']}`  "
+        f"|  schema `{sc['schema_version']}`",
         "",
     ]
     if sc["reference_source"]:
         lines += [f"Reference: {sc['reference_source']}", ""]
+    reconstruction = sc.get("reconstruction")
+    if isinstance(reconstruction, dict):
+        lines += [
+            "## Reconstruction Readiness",
+            "",
+            f"- status: `{reconstruction.get('status', 'unavailable')}`",
+            f"- geometry: `{reconstruction.get('geometry_status', 'unavailable')}`",
+            f"- timing: `{reconstruction.get('timing_status', 'unavailable')}`",
+            f"- entry/exit flows: {reconstruction.get('entry_exit_flow_count', 0)}",
+            "",
+        ]
     rmse = sc["metrics"].get("trajectory_rmse", {})
     if "rmse_m" in rmse:
         lines += [
@@ -1340,6 +1465,23 @@ def _empty_metric(metric_id: str) -> dict[str, Any]:
     """Return a standardized empty-metric placeholder mapping."""
 
     return {"metric_id": metric_id, "status": STATUS_EMPTY, "count": 0}
+
+
+def _entry_exit_time_span(
+    flows: Sequence[RealismEntryExitFlow],
+) -> dict[str, float] | None:
+    """Summarize observed entry/exit times without exporting trajectory coordinates.
+
+    Returns:
+        First-entry and last-exit times, or ``None`` when no flow records exist.
+    """
+
+    if not flows:
+        return None
+    return {
+        "first_entry_time_s": float(min(flow.entry_time_s for flow in flows)),
+        "last_exit_time_s": float(max(flow.exit_time_s for flow in flows)),
+    }
 
 
 def _derive_scorecard_status(

--- a/tests/benchmark/test_pedestrian_realism_validation.py
+++ b/tests/benchmark/test_pedestrian_realism_validation.py
@@ -19,6 +19,7 @@ from robot_sf.benchmark.pedestrian_realism_validation import (
     REALISM_CLAIM_BOUNDARY,
     REALISM_SCORECARD_SCHEMA_VERSION,
     RealismCrowdInputs,
+    RealismEntryExitFlow,
     RealismMetricConfig,
     RealismScorecard,
     RealismStagedDatasetReference,
@@ -293,6 +294,8 @@ def test_run_realism_validation_synthetic_end_to_end() -> None:
     )
 
     assert scorecard.status == "ok"
+    assert scorecard.to_dict()["evidence_status"] == "diagnostic-only"
+    assert scorecard.to_dict()["reconstruction"] is None
     rmse = scorecard.metrics["trajectory_rmse"]
     assert rmse["pair_count"] == 1
     assert rmse["rmse_m"]["mean"] == pytest.approx(0.0, abs=1e-9)
@@ -366,7 +369,7 @@ def test_track_reconstruction_plan_is_partial_and_content_light() -> None:
             ),
             EthUcyTrack(
                 pedestrian_id=2,
-                time_s=times,
+                time_s=times + 0.4,
                 positions=np.asarray([[3.0, 1.0], [2.0, 1.0], [1.0, 1.0]]),
             ),
         ),
@@ -389,9 +392,32 @@ def test_track_reconstruction_plan_is_partial_and_content_light() -> None:
     assert [ped.id for ped in plan.pedestrians] == ["eth_p1", "eth_p2"]
     assert plan.pedestrians[0].start == (0.0, 0.0)
     assert plan.pedestrians[0].trajectory == [(1.0, 0.0), (2.0, 0.0)]
+    assert plan.pedestrians[1].start_delay_s == pytest.approx(0.4)
+    assert plan.pedestrians[1].metadata["entry_delay_s"] == pytest.approx(0.4)
+    assert plan.timing_status == "entry_delay_only"
+    assert all(isinstance(flow, RealismEntryExitFlow) for flow in plan.entry_exit_flows)
+    first_flow, second_flow = plan.entry_exit_flows
+    assert first_flow.pedestrian_id == 1
+    assert first_flow.entry_position == (0.0, 0.0)
+    assert first_flow.exit_position == (2.0, 0.0)
+    assert first_flow.flow_direction == "positive"
+    assert first_flow.entry_time_s == pytest.approx(0.0)
+    assert first_flow.exit_time_s == pytest.approx(0.8)
+    assert second_flow.pedestrian_id == 2
+    assert second_flow.entry_position == (3.0, 1.0)
+    assert second_flow.exit_position == (1.0, 1.0)
+    assert second_flow.flow_direction == "negative"
+    assert second_flow.entry_time_s == pytest.approx(0.4)
+    assert second_flow.exit_time_s == pytest.approx(1.2)
+    assert second_flow.to_dict()["observed_duration_s"] == pytest.approx(0.8)
     assert "static scene geometry" in plan.blockers[0].lower()
+    assert "per-waypoint timestamps" in plan.blockers[1]
     summary = plan.summary_dict()
     assert summary["schema_version"] == "pedestrian_realism_validation.reconstruction.v1"
+    assert summary["entry_exit_flow_count"] == 2
+    assert summary["timing_status"] == "entry_delay_only"
+    assert summary["entry_exit_time_span_s"]["first_entry_time_s"] == pytest.approx(0.0)
+    assert summary["entry_exit_time_span_s"]["last_exit_time_s"] == pytest.approx(1.2)
     assert "positions" not in summary
     assert "trajectory" not in summary
 
@@ -404,7 +430,33 @@ def test_empty_track_reconstruction_plan_is_not_available() -> None:
     assert plan.status == "not_available"
     assert plan.scene_bounds_m is None
     assert plan.pedestrians == ()
+    assert plan.timing_status == "unavailable"
+    assert plan.summary_dict()["entry_exit_flow_count"] == 0
     assert any("stage the dataset" in blocker.lower() for blocker in plan.blockers)
+
+
+def test_track_reconstruction_rejects_non_monotonic_times() -> None:
+    """Timed replay must fail closed when a source track has invalid sample ordering."""
+
+    track_set = EthUcyTrackSet(
+        asset_id="eth-ucy",
+        group="eth",
+        split="eth",
+        format="obsmat",
+        docs_path="docs/datasets/eth-ucy.md",
+        tracks=(
+            EthUcyTrack(
+                pedestrian_id=1,
+                time_s=np.asarray([0.0, 0.4, 0.2]),
+                positions=np.asarray([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]]),
+            ),
+        ),
+        skipped_formats=(),
+        frame_period_s=0.4,
+    )
+
+    with pytest.raises(ValueError, match="strictly increasing"):
+        build_track_reconstruction_plan(track_set)
 
 
 def test_scorecard_writer_emits_schema_files(tmp_path: Path) -> None:
@@ -421,8 +473,10 @@ def test_scorecard_writer_emits_schema_files(tmp_path: Path) -> None:
     payload = json.loads(paths["summary_json"].read_text(encoding="utf-8"))
     assert payload["schema_version"] == REALISM_SCORECARD_SCHEMA_VERSION
     assert payload["claim_boundary"] == REALISM_CLAIM_BOUNDARY
+    assert payload["evidence_status"] == "diagnostic-only"
     md = paths["scorecard_md"].read_text(encoding="utf-8")
     assert "Pedestrian Realism Scorecard" in md
+    assert "evidence status: `diagnostic-only`" in md
     assert "Trajectory RMSE" in md
 
 
@@ -538,6 +592,8 @@ def test_provenance_gated_scorecard_fails_closed_without_manifest(tmp_path: Path
     )
 
     assert scorecard.status == "not_available"
+    assert scorecard.to_dict()["evidence_status"] == "not_available"
+    assert scorecard.to_dict()["reconstruction"]["status"] == "not_available"
     assert "provenance-gated" in scorecard.reference_source
     assert any("not success evidence" in note.lower() for note in scorecard.notes)
 
@@ -569,6 +625,10 @@ def test_provenance_gated_scorecard_uses_registry_manifest(tmp_path: Path) -> No
     )
 
     assert scorecard.status == "ok"
+    assert scorecard.to_dict()["evidence_status"] == "diagnostic-only"
+    assert scorecard.to_dict()["reconstruction"]["status"] == "partial"
+    assert scorecard.to_dict()["reconstruction"]["timing_status"] == "entry_delay_only"
+    assert scorecard.to_dict()["reconstruction"]["entry_exit_flow_count"] == 2
     assert scorecard.metrics["fundamental_diagram_comparison"]["status"] == "ok"
     assert any("provenance manifest passed" in note for note in scorecard.notes)
     assert any("replay seed plan status: partial" in note for note in scorecard.notes)


### PR DESCRIPTION
## Reviewer-critical summary

This progression slice for [issue #4975](https://github.com/ll7/robot_sf_ll7/issues/4975) preserves
observed pedestrian entry/exit semantics in the provenance-gated ETH/UCY replay plan and makes
metric availability distinct from evidence readiness.

- Why now: merged PR #5595 added provenance-gated trajectory-bound replay seeds; the live issue
  still needs entry/exit semantics and a matched simulator scorecard behind #4224 staging.
- New capability: typed `RealismEntryExitFlow` records, relative `start_delay_s` admission timing,
  content-light timing/flow readiness summaries, and scorecard `evidence_status`/`reconstruction`
  fields.
- Claim boundary: diagnostic-only. `status: ok` means a metric path computed; it is not a
  scene-faithful, calibrated, ranked, benchmark, paper, or dissertation result.
- Required validation: focused realism/provenance/flow regressions, Ruff, docs evidence checks, and
  the final `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` gate; all are
  CPU-only.
- Remaining blocker: maintainer-staged external bytes/provenance under #4224, trusted scene
  geometry/obstacle semantics, and a matched simulator trace for the first official-data scorecard.

## Contract delta

- `RealismEntryExitFlow` exposes each parsed track's observed entry/exit times and positions plus
  an inferred dominant-axis direction; it is an observed trajectory record, not scene annotation.
- `RealismReconstructionPlan` now carries `entry_exit_flows` and `timing_status`. Generated
  `SinglePedestrianDefinition` seeds preserve relative admission order with `start_delay_s` and
  explicitly label timing as `entry_delay_only`.
- Scorecard JSON adds `evidence_status` (derived fail-closed as `diagnostic-only` for computed
  metrics or `not_available` otherwise) and an optional content-light `reconstruction` summary.
  Metric formulas, metric values, existing `status` semantics, and schema version identifiers are
  unchanged; additions are defaulted for compatibility.
- Non-finite or non-monotonic source time axes fail closed before timed replay construction. The
  summary contains counts and time span only; it does not export trajectory coordinates.

<details>
<summary>Evidence, governance, and handoff appendix</summary>

### Scope and linkage

- Linked issue: [#4975](https://github.com/ll7/robot_sf_ll7/issues/4975)
- Base: current `origin/main` after final synchronization.
- Open-PR dedupe: no open PR covered #4975 or this exact scope at the final preflight.
- Fragmentation guard: one merged progression PR (#5595) was found in the last 24 hours, not two
  guardrail/checker/packet-refresh PRs; this PR adds the nameable progression capability above.
- Assumption: the smallest complete public-repository slice available without missing #4224 data
  or a simulator trace is timed entry/exit replay plus explicit readiness classification. This is
  reversible and leaves the external-input blocker visible.

### Research result guidance

- Target blocker: preserve dataset entry timing and prevent a computed metric scorecard from being
  mistaken for scene-faithful empirical evidence.
- Comparator/baseline: `origin/main` / merged PR #5595 replay plan and existing synthetic known-
  ground-truth realism/provenance fixtures.
- Evidence tier: targeted smoke / diagnostic-only.
- Result classification: blocker-resolution for public replay/readiness plumbing; no empirical
  realism result.
- Decision/stop rule: stop this slice at the explicit geometry and timing boundary; continue after
  #4224 supplies maintainer-approved staged bytes/provenance and a matched simulator trace.
- Downstream surface: issue #4975 and the existing ETH/UCY contract doc; no leaderboard, claim map,
  benchmark report, registry, paper, or dissertation surface is updated because no promoted result
  exists.
- New analysis tool first use: focused tests exercise the production scorecard, reconstruction,
  parser, and provenance paths on committed synthetic fixtures; no raw external data is used.

### Domain-aware approval

- Required for this PR: yes — it changes diagnostic evidence classification and replay readiness
  metadata.
- Domains reviewed: evidence classification, experimental comparison, benchmark interpretation.
- Status: approved.
- Approver/review source or waiver: self-review against `docs/code_review.md`,
  `docs/benchmark_governance.md`, the live #4975/#4224 contracts, and the focused production-path
  tests; maintainer approval remains required for merge.
- Validity checklist:
  - Target claim/hypothesis: make entry/exit replay readiness observable without promoting realism
    evidence.
  - Comparator or split/evidence validity: existing PR #5595 behavior versus synthetic staged
    tracks with known entry delays and directions.
  - Fallback/degraded exclusions: missing provenance remains `not_available`; partial geometry and
    entry-delay-only timing remain diagnostic-only.
  - Claim boundary: no calibrated threshold, benchmark ranking, sim-to-real result, paper claim,
    or scene-faithful geometry claim.
  - Implementation integrity vs experimental validity: tests prove the API and failure paths;
    official data validity remains blocked on #4224 and simulator trace availability.

### Falsification / non-transfer

- Mechanism activation: yes on committed synthetic fixtures; unknown on official datasets because
  no official bytes are staged in this public lane.
- Target scenario: not exercised; no scene-faithful map or simulator campaign is available.
- Result route: continue after #4224 staging and simulator-trace wiring; do not promote this smoke
  evidence.

### Next empirical action

- Rerun needed: yes, after #4224 private-side acquisition/provenance pinning and scene geometry or
  a trusted map/trace adapter become available.
- Extractor/analysis tool needed: no new extractor for this slice; a simulator trace adapter and
  scene-geometry contract remain future work.
- Artifact unavailable: official ETH/UCY bytes, trusted scene geometry/obstacle semantics, and a
  matched simulator trace.
- Stop/revise/continue: continue with the first staged-data scorecard once those prerequisites are
  available; keep current output diagnostic-only.
- Follow-up: existing #4224 staging work and the remaining #4975 checklist; no new issue opened.

### Validation / proof

Commands run on clean committed HEAD against fresh `origin/main`:

```text
uv run pytest tests/benchmark/test_pedestrian_realism_validation.py tests/data/external/test_eth_ucy_shape.py tests/tools/test_manage_external_data.py tests/benchmark/test_pedestrian_flow_validation.py -q
82 passed, 1 skipped

uv run ruff check robot_sf/benchmark/pedestrian_realism_validation.py tests/benchmark/test_pedestrian_realism_validation.py
All checks passed

uv run ruff format --check robot_sf/benchmark/pedestrian_realism_validation.py tests/benchmark/test_pedestrian_realism_validation.py
2 files already formatted

uv run python scripts/dev/check_docs_evidence_integrity.py --base-ref origin/main --files docs/datasets/eth-ucy.md
1 changed file passed

BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
OK

PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=<this body file> scripts/dev/pr_ready_check.sh
Pass — core lane: 2394 passed, 1 skipped; optional lane: 7272 passed, 17 skipped, 3 warnings;
changed-file coverage warning only (95.3% for the touched executable module); clean-tree
freshness stamp recorded for HEAD `52a58f29a8ef085b17ff6c58b5349358aa03ae87`.
```

The representative path stages a tiny synthetic ETH/UCY layout, writes a compact provenance
manifest through `manage_external_data.stage_asset`, builds timed replay inputs, and reaches the
real-reference scorecard path. It does not use official dataset bytes or claim empirical realism.

### Scope, provenance, and propagation

- No raw external data, generated scorecards, checkpoints, videos, or `output/` artifacts were
  committed. Existing ignored `output/` directories were not used as durable dependencies.
- No transient queue-routing state, target-host metadata, or packet-lineage pointer was added to
  tracked files.
- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Parent issue comment/state propagation: not posted because this lane is not authorized to comment;
  this PR body is the handoff surface and records the remaining work.
- Claim map, leaderboard, artifact catalog, context index, memory note, and registry/config index:
  not applicable because this PR promotes no result and changes no registry asset.
- Friction issues: none; no repository friction met the four required criteria for a new issue.

### Risks / rollout

- Compatibility risk is limited to additive optional JSON fields; existing metric functions and
  callers retain their defaults.
- The replay seed's `start_delay_s` preserves relative entry ordering only. It does not make the
  simulator reproduce per-waypoint timing, obstacles, or the original scene.
- Rollback is a single commit revert; future official-data runs must pass the provenance and
  scene/trace gates before being interpreted.

### Follow-up issues

- Deferred work:
  - [ ] Complete maintainer-staged ETH/UCY acquisition, checksum/provenance pinning in #4224.
  - [ ] Supply scene geometry/obstacle semantics and entry/exit adapter inputs for #4975.
  - [ ] Run the first matched simulator RMSE, fundamental-diagram, and lane-formation scorecard.
- Issues opened for follow-up: none; existing #4224 and #4975 contracts already carry the work.

### Reviewer notes

- Verify that `evidence_status` remains derived fail-closed and that metric `status: ok` is not
  treated as benchmark success.
- Verify the reconstruction summary stays content-light and that the explicit geometry/timing
  blockers are not removed when official data is eventually staged.
- This is a progression slice, not a guardrail-only refresh: its new capability is typed entry/exit
  flow preservation plus machine-readable readiness metadata.

</details>

Refs #4975
