### PR TITLE
Issue #5244: drive real SNQI tool through production post-campaign boundary (cheap-lane worker)

### DIFF
--- a/tests/tools/test_run_post_campaign_stage.py
+++ b/tests/tools/test_run_post_campaign_stage.py
@@ -15,9 +15,56 @@ from pathlib import Path
 
 import pytest
 
-from scripts.tools import run_post_campaign_stage
+from scripts.tools import run_post_campaign_stage, slurm_job_finalize
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The only public SNQI tool that emits job-13274's observed exit 5
+# (EXIT_OPTIONAL_DEPS_MISSING, e.g. matplotlib missing on a compute node). Driven
+# here as a real post-campaign step at the production boundary.
+SNQI_SENSITIVITY_ANALYSIS = REPO_ROOT / "scripts" / "snqi_sensitivity_analysis.py"
+
+
+def _write_minimal_snqi_fixtures(base: Path) -> Path:
+    """Write a minimal, self-consistent SNQI sensitivity-analysis fixture set.
+
+    Returns the episode JSONL path; weights/baseline paths are derived alongside it.
+    """
+    (base / "reports").mkdir(parents=True, exist_ok=True)
+    episodes = base / "episodes.jsonl"
+    episodes.write_text(
+        json.dumps(
+            {
+                "planner_key": "static",
+                "metrics": {
+                    "collision_rate": 0.1,
+                    "ttc_violation_rate": 0.2,
+                    "path_deviation": 0.3,
+                    "comfort_jerk": 0.4,
+                    "energy_efficiency": 0.5,
+                    "progress_smoothness": 0.6,
+                    "waiting_time": 0.7,
+                    "goal_deviation": 0.8,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    fields = [
+        "collision_rate",
+        "ttc_violation_rate",
+        "path_deviation",
+        "comfort_jerk",
+        "energy_efficiency",
+        "progress_smoothness",
+        "waiting_time",
+        "goal_deviation",
+    ]
+    baseline = {f: {"mean": 0.1 + 0.1 * i, "std": 0.01} for i, f in enumerate(fields)}
+    (base / "baseline.json").write_text(json.dumps({"static": baseline}), encoding="utf-8")
+    (base / "weights.json").write_text(json.dumps(dict.fromkeys(fields, 1.0)), encoding="utf-8")
+    return episodes
 
 
 class TestPostCampaignStageRunner:
@@ -131,6 +178,87 @@ class TestPostCampaignStageRunner:
         payload = json.loads(output.read_text(encoding="utf-8"))
         assert payload["job_exit_code"] == 0
         assert payload["post_campaign_stage"]["exit_code"] == 5
+
+    def test_real_snqi_analysis_stage_through_production_boundary(self, tmp_path: Path) -> None:
+        """The real ``snqi_sensitivity_analysis.py`` post-campaign step must run through
+        ``run_post_campaign_stage`` (the job-13274 exit-5 candidate tool) and preserve the
+        completed campaign's exit 0 all the way to ``slurm_job_finalize``.
+
+        Prior slices only exercised synthetic ``exit 5`` bash scripts; this drives the
+        actual public SNQI tool at the production dispatch/serialization boundary so a
+        completed ``enforcement=warn`` campaign cannot be relabeled by a downstream
+        analysis step.
+        """
+        campaign_root = tmp_path / "campaign"
+        summary = campaign_root / "reports" / "campaign_summary.json"
+        summary.parent.mkdir(parents=True, exist_ok=True)
+        summary.write_text(
+            json.dumps({"soft_contract_warning": True, "warnings": ["SNQI warn"]}),
+            encoding="utf-8",
+        )
+        episodes = _write_minimal_snqi_fixtures(tmp_path)
+        envelope_path = tmp_path / "stage_status.json"
+        snqi_out = tmp_path / "snqi_out"
+
+        primitive_exit = run_post_campaign_stage.main(
+            [
+                "--campaign-summary",
+                str(summary),
+                "--campaign-exit-code",
+                "0",
+                "--stage-name",
+                "snqi_sensitivity_analysis",
+                "--output",
+                str(envelope_path),
+                "--stage-command",
+                sys.executable,
+                str(SNQI_SENSITIVITY_ANALYSIS),
+                "--episodes",
+                str(episodes),
+                "--baseline",
+                str(tmp_path / "baseline.json"),
+                "--weights",
+                str(tmp_path / "weights.json"),
+                "--output",
+                str(snqi_out),
+                "--skip-visualizations",
+            ]
+        )
+        assert primitive_exit == 0
+
+        payload = json.loads(envelope_path.read_text(encoding="utf-8"))
+        assert payload["campaign"]["exit_code"] == 0
+        assert payload["campaign"]["soft_contract_warning"] is True
+        assert payload["job_exit_code"] == 0
+        assert payload["post_campaign_stage"]["exit_code"] == 0
+        assert payload["post_campaign_stage"]["name"] == "snqi_sensitivity_analysis"
+        # The real tool wrote its own artifacts (proof it actually ran).
+        assert (snqi_out / "sensitivity_analysis_results.json").is_file()
+
+        finalize_output = tmp_path / "finalize.json"
+        finalize_exit = slurm_job_finalize.main(
+            [
+                "--issue",
+                "5244",
+                "--job-id",
+                "13274",
+                "--job-state",
+                "COMPLETED",
+                "--expected-artifact",
+                str(envelope_path),
+                "--post-campaign-stage-status",
+                str(envelope_path),
+                "--output",
+                str(finalize_output),
+            ]
+        )
+        report = json.loads(finalize_output.read_text(encoding="utf-8"))
+        assert finalize_exit == 0
+        assert report["classification"] == "success"
+        lanes = report["exit_code_lanes"]
+        assert lanes["campaign"]["exit_code"] == 0
+        assert lanes["job_exit_code"] == 0
+        assert lanes["post_campaign_stage"]["exit_code"] == 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What / Why

Issue #5244 requires the **public production path** to keep a completed
`enforcement=warn` campaign at exit 0 through every launcher, scheduler, and
ledger layer while a soft warning stays visible (`soft_contract_warning: true`),
and to isolate any downstream post-campaign analysis step in its own exit lane.

Prior merged #5244 slices (#5625/#5647/#5653/#5664/#5687) built and adopted the
`robot-sf-post-campaign-stage-status.v1` envelope and the reusable
`run_post_campaign_stage` primitive, and tested them **only with synthetic
`exit 5` bash scripts**. The real job-13274 exit-5 candidate (per the issue
thread) is `snqi_sensitivity_analysis.py`, the only public tool that emits
`EXIT_OPTIONAL_DEPS_MISSING` (5) when an optional dependency such as matplotlib
is missing on the compute node. This slice adds NEW capability by driving that
**real** tool as a chained post-campaign step through the actual production
boundary: `run_post_campaign_stage.main` -> `slurm_job_finalize.main`, consuming
the exact on-disk envelope.

The new regression proves:
- a completed `enforcement=warn` campaign (`soft_contract_warning: true`) keeps
  `job_exit_code == 0` with the soft warning preserved;
- the real SNQI tool actually executes and writes its own artifacts;
- the tool's exit stays in the `post_campaign_stage` lane and never remaps the
  campaign exit;
- `slurm_job_finalize` classifies the job `success` with `exit_code_lanes`
  campaign/job `0` and the stage lane `0`.

## Validation

```
$ .venv/bin/python -m pytest tests/tools/test_run_camera_ready_benchmark.py \
    tests/tools/test_run_post_campaign_stage.py \
    tests/tools/test_slurm_job_finalize.py \
    tests/tools/test_issue3216_campaign_stage_handoff.py -q
47 passed
$ .venv/bin/ruff check tests/tools/test_run_post_campaign_stage.py
All checks passed!
$ .venv/bin/ruff format --check tests/tools/test_run_post_campaign_stage.py
1 file already formatted
```

Only one file changed: `tests/tools/test_run_post_campaign_stage.py`
(+129/-1), a focused regression at the production dispatch/serialization
boundary (no campaigns, Slurm, training, or benchmark/paper claims).

## Refs #5244 (partial slice — does not duplicate PR #5625/#5647/#5653/#5664/#5687)

Successor slice of the prior #5244 slices; adds NEW capability by exercising the
real SNQI post-campaign tool at the production handoff they left covered only by
synthetic scripts.

### What remains
- Inspect the private `.sl`/ledger wrapper for job 13274 and adopt this same
  envelope in that private consumer (out of scope for this public checkout, same
  as the #5687 "what remains" note).
- Reproduce the exact job-13274 exit-5 tail: that requires a compute node with
  matplotlib missing from `snqi_sensitivity_analysis.py`'s import path. In this
  checkout `matplotlib` is a hard dependency of `robot_sf` (via
  `robot_sf/common/__init__.py`), so the optional-deps-missing lane is
  structurally unreachable here and the test instead asserts the real tool runs
  successfully through the boundary while the synthetic `exit 5` path stays
  covered by prior tests.

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation
lane; the review gate hardens and merges.