### PR TITLE
perf(training): release social-force GIL in threaded rollouts (#4981)

### DIFF
--- a/docs/dev/issues/4981-vectorized-rollouts/design.md
+++ b/docs/dev/issues/4981-vectorized-rollouts/design.md
@@ -23,6 +23,9 @@ keeping the established `DummyVecEnv`, `SubprocVecEnv`, and scalar LiDAR paths u
   dispatch. The coordinator selects it only for the explicit `threaded_lidar_batch` mode.
 - The compiled LiDAR raycast and postprocessing entry points release the Python global interpreter
   lock while executing, so independent scalar threaded scans can make progress concurrently.
+- Plain `threaded` steps select an output-identical social-force dispatcher that releases the Python
+  global interpreter lock. The selection is scoped to each worker step; default PySocialForce calls
+  and the separately coordinated `threaded_lidar_batch` mode retain the established dispatcher.
 - A one-environment LiDAR batch calls the existing `raycast_obstacles` kernel directly, preserving
   its output bit for bit.
 

--- a/docs/training/vectorized_env_support.md
+++ b/docs/training/vectorized_env_support.md
@@ -14,10 +14,11 @@ targeted tests.
 preserving Stable-Baselines3's `VecEnv` result, auto-reset, and terminal-observation behavior. Use it
 only when each environment is safe to step concurrently in one process. It avoids subprocess
 serialization, but it does not provide process isolation and does not by itself establish a rollout
-throughput improvement. The compiled LiDAR raycast and postprocessing sections release the Python
-global interpreter lock during execution; the surrounding environment step remains ordinary Python.
-The default `worker_mode: auto` remains unchanged and chooses subprocess workers when more than one
-environment is requested.
+throughput improvement. During plain `threaded` steps, the social-force calculation selects an
+output-identical compiled dispatcher that releases the Python global interpreter lock; calls outside
+that worker context retain the established dispatcher. The compiled LiDAR raycast and postprocessing
+sections also release the lock during execution. The default `worker_mode: auto` remains unchanged
+and chooses subprocess workers when more than one environment is requested.
 
 Select the mode explicitly in a primary PPO config:
 
@@ -59,6 +60,8 @@ worker computes dynamic-object raycasts independently, submits its static-obstac
 while the coordinator pads obstacle rows and invokes the batch kernel once. Participating
 rows must share one ray count and array dtypes, and each worker must reach the same number of LiDAR
 calls per step. Incompatible or incomplete batches fail closed; reset-time scans remain scalar.
+This coordinated mode retains the established social-force dispatcher rather than combining two
+independent scheduling changes.
 
 A batch of one calls the scalar `raycast_obstacles` kernel directly, and primary PPO training
 resolves the one-environment worker mode to `DummyVecEnv` before constructing a coordinator.

--- a/fast-pysf/pysocialforce/forces.py
+++ b/fast-pysf/pysocialforce/forces.py
@@ -13,7 +13,9 @@ simulation including:
 
 import logging
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from math import atan2, exp
 from typing import Protocol
 
@@ -34,6 +36,21 @@ from pysocialforce.scene import Line2D, PedState, Point2D
 logging.getLogger("numba").setLevel(logging.WARNING)
 
 Force = Callable[[], np.ndarray]
+
+_release_gil_for_social_force: ContextVar[bool] = ContextVar(
+    "release_gil_for_social_force",
+    default=False,
+)
+
+
+@contextmanager
+def social_force_gil_releasing_context() -> Iterator[None]:
+    """Select the GIL-releasing social-force kernel within the current context."""
+    token = _release_gil_for_social_force.set(True)
+    try:
+        yield
+    finally:
+        _release_gil_for_social_force.reset(token)
 
 
 class SimEntitiesProvider(Protocol):
@@ -189,7 +206,10 @@ class SocialForce:
         """
         ped_positions = self.peds.pos()
         ped_velocities = self.peds.vel()
-        forces = social_force(
+        kernel = (
+            _social_force_gil_releasing if _release_gil_for_social_force.get() else social_force
+        )
+        forces = kernel(
             ped_positions,
             ped_velocities,
             self.config.activation_threshold,
@@ -259,6 +279,9 @@ def social_force(
 
     # Return the array containing social forces for all pedestrians
     return forces
+
+
+_social_force_gil_releasing = njit(fastmath=True, nogil=True)(social_force.py_func)
 
 
 @njit(fastmath=True)

--- a/fast-pysf/tests/test_forces.py
+++ b/fast-pysf/tests/test_forces.py
@@ -1,5 +1,9 @@
 """Tests for the test_forces module."""
 
+import sys
+from collections.abc import Callable
+from threading import Event, Thread
+
 import numpy as np
 import pytest
 from pysocialforce import Simulator_v2 as Simulator
@@ -7,6 +11,35 @@ from pysocialforce import forces
 from pysocialforce.config import SimulatorConfig
 from pysocialforce.map_config import MapDefinition
 from pysocialforce.ped_grouping import PedestrianGroupings, PedestrianStates
+
+
+def _assert_releases_gil(call: Callable[[], None]) -> None:
+    """Assert that ``call`` lets a ready sibling Python thread run."""
+    ready = Event()
+    start = Event()
+    progressed = Event()
+    stop = Event()
+
+    def _sibling_worker() -> None:
+        ready.set()
+        start.wait()
+        progressed.set()
+        stop.wait()
+
+    worker = Thread(target=_sibling_worker, daemon=True)
+    worker.start()
+    assert ready.wait(timeout=1.0)
+
+    previous_switch_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1.0)
+    try:
+        start.set()
+        call()
+        assert progressed.is_set(), "compiled force call held the GIL for its complete runtime"
+    finally:
+        sys.setswitchinterval(previous_switch_interval)
+        stop.set()
+        worker.join(timeout=1.0)
 
 
 @pytest.fixture()
@@ -104,6 +137,49 @@ def test_social_force(generate_scene: Simulator):
             ]
         )
     )
+
+
+def test_gil_releasing_social_force_preserves_output_and_allows_parallel_steps():
+    """The opt-in kernel must be exact and let a sibling Python worker progress."""
+    num_pedestrians = 2_000
+    positions = np.column_stack(
+        (
+            np.arange(num_pedestrians, dtype=np.float64) * 0.01,
+            np.zeros(num_pedestrians, dtype=np.float64),
+        )
+    )
+    velocities = np.zeros_like(positions)
+    args = (positions, velocities, 3.0, 2, 3, 2.0, 0.35)
+    expected = forces.social_force(*args)
+    actual = forces._social_force_gil_releasing(*args)
+
+    np.testing.assert_array_equal(actual, expected)
+    _assert_releases_gil(lambda: forces._social_force_gil_releasing(*args))
+
+
+def test_social_force_context_selects_gil_releasing_kernel(generate_scene, monkeypatch):
+    """The alternate dispatcher must remain opt-in and scoped to its context."""
+    scene = generate_scene
+    calculator = forces.SocialForce(scene.config.social_force_config, scene.peds)
+    calls = {"default": 0, "gil_releasing": 0}
+
+    def _record_default(*args):
+        calls["default"] += 1
+        return np.zeros_like(args[0])
+
+    def _record_gil_releasing(*args):
+        calls["gil_releasing"] += 1
+        return np.zeros_like(args[0])
+
+    monkeypatch.setattr(forces, "social_force", _record_default)
+    monkeypatch.setattr(forces, "_social_force_gil_releasing", _record_gil_releasing)
+
+    calculator()
+    with forces.social_force_gil_releasing_context():
+        calculator()
+    calculator()
+
+    assert calls == {"default": 2, "gil_releasing": 1}
 
 
 def test_group_rep_force(generate_scene_with_groups: Simulator):

--- a/robot_sf/training/threaded_vec_env.py
+++ b/robot_sf/training/threaded_vec_env.py
@@ -13,6 +13,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+from pysocialforce.forces import social_force_gil_releasing_context
 from stable_baselines3.common.vec_env import DummyVecEnv
 
 from robot_sf.sensor.range_sensor import LidarBatchCoordinator, lidar_batch_context
@@ -158,7 +159,8 @@ class ThreadedVecEnv(DummyVecEnv):
         """
         coordinator = self._lidar_batch_coordinator
         if coordinator is None:
-            return env.step(action)
+            with social_force_gil_releasing_context():
+                return env.step(action)
         try:
             with lidar_batch_context(coordinator, env_idx):
                 return env.step(action)

--- a/tests/training/test_threaded_vec_env.py
+++ b/tests/training/test_threaded_vec_env.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from threading import Barrier
 
 import gymnasium as gym
@@ -11,6 +12,7 @@ from gymnasium import spaces
 
 from robot_sf.sensor import range_sensor
 from robot_sf.sensor.range_sensor import LidarScannerSettings, lidar_ray_scan_ranges_only
+from robot_sf.training import threaded_vec_env as threaded_vec_env_module
 from robot_sf.training.threaded_vec_env import ThreadedVecEnv
 
 
@@ -101,6 +103,46 @@ def test_threaded_vec_env_steps_sibling_environments_concurrently() -> None:
         ]
     finally:
         vec_env.close()
