### PR TITLE
Issue #5244: adopt camera-ready stage-status envelope in Python launcher (cheap-lane worker)

### DIFF
--- a/scripts/tools/run_camera_ready_benchmark.py
+++ b/scripts/tools/run_camera_ready_benchmark.py
@@ -14,7 +14,7 @@ import json
 import shlex
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
@@ -25,6 +25,7 @@ from robot_sf.benchmark.camera_ready_campaign import (
 )
 from robot_sf.benchmark.fallback_policy import campaign_exit_code
 from robot_sf.benchmark.orca_preflight import OrcaRvo2PreflightError
+from scripts.tools.record_post_campaign_stage_status import build_stage_status
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -200,7 +201,41 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(json.dumps(result, indent=2))
     if args.mode == "preflight" and result.get("status") != "orca_preflight_failed":
         return 0
-    return campaign_exit_code(result)
+    exit_code = campaign_exit_code(result)
+    # Issue #5244: emit the post-campaign stage-status envelope so downstream
+    # schedulers/ledgers can classify a completed campaign whose report/analysis
+    # stage fails as a separate lane (job_exit_code follows the campaign lane and
+    # must not be remapped by a nonzero reporting stage). The campaign exit code is
+    # preserved regardless of whether the envelope was written.
+    _record_stage_status(result, exit_code)
+    return exit_code
+
+
+def _record_stage_status(result: dict[str, Any], exit_code: int) -> None:
+    """Best-effort emit of the post-campaign stage-status envelope.
+
+    A completed campaign with a failed reporting stage must still exit 0 here; the
+    envelope simply records the separate report lane. Any failure to write the
+    envelope is logged but never changes the campaign exit code.
+    """
+    campaign_root = result.get("campaign_root") if isinstance(result, dict) else None
+    summary_json = result.get("summary_json") if isinstance(result, dict) else None
+    if not campaign_root or not summary_json:
+        return
+    stage_status_path = Path(campaign_root) / "reports" / "post_campaign_stage_status.json"
+    try:
+        payload = build_stage_status(
+            campaign_summary_path=Path(summary_json),
+            campaign_exit_code=exit_code,
+            stage_name="camera_ready_campaign",
+            stage_exit_code=exit_code,
+        )
+        stage_status_path.parent.mkdir(parents=True, exist_ok=True)
+        stage_status_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    except (OSError, ValueError, TypeError) as exc:
+        logger.warning("post-campaign stage status not recorded: {}", exc)
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_run_camera_ready_benchmark.py
+++ b/tests/tools/test_run_camera_ready_benchmark.py
@@ -463,3 +463,137 @@ class TestOrcaRvo2PreflightCli:
         exit_code = orca_preflight_cli.main(["--config", str(config_path)])
 
         assert exit_code == 1
