### PR TITLE
Issue #5326: durable objective-comparison table + stop-rule (cheap-lane worker)

### DIFF
--- a/configs/adversarial/issue_5326_objective_comparison.yaml
+++ b/configs/adversarial/issue_5326_objective_comparison.yaml
@@ -42,3 +42,4 @@ example_command: >
   --seed 1101 --seed 2202 --seed 3303
   --output-dir output/adversarial/issue_5326_objective_comparison
   --out-json output/adversarial/issue_5326_objective_comparison/report.json
+  --out-md output/adversarial/issue_5326_objective_comparison/comparison_table.md

--- a/scripts/tools/compare_adversarial_samplers.py
+++ b/scripts/tools/compare_adversarial_samplers.py
@@ -403,6 +403,150 @@ def load_package_b_manifest(
     return config, samplers, budgets, seeds
 
 
+def render_durable_comparison_table(
+    *,
+    report_path: Path | None,
+    rows: Sequence[SamplerComparisonRow],
+    objectives: Sequence[str],
+    budget_grid: Sequence[int],
+    seeds: Sequence[int],
+) -> str:
+    """Render the issue #5326 durable comparison table (exclusions, failures, stop-rule).
+
+    The table is diagnostic-tier only: it never asserts a benchmark claim and
+    fails closed when any row shows fallback/degraded execution or is missing
+    the required objective columns. The signed ``temporal_robustness`` rows are
+    annotated with the per-property violation count read from their
+    ``robustness_report.json`` sidecar; baseline objectives carry none.
+    """
+    required_objectives = set(objectives)
+    observed_objectives = {row.objective for row in rows}
+    missing_objectives = sorted(required_objectives - observed_objectives)
+
+    degraded_rows = [
+        row for row in rows if row.fallback_candidate_count or row.degraded_candidate_count
+    ]
+    any_degraded = bool(degraded_rows)
+
+    header_cols = [
+        "objective",
+        "sampler",
+        "budget",
+        "seed",
+        "best_valid_objective",
+        "certified_valid_failures",
+        "replayable_valid_failures",
+        "replay_success_rate",
+        "invalid_candidate_rate",
+        "signed_property_violations",
+        "held_out_family_status",
+        "fallback/degraded",
+    ]
+    lines: list[str] = []
+    lines.append("## Issue #5326 durable objective-comparison table (diagnostic tier)\n")
+    lines.append(
+        "> Claim scope: not paper-facing benchmark evidence. Synthesized on the"
+        " `--synthetic` CPU path; full matched-budget certification/replay/"
+        "independent-seed confirmation requires a SLURM-capable worker (out of"
+        " cheap-lane scope).\n"
+    )
+    lines.append("| " + " | ".join(header_cols) + " |")
+    lines.append("| " + " | ".join("---" for _ in header_cols) + " |")
+    for row in rows:
+        signed_violations = _read_signed_property_violations(
+            bundle_path=Path(row.best_bundle_path) if row.best_bundle_path else None,
+            objective=row.objective,
+        )
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    row.objective,
+                    row.sampler,
+                    str(row.budget),
+                    str(row.seed),
+                    _fmt_opt(row.best_valid_objective),
+                    str(row.certified_valid_failure_count),
+                    str(row.replayable_valid_failure_count),
+                    _fmt_opt(row.replay_success_rate),
+                    f"{row.invalid_candidate_rate:.3f}",
+                    str(signed_violations) if signed_violations is not None else "-",
+                    row.held_out_family_status,
+                    (
+                        f"fb={row.fallback_candidate_count},dg={row.degraded_candidate_count}"
+                        if (row.fallback_candidate_count or row.degraded_candidate_count)
+                        else "none"
+                    ),
+                ]
+            )
+            + " |"
+        )
+
+    lines.append("")
+    lines.append("### Stop-rule decision")
+    lines.append("")
+    if any_degraded:
+        decision = (
+            "**STOP / fail closed.** One or more comparison rows report"
+            " fallback/degraded candidate execution; those rows are excluded from any"
+            " success interpretation and cannot serve as matched-budget evidence."
+        )
+    elif missing_objectives:
+        decision = (
+            "**NARROW / incomplete.** Required objective(s) missing from the comparison:"
+            f" {', '.join(missing_objectives)}. Cannot discriminate objective lift until all"
+            " objectives are present under matched budgets."
+        )
+    else:
+        decision = (
+            "**DIRECTION NARROWED (diagnostic).** Both objectives compared under matched"
+            " CPU-synthetic budgets with no degraded execution. This is a contract/structure"
+            " check only; it does not constitute benchmark evidence for the signed-objective"
+            " hypothesis (requires SLURM campaign with certification/replay/independent-seed"
+            " confirmation)."
+        )
+    lines.append(decision)
+
+    lines.append("")
+    lines.append("### Exclusions and caveats")
+    lines.append("")
+    lines.extend(
+        (
+            "- learned failure proposal #2921: stretch/out of scope",
+            "- held-out-family yield: not evaluated (narrow archive caveat)",
+            "- paper-facing success claims: forbidden at this tier",
+            "- campaign evidence: requires SLURM-capable worker",
+        )
+    )
+    lines.append(
+        f"- report_status: diagnostic_local_nominal; schema"
+        f" adversarial-sampler-comparison.v3; budgets={list(budget_grid)};"
+        f" seeds={list(seeds)}"
+    )
+    if report_path is not None:
+        lines.append(f"- source report: {report_path.as_posix()}")
+    return "\n".join(lines) + "\n"
+
+
+def _read_signed_property_violations(*, bundle_path: Path | None, objective: str) -> int | None:
+    """Return the per-property violation count for a signed-objective row sidecar."""
+    if objective != "temporal_robustness" or bundle_path is None:
+        return None
+    sidecar = bundle_path / "robustness_report.json"
+    if not sidecar.exists():
+        return None
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    properties = payload.get("properties") if isinstance(payload, dict) else None
+    if not isinstance(properties, list):
+        return None
+    return sum(1 for prop in properties if prop.get("violated"))
+
+
+def _fmt_opt(value: float | None) -> str:
+    """Format an optional float for the markdown table."""
+    return f"{value:.4f}" if value is not None else "-"
+
+
 def _synthetic_evaluator(
     config: SearchConfig,
     candidate: CandidateSpec,
@@ -521,6 +665,15 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Use a deterministic synthetic evaluator instead of running benchmark episodes.",
     )
     parser.add_argument("--out-json", type=Path, default=None)
