### PR TITLE
Issue #5675: harden pipeline persistence wiring after #5660 (cheap-lane worker)

### DIFF
--- a/docs/context/evidence/issue_5600_persistence_gate.md
+++ b/docs/context/evidence/issue_5600_persistence_gate.md
@@ -2,8 +2,10 @@
 # Issue #5600 — Persistence Promotion Gate (compact evidence)
 
 Status: implemented + wired (CPU-only, no campaigns). Evidence tier: schema +
-fail-closed unit contract + real pipeline-artifact conformance. No benchmark,
-metric, model-provenance, or paper-facing claim.
+fail-closed unit contract + real pipeline-artifact conformance. An explicit
+replay-results fixture is required for a promotion verdict; CPU-only mode alone
+cannot establish exact replay. No benchmark, metric, model-provenance, or
+paper-facing claim.
 
 ## What changed (slice 1: PR #5606)
 
@@ -43,23 +45,27 @@ Files (all under allowed paths):
 
 - `scripts/tools/evaluate_pipeline_persistence_gate.py` — **new, committed** wiring CLI.
   Loads a pipeline `run_manifest.json` (or a single candidate entry + episodes JSONL),
-  derives `exact_replay` from the trace, evaluates `critical_event_reproduced` from the
-  catalog entry's criticality block, and runs the preregistered perturbation grid in
-  CPU-only mode (timestamp shift + position interpolation). Emits one
-  `generated_scenario_persistence.v1` JSON per candidate plus a promote/reject summary.
+  validates trace identity against catalog provenance, consumes per-candidate
+  `replay-results` for exact replay/event/cell evidence, and otherwise runs only the
+  preregistered CPU perturbation grid (timestamp shift + position interpolation).
+  Emits one `generated_scenario_persistence.v1` JSON per candidate plus a
+  promote/reject summary. Missing traces, incomplete frozen config, and missing
+  precomputed cells fail closed.
 - `tests/benchmark/test_pipeline_persistence_gate_wiring.py` — **new**. Runs the real
   `run_generation_pipeline` with a deterministic fake batch runner, then wires the
   produced catalog + episodes through the tool and asserts one **promote** and one
-  **reject** verdict, both schema-valid. No simulations: the fake runner supplies the
-  step traces, satisfying the CPU-only constraint.
+  **reject** verdict, both schema-valid. No simulations: the fake runner and explicit
+  per-candidate replay fixture supply deterministic step traces and cell verdicts.
 
 The tool also accepts `--replay-results PATH` to skip CPU-only heuristics and consume
-pre-computed replay/perturbation verdicts from a simulation-capable runner (CARLA),
-preserving the generated-hypothesis boundary.
+per-candidate pre-computed replay/perturbation verdicts from a simulation-capable
+runner (CARLA), preserving the generated-hypothesis boundary. Without this input,
+`exact_replay` is `unknown` and promotion is rejected.
 
 ## The three statuses stay separate
 
-- `exact_replay`: byte/config-equivalent replay of the source episode (digest match).
+- `exact_replay`: identity and normalized simulation-step payload match from an
+  independent replay result (digest match).
 - `critical_event_reproduced`: event of `event_type` recurs under the source planner
   within declared time/location tolerances.
 - `perturbation_persistence`: the event survives a preregistered timing/speed grid.
@@ -70,7 +76,8 @@ when all three required statuses are `pass` and there are no missing cells.
 ## Conformance evidence (published, real pipeline artifact)
 
 The wiring test (`test_pipeline_persistence_gate_wiring.py`) executes the actual
-generation pipeline and produces two records from a real catalog + episode-trace pair:
+generation pipeline and produces two records from a real catalog + episode-trace pair,
+using a deterministic per-candidate replay fixture (not a simulator):
 
 - Candidate A (near-static robot/pedestrian pair): `exact_replay=pass`,
   `critical_event_reproduced=pass`, `perturbation_persistence` rate = 1.0 →
@@ -108,7 +115,8 @@ uv run python scripts/tools/validate_generated_scenario_persistence.py --help
 uv run python scripts/tools/evaluate_pipeline_persistence_gate.py \
   --manifest <run_manifest.json> \
   --config configs/analysis/issue_5600_persistence_gate.yaml \
-  --output <output_dir> --commit-hash <h> --config-hash <c>
+  --output <output_dir> --replay-results <replay_results.json> \
+  --commit-hash <h> --config-hash <c>
 # PROMOTE <output_dir>/generated-....persistence.json :: all three independent status checks passed
 # REJECT <output_dir>/generated-....persistence.json :: perturbation_cell:...:fail ...
 # Summary: 1 promoted, 1 rejected, 2 total
@@ -118,11 +126,12 @@ git diff --check   # clean
 ## Stop-rule note
 
 The gate is now wired through a real pipeline run and emits promote/reject evidence.