+
+
+class TestPostCampaignStageStatusEnvelope:
+    """Issue #5244 production-boundary regression for the camera-ready launcher.
+
+    The canonical Python launcher must emit the
+    ``robot-sf-post-campaign-stage-status.v1`` envelope at the real dispatch
+    boundary so downstream schedulers/ledgers can separate a completed campaign
+    from a failed reporting stage. The campaign exit code must be preserved.
+    """
+
+    def test_launcher_emits_stage_status_envelope_for_completed_campaign(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """A completed campaign must write the envelope and keep exit 0."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("name: test\n", encoding="utf-8")
+        sentinel_cfg = object()
+        summary_path = tmp_path / "cid" / "reports" / "campaign_summary.json"
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text(
+            json.dumps({"soft_contract_warning": True, "warnings": ["SNQI warn"]}),
+            encoding="utf-8",
+        )
+        campaign_root = tmp_path / "cid"
+
+        def _fake_load_campaign_config(path: Path):
+            assert path == config_path
+            return sentinel_cfg
+
+        def _fake_run_campaign(cfg, **kwargs):
+            assert cfg is sentinel_cfg
+            return {
+                "campaign_id": "cid",
+                "campaign_root": str(campaign_root),
+                "summary_json": str(summary_path),
+                "benchmark_success": True,
+                "status": "benchmark_success",
+                "campaign_execution_status": "completed",
+                "evidence_status": "valid",
+                "soft_contract_warning": True,
+                "row_status_summary": {
+                    "successful_evidence_rows": 1,
+                    "accepted_unavailable_rows": 0,
+                    "unexpected_failed_rows": 0,
+                    "fallback_or_degraded_rows": 0,
+                },
+                "successful_runs": 1,
+                "accepted_unavailable_runs": 0,
+                "unexpected_failed_runs": 0,
+                "non_success_runs": 0,
+                "total_runs": 1,
+            }
+
+        monkeypatch.setattr(
+            run_camera_ready_benchmark, "load_campaign_config", _fake_load_campaign_config
+        )
+        monkeypatch.setattr(run_camera_ready_benchmark, "run_campaign", _fake_run_campaign)
+        monkeypatch.setattr(
+            run_camera_ready_benchmark,
+            "prepare_campaign_preflight",
+            lambda *a, **kw: (_ for _ in ()).throw(AssertionError("unreachable")),
+        )
+
+        exit_code = run_camera_ready_benchmark.main(["--config", str(config_path)])
+
+        assert exit_code == 0
+        envelope = campaign_root / "reports" / "post_campaign_stage_status.json"
+        assert envelope.is_file()
+        payload = json.loads(envelope.read_text(encoding="utf-8"))
+        assert payload["schema_version"] == "robot-sf-post-campaign-stage-status.v1"
+        assert payload["campaign"]["exit_code"] == 0
+        assert payload["campaign"]["status"] == "completed"
+        assert payload["campaign"]["soft_contract_warning"] is True
+        assert payload["job_exit_code"] == 0
+        assert payload["post_campaign_stage"]["status"] == "completed"
+        assert payload["post_campaign_stage"]["exit_code"] == 0
+        assert payload["post_campaign_stage"]["name"] == "camera_ready_campaign"
+
+    def test_launcher_preserves_nonzero_exit_when_campaign_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-success campaign must still exit nonzero and record the lane."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("name: test\n", encoding="utf-8")
+        sentinel_cfg = object()
+        summary_path = tmp_path / "cid" / "reports" / "campaign_summary.json"
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text("{}", encoding="utf-8")
+        campaign_root = tmp_path / "cid"
+
+        def _fake_load_campaign_config(path: Path):
+            assert path == config_path
+            return sentinel_cfg
+
+        def _fake_run_campaign(cfg, **kwargs):
+            assert cfg is sentinel_cfg
+            return {
+                "campaign_id": "cid",
+                "campaign_root": str(campaign_root),
+                "summary_json": str(summary_path),
+                "benchmark_success": False,
+                "status": "failed",
+                "campaign_execution_status": "failed",
+                "evidence_status": "invalid",
+                "row_status_summary": {
+                    "successful_evidence_rows": 0,
+                    "accepted_unavailable_rows": 0,
+                    "unexpected_failed_rows": 1,
+                    "fallback_or_degraded_rows": 0,
+                },
+            }
+
+        monkeypatch.setattr(
+            run_camera_ready_benchmark, "load_campaign_config", _fake_load_campaign_config
+        )
+        monkeypatch.setattr(run_camera_ready_benchmark, "run_campaign", _fake_run_campaign)
+        monkeypatch.setattr(
+            run_camera_ready_benchmark,
+            "prepare_campaign_preflight",
+            lambda *a, **kw: (_ for _ in ()).throw(AssertionError("unreachable")),
+        )
+
+        exit_code = run_camera_ready_benchmark.main(["--config", str(config_path)])
+
+        assert exit_code == 2
+        payload = json.loads(
+            (campaign_root / "reports" / "post_campaign_stage_status.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert payload["campaign"]["exit_code"] == 2
+        assert payload["campaign"]["status"] == "failed"
+        assert payload["job_exit_code"] == 2


### PR DESCRIPTION
## What / Why

PR #5625 (predecessor slice) added the `robot-sf-post-campaign-stage-status.v1` envelope **producer** CLI and the **finalizer consumer**, but the canonical Python production launcher `scripts/tools/run_camera_ready_benchmark.py` never emitted the envelope — only the shell wrapper `run_issue3216_headline_campaign.sh` did. That left the real Python dispatch without the separate campaign/report exit lanes the finalizer expects, so a completed campaign whose report/analysis stage failed could not be classified as a distinct lane by downstream schedulers/ledgers.

This slice closes that production-adoption gap:

- `run_camera_ready_benchmark.main()` now records `reports/post_campaign_stage_status.json` at the real dispatch boundary after computing `campaign_exit_code`. The write is best-effort (`OSError`/`ValueError`/`TypeError` guarded) and **never changes the campaign exit code**: `job_exit_code` follows the campaign lane, so a failed reporting stage cannot remap a completed campaign to nonzero.
- `soft_contract_warning` from the campaign summary is carried into the envelope lane, satisfying the issue's "completed `enforcement=warn` campaign exits 0 and records `soft_contract_warning: true`" requirement.

## Validation

- `ruff check` + `ruff format --check` pass on both changed files.
- Focused tests added in `tests/tools/test_run_camera_ready_benchmark.py::TestPostCampaignStageStatusEnvelope`, driving the **actual `main()` entry point** (not just a returned payload):
  - `test_launcher_emits_stage_status_envelope_for_completed_campaign`: completed campaign → launcher exits 0, envelope written with `campaign.exit_code=0`, `job_exit_code=0`, `soft_contract_warning=true`, `post_campaign_stage.status=completed`.
  - `test_launcher_preserves_nonzero_exit_when_campaign_fails`: failed campaign → exit 2 preserved, envelope records `campaign.exit_code=2`/`job_exit_code=2`.
- Full run: `pytest tests/tools/test_run_camera_ready_benchmark.py tests/tools/test_slurm_job_finalize.py` → **38 passed** (includes the pre-existing finalizer regression covering missing/mismatch/report-failure/hard-failure paths).

## Successor statement

Successor slice of **PR #5625**; does **not** duplicate it. PR #5625 built the producer CLI and finalizer consumer; this slice adopts the envelope in the production Python launcher and adds the production-boundary regression.

## Remaining (out of scope for this slice)

- The exact private-ops `.sl` scheduler/ledger path and the job-13274 stdout/stderr tail still need inspection and adoption on the private execution host (tracked on the issue; this PR does not claim the private root-cause has been identified).

## Required sentence

This PR was produced by the CommandCode/Tencent-Hy3 cheap implementation lane; the review gate hardens and merges.

Refs #5244