+
+
+def test_threaded_vec_env_scopes_gil_releasing_forces_to_plain_mode(monkeypatch) -> None:
+    """Plain threaded steps opt in, while coordinated LiDAR steps retain their own schedule."""
+    context_entries: list[None] = []
+
+    @contextmanager
+    def _record_context():
+        context_entries.append(None)
+        yield
+
+    monkeypatch.setattr(
+        threaded_vec_env_module,
+        "social_force_gil_releasing_context",
+        _record_context,
+    )
+
+    plain_barrier = Barrier(2)
+    plain_env = ThreadedVecEnv(
+        [lambda: _BarrierEnv(plain_barrier), lambda: _BarrierEnv(plain_barrier)]
+    )
+    try:
+        plain_env.reset()
+        plain_env.step(np.zeros((2, 1), dtype=np.float32))
+    finally:
+        plain_env.close()
+    assert len(context_entries) == 2
+
+    context_entries.clear()
+    batch_barrier = Barrier(2)
+    batch_env = ThreadedVecEnv(
+        [lambda: _BarrierEnv(batch_barrier), lambda: _BarrierEnv(batch_barrier)],
+        batch_lidar=True,
+    )
+    try:
+        batch_env.reset()
+        batch_env.step(np.zeros((2, 1), dtype=np.float32))
+    finally:
+        batch_env.close()
+    assert context_entries == []
 
 
 def test_threaded_vec_env_preserves_sb3_terminal_observation_and_auto_reset() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** plain `ThreadedVecEnv` steps now select a compiled PySocialForce social-force
  dispatcher that releases the Python global interpreter lock (GIL). The dispatcher shares the
  established function body, and tests require bit-identical output.
