### PR TITLE
fix(readiness): preflight bundled fast-pysf API (#5665)

### DIFF
--- a/scripts/dev/check_fast_pysf_runtime.py
+++ b/scripts/dev/check_fast_pysf_runtime.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Check that the installed fast-pysf runtime matches the threaded rollout API."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+EXPECTED_SYMBOL = "social_force_gil_releasing_context"
+REPAIR_COMMAND = "uv sync --all-extras --reinstall-package robot-sf"
+
+
+def check_fast_pysf_runtime() -> str | None:
+    """Return an actionable error when the required fast-pysf API is unavailable."""
+    try:
+        forces = importlib.import_module("pysocialforce.forces")
+    except ImportError as exc:
+        return f"could not import pysocialforce.forces ({exc})"
+
+    if not callable(getattr(forces, EXPECTED_SYMBOL, None)):
+        return f"pysocialforce.forces.{EXPECTED_SYMBOL} is missing"
+    return None
+
+
+def main() -> int:
+    """Run the fast-pysf readiness check and print repair guidance on failure."""
+    error = check_fast_pysf_runtime()
+    if error is None:
+        print("fast-pysf runtime preflight passed")
+        return 0
+
+    print("fast-pysf runtime preflight failed: " + error, file=sys.stderr)
+    print(
+        "The installed PySocialForce package is older than this checkout's threaded rollout API.",
+        file=sys.stderr,
+    )
+    print(
+        f"Refresh the environment with `{REPAIR_COMMAND}`, then rerun readiness.", file=sys.stderr
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/common_setup.sh
+++ b/scripts/dev/common_setup.sh
@@ -70,3 +70,17 @@ PY
     exit 2
   fi
 }
+
+# The threaded rollout path imports a context manager added to the vendored
+# fast-pysf package.  A stale force-included install otherwise fails during
+# pytest collection with an opaque ImportError (issue #5665).
+preflight_check_fast_pysf() {
+  if [ "${PR_READY_SKIP_PREFLIGHT:-0}" = "1" ]; then
+    return 0
+  fi
+  if ! uv run python "$REPO_ROOT/scripts/dev/check_fast_pysf_runtime.py"; then
+    printf 'Final PR readiness cannot collect the core suite with this PySocialForce environment.\n' >&2
+    printf 'Run `uv sync --all-extras --reinstall-package robot-sf` in this worktree, then rerun readiness.\n' >&2
+    exit 2
+  fi
+}

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -18,8 +18,8 @@ Environment variables:
   PR_READY_FINAL      Legacy compatibility flag: "1", "true", "yes", or "on"
                       for final mode; "0", "false", "no", "off" for interim.
                       Ignored when PR_READY_MODE is set.
-  PR_READY_SKIP_PREFLIGHT  Set to "1" to skip the cheap preflight check for
-                      test-collection dependencies (duckdb, pyarrow).
+  PR_READY_SKIP_PREFLIGHT  Set to "1" to skip cheap preflight checks for
+                      test-collection dependencies and the bundled fast-pysf API.
   PR_READY_PR_BODY_FILE  Optional markdown PR body. When set, readiness checks
                       that deferred work has a linked issue or explicit NA.
   PR_READY_REQUIRE_OPEN_FOLLOWUP_ISSUES
@@ -223,6 +223,7 @@ fi
 
 if [[ "$pr_ready_final" == "1" ]]; then
   preflight_check_test_deps
+  preflight_check_fast_pysf
 fi
 
 resolve_base_ref

--- a/tests/dev/test_check_fast_pysf_runtime.py
+++ b/tests/dev/test_check_fast_pysf_runtime.py
@@ -1,0 +1,44 @@
+"""Regression tests for the fast-pysf readiness preflight."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "check_fast_pysf_runtime.py"
+
+
+def test_missing_gil_context_reports_environment_repair(tmp_path: Path) -> None:
+    """A stale PySocialForce install fails with the targeted repair command."""
+    package = tmp_path / "pysocialforce"
+    package.mkdir()
+    (package / "__init__.py").write_text("\n", encoding="utf-8")
+    (package / "forces.py").write_text("def social_force():\n    return None\n", encoding="utf-8")
+
+    env = {**os.environ, "PYTHONPATH": str(tmp_path)}
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "social_force_gil_releasing_context is missing" in result.stderr
+    assert "uv sync --all-extras --reinstall-package robot-sf" in result.stderr
+
+
+def test_current_fast_pysf_runtime_passes() -> None:
+    """The repository-supported environment exposes the threaded rollout API."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "fast-pysf runtime preflight passed" in result.stdout


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Added a reusable final-readiness preflight that verifies
  `pysocialforce.forces.social_force_gil_releasing_context` is importable and
  callable before pytest collection; stale environments now fail closed with the
  exact reinstall command. Added a regression test for the missing-symbol case.
- **Why now:** Current `origin/main` imports this API from
  `robot_sf/training/threaded_vec_env.py`, while a stale installed PySocialForce
  package can fail the base-sensitive collection lane before any test runs.
- **Claim boundary:** This is a CPU-only readiness/environment diagnostic. It
  changes no simulator, planner, metric, benchmark, or paper semantics.
- **Required validation:** Fresh-worktree base-sensitive collection, focused
  regression tests, and `PR_READY_MODE=final BASE_REF=origin/main
  scripts/dev/pr_ready_check.sh` on the committed head.
- **Remaining blocker:** None for issue #5665. A stale environment must be
  refreshed before final readiness can proceed; that is now reported directly.

## Contract delta

- **New schema fields:** None.
- **New fail-closed blocker:** Final readiness exits 2 before pytest collection
  when the installed PySocialForce package lacks the threaded rollout context
  manager, with `uv sync --all-extras --reinstall-package robot-sf` guidance.
- **Compatibility impact:** Fresh supported environments are unchanged; the
  existing `PR_READY_SKIP_PREFLIGHT=1` escape hatch remains available for an
  explicitly verified environment.

Closes #5665

<details>
<summary>Implementation, validation, and governance appendix</summary>

## Issue and scope

Issue: https://github.com/ll7/robot_sf_ll7/issues/5665

This PR implements the complete issue ask: detect the known stale
`pysocialforce` API mismatch before core readiness collection and provide a
focused regression contract. No transient queue-routing state is encoded in
tracked files.

## Summary

The final readiness setup now calls `scripts/dev/check_fast_pysf_runtime.py`
after the existing dependency preflight. The checker reports a concise repair
hint instead of allowing the import failure to surface deep in collection.

## Validation / Proof

- `uv run pytest -q tests/dev/test_check_fast_pysf_runtime.py` -> 2 passed.
- `uv run pytest -q tests/dev/test_base_sensitive_gate_contract.py::TestBaseSensitiveMarker::test_marker_can_select_tests tests/dev/test_check_fast_pysf_runtime.py` -> 3 passed.
- `uv run python -m pytest -m base_sensitive --collect-only --quiet --tb=short` -> exit 0; 19/16308 tests collected.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=16 scripts/dev/pr_ready_check.sh` (with the PR body supplied to the final contract check) -> passed; 2407 core tests passed, 1 skipped, changed-file coverage/docstring/broad-exception gates passed, and the final freshness stamp was clean.
- Real stale-primary-environment probe -> exit 2 with the missing-symbol message and reinstall command.
- `uv run ruff check scripts/dev/check_fast_pysf_runtime.py tests/dev/test_check_fast_pysf_runtime.py` -> passed.
- `uv run ruff format --check scripts/dev/check_fast_pysf_runtime.py tests/dev/test_check_fast_pysf_runtime.py` -> passed.
- `bash -n scripts/dev/common_setup.sh scripts/dev/pr_ready_check.sh` -> passed.

## Research Result Guidance

- Target claim / hypothesis / blocker: NA - support/readiness helper with no research claim.
- Comparator or baseline, if applicable: NA.
- Evidence tier: NA - support helper.
- Result classification: NA - no research or benchmark result.
- Decision or stop rule, if applicable: NA.
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA - issue #5665 is linked in this PR.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper only.

## Domain-Aware Approval

- Required for this PR: no - support/readiness tooling only; no evidence semantics change.
- Status: not required.

## Falsification / Non-Transfer Check

- Did the mechanism activate? yes - the simulated stale package is rejected with exit 2 and actionable repair guidance.
- Did the intervention change command source, selected command, trajectory, or route progress? NA - no runtime simulation path changed.
- Did the scenario actually contain the targeted failure mode? yes - the real primary environment lacked the symbol; the fresh worktree passed.
- Result route: continue with merge review.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action

- Rerun needed: no - the issue's collection and repair-hint contracts are covered.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: no durable benchmark artifact is required.
- Stop / revise / continue decision: continue with normal PR gate review.
- Proposed child issue or existing follow-up: none.

## Risks / Rollout

- Compatibility risk: an environment with an intentionally different PySocialForce package must refresh or explicitly bypass the preflight after independent verification.
- Failure mode: missing or broken PySocialForce fails readiness before collection, preserving a fail-closed status.
- Rollback: revert this readiness-only commit.

## Docs / Provenance

- Updated docs: `--help` text in `scripts/dev/pr_ready_check.sh`.
- Relevant provenance: issue #5665 reproduction and the focused subprocess fixture.
- Assumptions: the vendored threaded rollout API requires the named context manager.

## Downstream Propagation

- Parent issue updated: no - PR body is the durable slice record; issue comments were not authorized.
- Claim map / benchmark report updated: NA - no benchmark claim.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened for deferred propagation: NA.
- Not applicable because: this is bounded readiness support with no evidence artifact or queue-state change.

## Follow-Up Issues

- Deferred work: none for #5665.
- Issues opened for follow-up: [#5673](https://github.com/ll7/robot_sf_ll7/issues/5673) tracks the non-failing coverage warning from the existing temporary-source base-sensitive test.

## Explicit out of scope

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

## Reviewer Notes

- Verify the preflight runs only in final readiness mode and preserves the existing skip variable.
- The check is intentionally narrow: it protects the exact API that current threaded rollout collection imports.
- Shared-helper migration: not applicable; this adds one canonical checker and wires it into the canonical final readiness path.
- Late live-issue check immediately before opening: issue #5665 has no maintainer comments or newer implementation guidance.
- Fragmentation guard: zero guardrail/checker/packet-refresh PRs for #5665 merged in the last 24 hours; the single search hit, PR #5637, is an unrelated parent PR that only records #5665 as a baseline follow-up.

</details>
