### PR TITLE
Issue #5683: reject non-string identity values in predicate export (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/trace_predicate_export.py
+++ b/robot_sf/benchmark/trace_predicate_export.py
@@ -97,10 +97,16 @@ def _episode_metadata(record: Mapping[str, Any], *, run_id: str | None) -> dict[
     def required_text(keys: tuple[str, ...], label: str) -> str:
         for key in keys:
             value = record.get(key)
-            if isinstance(value, str):
-                value = value.strip()
-            if value not in (None, ""):
-                return str(value)
+            if value is None:
+                continue
+            if not isinstance(value, str):
+                raise TracePredicateExportError(
+                    f"episode field {label} must be a string, got {type(value).__name__}: {value!r}"
+                )
+            value = value.strip()
+            if value == "":
+                raise TracePredicateExportError(f"episode field {label} must be a non-empty string")
+            return value
         raise TracePredicateExportError(f"missing required episode field: {label}")
 
     seed = record.get("seed")

--- a/tests/benchmark/test_trace_predicate_export.py
+++ b/tests/benchmark/test_trace_predicate_export.py
@@ -161,6 +161,34 @@ class TestBuildExport:
         with pytest.raises(TracePredicateExportError, match="scenario_id"):
             build_trace_predicate_export([record])
 
+    def test_malformed_identity_types_fail_closed(self) -> None:
+        """Required identity fields must be non-empty strings."""
+        # scenario_id = 0 (integer)
+        record = _record_with_all_predicates()
+        record["scenario_id"] = 0
+        with pytest.raises(TracePredicateExportError, match="scenario_id must be a string"):
+            build_trace_predicate_export([record])
+
+        # algo = False (boolean)
+        record = _record_with_all_predicates()
+        record["algo"] = False
+        with pytest.raises(TracePredicateExportError, match="planner must be a string"):
+            build_trace_predicate_export([record])
+
+        # episode_id = dict (mapping)
+        record = _record_with_all_predicates()
+        record["episode_id"] = {"id": "ep-001"}
+        with pytest.raises(TracePredicateExportError, match="episode_id must be a string"):
+            build_trace_predicate_export([record])
+
+        # blank scenario_id
+        record = _record_with_all_predicates()
+        record["scenario_id"] = "   "
+        with pytest.raises(
+            TracePredicateExportError, match="scenario_id must be a non-empty string"
+        ):
+            build_trace_predicate_export([record])
+
     def test_malformed_predicate_record_fails_closed(self) -> None:
         """Malformed producer payloads must not be promoted as exported evidence."""
         record = _record_with_all_predicates()


### PR DESCRIPTION
## Goal / Problem

Strictly validate scenario/planner/episode identity fields in the trace-predicate exporter.
On the merged head, `_episode_metadata.required_text` converted non-string identity values to text (e.g. `scenario_id=0`, `algo=False`, or `episode_id={"id": "ep-001"}`) instead of failing closed, which could fabricate provenance and create collisions downstream.

## Solution

Updated `required_text` in `robot_sf/benchmark/trace_predicate_export.py` to check that identity values are explicitly non-empty strings, raising `TracePredicateExportError` on invalid types or blank/empty strings.
Also added focused regression tests under `tests/benchmark/test_trace_predicate_export.py`.

## Validation

All verification checks pass. The outputs of `./scripts/dev/pr_ready_check.sh` and tests are:
```
pr_ready_check: checking against BASE_REF=origin/main
pr_ready_check: running Ruff format check...
3083 files already formatted
pr_ready_check: running Ruff lint check...
All checks passed!
pr_ready_check: running type check (mypy)...
Success: no issues found in 107 source files
pr_ready_check: checking changed files for broad exceptions...
Broad exception ratchet passed with 174 entries.
pr_ready_check: running changed/affected tests...
============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-9.1.1, pluggy-1.6.0
collected 22 items

tests/benchmark/test_trace_predicate_export.py ......................    [100%]
============================== 22 passed in 2.15s ==============================
pr_ready_check: checking coverage of changed files...
Name                                            Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------
robot_sf/benchmark/trace_predicate_export.py      219      7    97%   21, 205, 439-442
-----------------------------------------------------------------------------
TOTAL                                             219      7    97%
pr_ready_check: checking docstrings of changed/added functions...
Docstring check passed for changed files.
pr_ready_check: checking schema versions...
Schema validation passed.
pr_ready_check: checking import conventions...
Import conventions check passed.
pr_ready_check: PR readiness check PASSED!
```

## Successor / Linkage Statement

- This PR fully resolves/closes the issue.
- Links parent issue #5593 and the merged PR #5657.
- Closes #5683

This PR was produced by the agy/Gemini-3.5-Flash cheap implementation lane; the review gate hardens and merges.
