### PR TITLE
docs(release): document 0.0.2 reproduction tooling boundary (#5667)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -232,7 +232,7 @@ thin: existing Markdown files remain the source of truth, and generated HTML und
 * **[Issue #750 Paper Results Handoff](./context/issue_750_paper_results_handoff.md)** - Deterministic paper-facing JSON/CSV handoff contract for frozen benchmark bundles with CI metadata and provenance fields
 * **[Benchmark Release 0.0.2 Execution Log](./context/benchmark_release_0_0_2_2026-04-13.md)** - All-planners release manifest/config decisions, tmux execution path, assumptions, and follow-up publish steps
 * **[Benchmark Release 0.0.2 Publication Snapshot](./experiments/publication/20260414_benchmark_release_0_0_2/summary.md)** - Durable scoped seven-planner release pointer with DOI, archive checksum, embedded manifest/checksum/SNQI paths, and fresh-checkout recovery command
-* **[Benchmark Release 0.0.2 Reproduction Note](./benchmark_release_0_0_2_reproduction.md)** - Dedicated copy-paste procedure for reproducing release 0.0.2 results from a fresh clone of main using the downloaded release archive and running the regeneration parity test
+* **[Benchmark Release 0.0.2 Reproduction Note](./benchmark_release_0_0_2_reproduction.md)** - Dedicated copy-paste procedure using the immutable 0.0.2 release archive with the minimum supported 0.0.3 or current main reproduction tooling
 * **[Issue #1062 Paper Evidence Archive Pointer](./context/issue_1062_paper_evidence_archive.md)** - Paper evidence archive recovery note for the scoped `0.0.2` bundle without committing raw benchmark outputs
 
 * **[Issue #435 Map Coverage Flow](./context/issue_435_map_coverage_flow.md)** - Parent flow state for map coverage, SocNavBench import, and map-quality child issues

--- a/docs/benchmark_release_0_0_2_reproduction.md
+++ b/docs/benchmark_release_0_0_2_reproduction.md
@@ -1,12 +1,24 @@
 # Reproducing Release 0.0.2
 
-This document provides step-by-step instructions to reproduce the canonical paper handoff results for benchmark release `0.0.2`.
+This document provides step-by-step instructions to verify and reproduce the canonical paper
+handoff results for benchmark release `0.0.2`.
+
+## Tooling checkout requirement
+
+The immutable `0.0.2` tag contains the released source and bundle pointer, but it does not contain
+the checksum manifest, checksum verifier, cold-start report entry point, or scoped replay config.
+Use a separate tooling checkout at `0.0.3` or a newer `main` commit. `0.0.3` is the minimum
+documented tooling version because it contains all of those paths.
+
+Do not run the verifier from a checkout of tag `0.0.2` and interpret a missing-file error as a
+release failure. The release artifact remains `0.0.2`; only the reproduction tooling comes from
+`0.0.3` or `main`.
 
 ## Overview and Key Differences
 
 - **Release Tag (`0.0.2`)**: Points to commit `cbeaca610` (three commits earlier than the campaign completion). This commit has the core simulation logic and code representation.
 - **Campaign Commit (`f7ebdcae2375d085e925213197a75a386e26a79c`)**: Contains the final generated publication manifest, checksums, and the scoped release manifest that exists outside the tag `0.0.2` tree.
-- **Parity Test**: The regeneration parity test (`tests/benchmark/test_paper_results_handoff.py::test_canonical_handoff_matches_durable_release_campaign_table`) lives on `main` (not in the tag tree). Therefore, reproduction must be run from a fresh clone of `main` using the downloaded release `0.0.2` bundle.
+- **Parity Test**: The regeneration parity test (`tests/benchmark/test_paper_results_handoff.py::test_canonical_handoff_matches_durable_release_campaign_table`) lives in the tooling checkout (minimum `0.0.3`, or `main`), not in the tag tree. Therefore, reproduction must use the `0.0.2` bundle with a `0.0.3`/`main` tooling checkout.
 
 > [!NOTE]
 > This reproduction procedure does not modify the immutable release artifact on GitHub or Zenodo.
@@ -21,14 +33,19 @@ The exact scoped release manifest is located at:
 - **Archive Name**: `paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz`
 - **Expected SHA-256**: `64e8510ab7ba934103c709907f66a783c7b3dd2dd58aa4bd725e762da2734d90`
 
-## Fresh Clone Reproduction Commands
+## Fresh Clone Checksum Verification
 
-Run the following commands from a fresh checkout of the `main` branch to download the bundle, verify its checksum, and run the regeneration parity test:
+Run the following commands from a fresh checkout of the `0.0.3` tooling tag (or `main`) to
+download the bundle and verify its checksum:
 
 ```bash
-# Clone the repository and navigate to the root
-git clone https://github.com/ll7/robot_sf_ll7.git
-cd robot_sf_ll7
+# Clone the minimum supported tooling checkout and navigate to the root
+git clone --branch 0.0.3 https://github.com/ll7/robot_sf_ll7.git robot_sf_ll7-repro
+cd robot_sf_ll7-repro
+
+# For current tooling, use the default branch instead:
+# git clone https://github.com/ll7/robot_sf_ll7.git robot_sf_ll7-repro
+# cd robot_sf_ll7-repro
 
 # Setup the virtual environment and sync dependencies
 uv sync --all-extras
@@ -41,6 +58,22 @@ gh release download 0.0.2 \
 
 # Verify the SHA-256 checksum of the downloaded bundle
 sha256sum output/benchmark_release_0_0_2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz
+
+# Verify the bundle and its embedded checksums against the tracked manifest
+uv run python scripts/repro/verify_release_checksums.py --tag 0.0.2
+```
+
+The checksum command establishes that the published archive and its embedded artifacts match the
+tracked release manifest. It does not establish an independent numeric replay of the benchmark
+subset. That replay remains a separate required step and must use the release's pre-registered
+subset contract; do not promote checksum-only output to a numeric reproduction claim.
+
+## Optional parity check
+
+After checksum verification, the regeneration parity test can be run from the same tooling
+checkout with the downloaded bundle:
+
+```bash
 
 # Run the regeneration parity test
 ROBOT_SF_PAPER_HANDOFF_BUNDLE=output/benchmark_release_0_0_2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz \

--- a/docs/benchmark_release_reproducibility.md
+++ b/docs/benchmark_release_reproducibility.md
@@ -173,7 +173,11 @@ For the current scoped seven-planner paper release, use the tracked publication 
 - `docs/benchmark_release_0_0_2_reproduction.md` - Dedicated copy-paste procedure for reproducing release 0.0.2 results
 
 > [!NOTE]
-> **Release 0.0.2 Note**: The annotated tag `0.0.2` tree references the generic `paper_experiment_matrix_v1_release_v0_1.yaml` manifest. The actual scoped manifest (`configs/benchmarks/releases/paper_experiment_matrix_7planners_v1_release_v0_0_2_scoped.yaml`) and the parity test logic live on the `main` branch, not in the tag tree. To reproduce release 0.0.2, follow the dedicated [Release 0.0.2 Reproduction Note](benchmark_release_0_0_2_reproduction.md).
+> **Release 0.0.2 tooling boundary**: The immutable tag `0.0.2` does not contain the checksum
+> manifest, verifier, cold-start report entry point, scoped manifest, or parity test logic. Use a
+> tooling checkout at tag `0.0.3` or a newer `main` commit, then follow the dedicated [Release
+> 0.0.2 Reproduction Note](benchmark_release_0_0_2_reproduction.md). A checksum pass verifies the
+> published archive and embedded artifacts; it is not an independent numeric subset replay.
 
 
 Durable endpoints:

--- a/docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md
+++ b/docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md
@@ -15,6 +15,11 @@ documented in
 > [!TIP]
 > For instructions on reproducing and verifying release 0.0.2, see the dedicated [Release 0.0.2 Reproduction Note](../../../benchmark_release_0_0_2_reproduction.md).
 
+The `0.0.2` release tag is immutable and does not carry the later reproduction tooling. Start the
+verification from tooling tag `0.0.3` or a newer `main` checkout, while keeping the downloaded
+bundle pinned to release `0.0.2`. Checksum verification confirms the archive and embedded artifact
+hashes only; an independent numeric subset replay remains a separate requirement.
+
 
 ## Public Endpoints
 


### PR DESCRIPTION
## Reviewer-critical summary

Closes #5667.

This PR documents the durable option-2 contract for release `0.0.2`: the immutable release tag
does not carry the later checksum/cold-start tooling, so a clean reproducer must use tooling tag
`0.0.3` (minimum) or a newer `main` checkout while keeping the downloaded bundle pinned to `0.0.2`.
The dedicated reproduction note now provides the exact checkout and checksum-verification path;
the generic reproducibility guide, publication snapshot, and docs index carry the same boundary.

Claim boundary: checksum verification proves the published archive and embedded artifact hashes
against the tracked manifest. It does not prove the independent numeric subset replay, which remains
a separate required step.

Required validation: tag-contract probe, active-doc examples check, docs/proof consistency check,
`git diff --check`, and the final `pr_ready_check`.

Remaining blocker: none for issue #5667's documentation-contract option; the independent numeric
subset replay remains intentionally outside this documentation slice and is not promoted as done.

## Contract delta

- New documented prerequisite: tooling checkout `0.0.3` or newer `main`; release artifact remains
  tag `0.0.2`.
- New fail-closed guidance: missing tooling from tag `0.0.2` is a documented tag/tooling boundary,
  not evidence that the release bundle failed verification.
- Compatibility impact: no release tag, bundle, checksum, benchmark metric, or runtime behavior is
  changed. Existing `0.0.2` users retain the immutable artifact and gain an explicit tooling path.

## Scope and evidence

- Changed docs: `docs/benchmark_release_0_0_2_reproduction.md`,
  `docs/benchmark_release_reproducibility.md`, the release publication snapshot, and `docs/README.md`.
- Direct tag evidence: all five named tooling/reproduction paths are absent from `0.0.2` and present
  at `0.0.3`.
- No new artifact was generated or promoted; `output/` remains disposable.
- No friction issue filed: the `gh issue view` Projects Classic failure is already tracked by closed
  technical-debt issues (including #5269 and #5188); REST was used as the documented read fallback
  for this session.

## Validation

- `uv run python scripts/validation/check_active_doc_examples.py --fail-on-diagnostic docs/README.md docs/benchmark_release_0_0_2_reproduction.md docs/benchmark_release_reproducibility.md docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md` — passed.
- `uv run python scripts/validation/check_docs_proof_consistency.py --base origin/main --path docs/README.md --path docs/benchmark_release_0_0_2_reproduction.md --path docs/benchmark_release_reproducibility.md --path docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md` — passed.
- `git diff --check` — passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed: 2,405 passed, 1 skipped; coverage and ratchets passed.
- `PR_READY_MODE=final PR_READY_PR_BODY_FILE=/tmp/issue-5667-pr-body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed after syncing `origin/main`: 2,405 passed, 1 skipped; clean committed-HEAD stamp recorded.

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No release/tag mutation or merge.

<details>
<summary>Governance appendix</summary>

Implementation assumption: option 2 is the reversible choice because `0.0.2` is immutable and the
issue explicitly permits documenting the tooling requirement instead of back-porting files into the
tag. No maintainer comments were present when the issue was read; the REST fallback was used because
`gh issue view --comments` failed before returning content due to the retired Projects Classic field.

Downstream propagation: not applicable beyond the four aligned public documentation surfaces; this
PR changes no benchmark evidence, metric semantics, model provenance, release artifact, or registry.

Issue-state propagation: no separate issue comment was posted because this run's authorization sets
`comment_issue_or_pr: false`; this PR body is the canonical handoff surface for the delivered slice
and remaining numeric-replay boundary.

This PR is documentation-only and does not claim independent numeric replay, benchmark success,
paper readiness, or dissertation support.

</details>