+    parser.add_argument(
+        "--out-md",
+        type=Path,
+        default=None,
+        help=(
+            "Write the durable issue #5326 comparison table (markdown) with exclusions,"
+            " failures, and the stop-rule decision."
+        ),
+    )
     args = parser.parse_args(argv)
     if args.manifest is None and args.output_dir is None:
         parser.error("--output-dir is required unless --manifest is supplied")
@@ -582,6 +735,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             json.dumps(payload, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
+    if args.out_md is not None:
+        out_md = (
+            args.out_md if args.out_md.is_absolute() else (args.repo_root.resolve() / args.out_md)
+        )
+        out_md.parent.mkdir(parents=True, exist_ok=True)
+        table_md = render_durable_comparison_table(
+            report_path=out_json,
+            rows=rows,
+            objectives=objectives,
+            budget_grid=budgets,
+            seeds=seeds,
+        )
+        out_md.write_text(table_md, encoding="utf-8")
     print(json.dumps(payload, sort_keys=True))
     return 0
 

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import dataclasses
 import json
 import sys
 import types
@@ -55,6 +56,7 @@ from robot_sf.nav.obstacle import Obstacle
 from robot_sf.ped_npc.ped_population import populate_single_pedestrians
 from scripts.tools.compare_adversarial_samplers import (
     _comparison_row_from_manifest,
+    render_durable_comparison_table,
     run_sampler_comparison,
 )
 
@@ -1652,6 +1654,77 @@ def test_issue_5326_objective_comparison_contract(tmp_path: Path) -> None:
         assert row.fallback_candidate_count == 0
         assert row.degraded_candidate_count == 0
         assert row.held_out_family_status == "not_evaluated_narrow_archive"
+
+
+def test_issue_5326_durable_comparison_table(tmp_path: Path) -> None:
+    """Issue #5326 durable table must record both objectives, failures, and a stop-rule.
+
+    The renderer is the missing durable-report DoD item: it must expose both
+    objectives, annotate the signed objective with its per-property violation
+    count from the robustness sidecar while the baseline shows none, fail closed
+    on any degraded row, and emit a non-benchmark stop-rule decision.
+    """
+    config = _config(tmp_path, workers=1)
+
+    rows = run_sampler_comparison(
+        config=config,
+        sampler_names=("random", "random"),
+        objective_names=("worst_case_snqi", "temporal_robustness"),
+        synthetic=True,
+    )
+
+    table_md = render_durable_comparison_table(
+        report_path=None,
+        rows=rows,
+        objectives=("worst_case_snqi", "temporal_robustness"),
+        budget_grid=(8,),
+        seeds=(1101,),
+    )
+
+    assert "worst_case_snqi" in table_md
+    assert "temporal_robustness" in table_md
+    assert "Stop-rule decision" in table_md
+    assert "not paper-facing benchmark evidence" in table_md
+    assert "signed_property_violations" in table_md
+
+    by_objective = {(row.objective, row.sampler): row for row in rows}
+    signed_row = by_objective[("temporal_robustness", "random")]
+    signed_bundle = Path(str(signed_row.best_bundle_path))
+    sidecar = json.loads((signed_bundle / "robustness_report.json").read_text(encoding="utf-8"))
+    expected_violations = sum(1 for p in sidecar["properties"] if p["violated"])
+
+    signed_line = next(ln for ln in table_md.splitlines() if ln.startswith("| temporal_robustness"))
+    assert f"| {expected_violations} |" in signed_line
+    baseline_line = next(ln for ln in table_md.splitlines() if ln.startswith("| worst_case_snqi"))
+    assert "| - |" in baseline_line
+
+    assert "fallback/degraded" in table_md
+    assert "**STOP / fail closed**" not in table_md
+
+
+def test_issue_5326_durable_table_fails_closed_on_degraded(tmp_path: Path) -> None:
+    """The durable table must stop/fail closed when any row is fallback/degraded."""
+    config = _config(tmp_path, workers=1)
+    rows = run_sampler_comparison(
+        config=config,
+        sampler_names=("random", "random"),
+        objective_names=("worst_case_snqi", "temporal_robustness"),
+        synthetic=True,
+    )
+    degraded_rows = [
+        dataclasses.replace(row, fallback_candidate_count=1)
+        if row.objective == "worst_case_snqi"
+        else row
+        for row in rows
+    ]
+    table_md = render_durable_comparison_table(
+        report_path=None,
+        rows=degraded_rows,
+        objectives=("worst_case_snqi", "temporal_robustness"),
+        budget_grid=(8,),
+        seeds=(1101,),
+    )
+    assert "**STOP / fail closed" in table_md
 
 
 def test_invalid_optimizer_proposals_are_rejected_before_evaluation(tmp_path: Path) -> None:


### PR DESCRIPTION
## What / Why

Issue #5326 asks to evaluate the signed temporal-logic robustness objective (#5304)
against the criticality/SNQI objectives under matched simulator-call budgets and to
record the result in a **durable report/table** recording exclusions, failures, and the
stop-rule decision (its Definition of Done). PR #5325 (objective), PR #5333 (runner +
config), and PR #5658 (contract test) are merged, but the durable comparison **table** —
the actual artifact the DoD names — was never built. This PR delivers that CPU-achievable
slice.

