### PR TITLE
Issue #5244: reusable post-campaign stage runner isolating exit 5 (cheap-lane worker)

### DIFF
--- a/scripts/tools/run_post_campaign_stage.py
+++ b/scripts/tools/run_post_campaign_stage.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Run a chained post-campaign stage and record its exit as a separate lane.
+
+Issue #5244 root-cause candidate: a post-campaign analysis step (for example an
+SNQI tool such as ``recompute_snqi_weights.py``) chained after a completed camera-ready
+campaign can surface its own nonzero exit — e.g. ``EXIT_OPTIONAL_DEPS_MISSING`` (5)
+when an optional dependency such as matplotlib is missing on the compute node. Under
+``set -e``/``set -euo pipefail`` a naive wrapper then propagates that code as the job
+exit, orphaning an otherwise complete campaign.
+
+This helper runs the chained stage as a subprocess and records its exit in the
+``post_campaign_stage`` lane of the ``robot-sf-post-campaign-stage-status.v1`` envelope
+without overwriting the campaign exit. The overall process exit follows the campaign
+lane only; a failed reporting/analysis stage stays visible but never relabels a
+completed campaign as a failed scheduler job.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from scripts.tools.record_post_campaign_stage_status import build_stage_status
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+
+def _exit_code(value: str) -> int:
+    """Parse a portable process exit code."""
+    parsed = int(value)
+    if not 0 <= parsed <= 255:
+        raise argparse.ArgumentTypeError("exit code must be between 0 and 255")
+    return parsed
+
+
+def run_stage_command(command: Sequence[str]) -> tuple[int, str, str]:
+    """Run a post-campaign stage command, returning (exit_code, stdout, stderr).
+
+    The stage command is executed via ``subprocess.run`` so a nonzero exit is captured
+    rather than propagating to the parent process under ``set -e``. ``FileNotFoundError``
+    (the command itself is unavailable) is reported as the dedicated optional-deps-missing
+    lane code shared with SNQI tooling.
+    """
+    try:
+        completed = subprocess.run(
+            list(command),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return 5, "", f"post-campaign stage command not found: {exc}"
+    return completed.returncode, completed.stdout or "", completed.stderr or ""
+
+
+def build_post_campaign_stage_payload(
+    *,
+    campaign_summary_path: Path,
+    campaign_exit_code: int,
+    stage_name: str,
+    stage_command: Sequence[str],
+    output: Path | None = None,
+) -> tuple[int, dict[str, Any]]:
+    """Run a post-campaign stage and build its status envelope.
+
+    Returns:
+        The process exit code and the stage-status payload. The process exit code
+        follows the campaign lane (``campaign_exit_code``); a failed stage is recorded
+        separately and does not remap a completed campaign.
+    """
+    stage_exit_code, _, _ = run_stage_command(stage_command)
+    payload = build_stage_status(
+        campaign_summary_path=campaign_summary_path,
+        campaign_exit_code=campaign_exit_code,
+        stage_name=stage_name,
+        stage_exit_code=stage_exit_code,
+    )
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return campaign_exit_code, payload
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--campaign-summary", type=Path, required=True)
+    parser.add_argument("--campaign-exit-code", type=_exit_code, required=True)
+    parser.add_argument("--stage-name", required=True)
+    parser.add_argument(
+        "--stage-command",
+        nargs=argparse.REMAINDER,
+        required=True,
+        help="Post-campaign stage command to run (e.g. a chained SNQI analysis step).",
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    """Run the chained stage and write its status envelope at the dispatch boundary."""
+    args = _parse_args(list(argv) if argv is not None else None)
+    # ``argparse.REMAINDER`` may keep a leading "--" separator when present.
+    stage_command = [token for token in args.stage_command if token != "--"]
+    if not stage_command:
+        print("error: empty post-campaign stage command", file=sys.stderr)
+        return 2
+    process_exit_code, payload = build_post_campaign_stage_payload(
+        campaign_summary_path=args.campaign_summary,
+        campaign_exit_code=args.campaign_exit_code,
+        stage_name=args.stage_name,
+        stage_command=stage_command,
+        output=args.output,
+    )
+    print(json.dumps(payload, sort_keys=True))
+    if payload["post_campaign_stage"]["exit_code"] != 0:
+        print(
+            f"WARNING: post-campaign stage '{args.stage_name}' failed "
+            f"(exit {payload['post_campaign_stage']['exit_code']}); "
+            f"campaign exit remains {args.campaign_exit_code}.",
+            file=sys.stderr,
+        )
+    return process_exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_run_post_campaign_stage.py
+++ b/tests/tools/test_run_post_campaign_stage.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Regression tests for the post-campaign stage runner (issue #5244).
+
+These exercise the real subprocess dispatch + serialization boundary: a chained
+SNQI-style step that exits 5 (optional-deps-missing, the job-13274 candidate) must be
+recorded in the ``post_campaign_stage`` lane without remapping a completed campaign's
+exit 0. The hard-fail path must stay nonzero.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.tools import run_post_campaign_stage
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class TestPostCampaignStageRunner:
+    """Issue #5244: post-campaign stage exit 5 must not remap a completed campaign."""
+
+    def test_completed_campaign_keeps_exit_zero_when_stage_exits_five(self, tmp_path: Path) -> None:
+        """A chained stage exit 5 is recorded separately; process exit stays 0."""
+        summary = tmp_path / "campaign" / "reports" / "campaign_summary.json"
+        summary.parent.mkdir(parents=True, exist_ok=True)
+        summary.write_text(
+            json.dumps({"soft_contract_warning": True, "warnings": ["SNQI warn"]}),
+            encoding="utf-8",
+        )
+        output = tmp_path / "stage_status.json"
+        stage_script = tmp_path / "stage_fail.sh"
+        stage_script.write_text("#!/usr/bin/env bash\nexit 5\n", encoding="utf-8")
+        stage_script.chmod(0o755)
+
+        exit_code, payload = run_post_campaign_stage.build_post_campaign_stage_payload(
+            campaign_summary_path=summary,
+            campaign_exit_code=0,
+            stage_name="snqi_recompute_weights",
+            stage_command=[str(stage_script)],
+            output=output,
+        )
+
+        assert exit_code == 0
+        assert payload["schema_version"] == "robot-sf-post-campaign-stage-status.v1"
+        assert payload["campaign"]["exit_code"] == 0
+        assert payload["campaign"]["status"] == "completed"
+        assert payload["campaign"]["soft_contract_warning"] is True
+        assert payload["job_exit_code"] == 0
+        assert payload["post_campaign_stage"]["name"] == "snqi_recompute_weights"
+        assert payload["post_campaign_stage"]["exit_code"] == 5
+        assert payload["post_campaign_stage"]["status"] == "report_stage_failed"
+        assert output.is_file()
+
+    def test_hard_campaign_failure_stays_nonzero_when_stage_succeeds(self, tmp_path: Path) -> None:
+        """A hard campaign exit must remain nonzero even if the stage succeeds."""
+        summary = tmp_path / "campaign" / "reports" / "campaign_summary.json"
+        summary.parent.mkdir(parents=True, exist_ok=True)
+        summary.write_text("{}", encoding="utf-8")
+        output = tmp_path / "stage_status.json"
+        stage_script = tmp_path / "stage_ok.sh"
+        stage_script.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        stage_script.chmod(0o755)
+
+        exit_code, payload = run_post_campaign_stage.build_post_campaign_stage_payload(
+            campaign_summary_path=summary,
+            campaign_exit_code=2,
+            stage_name="snqi_recompute_weights",
+            stage_command=[str(stage_script)],
+            output=output,
+        )
+
+        assert exit_code == 2
+        assert payload["campaign"]["exit_code"] == 2
+        assert payload["campaign"]["status"] == "failed"
+        assert payload["job_exit_code"] == 2
+        assert payload["post_campaign_stage"]["exit_code"] == 0
+        assert payload["post_campaign_stage"]["status"] == "completed"
+
+    def test_missing_stage_command_records_optional_deps_missing_lane(self, tmp_path: Path) -> None:
+        """A missing chained command is reported as the optional-deps-missing lane."""
+        summary = tmp_path / "campaign" / "reports" / "campaign_summary.json"
+        summary.parent.mkdir(parents=True, exist_ok=True)
+        summary.write_text("{}", encoding="utf-8")
+        output = tmp_path / "stage_status.json"
+
+        exit_code, payload = run_post_campaign_stage.build_post_campaign_stage_payload(
+            campaign_summary_path=summary,
+            campaign_exit_code=0,
+            stage_name="snqi_sensitivity_analysis",
+            stage_command=["/nonexistent/command_5244"],
+            output=output,
+        )
+
+        assert exit_code == 0
+        assert payload["post_campaign_stage"]["exit_code"] == 5
+        assert payload["post_campaign_stage"]["status"] == "report_stage_failed"
+
+    def test_cli_runs_real_subprocess_and_writes_envelope(self, tmp_path: Path) -> None:
+        """The CLI entry point drives a real subprocess at the dispatch boundary."""
+        summary = tmp_path / "campaign" / "reports" / "campaign_summary.json"
+        summary.parent.mkdir(parents=True, exist_ok=True)
+        summary.write_text(
+            json.dumps({"soft_contract_warning": True, "warnings": []}),
+            encoding="utf-8",
+        )
+        output = tmp_path / "stage_status.json"
+        stage_script = tmp_path / "stage_fail.sh"
+        stage_script.write_text("#!/usr/bin/env bash\nexit 5\n", encoding="utf-8")
+        stage_script.chmod(0o755)
+
+        exit_code = run_post_campaign_stage.main(
+            [
+                "--campaign-summary",
+                str(summary),
+                "--campaign-exit-code",
+                "0",
+                "--stage-name",
+                "snqi_recompute_weights",
+                "--output",
+                str(output),
+                "--stage-command",
+                str(stage_script),
+            ]
+        )
+
+        assert exit_code == 0
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        assert payload["job_exit_code"] == 0
+        assert payload["post_campaign_stage"]["exit_code"] == 5
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Added a reusable primitive, `scripts/tools/run_post_campaign_stage.py`,
  that runs a **chained post-campaign analysis step** as a subprocess and records its exit in
  the `post_campaign_stage` lane of the `robot-sf-post-campaign-stage-status.v1` envelope
  **without remapping the campaign exit**. This addresses the second root-cause candidate for
  job 13274's observed `exit 5`: a chained SNQI tool (e.g. `recompute_snqi_weights.py`) failing
  with `EXIT_OPTIONAL_DEPS_MISSING` (5) when an optional dependency such as matplotlib is missing
  on the compute node, which a naive `set -e` wrapper would propagate as the job exit and orphan
  a complete campaign.
- **Why now:** PRs #5321 and #5625 merged the public launcher producer and finalizer consumer of
  the status envelope, but the **chained-SNQI exit-5 path had no reusable primitive** isolating
  its exit in the stage lane. The issue-3216 shell wrapper inlines this only for its own report
  step; chained SNQI analysis steps (the likely job-13274 tail) still had no artifact-first
  boundary. This PR adds that primitive plus a production-boundary regression.
- **Claim boundary:** No SNQI metric semantics, benchmark methodology, planner result, or
  paper/dissertation claim is changed. A completed campaign with a failed reporting/analysis step
  remains outside benchmark evidence.
- **Validation required:** focused subprocess + envelope-serialization regression, Ruff, and
  related wrapper/finalizer suites.

## Refs #5244 (partial slice — does not duplicate PR #5321 / PR #5625)

Successor slice: adds a **new, reusable post-campaign stage runner** for the chained-SNQI
`exit 5` candidate that PR #5321/#5625 did not cover (they repaired the launcher producer and
finalizer consumer only). This slice adds NEW capability at a real dispatch boundary and names
it here.

### What remains
- Inspect the private `.sl`/ledger wrapper for job 13274 and adopt this envelope in that private
  consumer (still out of scope for this public-only checkpoint; the private host is not available
  in this checkout).
- Wire an actual chained SNQI step (e.g. `recompute_snqi_weights.py`) through
  `run_post_campaign_stage.py` in a production wrapper on the private ops host.

## Validation output

```
$ uv run pytest tests/tools/test_run_post_campaign_stage.py -q
4 passed in 0.03s

$ uv run pytest tests/tools/test_run_post_campaign_stage.py \
    tests/tools/test_run_camera_ready_benchmark.py \
    tests/tools/test_slurm_job_finalize.py \
    tests/benchmark/test_issue_5240_soft_contract_exit_code.py -q
60 passed in 1.10s

$ uv run ruff check scripts/tools/run_post_campaign_stage.py tests/tools/test_run_post_campaign_stage.py
All checks passed!
$ uv run ruff format --check scripts/tools/run_post_campaign_stage.py tests/tools/test_run_post_campaign_stage.py
# (reformatted, then clean)
```

The regression exercises the real subprocess dispatch + on-disk envelope serialization for:
- completed campaign (exit 0) + chained stage exit 5 -> `job_exit_code == 0`,
  `post_campaign_stage.status == report_stage_failed`, `exit_code == 5`;
- hard campaign failure (exit 2) + stage success -> process exit stays 2;
- missing chained command -> recorded as the optional-deps-missing lane (5);
- CLI entry point driving a real subprocess at the dispatch boundary.

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.