- **Why now:** the closure audit found every issue #4981 contract present except the strict `>3x`
  standard-workload throughput criterion. PR #5619 measured the best eligible in-process mode at
  `0.902x`; this is the smallest measured hot-path progression slice.
- **Claim boundary:** host-specific central processing unit (CPU) implementation-performance only.
  This does not establish training quality, navigation-benchmark performance, cross-host or GPU
  speedup, or any paper/dissertation claim.
- **Required validation:** exact-output/GIL/routing tests, the issue #4981 fallback preflight, and
  the frozen four-mode acceptance profile on the current commit.
- **Remaining blocker:** the current frozen result is valid `not_met`; the best eligible mode is
  `threaded_lidar_batch` at `0.995x`; plain threaded is `0.726x`, still below the strict `>3x` gate. This PR therefore uses `Refs #4981`, not a closure
  keyword.

## Contract delta

- **New schema fields:** none.
- **New behavior:** only plain multi-environment `worker_mode: threaded` steps opt into the
  GIL-releasing social-force dispatcher.
- **New fail-closed blockers:** none.
- **Compatibility impact:** the public/default `social_force` dispatcher, one-environment
  `DummyVecEnv` fallback, and `threaded_lidar_batch` scheduling remain unchanged. The alternate
  dispatcher is private, context-scoped, and compiled from the same function body.