## Slice implemented (new capability)

- `render_durable_comparison_table(...)` in `scripts/tools/compare_adversarial_samplers.py`
  renders the issue #5326 durable comparison table at diagnostic tier: it exposes **both**
  objectives, annotates the signed `temporal_robustness` rows with their per-property
  violation count read from the `robustness_report.json` sidecar (baseline `worst_case_snqi`
  shows `-`), records fallback/degraded exclusion columns, and emits a fail-closed
  **stop-rule decision**: `**STOP / fail closed**` when any row is fallback/degraded,
  `NARROW` when a required objective is missing, otherwise `DIRECTION NARROWED (diagnostic)`.
- `--out-md` CLI flag writes the table next to `--out-json`; the committed config's
  `example_command` is updated to include it.
- Focused tests: `test_issue_5326_durable_comparison_table` (both objectives, sidecar
  violation annotation, non-benchmark stop-rule) and `test_issue_5326_durable_table_fails_closed_on_degraded`
  (fail-closed on degraded rows).

This slice does **not** duplicate PR #5325 (objective), PR #5333 (runner/config), or
PR #5658 (contract test); it adds the durable-report artifact those slices left unbuilt.

## Validation

- `uv run pytest tests/adversarial/test_adversarial_search.py` → **56 passed** (incl. 2 new tests).
- `uv run ruff check` + `ruff format --check` on changed files → clean.
- Real diagnostic artifact produced via the committed config:
  `uv run python scripts/tools/compare_adversarial_samplers.py --objective worst_case_snqi
  --objective temporal_robustness --sampler random --sampler coordinate --budget 8 --budget 16
  --seed 1101 --seed 2202 --synthetic --output-dir output/adversarial/issue_5326_objective_comparison
  --out-json output/adversarial/issue_5326_objective_comparison/report.json --out-md
  output/adversarial/issue_5326_objective_comparison/comparison_table.md`
  → 16 rows (8 per objective × 2 samplers × 2 budgets × 2 seeds),
  `schema_version: adversarial-sampler-comparison.v3`, `claim_scope:
  not_paper_facing_benchmark_evidence`, stop-rule `DIRECTION NARROWED (diagnostic)`.
  The `output/` artifact is gitignored per repo convention; it is reproduced from the
  config command above.

## Successor statement

Successor slice (requires SLURM-capable worker — out of cheap-lane scope): the **full
matched-budget campaign** with certification, replay, and independent-seed confirmation
for random/TPE/CMA-ES-class search, plus the held-out-family yield and the durable
benchmark-tier stop-rule comparison table. This PR closes the diagnostic-tier reporting
DoD item only.

Refs #5326

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.