### PR TITLE
Issue #5613: keep VecEnv throughput comparator output compact (cheap-lane worker)

### DIFF
--- a/scripts/validation/run_vecenv_worker_mode_throughput.py
+++ b/scripts/validation/run_vecenv_worker_mode_throughput.py
@@ -20,6 +20,15 @@ Usage
         --num-envs 4 --repetitions 3 --warmup-steps 10 --measure-steps 50 \\
         --output output/vecenv_throughput.json
 
+Output verbosity
+----------------
+The comparator configures its own logging before constructing the
+environment stack so the default command stays compact: progress lines and
+the result table are printed, while TensorFlow/oneDNN/abseil C++ chatter and
+Loguru ``DEBUG`` records from the environment stack are suppressed. Pass
+``--verbose`` to restore full diagnostics to stderr, or ``--log-path PATH`` to
+write the full ``DEBUG`` log to a file while keeping the terminal compact.
+
 Output schema (``vecenv_throughput_comparator.v2``)
 ----------------------------------------------------
 ::
@@ -78,6 +87,7 @@ import contextlib
 import dataclasses
 import hashlib
 import json
+import os
 import platform
 import socket
 import statistics
@@ -86,6 +96,41 @@ import sys
 import time
 from pathlib import Path
 from typing import Any
+
+# Third-party C++ stacks (TensorFlow/oneDNN/abseil) are noisy by default; keep
+# them quiet unless the user explicitly asks for verbose diagnostics. Setting
+# this before any such import holds for the whole process.
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
+
+
+def _silence_third_party_loggers(*, verbose: bool) -> None:
+    """Quiet noisy third-party Python loggers in compact mode.
+
+    Mirrors robot_sf.benchmark.cli's suppression pattern: in compact mode the
+    matplotlib/PIL/pygame/tensorflow/absl/numba loggers are pinned to ERROR so
+    only the comparator's own progress/result lines reach the terminal.
+    ``--verbose`` (without ``--log-path``) restores them.
+    """
+    import logging
+
+    os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
+    if verbose:
+        # Full diagnostics requested: let third-party loggers speak too.
+        os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
+        return
+
+    os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
+    for logger_name in (
+        "matplotlib",
+        "PIL",
+        "pygame",
+        "moviepy",
+        "tensorflow",
+        "numba",
+        "OpenGL",
+    ):
+        logging.getLogger(logger_name).setLevel(logging.ERROR)
+
 
 _REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
 _DEFAULT_CONFIG = _REPO_ROOT / "configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml"
@@ -100,6 +145,57 @@ _RECOVERABLE_MODE_ERRORS = (
     TypeError,
     ValueError,
 )
+
+
+# ---------------------------------------------------------------------------
+# Logging setup (comparator-owned compact output)
+# ---------------------------------------------------------------------------
+
+
+def _configure_comparator_logging(
+    *,
+    verbose: bool,
+    log_path: str | None,
+) -> None:
+    """Make comparator output compact by default, full diagnostics on request.
+
+    The environment stack (svg_map_parser, environment_factory, ...) emits
+    Loguru ``DEBUG`` records and TensorFlow/oneDNN/abseil write C++ chatter to
+    STDERR. By default we route Loguru at ``INFO`` and keep ``TF_CPP_MIN_LOG_LEVEL``
+    quiet so only progress/result lines reach the terminal. ``--verbose`` restores
+    ``DEBUG`` to stderr; ``--log-path`` writes the full ``DEBUG`` stream to a file
+    while leaving the terminal compact.
+    """
+    from loguru import logger
+
+    from robot_sf.common.logging import configure_logging
+
+    _silence_third_party_loggers(verbose=verbose and not log_path)
+
+    if log_path:
+        file_sink = Path(log_path)
+        file_sink.parent.mkdir(parents=True, exist_ok=True)
+        logger.remove()
+        logger.add(
+            str(file_sink),
+            level="DEBUG",
+            colorize=False,
+            backtrace=verbose,
+            diagnose=verbose,
+        )
+        # Terminal stays compact: INFO to stderr, full detail in the file.
+        logger.add(
+            sys.stderr,
+            level="INFO",
+            colorize=True,
+            backtrace=False,
+            diagnose=False,
+        )
+        # Verbose C++ logging is still suppressed from the terminal.
+        os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
+        return
+
+    configure_logging(verbose=verbose)
 
 
 # ---------------------------------------------------------------------------