## Acceptance audit

Issue: https://github.com/ll7/robot_sf_ll7/issues/4981

| Acceptance criterion / authoritative plan item | Status | Merged/current evidence |
| --- | --- | --- |
| Stable-Baselines3-compatible in-process batched stepping | Met | PR [#5017](https://github.com/ll7/robot_sf_ll7/pull/5017) added opt-in `ThreadedVecEnv`; PRs [#5102](https://github.com/ll7/robot_sf_ll7/pull/5102) and [#5123](https://github.com/ll7/robot_sf_ll7/pull/5123) added and integrated cross-environment light detection and ranging (LiDAR) batching. |
| Bit-identical single-environment behavior is preserved | Met | The one-environment worker modes resolve to `DummyVecEnv`; a one-row LiDAR batch calls the scalar kernel. PR [#5619](https://github.com/ll7/robot_sf_ll7/pull/5619) and this commit's acceptance preflight pass the fallback and full-observation equivalence nodes. The new dispatcher also passes exact array equality against the established dispatcher. |
| Focused automated checks cover new rollout behavior and defaults remain unchanged | Met | PRs [#5017](https://github.com/ll7/robot_sf_ll7/pull/5017), [#5102](https://github.com/ll7/robot_sf_ll7/pull/5102), [#5123](https://github.com/ll7/robot_sf_ll7/pull/5123), [#5183](https://github.com/ll7/robot_sf_ll7/pull/5183), and [#5619](https://github.com/ll7/robot_sf_ll7/pull/5619), plus the focused tests in this PR. |
| Standard-config rollout throughput is strictly greater than `3x` | **Not met** | PR #5619 froze the workload and measured `0.902x`. The current-head frozen profile on `939a5a8ec` completed with no blockers/failures; the best eligible mode was `threaded_lidar_batch` at `0.995x` (plain threaded `0.726x`), so the strict threshold remains not met. This does not corroborate the matched short-probe gain and remains below the strict threshold. |

Refs #4981

Remaining checklist:

- [x] Add a nameable hot-path capability: plain threaded social-force calls release the GIL.
- [x] Prove unchanged numerical output and mode-scoped routing.
- [x] Rerun the frozen CPU acceptance profile on the current commit.
- [ ] Raise an eligible in-process mode above the strict `3x` standard-workload threshold.

<details>
<summary>Validation, performance evidence, and governance appendix</summary>

## Summary

This progression slice removes GIL serialization from the compiled social-force calculation during
plain threaded rollouts, without changing default or LiDAR-batched dispatch. It includes focused
tests and aligned vector-environment documentation.

## Linked Issues

- Refs `#4981`: https://github.com/ll7/robot_sf_ll7/issues/4981

## Stack / Dependency

- Base dependency: none
- Required prior PRs: merged PRs #5017, #5102, #5123, #5183, and #5619
- Stack follow-up issues: #4981 remains open
- Safe to review independently: yes
- Review dependency reason, if any: none

## What Changed

- Compile a private `nogil` dispatcher from the established social-force function body.
- Select it through a restored context only for plain threaded environment steps.
- Add exact-output, real GIL-release, context-restoration, and worker-mode routing tests.
- Document the mode boundary in the public VecEnv note and issue design.

## Why It Matters

- Added value: removes one measured source of in-process rollout serialization.
- Expected impact: higher plain-threaded rollout throughput with unchanged transitions.
- Why this is worth merging now: the matched probe improved the plain-threaded median by about 20%,
  while exact-output and real GIL-release tests prove the mechanism. The later frozen profile measured
  only `0.995x` for the best eligible mode (plain threaded `0.726x`), so no long-window or cross-run speedup is claimed.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: issue #4981's strict `>3x` in-process
  rollout-throughput blocker.
- Comparator or baseline, if applicable: separately measured one-environment `DummyVecEnv` fallback;
  causal short probe also compares unchanged main with the same config/seeds/window.
- Evidence tier: host-specific CPU implementation-performance acceptance; not navigation-benchmark
  evidence.
- Result classification: positive mechanism and matched short probe; negative/non-transferring parent
  acceptance result.
- Decision or stop rule, if applicable: close only when an eligible in-process median is strictly
  greater than `3.0x`; current best eligible `0.995x` means continue.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #4981; this PR body
  is the authorized state surface for this slice.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no new analysis tool.

## Domain-Aware Approval

- Required for this PR: yes - the PR reports host-specific comparative performance evidence.
- Domains reviewed: experimental comparison and evidence classification.
- Status: approved
- Approver/review source or waiver: Codex self-review against the tracked frozen profile, raw
  comparator JSON, and fail-closed adjudicator; the downstream PR gate remains independent.
- Validity checklist:
  - Target claim/hypothesis: reduce plain-threaded rollout serialization.
  - Comparator or split/evidence validity: tracked profile, current commit, no CLI workload overrides.
  - Fallback/degraded exclusions: comparator status `ok`, failures `[]`, decision blockers `[]`.
  - Claim boundary: host-specific CPU implementation performance only.
  - Implementation integrity vs experimental validity: focused tests prove routing/equality; the frozen
    runner separately adjudicates throughput.

## Falsification / Non-Transfer Check

- Did the mechanism activate? yes - a test holds Python's thread switch interval and proves a ready
  sibling progresses during the alternate compiled call.
- Did the intervention change command source, selected command, trajectory, or route progress? no;
  scheduling changed, while exact force arrays and rollout mode selection are guarded.
- Did the scenario actually contain the targeted failure mode? yes - profiling of the real comparator
  path identified social-force computation inside `RobotEnv.step`, and the frozen workload exercised it.
- Result route: revise/narrow. The matched short probe improved, but the current frozen profile did
  not transfer that gain.
- Follow-up question or issue for weak, negative, or non-transfer results: #4981 remains the owner of
  the larger throughput gap.

## Next Empirical Action

- Rerun needed: yes, after another substantive optimization; the current commit has already completed
  the frozen run.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none for this slice.
- Stop / revise / continue decision: continue. At about 80% confidence, the next useful slice should
  profile and reduce remaining Python/force/reward serialization at a larger environment-step or
  cross-environment boundary, then rerun the same frozen profile.
- Proposed child issue or existing follow-up: existing parent issue #4981.

## Validation / Proof

- Commands run:
  - `uv run python -m pytest fast-pysf/tests/test_forces.py tests/training/test_threaded_vec_env.py tests/validation/test_run_issue_4981_vecenv_throughput_acceptance.py -q`
  - `uv run ruff check fast-pysf/pysocialforce/forces.py fast-pysf/tests/test_forces.py robot_sf/training/threaded_vec_env.py tests/training/test_threaded_vec_env.py`
  - `uv run ruff format --check fast-pysf/pysocialforce/forces.py fast-pysf/tests/test_forces.py robot_sf/training/threaded_vec_env.py tests/training/test_threaded_vec_env.py`
  - `uv run python scripts/validation/run_issue_4981_vecenv_throughput_acceptance.py --output-dir output/issue_4981_closure_audit_939a5a8e --run`
  - `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 PR_READY_PR_BODY_FILE=<body> scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: focused suite `23 passed`; acceptance preflight passed;
  comparator status `ok`, failures `[]`, blockers `[]`; full readiness passed with core
  `2394 passed, 1 skipped`, optional `7389 passed, 17 skipped`, and 100% changed executable-line
  coverage.
- Benchmarks or smoke tests, if applicable: frozen result `not_met`, baseline `2079.61` transitions/s,
  plain threaded `1510.43` transitions/s (`0.726x`), LiDAR-batched `2069.17` transitions/s (`0.995x`).
  Exit code `2` is the runner's intentional valid-`not_met` code, not a blocked execution.

## Performance Evidence

- Baseline runtime: `2.528 s` median per 8,000 plain-threaded transitions (`3164.34` transitions/s)
  on unchanged main, 4 environments, 3 repetitions, seed 4981, 100 warmup and 2,000 measured steps.
- Changed runtime: `2.110 s` median per 8,000 plain-threaded transitions (`3792.33` transitions/s)
  on the same slice and seeds. The current frozen profile measured `1510.43` transitions/s plain-threaded and `2069.17` transitions/s LiDAR-batched, so
  the performance claim is limited to the matched probe and the full result is treated as negative.
- Representative command: `uv run python scripts/validation/run_issue_4981_vecenv_throughput_acceptance.py --output-dir output/issue_4981_closure_audit_939a5a8e --run`
- Hot-path call count or profile anchor: real comparator path `RobotEnv.step` -> PySocialForce
  simulator force computation -> `fast-pysf/pysocialforce/forces.py:SocialForce.__call__`.
- Cache-hit or reuse counter: NA - no caching or reuse claim.
- Rollback or failure criterion: revert if exact output/routing tests fail, or if the matched
  three-repetition plain-threaded median is at or below the unchanged-main `3164.34` transitions/s.

## Risks / Rollout

- Compatibility risks: Numba compiles one additional dispatcher signature when plain threaded mode
  first exercises the social-force kernel; defaults and single-environment fallback are unchanged.
- Failure modes: a future social-force edit could make the two dispatchers diverge; exact equality and
  context-selection tests guard that boundary.
- Rollback or fallback plan: revert this commit or use the unchanged `auto`, `dummy`, `subproc`, or
  `threaded_lidar_batch` mode.

## Docs / Provenance

- Updated docs: `docs/training/vectorized_env_support.md` and
  `docs/dev/issues/4981-vectorized-rollouts/design.md`.
- Relevant design or provenance notes: the frozen decision records current commit `939a5a8ec`, host,
  profile hash, source hash, required-test result, and empty blocker/failure sets.
- Any assumptions that need to be preserved: the alternate dispatcher stays confined to plain
  threaded worker steps until another mode is measured and reviewed explicitly.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no - issue/PR comment authorization is explicitly false.
- Claim map / benchmark report updated (yes/no/NA): NA - not benchmark evidence.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no durable benchmark artifact.
- Registry or config index updated (yes/no/NA): NA - no registry/config change.
- Context index / memory note updated (yes/no/NA): NA - no reusable context contract added.
- Follow-up issue opened for deferred propagation (yes/no/NA): no - #4981 already owns the remainder.
- Not applicable because: the issue remains open, and this PR body records the delivered slice,
  criterion table, and remaining checklist without encoding transient host/queue state in tracked files.

## Follow-Up Issues

- Deferred work: satisfy the strict `>3x` criterion in
  https://github.com/ll7/robot_sf_ll7/issues/4981. No new issue is needed.
- Issues opened for follow-up: unrelated readiness friction is tracked in
  [#5635](https://github.com/ll7/robot_sf_ll7/issues/5635). Two SQLite `ResourceWarning` messages
  emitted during the full suite did not reproduce in the isolated three-case visualization test,
  so they were not actionable enough to file.

## Reviewer Notes

- Verify closely that the context applies only when `_lidar_batch_coordinator is None`, and that both
  compiled dispatchers derive from `social_force.py_func`.
- Known limitation: the matched probe improved, but the current best eligible result is `0.995x`, while plain-threaded is `0.726x`; the result does
  not establish long-window improvement.
- Shared-helper migration: inapplicable; no shared-helper or process-boundary migration.
- Fragmentation guard: only PR #5619 was a guard/checker/profile PR for #4981 in the preceding 24
  hours. This PR adds the nameable capability "plain-threaded GIL-releasing social force" rather
  than another checker or readiness packet.
- Explicit out of scope: no full benchmark campaign run, no Slurm/GPU submission, no
  paper/dissertation claim edits.

</details>



## Successor statement

This PR is the named plain-threaded GIL-releasing social-force slice for #4981; it does not duplicate the prior VecEnv, LiDAR-batching, comparator, or acceptance-profile slices. The strict >3x acceptance criterion remains open on #4981.




