### PR TITLE
Issue #5607: separate completed rank evidence from blocked-until-run (cheap-lane worker)

### DIFF
--- a/docs/context/issue_3216_headline_ci_rank_stability.md
+++ b/docs/context/issue_3216_headline_ci_rank_stability.md
@@ -36,11 +36,15 @@ the increased-seed-budget run, and the durable
   resampling (`kendall_tau_mean`, `kendall_tau_min`, `rank_flip_rate`,
   `top1_stable`).
 - Emits `result.json` + `report.md` and classifies the result
-  `paper_grade | nominal | diagnostic | blocked_until_run`. **Insufficient seed
-  budget (S10 or fewer) is never paper-grade**: it emits `diagnostic`; an all-
-  excluded input emits `blocked_until_run`. Even at S20+ per cell the harness
-  emits `blocked_until_run` because paper-grade promotion requires the actual
-  predeclared S20/S30 SLURM run (#1554) plus claim-card review. Captures git HEAD.
+  `paper_grade | nominal | diagnostic | completed_needs_claim_review |
+  blocked_until_run`. **Insufficient seed budget (S10 or fewer) is never
+  paper-grade**: it emits `diagnostic`. An all-excluded (no countable cells)
+  input emits `blocked_until_run`. Even at S20+ per cell the harness emits
+  `completed_needs_claim_review` (not `blocked_until_run`) because
+  `blocked_until_run` means the campaign has not produced countable evidence;
+  at S20+ the evidence was measured and analyzed, so paper-grade promotion
+  merely requires the predeclared S20/S30 SLURM run (#1554) plus claim-card
+  review. Captures git HEAD.
 
 ### Launch packet
 

--- a/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
+++ b/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
@@ -23,7 +23,11 @@ bootstrap / rank / Kendall logic:
 It is analysis tooling. It makes NO benchmark or paper-grade claim by itself:
 the paper-grade 7x7 headline run needs the increased seed budget (S20/S30 via
 #1554) and is SLURM. On insufficient seed budget the harness classifies the
-result ``blocked_until_run`` or ``diagnostic`` and never claims ``paper_grade``.
+result ``diagnostic`` or ``completed_needs_claim_review`` and never claims
+``paper_grade``. ``blocked_until_run`` is reserved for input that has not been
+executed (no countable cells); measured evidence that only awaits claim-card
+review is ``completed_needs_claim_review`` so the report never reads as missing
+execution.
 
 Coordination:
 
@@ -106,7 +110,8 @@ CLAIM_BOUNDARY = (
     "fail-closed cell status. This harness makes NO paper-grade or planner-ranking "
     "claim on its own: the paper-grade 7x7 headline run requires the increased "
     "seed budget (S20/S30 via #1554) and is SLURM. On insufficient seed budget the "
-    "result is classified blocked_until_run or diagnostic."
+    "result is classified diagnostic or completed_needs_claim_review. "
+    "blocked_until_run is used only when no countable cells exist."
 )
 
 
@@ -955,23 +960,49 @@ def build_adjacent_rank_claims(
     return claims
 
 
+# Classification values. ``blocked_until_run`` is reserved for input that has
+# NOT been executed (no countable cells). Measured evidence that still needs
+# domain-aware review before any claim promotion uses ``completed_needs_claim_review``
+# so the report never reads as "missing execution".
+CLASSIFICATIONS = frozenset(
+    {
+        "paper_grade",
+        "nominal",
+        "diagnostic",
+        "completed_needs_claim_review",
+        "blocked_until_run",
+    }
+)
+
+
 def classify(
     cells: Sequence[CellResult],
     rank_stability: Sequence[ScenarioRankStability],
 ) -> tuple[str, str]:
     """Classify the overall result with fail-closed seed-budget gating.
 
+    Execution state is kept distinct from claim readiness:
+
+    - ``blocked_until_run`` means the input was NOT executed (no countable
+      cells) — the campaign must run before any statistics exist.
+    - ``completed_needs_claim_review`` means the evidence was measured and
+      analyzed, but paper-grade promotion still requires the predeclared
+      S20/S30 SLURM headline run (#1554) and claim-card review. The campaign
+      ran; this is not a "missing execution" state.
+    - ``diagnostic`` means the measured seed budget is below the nominal
+      threshold and CIs/rank-stability are diagnostic only.
+
     Returns:
-        Tuple of (classification, rationale). Classification is one of
-        ``paper_grade``, ``nominal``, ``diagnostic``, ``blocked_until_run``.
+        Tuple of (classification, rationale).
     """
     counted = [cell for cell in cells if cell.counted]
     if not counted:
         return (
             "blocked_until_run",
             "No fail-closed-clean cells; all cells were degraded/fallback/"
-            "not_available or otherwise non-success. Run the S20/S30 headline "
-            "campaign (#1554) to populate countable cells.",
+            "not_available or otherwise non-success. The headline campaign has "
+            "not produced countable evidence; run the S20/S30 run (#1554) to "
+            "populate countable cells.",
         )
     min_seeds = min(cell.seed_count for cell in counted)
     max_seeds = max(cell.seed_count for cell in counted)
@@ -979,12 +1010,16 @@ def classify(
     if min_seeds >= PAPER_GRADE_MIN_SEEDS and identifiable_scenarios:
         # Even at S20+, paper-grade promotion is gated on the run being the
         # actual SLURM headline campaign; this harness never self-certifies.
+        # The evidence was executed and analyzed, so it is NOT "blocked until
+        # run" — it is completed and awaiting claim review.
         return (
-            "blocked_until_run",
+            "completed_needs_claim_review",
             f"Per-cell seed budget reaches paper-grade threshold "
-            f"(min_seeds={min_seeds} >= {PAPER_GRADE_MIN_SEEDS}), but paper-grade "
-            "promotion requires the predeclared S20/S30 SLURM headline run (#1554) "
-            "and claim-card review. This local harness emits the statistics only.",
+            f"(min_seeds={min_seeds} >= {PAPER_GRADE_MIN_SEEDS}) and the evidence "
+            "was measured and analyzed, but paper-grade promotion still requires "
+            "the predeclared S20/S30 SLURM headline run (#1554) and claim-card "
+            "review. This local harness emits the statistics only; it does not "
+            "self-certify paper-grade.",
         )
     if min_seeds < NOMINAL_MIN_SEEDS:
         return (
@@ -1566,7 +1601,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "Build per-cell CI + rank-stability report for the 7x7 headline "
             "planner comparison (#3216). Reuses canonical seed_variance, "
             "fidelity_rank_stability, and canonical_table_export owners. Emits "
-            "blocked_until_run/diagnostic on insufficient seed budget; never "
+            "blocked_until_run when no countable cells exist, else "
+            "completed_needs_claim_review or diagnostic; never "
             "self-certifies paper-grade."
         )
     )

--- a/scripts/benchmark/run_issue3216_headline_campaign.sh
+++ b/scripts/benchmark/run_issue3216_headline_campaign.sh
@@ -14,8 +14,11 @@
 #
 # Honesty boundary (docs/maintainer_values.md): this payload cannot
 # self-certify paper-grade. The report harness classifies the bundle
-# (paper_grade | nominal | diagnostic | blocked_until_run), but emitted
-# numbers must not be presented as paper-grade without claim-card review.
+# (paper_grade | nominal | diagnostic | completed_needs_claim_review |
+# blocked_until_run), but emitted numbers must not be presented as paper-grade
+# without claim-card review. blocked_until_run is reserved for input with no
+# countable cells; completed_needs_claim_review means the evidence was measured
+# and analyzed but awaits claim-card review.
 #
 # Usage:
 # scripts/benchmark/run_issue3216_headline_campaign.sh [--preflight-only] [--campaign-id ID] [--output-root DIR]

--- a/tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py
@@ -144,14 +144,38 @@ def test_s20_preflight_stays_no_claim_but_allows_table_review() -> None:
         campaign="issue3216_s20_fixture",
     )
 
-    assert report["classification"] == "blocked_until_run"
+    assert report["classification"] == "completed_needs_claim_review"
     assert "claim-card review" in report["classification_rationale"]
+    assert "not been executed" not in report["classification_rationale"]
     assert report["decision_packet"]["manuscript_table_status"] == (
         "ready_for_table_review_no_claim_promotion"
     )
     assert report["decision_packet"]["s30_decision_status"] == "not_required_by_local_preflight"
     assert {claim["decision"] for claim in report["adjacent_rank_claims"]} == {"ci_separable"}
     assert report["decision_packet"]["constraints_first_metric_gaps"] == []
+
+
+def test_verified_completed_s20_never_renders_blocked_until_run() -> None:
+    """A verified completed S20 campaign must not read as 'missing execution'.
+
+    Regression for issue #5607: the report must separate execution state
+    (the campaign ran) from claim readiness (claim-card review still pending).
+    A completed, analyzed S20 result classifies ``completed_needs_claim_review``,
+    never ``blocked_until_run``.
+    """
+    report = build_report(
+        _stable_s20_rows(),
+        ReportConfig(bootstrap_samples=32, resamples=16),
+        campaign="issue3216_s20_fixture",
+    )
+
+    assert report["classification"] != "blocked_until_run"
+    assert report["classification"] == "completed_needs_claim_review"
+    assert report["inputs"]["counted_cells"] > 0
+    assert report["inputs"]["excluded_cells"] == 0
+    assert "not executed" not in report["classification_rationale"]
+    # The remaining blocker is explicitly claim review, not missing execution.
+    assert "claim-card review" in report["classification_rationale"]
 
 
 def test_expected_headline_grid_missing_cell_blocks_packet() -> None:

--- a/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
@@ -212,9 +212,11 @@ def test_paper_grade_seed_budget_still_blocked_until_slurm_run():
         _cell_row("merging", "worst", {"snqi": small}),
     ]
     report = _report(rows)
-    # Never self-certifies paper_grade; promotion requires the SLURM run.
-    assert report["classification"] == "blocked_until_run"
+    # Measured S20+ evidence is NOT "blocked until run" — it was executed and
+    # analyzed. Promotion to paper-grade requires the SLURM run plus review.
+    assert report["classification"] == "completed_needs_claim_review"
     assert "S20/S30" in report["classification_rationale"]
+    assert "not executed" not in report["classification_rationale"]
 
 
 def test_report_records_canonical_owners_and_git_head():


### PR DESCRIPTION
## What / Why

Issue #5607 (friction): the #3216 headline CI/rank-stability report reused the
`blocked_until_run` classification for *measured* S20+ evidence that only
awaited claim-card review. That made a completed, analyzed campaign read as if
execution were missing — exactly the misread reported in #5607/#5247.

This PR separates **execution state** from **claim readiness** in
`scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py`:

- `blocked_until_run` is now reserved for input with **no countable cells**
  (the campaign has not produced evidence).
- Measured evidence that only awaits claim-card review now classifies
  `completed_needs_claim_review` (new, backward-compatible value).
- Metric calculations and the fail-closed cell-exclusion logic are unchanged;
  the scheme is additive, so prior `diagnostic`/`blocked_until_run` consumers
  keep working (no countable cells still yields `blocked_until_run`).

Updated surfaces: harness `classify()`, the campaign shell payload honesty
boundary, the issue #3216 context doc, the historical-artifact clarification,
and the existing assertions.

## Research Result Guidance

- Target claim / hypothesis / blocker: resolve #5607’s misleading execution-versus-claim-readiness label.
- Comparator or baseline: the prior `blocked_until_run` output for counted S20+ evidence.
- Evidence tier: diagnostic probe.
- Result classification: blocker-resolution.
- Decision or stop rule: merge only with the completed-S20 regression proof and no paper-grade promotion; live campaign interpretation remains claim-card/domain-review gated.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #5607 and `docs/context/issue_3216_headline_ci_rank_stability.md`.
- Analysis tool representative use: the committed `_stable_s20_rows` fixture is exercised by `uv run pytest -q tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py::test_verified_completed_s20_never_renders_blocked_until_run`.

## Domain-Aware Approval

- Required for this PR: yes.
- Domains reviewed: evidence classification / benchmark interpretation.
- Status: approved for this diagnostic classification repair; no experimental comparison or paper-facing result is promoted.
- Approver/review source or waiver: gate review comment on this PR.
- Validity checklist:
  - Target claim/hypothesis: measured S20+ execution must not be labeled as missing execution.
  - Comparator or split/evidence validity: prior `blocked_until_run` label versus the additive `completed_needs_claim_review` label; metrics and row selection are unchanged.
  - Fallback/degraded exclusions: unchanged fail-closed exclusion of fallback, degraded, unavailable, and non-success rows.
  - Claim boundary: diagnostic/tooling result only; paper-grade promotion still requires the declared S20/S30 run and claim-card review.
  - Implementation integrity vs experimental validity: implementation/evidence-classification integrity reviewed; no new experimental validity claim.

## Validation

- `pytest tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py` → **55 passed**.
- `ruff check` + `ruff format --check` → clean on all changed files.
- Representative versioned-fixture proof: `uv run pytest -q tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py::test_verified_completed_s20_never_renders_blocked_until_run`.
- CPU end-to-end check on a synthetic completed S20 campaign root (6 counted cells, 0 excluded) routed through the recovery path: `classification = completed_needs_claim_review` (never `blocked_until_run`).

## Downstream Propagation

- Parent issue updated: no — the gate will post the criterion→PR state after merge; #5607 remains linked until the merge/closure check.
- Claim map / benchmark report updated: NA — no benchmark result or metric changed.
- Leaderboard / artifact catalog updated: NA — no promoted artifact changed.
- Registry or config index updated: NA.
- Context index / memory note updated: yes — the issue #3216 context note is corrected in this PR.
- Follow-up issue opened for deferred propagation: NA — the remaining post-merge state is tracked by #5607.
- Not applicable because: this is a diagnostic evidence-label repair, not a new benchmark result.

## Risks / Rollout

- Compatibility risk: consumers that enumerate the old labels must accept the additive value; `blocked_until_run` remains the no-countable-cell value.
- Failure mode: claim-card or S30 review remains explicitly blocked in the decision packet and claim boundary.
- Rollback: revert the additive classification/documentation change; metric calculations are untouched.

Closes #5607

This PR was produced by the CommandCode/Tencent-Hy3 cheap implementation lane; the review gate hardens and merges.