@@ -445,6 +541,23 @@ def build_arg_parser() -> argparse.ArgumentParser:
         metavar="PATH",
         help="JSON output path (default: output/vecenv_throughput_<host>.json).",
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help=(
+            "Emit full Loguru DEBUG diagnostics and TensorFlow/oneDNN/abseil "
+            "C++ chatter to stderr (default: compact output)."
+        ),
+    )
+    parser.add_argument(
+        "--log-path",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Write the full DEBUG log to this file while keeping the terminal "
+            "compact (implies DEBUG file logging regardless of --verbose)."
+        ),
+    )
     return parser
 
 
@@ -578,6 +691,8 @@ def main(argv: list[str] | None = None) -> int:
     """CLI entry point: measure and report VecEnv worker-mode throughput."""
     parser = build_arg_parser()
     args = parser.parse_args(argv)
+
+    _configure_comparator_logging(verbose=args.verbose, log_path=args.log_path)
 
     host = socket.gethostname()
     config_path = Path(args.config).resolve()

--- a/tests/validation/test_run_vecenv_worker_mode_throughput.py
+++ b/tests/validation/test_run_vecenv_worker_mode_throughput.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -19,12 +20,14 @@ sys.path.insert(0, str(_REPO_ROOT))
 from scripts.validation.run_vecenv_worker_mode_throughput import (  # noqa: E402
     _build_env_fns,
     _build_vec_env,
+    _configure_comparator_logging,
     _env_factory_kwargs,
     _env_overrides,
     _EnvFactory,
     _measure_mode,
     _resolve_num_envs,
     _sha256_file,
+    _silence_third_party_loggers,
     main,
 )
 
