### PR TITLE
Issue #5326: lock signed-robustness objective CPU comparison contract (cheap-lane worker)

### DIFF
--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -1608,6 +1608,52 @@ def test_sampler_comparison_multi_objective(tmp_path: Path) -> None:
         )
 
 
+def test_issue_5326_objective_comparison_contract(tmp_path: Path) -> None:
+    """Issue #5326 comparison must tag both objectives and write the signed robustness sidecar.
+
+    The signed temporal-logic robustness objective (issue #5304) must produce a
+    per-candidate ``robustness_report.json`` sidecar, while the baseline
+    ``worst_case_snqi`` objective must not. The comparison row must also expose
+    the fallback/degraded exclusion fields so the durable report can fail closed
+    against degraded execution.
+    """
+    config = _config(tmp_path, workers=1)
+
+    rows = run_sampler_comparison(
+        config=config,
+        sampler_names=("random", "random"),
+        objective_names=("worst_case_snqi", "temporal_robustness"),
+        synthetic=True,
+    )
+
+    by_objective = {(row.objective, row.sampler): row for row in rows}
+    assert ("worst_case_snqi", "random") in by_objective
+    assert ("temporal_robustness", "random") in by_objective
+
+    snqi_row = by_objective[("worst_case_snqi", "random")]
+    signed_row = by_objective[("temporal_robustness", "random")]
+
+    bundle_dir = Path(str(signed_row.best_bundle_path))
+    assert (bundle_dir / "robustness_report.json").is_file()
+    report = json.loads((bundle_dir / "robustness_report.json").read_text(encoding="utf-8"))
+    assert report["schema_version"] == "robustness-report.v1"
+    assert {p["property_name"] for p in report["properties"]} == {
+        "clearance",
+        "ttc",
+        "goal",
+        "progress",
+        "collision",
+    }
+
+    snqi_bundle_dir = Path(str(snqi_row.best_bundle_path))
+    assert not (snqi_bundle_dir / "robustness_report.json").exists()
+
+    for row in rows:
+        assert row.fallback_candidate_count == 0
+        assert row.degraded_candidate_count == 0
+        assert row.held_out_family_status == "not_evaluated_narrow_archive"
+
+
 def test_invalid_optimizer_proposals_are_rejected_before_evaluation(tmp_path: Path) -> None:
     """Search-space validation must fail closed before benchmark evaluation."""
     config = _config(tmp_path)


### PR DESCRIPTION
## What / Why

Issue #5326 asks to evaluate the signed temporal-logic robustness objective (#5304) against the existing criticality/SNQI objectives under matched simulator-call budgets. The thread's earlier "blocked" comments are **stale**: PR #5325 (the objective) and PR #5333 (the multi-objective runner + `configs/adversarial/issue_5326_objective_comparison.yaml`) are both merged, so the cheap-lane prerequisites no longer hold.

Cheap-lane is structurally prohibited from running the matched-budget campaign (SLURM). The runner ships a `--synthetic` CPU path that produces the issue's durable reporting artifact at the diagnostic tier, so this PR delivers the CPU-achievable slice: it **locks the issue #5326 reporting contract** with a focused, real test and produces the diagnostic `report.json`.

## Slice implemented (new capability)
- `tests/adversarial/test_adversarial_search.py::test_issue_5326_objective_comparison_contract` asserts the comparison emits **both** `worst_case_snqi` and `temporal_robustness` columns, that the signed objective writes the per-candidate `robustness_report.json` sidecar (clearance/ttc/goal/progress/collision per-property rows) while the baseline objective does **not**, and that every row exposes `fallback_candidate_count`/`degraded_candidate_count`/`held_out_family_status` so the durable report can fail closed against degraded execution.
- Real diagnostic artifact produced at `output/adversarial/issue_5326_objective_comparison/report.json` (16 rows: 8 per objective × 2 samplers × 2 budgets × 2 seeds), `schema_version: adversarial-sampler-comparison.v3`, `claim_scope: not_paper_facing_benchmark_evidence`, `report_status: diagnostic_local_nominal`. (Path is under gitignored `output/` per repo convention; contents summarized here and reproduced via the config's `example_command`.)

## Validation
- `uv run pytest tests/adversarial/test_adversarial_search.py tests/test_adversarial_robustness.py` → **97 passed** (incl. new test).
- `uv run ruff check` + `ruff format --check` on the changed file → clean.
- Reproduction command (from the committed config):
  `uv run python scripts/tools/compare_adversarial_samplers.py --objective worst_case_snqi --objective temporal_robustness --sampler random --sampler coordinate --budget 8 --budget 16 --seed 1101 --seed 2202 --synthetic --output-dir output/adversarial/issue_5326_objective_comparison --out-json output/adversarial/issue_5326_objective_comparison/report.json`

## Successor statement
Successor slice (requires SLURM-capable worker — out of cheap-lane scope): the **full matched-budget campaign** with certification, replay, and independent-seed confirmation for random/TPE/CMA-ES-class search, plus the durable stop-rule comparison table and held-out-family yield. This PR does **not** duplicate PR #5325 (objective) or PR #5333 (runner/config infrastructure).

Refs #5326

This PR was produced by the CommandCode/Tencent-Hy3 cheap implementation lane; the review gate hardens and merges.