-The CPU-only perturbation mode proves the wiring end-to-end but does not substitute
-for a real simulator replay; production use should pass `--replay-results` from a
+The CPU-only perturbation mode proves the perturbation wiring but does not substitute
+for an independent replay; production use must pass `--replay-results` from a
 CARLA-capable runner. The negative-conformance path (promote none) is inherent: any
-`fail`/`unknown` required status or missing cell fails closed. No threshold loosening
-is possible because ranges are frozen.
+`fail`/`unknown` required status, missing trace, incomplete config, or missing cell
+fails closed. No threshold loosening is possible because the grid and promotion
+threshold are validated from the frozen config.
 
 ## Claim boundary
 

--- a/scripts/tools/evaluate_pipeline_persistence_gate.py
+++ b/scripts/tools/evaluate_pipeline_persistence_gate.py
@@ -13,9 +13,10 @@ The script supports two perturbation-evaluation modes:
 
 * **cpu** (default, requires no simulator): uses the source trace to simulate
   timing/speed perturbations by shifting trace timestamps and interpolating
-  pedestrian positions.  This exercises the wiring end-to-end but does **not**
-  prove that the perturbation would survive a real CARLA replay.  Production
-  use should supply pre-computed replay results via ``--replay-results``.
+  actor positions.  This exercises perturbation wiring but does **not** establish
+  an independent exact replay or prove survival in a real CARLA replay.  A
+  promotion-capable run must supply pre-computed replay results via
+  ``--replay-results``.
 
 * **precomputed** (``--replay-results PATH``): loads replay/perturbation results
   from an external JSON file produced by a simulation-capable runner.  The
@@ -41,8 +42,10 @@ Usage
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
+import subprocess
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -106,18 +109,18 @@ def _build_parser() -> argparse.ArgumentParser:
         type=Path,
         help=(
             "Path to pre-computed replay/perturbation results JSON.  When absent, "
-            "CPU-only mode derives replay and perturbation verdicts from the source trace."
+            "CPU-only mode evaluates perturbation cells but exact replay remains unknown."
         ),
     )
     parser.add_argument(
         "--commit-hash",
-        default="unknown",
-        help="Git commit hash for the code (default: 'unknown').",
+        default=None,
+        help="Git commit hash for the code (default: checked-out repository HEAD).",
     )
     parser.add_argument(
         "--config-hash",
-        default="unknown",
-        help="Git commit hash for the config (default: 'unknown').",
+        default=None,
+        help="Hash for the config bytes (default: computed from --config).",
     )
     return parser
 
@@ -129,8 +132,8 @@ def evaluate_pipeline_candidates(
     config_path: Path,
     output_dir: Path,
     replay_results_path: Path | None = None,
-    commit_hash: str = "unknown",
-    config_hash: str = "unknown",
+    commit_hash: str | None = None,
+    config_hash: str | None = None,
 ) -> list[dict[str, Any]]:
     """Load pipeline artifacts and produce persistence records for each candidate.
 
@@ -139,8 +142,56 @@ def evaluate_pipeline_candidates(
     """
 
     frozen_config = _load_frozen_config(config_path)
-    commit_hashes = {"code": commit_hash, "config": config_hash}
+    commit_hashes = {
+        "code": _resolve_commit_hash(commit_hash),
+        "config": _resolve_config_hash(config_hash, frozen_config),
+    }
 
+    resolved_episodes, entries = _load_pipeline_inputs(
+        manifest_path=manifest_path,
+        candidate_path=candidate_path,
+        episodes_path=episodes_path,
+    )
+
+    if not entries:
+        raise ValueError("catalog contains no candidate entries")
+
+    episodes_index = _build_episodes_index(resolved_episodes)
+
+    replay_data = _load_replay_results(replay_results_path)
+
+    records: list[dict[str, Any]] = []
+
+    for entry_idx, entry in enumerate(entries):
+        records.append(
+            _evaluate_one_candidate(
+                entry=entry,
+                entry_idx=entry_idx,
+                frozen_config=frozen_config,
+                commit_hashes=commit_hashes,
+                episodes_index=episodes_index,
+                replay_data=replay_data,
+                entry_count=len(entries),
+            )
+        )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for record in records:
+        scenario_id = record["scenario_id"]
+        out_path = output_dir / f"{scenario_id}.persistence.json"
+        out_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        verdict = record["promotion"]["verdict"]
+        print(f"{verdict.upper()} {out_path} :: {record['promotion']['exclusion_reason']}")
+
+    return records
+
+
+def _load_pipeline_inputs(
+    *,
+    manifest_path: Path | None,
+    candidate_path: Path | None,
+    episodes_path: Path | None,
+) -> tuple[Path, list[dict[str, Any]]]:
     if manifest_path is not None:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         artifact_paths = manifest.get("artifacts", {})