@@ -528,3 +531,158 @@ def test_main_rejects_invalid_measurement_parameters(tmp_path, capsys, flag, val
 
     assert rc == 1
     assert expected in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Compact output contract (issue #5613)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not _SMOKE_CONFIG.exists(),
+    reason="smoke config not found",
+)
+def test_default_output_is_compact(tmp_path, capsys):
+    """By default the comparator keeps stdout/stderr compact (no DEBUG chatter)."""
+    out = tmp_path / "result.json"
+    with patch(
+        "scripts.validation.run_vecenv_worker_mode_throughput._build_vec_env",
+        side_effect=_patch_build_vec_env,
+    ):
+        rc = main(
+            [
+                "--config",
+                str(_SMOKE_CONFIG),
+                "--modes",
+                "dummy",
+                "threaded",
+                "--num-envs",
+                "2",
+                "--warmup-steps",
+                "1",
+                "--measure-steps",
+                "2",
+                "--output",
+                str(out),
+            ]
+        )
+    assert rc == 0
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+
+    # Progress + result table still present.
+    assert "VecEnv throughput comparator" in captured.err
+    assert "mode" in captured.out and "speedup" in captured.out
+
+    # Loguru DEBUG lines from the env stack must be suppressed by default.
+    assert "robot_sf.nav.svg_map_parser" not in combined
+    assert "robot_sf.gym_env.environment_factory" not in combined
+
+
+@pytest.mark.skipif(
+    not _SMOKE_CONFIG.exists(),
+    reason="smoke config not found",
+)
+def test_verbose_restores_debug_diagnostics(tmp_path, capsys):
+    """--verbose must surface the env-stack DEBUG records that compact mode hides."""
+    from loguru import logger
+
+    def _emit_debug_build(mode, env_fns):
+        # Mimic what the real env stack emits through Loguru DEBUG.
+        logger.debug("Converting SVG map ...")
+        return _FakeVecEnv(env_fns)
+
+    out = tmp_path / "result.json"
+    with patch(
+        "scripts.validation.run_vecenv_worker_mode_throughput._build_vec_env",
+        side_effect=_emit_debug_build,
+    ):
+        rc = main(
+            [
+                "--config",
+                str(_SMOKE_CONFIG),
+                "--modes",
+                "dummy",
+                "--num-envs",
+                "2",
+                "--warmup-steps",
+                "0",
+                "--measure-steps",
+                "1",
+                "--verbose",
+                "--output",
+                str(out),
+            ]
+        )
+    assert rc == 0
+    assert "Converting SVG map" in capsys.readouterr().err
+
+
+@pytest.mark.skipif(
+    not _SMOKE_CONFIG.exists(),
+    reason="smoke config not found",
+)
+def test_default_suppresses_debug_diagnostics(tmp_path, capsys):
+    """Compact default mode must not echo the env-stack DEBUG records to stderr."""
+    from loguru import logger
+
+    def _emit_debug_build(mode, env_fns):
+        logger.debug("Converting SVG map ...")
+        return _FakeVecEnv(env_fns)
+
+    out = tmp_path / "result.json"
+    with patch(
+        "scripts.validation.run_vecenv_worker_mode_throughput._build_vec_env",
+        side_effect=_emit_debug_build,
+    ):
+        rc = main(
+            [
+                "--config",
+                str(_SMOKE_CONFIG),
+                "--modes",
+                "dummy",
+                "--num-envs",
+                "2",
+                "--warmup-steps",
+                "0",
+                "--measure-steps",
+                "1",
+                "--output",
+                str(out),
+            ]
+        )
+    assert rc == 0
+    assert "Converting SVG map" not in capsys.readouterr().err
+
+
+def test_log_path_keeps_terminal_compact_and_writes_debug(tmp_path, capsys):
+    """--log-path writes DEBUG to a file while the terminal stays compact."""
+    from loguru import logger
+
+    log_file = tmp_path / "debug.log"
+    _configure_comparator_logging(verbose=False, log_path=str(log_file))
+
+    logger.debug("Converting SVG map ...")
+    logger.info("progress line")
+
+    terminal = capsys.readouterr()
+    # Terminal compact: DEBUG line not echoed, INFO progress still visible.
+    assert "Converting SVG map" not in terminal.err, terminal.err
+    assert "progress line" in terminal.err, terminal.err
+    assert log_file.read_text().count("Converting SVG map") == 1
+
+
+def test_silence_third_party_loggers_compact_sets_tf_l2(monkeypatch):
+    """Compact mode pins TF/third-party logging quiet so the terminal stays compact."""
+    monkeypatch.delitem(os.environ, "TF_CPP_MIN_LOG_LEVEL", raising=False)
+    _silence_third_party_loggers(verbose=False)
+    assert os.environ["TF_CPP_MIN_LOG_LEVEL"] == "2"
+    assert os.environ.get("PYGAME_HIDE_SUPPORT_PROMPT")
+
+
+def test_silence_third_party_loggers_verbose_sets_tf_l0(monkeypatch):
+    """Verbose mode opens TF logging back up for full diagnostics."""
+    monkeypatch.delitem(os.environ, "TF_CPP_MIN_LOG_LEVEL", raising=False)
+    _silence_third_party_loggers(verbose=True)
+    assert os.environ["TF_CPP_MIN_LOG_LEVEL"] == "0"


### PR DESCRIPTION
## What / Why

Issue #5613 is a `friction:` technical-debt report: the VecEnv throughput
comparator (`scripts/validation/run_vecenv_worker_mode_throughput.py`) flooded
stderr on even a minimal run (123 lines / ~19.6 KB in the report's reproduction),
mostly from Loguru `DEBUG` records emitted by the environment stack
(`robot_sf.nav.svg_map_parser`, `robot_sf.gym_env.environment_factory`) plus
noisy third-party loggers.

This PR makes the comparator **own its output verbosity** instead of relying on
an external wrapper. Changes:

- Call comparator-owned logging setup at the top of `main()` before any env
  construction.
- Default (compact) mode routes Loguru at `INFO` and silences
  matplotlib/PIL/pygame/tensorflow/numba/OpenGL loggers
  (`TF_CPP_MIN_LOG_LEVEL=2`, `PYGAME_HIDE_SUPPORT_PROMPT`), so only progress
  lines and the result table reach the terminal.
- `--verbose` restores full `DEBUG` diagnostics to stderr.
- `--log-path PATH` writes the full `DEBUG` stream to a file while keeping the
  terminal compact.

## Validation

- `pytest tests/validation/test_run_vecenv_worker_mode_throughput.py`: **35 passed**.
- `ruff check` + `ruff format --check` clean on both changed files.
- CPU end-to-end reproduction (the issue's exact command, dummy+threaded,
  1 measured step):
  - compact default: Loguru `DEBUG` lines from the env stack gone; only progress
    + result table on stdout/stderr.
  - `--verbose`: 64 DEBUG lines restored to stderr.
  - `--log-path output/debug.log`: terminal compact (0 DEBUG lines), 64 DEBUG
    lines written to the file.

## Scope

This is the complete, bounded fix the issue requested (comparator-owned compact
output + tests). No campaigns, Slurm, training, or benchmark claims.

Closes #5613

This PR was produced by the CommandCode/Tencent-Hy3 cheap implementation lane; the review gate hardens and merges.
