### PR TITLE
Issue #5673: avoid coverage warning from dynamic base-sensitive gate test (cheap-lane worker)

### DIFF
--- a/tests/dev/test_base_sensitive_gate_contract.py
+++ b/tests/dev/test_base_sensitive_gate_contract.py
@@ -203,8 +203,12 @@ module.TestOptionalImportGuardInventory().test_no_new_unblessed_spelling_and_no_
         Creates a new Python file with an unblessed guard, verifies the
         base_sensitive subset catches it, then cleans up.
         """
-        # Create a test file with a new optional-import guard
-        test_file = REPO_ROOT / "robot_sf" / "_test_gate_spelling_check.py"
+        # Create a test file with a new optional-import guard.
+        # The file name starts with "test_" so it matches the coverage omit
+        # glob ("*/test_*") in pyproject.toml and is not tracked by coverage;
+        # this avoids the "Couldn't parse" CoverageWarning emitted when the
+        # file is created and removed while xdist reports coverage. See #5673.
+        test_file = REPO_ROOT / "robot_sf" / "test_gate_spelling_check_dynamic.py"
         guard_code = '"""Module to test gate detection of new import guards."""\n\n'
         guard_code += "from __future__ import annotations\n\n"
         guard_code += "try:\n"


### PR DESCRIPTION
## What / Why

Issue #5673 reports a `CoverageWarning` emitted during the final CPU readiness gate:

```text
CoverageWarning: Couldn't parse 'robot_sf/_test_gate_spelling_check.py': No source for code: 'robot_sf/_test_gate_spelling_check.py'.
```

Root cause: `tests/dev/test_base_sensitive_gate_contract.py::test_gate_catches_new_unblessed_spelling` created a temporary source file `robot_sf/_test_gate_spelling_check.py` (name does NOT start with `test_`). Under `parallel = true` coverage, xdist tracks and later tries to report coverage for that file; because the test deletes the file in a `finally` block before reporting, coverage warns it cannot find the source. The file name also does not match the existing `omit` glob `*/test_*`, so coverage treated it as a real source.

Fix: rename the dynamic file to `robot_sf/test_gate_spelling_check_dynamic.py`. The `test_` prefix matches the `*/test_*` omit rule, so coverage never tracks it and no warning is emitted. The ratchet assertion (gate must fail on the new unblessed spelling) and xdist safety are preserved unchanged.

## Validation

- `pytest tests/dev/test_base_sensitive_gate_contract.py::TestSimulatedStaleBase` → 2 passed.
- `pytest ...::test_gate_catches_new_unblessed_spelling` → 1 passed.
- Re-ran under `pytest -n2 --cov=robot_sf --cov-report=` (the scenario that produced the warning): **no `CoverageWarning: Couldn't parse`** line appears.
- `ruff check tests/dev/test_base_sensitive_gate_contract.py` → All checks passed.

Scope: CPU-only, no campaign/Slurm/training, no benchmark or paper claims.

This fully resolves issue #5673 (a fix: issue): the warning-producing test code is corrected.

Closes #5673

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.