@@ -163,48 +214,23 @@ def evaluate_pipeline_candidates(
                 "Supply --candidate directly or check the manifest's artifacts.generated_catalog path."
             )
         raw = yaml.safe_load(resolved_catalog.read_text(encoding="utf-8"))
-        entries = list(raw.get("entries", []) if isinstance(raw, dict) else [])
-    elif candidate_path is not None:
-        if episodes_path is None or not episodes_path.exists():
-            raise FileNotFoundError(
-                "--episodes is required with --candidate and must point to a valid episodes.jsonl"
-            )
-        resolved_episodes = episodes_path
-        raw = _load_candidate_entry(candidate_path)
-        entries = [raw]
-    else:
-        raise ValueError("one of --manifest or --candidate is required")
-
-    episodes_index = _build_episodes_index(resolved_episodes)
-
-    if replay_results_path is not None:
-        replay_data = json.loads(replay_results_path.read_text(encoding="utf-8"))
-    else:
-        replay_data = None
-
-    records: list[dict[str, Any]] = []
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    for entry_idx, entry in enumerate(entries):
-        record = _evaluate_one_candidate(
-            entry=entry,
-            entry_idx=entry_idx,
-            frozen_config=frozen_config,
-            commit_hashes=commit_hashes,
-            episodes_index=episodes_index,
-            replay_data=replay_data,
+        if not isinstance(raw, dict) or not isinstance(raw.get("entries"), list):
+            raise ValueError(f"catalog must contain an entries list: {resolved_catalog}")
+        return resolved_episodes, list(raw["entries"])
+    if candidate_path is None or episodes_path is None or not episodes_path.exists():
+        raise FileNotFoundError(
+            "--episodes is required with --candidate and must point to a valid episodes.jsonl"
         )
-        if record is None:
-            continue
-        records.append(record)
+    return episodes_path, [_load_candidate_entry(candidate_path)]
 
-        scenario_id = record["scenario_id"]
-        out_path = output_dir / f"{scenario_id}.persistence.json"
-        out_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        verdict = record["promotion"]["verdict"]
-        print(f"{verdict.upper()} {out_path} :: {record['promotion']['exclusion_reason']}")
 
-    return records
+def _load_replay_results(path: Path | None) -> dict[str, Any] | None:
+    if path is None:
+        return None
+    replay_data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(replay_data, dict):
+        raise ValueError("replay results must contain a JSON object")
+    return replay_data
 
 
 def _evaluate_one_candidate(
@@ -215,8 +241,9 @@ def _evaluate_one_candidate(
     commit_hashes: Mapping[str, str],
     episodes_index: Mapping[str, dict[str, Any]],
     replay_data: Mapping[str, Any] | None,
-) -> dict[str, Any] | None:
-    """Build a persistence record for one catalog entry, or None when its trace is missing."""
+    entry_count: int,
+) -> dict[str, Any]:
+    """Build a persistence record for one catalog entry, failing closed on missing data."""
 
     validate_catalog_entry(entry)
     scenario_id = str(entry.get("scenario_id", f"candidate-{entry_idx:04d}"))
@@ -227,63 +254,63 @@ def _evaluate_one_candidate(
 
     trace_episode = episodes_index.get(episode_id)
     if trace_episode is None:
-        print(
-            f"WARNING: episode {episode_id!r} not found in episodes data; skipping {scenario_id}",
-            file=sys.stderr,
+        raise FileNotFoundError(
+            f"episode {episode_id!r} for candidate {scenario_id!r} not found in episodes data"
         )
-        return None
+    _validate_trace_identity(
+        trace_episode,
+        episode_id=episode_id,
+        source_seed=source_seed,
+        source_map=source_map,
+    )
 
-    replayed: dict[str, Any] | None = None
-    replay_error: str | None = None
-    if replay_data is not None:
-        replay_info = replay_data.get(scenario_id) or replay_data.get(episode_id) or {}
-        if "error" in replay_info:
-            replay_error = replay_info["error"]
-        elif "episode" in replay_info:
-            replayed = replay_info["episode"]
-    else:
-        # CPU-only mode: use source trace as its own exact replay.
-        replayed = _build_episode_fields(trace_episode, source_map)
+    replayed, replay_error, replay_info = _load_replay_info(
+        replay_data,
+        scenario_id=scenario_id,
+        episode_id=episode_id,
+        entry_count=entry_count,
+    )
 
     source_episode_fields = _build_source_episode_fields(entry, trace_episode)
 
-    # Exact replay: the source episode is byte/config-equivalent to itself.
-    exact_replay_block = assess_exact_replay(
+    # CPU-only mode deliberately has no independent replay evidence.
+    exact_replay_block = _assess_exact_replay(
         source_episode_fields,
+        source_trace=trace_episode,
         replayed_episode=replayed,
         replay_error=replay_error,
     )
 
     # Critical event reproduction.
-    critical_block = _evaluate_critical_event(entry, trace_episode, replayed)
+    critical_config = frozen_config["critical_event"]
+    critical_block = _evaluate_critical_event(
+        entry,
+        trace_episode,
+        replayed,
+        time_tolerance_s=float(critical_config["time_tolerance_s"]),
+        location_tolerance_m=float(critical_config["location_tolerance_m"]),
+    )
 
     # Perturbation grid.
-    config_grid = frozen_config.get("perturbation", {})
-    timing_offsets = list(config_grid.get("timing_offsets_s", [-0.25, 0.0, 0.25]))
-    speed_deltas = list(config_grid.get("speed_deltas_m_s", [-0.2, 0.0, 0.2]))
+    config_grid = frozen_config["perturbation"]
+    timing_offsets = list(config_grid["timing_offsets_s"])
+    speed_deltas = list(config_grid["speed_deltas_m_s"])
 
-    if replay_data is not None and "cells" in replay_data:
-        cells = replay_data["cells"]
-        missing = replay_data.get("missing_cell_reasons", [])
-    else:
-        cells, missing = evaluate_perturbation_grid(
-            timing_offsets_s=timing_offsets,
-            speed_deltas_m_s=speed_deltas,
-            cell_verdict_fn=_build_cpu_verdict_fn(
-                trace_episode=trace_episode,
-                critical_event=critical_block,
-            ),
-        )
+    cells, missing = _evaluate_cells(
+        replay_data=replay_data,
+        replay_info=replay_info,
+        timing_offsets=timing_offsets,
+        speed_deltas=speed_deltas,
+        trace_episode=trace_episode,
+        critical_event=critical_block,
+    )
 
     perturbation_grid = {
         "timing_offsets_s": timing_offsets,
         "speed_deltas_m_s": speed_deltas,
     }
 
-    # The gate computes the exact-replay digest from the source episode
-    # identity; echo it back so the persistence record's source_episode
-    # block is schema-complete.  When no source digest exists, the gate has
-    # already returned FAIL via missing-identity-field detection.
+    # Echo the computed digest so the source_episode block is schema-complete.
     source_episode_fields = dict(source_episode_fields)
     source_episode_fields["replay_digest"] = exact_replay_block["replay_digest"]
 
@@ -291,7 +318,7 @@ def _evaluate_one_candidate(
         scenario_id=scenario_id,
         source_episode=source_episode_fields,
         generated_scenario=_build_generated_scenario(entry, scenario_id),
-        planner=frozen_config.get("planner", "goal"),
+        planner=str(frozen_config.get("planner", "goal")),
         seed=source_seed,
         config=_build_promotion_config(frozen_config),
         commit_hashes=commit_hashes,
@@ -303,6 +330,159 @@ def _evaluate_one_candidate(
     )
 
 
+def _load_replay_info(
+    replay_data: Mapping[str, Any] | None,
+    *,
+    scenario_id: str,
+    episode_id: str,
+    entry_count: int,
+) -> tuple[dict[str, Any] | None, str | None, Mapping[str, Any]]:
+    if replay_data is None:
+        return None, None, {}
+    candidate_replay = replay_data.get(scenario_id) or replay_data.get(episode_id)
+    if candidate_replay is None and "cells" in replay_data:
+        if entry_count != 1:
+            raise ValueError(
+                "multi-candidate replay results must key cells by scenario_id or episode_id"
+            )
+        candidate_replay = replay_data
+    if candidate_replay is not None and not isinstance(candidate_replay, dict):
+        raise ValueError(f"replay result for {scenario_id} must be a JSON object")
+    replay_info = candidate_replay or {}
+    if "error" in replay_info:
+        return None, str(replay_info["error"]), replay_info
+    replayed = replay_info.get("episode")
+    if replayed is not None and not isinstance(replayed, dict):
+        raise ValueError(f"replay episode for {scenario_id} must be a JSON object")
+    return replayed, None, replay_info
+
+
+def _evaluate_cells(
+    *,
+    replay_data: Mapping[str, Any] | None,
+    replay_info: Mapping[str, Any],
+    timing_offsets: Sequence[float],
+    speed_deltas: Sequence[float],
+    trace_episode: Mapping[str, Any],
+    critical_event: Mapping[str, Any],
+) -> tuple[Any, Any]:
+    if replay_data is not None:
+        if "cells" not in replay_info:
+            return [], [
+                {
+                    "timing_offset_s": float(timing_offsets[0]),
+                    "speed_delta_m_s": float(speed_deltas[0]),
+                    "reason": "precomputed replay result omitted perturbation cells",
+                }
+            ]
+        return replay_info["cells"], replay_info.get("missing_cell_reasons", [])
+    return evaluate_perturbation_grid(
+        timing_offsets_s=timing_offsets,
+        speed_deltas_m_s=speed_deltas,
+        cell_verdict_fn=_build_cpu_verdict_fn(
+            trace_episode=trace_episode,
+            critical_event=critical_event,
+        ),
+    )
+
+
+def _assess_exact_replay(
+    source_episode: Mapping[str, Any],
+    *,
+    source_trace: Mapping[str, Any],
+    replayed_episode: Mapping[str, Any] | None,
+    replay_error: str | None,
+) -> dict[str, Any]:
+    """Require both replay identity and the normalized trace payload to match."""
+
+    identity_block = assess_exact_replay(
+        source_episode,
+        replayed_episode=replayed_episode,
+        replay_error=replay_error,
+    )
+    if identity_block["status"] != "pass" or replayed_episode is None:
+        return identity_block
+
+    source_digest = _trace_digest(source_trace, source_episode)
+    replay_digest = _trace_digest(replayed_episode, source_episode)
+    if source_digest != replay_digest:
+        return {
+            "status": "fail",
+            "divergence_reason": (
+                f"replay trace digest mismatch: source={source_digest} replay={replay_digest}"
+            ),
+            "replay_digest": source_digest,
+        }
+    return {
+        "status": "pass",
+        "divergence_reason": "episode identity and normalized trace payload matched source",
+        "replay_digest": source_digest,
+    }
+
+
+def _trace_digest(trace: Mapping[str, Any], fallback: Mapping[str, Any]) -> str:
+    """Hash the identity and simulation-step payload used for replay comparison."""
+
+    payload = {
+        "episode_id": str(trace.get("episode_id", fallback.get("episode_id", ""))),
+        "source_seed": int(
+            trace.get("source_seed", trace.get("seed", fallback.get("source_seed", 0)))
+        ),
+        "source_map": str(_trace_source_map(trace) or fallback.get("source_map", "")),
+        "steps": _extract_steps(trace),
+    }
+    try:
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"trace payload is not JSON-serializable: {exc}") from exc
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _validate_trace_identity(
+    trace_episode: Mapping[str, Any],
+    *,
+    episode_id: str,
+    source_seed: int,
+    source_map: str,
+) -> None:
+    """Require pipeline trace identity to agree with the catalog provenance."""
+
+    observed_episode_id = str(trace_episode.get("episode_id", ""))
+    observed_seed = trace_episode.get("source_seed", trace_episode.get("seed"))
+    observed_map = _trace_source_map(trace_episode)
+    if observed_episode_id != episode_id:
+        raise ValueError(
+            f"trace episode_id {observed_episode_id!r} does not match catalog {episode_id!r}"
+        )
+    if not isinstance(observed_seed, int) or isinstance(observed_seed, bool):
+        raise ValueError(f"trace {episode_id!r} is missing an integer seed")
+    if observed_seed != source_seed:
+        raise ValueError(
+            f"trace seed {observed_seed} does not match catalog source_seed {source_seed}"
+        )
+    if not isinstance(observed_map, str) or not observed_map.strip():
+        raise ValueError(f"trace {episode_id!r} is missing source_map")
+    if observed_map != source_map:
+        raise ValueError(
+            f"trace source_map {observed_map!r} does not match catalog source_map {source_map!r}"
+        )
+
+
+def _trace_source_map(trace_episode: Mapping[str, Any]) -> str | None:
+    """Read map provenance from the normalized trace or native runner identity."""
+
+    source_map = trace_episode.get("source_map")
+    if isinstance(source_map, str) and source_map.strip():
+        return source_map
+    scenario_params = trace_episode.get("scenario_params")
+    if isinstance(scenario_params, dict):
+        for key in ("source_map", "map_file"):
+            candidate = scenario_params.get(key)
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate
+    return None
+
+
 def _build_promotion_config(frozen_config: Mapping[str, Any]) -> dict[str, Any]:
     """Assemble the ``config`` block required by ``compute_persistence_record``.
 
@@ -312,15 +492,13 @@ def _build_promotion_config(frozen_config: Mapping[str, Any]) -> dict[str, Any]:
     """
 
     return {
-        "config_id": str(frozen_config.get("config_id", "issue-5600-persistence-gate")),
-        "frozen": bool(frozen_config.get("frozen", False)),
-        "config_hash": str(frozen_config.get("config_hash", "")) or _config_hash(frozen_config),
+        "config_id": str(frozen_config["config_id"]),
+        "frozen": True,
+        "config_hash": str(frozen_config["config_hash"]),
     }
 
 
 def _config_hash(payload: Mapping[str, Any]) -> str:
-    import hashlib
-
     digest = hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     )
@@ -331,9 +509,104 @@ def _load_frozen_config(config_path: Path) -> dict[str, Any]:
     raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     if not isinstance(raw, dict):
         raise ValueError(f"config must be a YAML mapping: {config_path}")
-    if not raw.get("frozen"):
+    if raw.get("frozen") is not True:
         raise ValueError(f"config {config_path} must have frozen: true")
-    return dict(raw)
+    config_id = raw.get("config_id")
+    if not isinstance(config_id, str) or not config_id.strip():
+        raise ValueError("config.config_id must be a non-empty string")
+
+    raw["perturbation"] = _normalize_perturbation_grid(raw.get("perturbation"))
+    raw["critical_event"] = _normalize_critical_event(raw.get("critical_event"))
+    _validate_promotion_config(raw.get("promotion"))
+
+    loaded = dict(raw)
+    loaded["config_hash"] = hashlib.sha256(config_path.read_bytes()).hexdigest()
+    return loaded
+
+
+def _normalize_perturbation_grid(raw: Any) -> dict[str, list[float]]:
+    if not isinstance(raw, dict):
+        raise ValueError("config must define a perturbation mapping")
+    normalized: dict[str, list[float]] = {}
+    for key in ("timing_offsets_s", "speed_deltas_m_s"):
+        values = raw.get(key)
+        if not isinstance(values, list) or not values:
+            raise ValueError(f"config.perturbation.{key} must be a non-empty list")
+        normalized_values: list[float] = []
+        for value in values:
+            try:
+                numeric = float(value)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"config.perturbation.{key} must contain numbers") from exc
+            if not math.isfinite(numeric):
+                raise ValueError(f"config.perturbation.{key} must contain finite numbers")
+            normalized_values.append(numeric)
+        normalized[key] = normalized_values
+    return normalized
+
+
+def _normalize_critical_event(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ValueError("config must define a critical_event mapping")
+    if raw.get("event_type") != "min_clearance":
+        raise ValueError("config.critical_event.event_type must be min_clearance")
+    normalized = dict(raw)
+    for key in ("time_tolerance_s", "location_tolerance_m"):
+        try:
+            numeric = float(raw[key])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(f"config.critical_event.{key} must be numeric") from exc
+        if not math.isfinite(numeric) or numeric < 0.0:
+            raise ValueError(f"config.critical_event.{key} must be finite and non-negative")
+        normalized[key] = numeric
+    return normalized
+
+
+def _validate_promotion_config(raw: Any) -> None:
+    if not isinstance(raw, dict):
+        raise ValueError("config must define a promotion mapping")
+    required_statuses = raw.get("required_statuses")
+    if required_statuses != [
+        "exact_replay",
+        "critical_event_reproduced",
+        "perturbation_persistence",
+    ]:
+        raise ValueError("config.promotion.required_statuses must list all three gate statuses")
+    try:
+        min_persistence_rate = float(raw["min_persistence_rate"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("config.promotion.min_persistence_rate must be numeric") from exc
+    if min_persistence_rate != 1.0:
+        raise ValueError("only min_persistence_rate=1.0 is supported by the fail-closed gate")
+
+
+def _resolve_commit_hash(commit_hash: str | None) -> str:
+    if commit_hash is not None:
+        resolved = commit_hash.strip()
+        if not resolved or resolved.lower() == "unknown":
+            raise ValueError("commit_hash must be a real non-empty value")
+        return resolved
+    repository_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository_root,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    resolved = result.stdout.strip()
+    if result.returncode != 0 or not resolved:
+        raise RuntimeError("unable to resolve repository HEAD for code provenance")
+    return resolved
+
+
+def _resolve_config_hash(config_hash: str | None, frozen_config: Mapping[str, Any]) -> str:
+    if config_hash is None:
+        return str(frozen_config["config_hash"])
+    resolved = config_hash.strip()
+    if not resolved or resolved.lower() == "unknown":
+        raise ValueError("config_hash must be a real non-empty value")
+    return resolved
 
 
 def _resolve_artifact(base_dir: Path, artifact_path: str) -> Path | None:
@@ -381,20 +654,6 @@ def _build_source_episode_fields(
     }
 
 
-def _build_episode_fields(
-    trace_episode: Mapping[str, Any],
-    source_map: str,
-) -> dict[str, Any]:
-    steps = _extract_steps(trace_episode)
-    return {
-        "episode_id": str(trace_episode.get("episode_id", "")),
-        "source_seed": int(trace_episode.get("seed", 0)),
-        "source_map": source_map,
-        "replay_digest": trace_episode.get("replay_digest", "") or "",
-        "steps": list(steps) if isinstance(steps, list) else [],
-    }
-
-
 def _build_generated_scenario(entry: Mapping[str, Any], scenario_id: str) -> dict[str, Any]:
     digest = entry.get("provenance", {}).get("digest", "")
     if not digest:
@@ -410,6 +669,9 @@ def _evaluate_critical_event(
     entry: Mapping[str, Any],
     source_trace: Mapping[str, Any],
     replayed_trace: Mapping[str, Any] | None,
+    *,
+    time_tolerance_s: float,
+    location_tolerance_m: float,
 ) -> dict[str, Any]:
     """Evaluate whether the source critical event reproduces in the replayed trace.
 
@@ -445,8 +707,8 @@ def _evaluate_critical_event(
         source_event_location=source_location or [0.0, 0.0],
         replayed_event_time_s=replayed_event["time_s"],
         replayed_event_location=replayed_event["location"],
-        time_tolerance_s=0.5,
-        location_tolerance_m=0.75,
+        time_tolerance_s=time_tolerance_s,
+        location_tolerance_m=location_tolerance_m,
     )
 
 
@@ -572,13 +834,9 @@ class _CpuCellVerdict:
             time_s = float(frame.get("time_s", 0)) + timing_offset_s
             if time_s < 0:
                 continue
-            robot_pos = self._shift_position(frame, i, timing_offset_s, speed_delta_m_s, "robot")
+            robot_pos = self._shift_position(frame, i, speed_delta_m_s, "robot")
             pedestrians = [
-                {
-                    "position": self._shift_position(
-                        frame, i, timing_offset_s, speed_delta_m_s, "ped", j
-                    )
-                }
+                {"position": self._shift_position(frame, i, speed_delta_m_s, "ped", j)}
                 for j in range(len(frame.get("pedestrians", [])))
             ]
             shifted.append(
@@ -590,7 +848,6 @@ class _CpuCellVerdict:
         self,
         frame: Mapping[str, Any],
         index: int,
-        timing_offset_s: float,
         speed_delta_m_s: float,
         actor: str,
         ped_index: int | None = None,
@@ -618,7 +875,7 @@ class _CpuCellVerdict:
         dist = math.hypot(direction[0], direction[1])
         if dist == 0:
             return current
-        scale = speed_delta_m_s * (timing_offset_s if timing_offset_s != 0 else 1.0) / dist
+        scale = speed_delta_m_s * dt / dist
         return [current[0] + direction[0] * scale, current[1] + direction[1] * scale]
 
     def _verdict(self, shifted_steps: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
@@ -674,13 +931,13 @@ def main() -> int:
             commit_hash=args.commit_hash,
             config_hash=args.config_hash,
         )
-    except (FileNotFoundError, ValueError, ScenarioPersistenceValidationError) as exc:
+    except (FileNotFoundError, RuntimeError, ValueError, ScenarioPersistenceValidationError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
     if not records:
-        print("WARNING: no persistence records produced; pipeline may be empty.", file=sys.stderr)
-        return 0
+        print("ERROR: no persistence records produced; refusing empty evidence.", file=sys.stderr)
+        return 1
 
     passed = sum(1 for rec in records if rec["promotion"]["verdict"] == "promote")
     rejected = sum(1 for rec in records if rec["promotion"]["verdict"] == "reject")

--- a/tests/benchmark/test_pipeline_persistence_gate_wiring.py
+++ b/tests/benchmark/test_pipeline_persistence_gate_wiring.py
@@ -15,6 +15,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import pytest
 import yaml
 
 from robot_sf.benchmark.scenario_generation.persistence_gate import validate_persistence_record
@@ -26,6 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
 _PERSISTENCE_CONFIG = "configs/analysis/issue_5600_persistence_gate.yaml"
 _FROZEN_CONFIG_ID = "issue-5600-persistence-gate"
 
@@ -114,6 +116,7 @@ def _fake_batch_runner(
                 "episode_id": trace["episode_id"],
                 "scenario_id": scenario["name"],
                 "seed": scenario["seeds"][0],
+                "scenario_params": {"map_file": trace["source_map"]},
                 "status": "failure",
                 "termination_reason": "timeout",
                 "metrics": {},
@@ -171,12 +174,46 @@ def _run_wiring(tmp_path: Path) -> list[dict[str, Any]]:
         batch_runner=_fake_batch_runner,
         replay_config_builder=lambda *_args, **_kwargs: object(),
     )
+    episodes = [
+        json.loads(line)
+        for line in (output_root / "episodes.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    entries = yaml.safe_load((output_root / "generated_catalog.yaml").read_text(encoding="utf-8"))[
+        "entries"
+    ]
+    episodes_by_id = {episode["episode_id"]: episode for episode in episodes}
+    replay_results: dict[str, Any] = {}
+    for index, entry in enumerate(entries):
+        episode = episodes_by_id[entry["source_episode"]["episode_id"]]
+        replay_results[entry["scenario_id"]] = {
+            "episode": {
+                "episode_id": episode["episode_id"],
+                "source_seed": episode["seed"],
+                "source_map": entry["source_episode"]["source_map"],
+                "steps": episode["algorithm_metadata"]["simulation_step_trace"]["steps"],
+            },
+            "cells": [
+                {
+                    "timing_offset_s": timing_offset_s,
+                    "speed_delta_m_s": speed_delta_m_s,
+                    "verdict": "pass" if index == 0 else "fail",
+                    "reason": "deterministic replay fixture",
+                }
+                for timing_offset_s in (-0.25, 0.0, 0.25)
+                for speed_delta_m_s in (-0.2, 0.0, 0.2)
+            ],
+            "missing_cell_reasons": [],
+        }
+    replay_results_path = tmp_path / "replay_results.json"
+    replay_results_path.write_text(json.dumps(replay_results), encoding="utf-8")
     records = evaluate_pipeline_candidates(
         manifest_path=output_root / "run_manifest.json",
         candidate_path=None,
         episodes_path=None,
-        config_path=Path(_PERSISTENCE_CONFIG),
+        config_path=REPO_ROOT / _PERSISTENCE_CONFIG,
         output_dir=tmp_path / "records",
+        replay_results_path=replay_results_path,
         commit_hash="deadbee",
         config_hash="c0ffee",
     )
@@ -223,3 +260,41 @@ def test_wiring_emits_schema_valid_evidence_records(tmp_path: Path) -> None:
         assert record["config"]["config_id"] == _FROZEN_CONFIG_ID
         assert record["commit_hashes"] == {"code": "deadbee", "config": "c0ffee"}
         validate_persistence_record(record)
+
+
+def test_cpu_speed_delta_uses_frame_duration_not_timing_offset() -> None:
+    """Timing sign must not change the physical duration of a speed perturbation."""
+
+    from scripts.tools.evaluate_pipeline_persistence_gate import _CpuCellVerdict
+
+    evaluator = _CpuCellVerdict(
+        original_steps=[
+            {"time_s": 0.0, "robot": {"position": [0.0, 0.0]}, "pedestrians": []},
+            {"time_s": 1.0, "robot": {"position": [1.0, 0.0]}, "pedestrians": []},
+        ],
+        original_critical_value=None,
+        event_type="min_clearance",
+    )
+
+    for timing_offset_s in (-0.25, 0.25):
+        shifted = evaluator._shift_steps(timing_offset_s, 0.2)
+        assert shifted[-1]["robot"]["position"] == pytest.approx([1.2, 0.0])
+
+
+def test_cpu_only_mode_does_not_claim_exact_replay() -> None:
+    """Without independent replay input, exact replay remains unknown."""
+
+    from scripts.tools.evaluate_pipeline_persistence_gate import _assess_exact_replay
+
+    source = {
+        "episode_id": "episode-1",
+        "source_seed": 7,
+        "source_map": "maps/svg_maps/classic_crossing.svg",
+    }
+    block = _assess_exact_replay(
+        source,
+        source_trace={**source, "seed": 7, "steps": []},
+        replayed_episode=None,
+        replay_error=None,
+    )
+    assert block["status"] == "unknown"


### PR DESCRIPTION
## What / Why

Ports the gate-review repair for issue #5675 that was prepared (commit 177a40c44)
but not merged into `main` after PR #5660 (merged as 04531a1). This is NOT a duplicate
of PR #5660: PR #5660 wired the pipeline persistence gate; this slice hardens its
fail-closed correctness and provenance gaps identified during that gate review.

## Changes (successor slice of #5660)
- Missing catalog traces, empty catalogs, malformed replay results, and partial
  candidate coverage now fail closed with non-zero CLI result (no silently accepted
  partial evidence).
- Frozen perturbation/event config, grid, tolerances, required statuses, and promotion
  threshold are validated and used; unsupported config variants fail closed.
- CPU speed perturbations use frame duration `dt` (regression test independent of
  timing-offset sign).
- Episode ID / seed / source-map provenance cross-checked between catalog and native trace.
- Code/config hashes resolve to real provenance; literal `unknown` rejected.
- CPU-only mode cannot claim `exact_replay`; explicit replay compares identity + normalized payload.
- Wiring test resolves repo paths from `Path(__file__)`; evidence note states CPU-only
  perturbation is diagnostic and independent replay is required for promotion.

## Validation
- `pytest tests/benchmark/test_pipeline_persistence_gate_wiring.py` -> 4 passed
- `pytest tests/benchmark/test_scenario_persistence_gate.py` -> 15 passed
- `ruff check` on changed files -> All checks passed
- `check_docs_evidence_integrity.py` -> 1 changed file passed
- `check_docs_proof_consistency.py --check-evidence-catalog` -> passed

Closes #5675

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation
lane; the review gate hardens and merges.
