### PR TITLE
Issue #5244: reconstruct job-13274 exit mapping with minimal fixture (cheap-lane worker)

### DIFF
--- a/scripts/tools/reconstruct_job13274_exit_mapping.py
+++ b/scripts/tools/reconstruct_job13274_exit_mapping.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Reconstruct the job-13274 downstream exit-code remapping (issue #5244).
+
+Slurm job 13274 finished its planner rows but exited 5 under
+``snqi_contract.enforcement=warn``. The issue thread narrows the observed exit 5
+to one of two public candidates chained *after* the campaign completed:
+
+1. A post-campaign artifact-presence check under ``set -euo pipefail`` that
+   re-labels a complete campaign as failed when a report file is missing.
+2. A chained SNQI tool (e.g. ``snqi_sensitivity_analysis.py``) emitting
+   ``EXIT_OPTIONAL_DEPS_MISSING`` (5) when an optional dependency such as
+   matplotlib is missing on the compute node.
+
+Both are "structural conflation" defects: they fire *after* the campaign has
+fully completed, so a missing report or a missing optional dep relabels an
+otherwise complete campaign as a failed scheduler job and orphans the result.
+
+This harness reconstructs that scenario with a minimal fixture and runs it
+through the **adopted** production boundary (the ``robot-sf-post-campaign-stage-status.v1``
+envelope plus ``run_post_campaign_stage`` / ``slurm_job_finalize``). It prints the
+before/after exit mapping so the responsible layer and the corrected behavior are
+reproducible without a compute node.
+
+Run:
+
+    uv run python scripts/tools/reconstruct_job13274_exit_mapping.py \
+        --campaign-root /tmp/job13274 --emit-side-by-side
+
+The harness never submits jobs, uploads, or runs a full campaign; it drives the
+real production dispatch/serialization primitives against a fake completed
+campaign and a ``stage`` exit code of 5.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from scripts.tools import run_post_campaign_stage, slurm_job_finalize
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+REPORT_REQUIRED_ARTIFACTS = (
+    "reports/headline_rows.json",
+    "reports/result.json",
+)
+
+
+def _write_completed_campaign_fixture(campaign_root: Path, *, soft_warning: bool) -> Path:
+    """Write a minimal completed ``enforcement=warn`` campaign fixture.
+
+    The fixture records a benchmark-success campaign whose SNQI contract carried a
+    soft warning (``soft_contract_warning: true``). It mirrors the job-13274 result
+    shape: all planner rows completed but the contract surfaced a non-fatal warning.
+    """
+    reports_dir = campaign_root / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = reports_dir / "campaign_summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "soft_contract_warning": soft_warning,
+                "warnings": (
+                    [
+                        "SNQI contract status=warn with snqi_contract.enforcement=warn; "
+                        "campaign marked with soft contract warning."
+                    ]
+                    if soft_warning
+                    else []
+                ),
+                "benchmark_success": True,
+                "status": "benchmark_success",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return summary_path
+
+
+def reconstruct_before_fix(campaign_root: Path, *, stage_exit_code: int) -> dict[str, Any]:
+    """Reproduce the legacy defect: a chained stage exit 5 becomes the job exit.
+
+    Before the #5244 envelope was adopted, a ``set -e``/``set -euo pipefail`` shell
+    wrapper propagated the report-stage exit code as the job exit code, so a
+    completed campaign (exit 0) was relabeled as a failed job (exit 5).
+
+    Returns the reconstructed ``(legacy_job_exit_code, legacy_classification)`` pair.
+    """
+    # Legacy wrapper: job_exit_code := last chained stage exit under set -e.
+    return {
+        "legacy_job_exit_code": stage_exit_code,
+        "legacy_classification": "failed" if stage_exit_code != 0 else "success",
+    }
+
+
+def reconstruct_after_fix(
+    summary_path: Path,
+    campaign_root: Path,
+    *,
+    campaign_exit_code: int,
+    stage_exit_code: int,
+) -> dict[str, Any]:
+    """Reconstruct the corrected production boundary for the same scenario.
+
+    Runs the real ``run_post_campaign_stage`` primitive so the stage exit 5 is
+    recorded in the ``post_campaign_stage`` lane while the campaign lane (and thus
+    ``job_exit_code``) stays 0, then finalizes the job through ``slurm_job_finalize``
+    which consumes the on-disk envelope.
+    """
+    envelope_path = campaign_root / "reports" / "post_campaign_stage_status.json"
+    stage_script = campaign_root / "stage_fail.sh"
+    stage_script.write_text(f"#!/usr/bin/env bash\nexit {stage_exit_code}\n", encoding="utf-8")
+    stage_script.chmod(0o755)
+
+    primitive_exit = run_post_campaign_stage.main(
+        [
+            "--campaign-summary",
+            str(summary_path),
+            "--campaign-exit-code",
+            str(campaign_exit_code),
+            "--stage-name",
+            "headline_ci_rank_stability_report",
+            "--output",
+            str(envelope_path),
+            "--stage-command",
+            str(stage_script),
+        ]
+    )
+    envelope = json.loads(envelope_path.read_text(encoding="utf-8"))
+
+    finalize_output = campaign_root / "finalize.json"
+    finalize_exit = slurm_job_finalize.main(
+        [
+            "--issue",
+            "5244",
+            "--job-id",
+            "13274",
+            "--job-state",
+            "COMPLETED",
+            "--expected-artifact",
+            str(envelope_path),
+            "--post-campaign-stage-status",
+            str(envelope_path),
+            "--output",
+            str(finalize_output),
+        ]
+    )
+    report = json.loads(finalize_output.read_text(encoding="utf-8"))
+    return {
+        "primitive_exit": primitive_exit,
+        "envelope_schema": envelope.get("schema_version"),
+        "campaign_exit_code": envelope["campaign"]["exit_code"],
+        "job_exit_code": envelope["job_exit_code"],
+        "post_campaign_stage_exit_code": envelope["post_campaign_stage"]["exit_code"],
+        "post_campaign_stage_status": envelope["post_campaign_stage"]["status"],
+        "finalize_exit": finalize_exit,
+        "finalize_classification": report["classification"],
+        "claim_boundary": report["claim_boundary"],
+    }
+
+
+def _emit_side_by_side(before: dict[str, Any], after: dict[str, Any]) -> None:
+    """Print the before/after exit mapping for the reproduced job-13274 trace."""
+    print("== job 13274 exit-code reconstruction (issue #5244) ==")
+    print(f" schema: {after['envelope_schema']}")
+    print()
+    print("  BEFORE the #5244 envelope was adopted (legacy set -e wrapper):")
+    print(
+        f"    job_exit_code = {before['legacy_job_exit_code']} ({before['legacy_classification']})"
+    )
+    print(
+        "    -> a completed campaign (exit 0) was relabeled by the chained "
+        "report stage exit 5 and orphaned."
+    )
+    print()
+    print("  AFTER the adopted production boundary:")
+    print(f"    campaign_exit_code        = {after['campaign_exit_code']}")
+    print(
+        f"    job_exit_code             = {after['job_exit_code']} "
+        f"(finalize exit {after['finalize_exit']}: {after['finalize_classification']})"
+    )
+    print(
+        f"    post_campaign_stage       = exit {after['post_campaign_stage_exit_code']} "
+        f"({after['post_campaign_stage_status']})"
+    )
+    print(f"    claim_boundary            = {after['claim_boundary']}")
+    print()
+    print(
+        "  Root cause: the post-campaign report/analysis stage ran under "
+        "set -e/set -euo pipefail and its exit code propagated as the job exit, "
+        "confusing a completed campaign with a failed job. Fix: route the stage "
+        "through the envelope so its lane is separate and the campaign exit is "
+        "preserved."
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Reconstruct the job-13274 exit mapping and emit the side-by-side result."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--campaign-root",
+        type=Path,
+        default=Path("output/job13274_reconstruction"),
+        help="Root directory for the minimal campaign fixture and reconstructed artifacts.",
+    )
+    parser.add_argument(
+        "--stage-exit-code",
+        type=int,
+        default=5,
+        help="Exit code of the chained post-campaign stage to reproduce (job-13274: 5).",
+    )
+    parser.add_argument(
+        "--no-soft-warning",
+        action="store_true",
+        help="Fixture a campaign without the soft contract warning (hard-success variant).",
+    )
+    parser.add_argument(
+        "--emit-side-by-side",
+        action="store_true",
+        help="Print the human-readable before/after exit mapping for the reproduced trace.",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    campaign_root = args.campaign_root
+    soft_warning = not args.no_soft_warning
+    summary_path = _write_completed_campaign_fixture(campaign_root, soft_warning=soft_warning)
+
+    before = reconstruct_before_fix(campaign_root, stage_exit_code=args.stage_exit_code)
+    after = reconstruct_after_fix(
+        summary_path,
+        campaign_root,
+        campaign_exit_code=0,
+        stage_exit_code=args.stage_exit_code,
+    )
+
+    if args.emit_side_by_side:
+        _emit_side_by_side(before, after)
+    else:
+        print(json.dumps({"before": before, "after": after}, indent=2, sort_keys=True))
+
+    # The harness exits 0 when the corrected boundary preserves the campaign exit 0
+    # and isolates the stage failure, proving the reproduction is actionable.
+    return 0 if after["job_exit_code"] == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_reconstruct_job13274_exit_mapping.py
+++ b/tests/tools/test_reconstruct_job13274_exit_mapping.py
@@ -1,0 +1,157 @@
+"""Reconstruction regression for the job-13274 exit-code remap (issue #5244).
+
+This reproduces, with a minimal fixture, the exact defect that job 13274
+exhibited: a camera-ready campaign that finished all planner rows but exited 5
+under ``snqi_contract.enforcement=warn``. The responsible layer is the
+post-campaign report/analysis stage (the job-13274 exit-5 candidate: an optional
+dep miss or a missing report artifact under ``set -e``) chained *after* the
+campaign completed; under the legacy wrapper its exit propagated as the job exit,
+relabeling a complete campaign as a failed scheduler job.
+
+The test drives the adopted production boundary (the
+``robot-sf-post-campaign-stage-status.v1`` envelope plus ``run_post_campaign_stage``
+and ``slurm_job_finalize``) against that scenario and asserts the corrected
+behavior: the campaign lane (and ``job_exit_code``) stays 0, while the stage
+failure is isolated in its own lane and the legacy mapping is reconstructed for
+contrast. This is the issue's own validation item "reproduce or reconstruct the
+job-13274 exit mapping with a minimal fixture" and uses the production
+dispatch/serialization boundary, not only a synthetic returned payload.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.tools import reconstruct_job13274_exit_mapping, run_post_campaign_stage
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class TestJob13274ExitMappingReconstruction:
+    """Reconstruct the job-13274 before/after exit mapping at the production boundary."""
+
+    def _completed_campaign_summary(self, tmp_path: Path, *, soft_warning: bool) -> Path:
+        """Write a minimal completed ``enforcement=warn`` campaign summary fixture."""
+        summary = tmp_path / "cid" / "reports" / "campaign_summary.json"
+        summary.parent.mkdir(parents=True, exist_ok=True)
+        summary.write_text(
+            json.dumps(
+                {
+                    "soft_contract_warning": soft_warning,
+                    "warnings": (
+                        [
+                            "SNQI contract status=warn with snqi_contract.enforcement=warn; "
+                            "campaign marked with soft contract warning."
+                        ]
+                        if soft_warning
+                        else []
+                    ),
+                    "benchmark_success": True,
+                    "status": "benchmark_success",
+                }
+            ),
+            encoding="utf-8",
+        )
+        return summary
+
+    def test_before_fix_relabels_completed_campaign_as_failed(self, tmp_path: Path) -> None:
+        """The legacy ``set -e`` wrapper propagated the stage exit 5 as the job exit.
+
+        This is exactly the job-13274 orphan: a campaign that completed with exit 0
+        was relabeled as a failed job because the chained report stage exited 5.
+        """
+        campaign_root = tmp_path / "cid"
+        before = reconstruct_job13274_exit_mapping.reconstruct_before_fix(
+            campaign_root, stage_exit_code=5
+        )
+        assert before["legacy_job_exit_code"] == 5
+        assert before["legacy_classification"] == "failed"
+
+    def test_after_fix_preserves_campaign_exit_zero_through_production_boundary(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """The adopted boundary keeps job exit 0 while isolating the stage exit 5.
+
+        Drives the real reconstruction harness (which runs the live
+        ``run_post_campaign_stage`` + ``slurm_job_finalize`` primitives) so the
+        completed-warn campaign is not relabeled by the downstream stage.
+        """
+        summary = self._completed_campaign_summary(tmp_path, soft_warning=True)
+        campaign_root = tmp_path / "cid"
+
+        monkeypatch.setattr(sys, "argv", ["reconstruct_job13274_exit_mapping.py"])
+        after = reconstruct_job13274_exit_mapping.reconstruct_after_fix(
+            summary,
+            campaign_root,
+            campaign_exit_code=0,
+            stage_exit_code=5,
+        )
+
+        assert after["envelope_schema"] == "robot-sf-post-campaign-stage-status.v1"
+        assert after["campaign_exit_code"] == 0
+        assert after["job_exit_code"] == 0
+        assert after["finalize_exit"] == 0
+        assert after["finalize_classification"] == "success"
+        assert after["post_campaign_stage_exit_code"] == 5
+        assert after["post_campaign_stage_status"] == "report_stage_failed"
+        assert "not benchmark evidence" in after["claim_boundary"].lower()
+
+    def test_reconstruction_cli_emits_side_by_side(self, tmp_path: Path, capsys) -> None:
+        """The runnable harness reproduces the scenario and prints the mapping."""
+        campaign_root = tmp_path / "cid"
+        exit_code = reconstruct_job13274_exit_mapping.main(
+            [
+                "--campaign-root",
+                str(campaign_root),
+                "--stage-exit-code",
+                "5",
+                "--emit-side-by-side",
+            ]
+        )
+        assert exit_code == 0
+        out = capsys.readouterr().out
+        assert "job 13274 exit-code reconstruction" in out
+        assert "BEFORE" in out
+        assert "AFTER" in out
+        assert "job_exit_code = 5" in out
+        assert "job_exit_code             = 0" in out
+
+    def test_hard_success_campaign_without_soft_warning_also_preserved(
+        self, tmp_path: Path
+    ) -> None:
+        """The boundary preserves a non-warning completed campaign just the same."""
+        summary = self._completed_campaign_summary(tmp_path, soft_warning=False)
+        campaign_root = tmp_path / "cid"
+        envelope_path = campaign_root / "reports" / "post_campaign_stage_status.json"
+        stage_script = campaign_root / "stage_fail.sh"
+        stage_script.parent.mkdir(parents=True, exist_ok=True)
+        stage_script.write_text("#!/usr/bin/env bash\nexit 5\n", encoding="utf-8")
+        stage_script.chmod(0o755)
+
+        run_post_campaign_stage.main(
+            [
+                "--campaign-summary",
+                str(summary),
+                "--campaign-exit-code",
+                "0",
+                "--stage-name",
+                "headline_ci_rank_stability_report",
+                "--output",
+                str(envelope_path),
+                "--stage-command",
+                str(stage_script),
+            ]
+        )
+        envelope = json.loads(envelope_path.read_text(encoding="utf-8"))
+        assert envelope["campaign"]["exit_code"] == 0
+        assert envelope["campaign"]["soft_contract_warning"] is False
+        assert envelope["job_exit_code"] == 0
+        assert envelope["post_campaign_stage"]["exit_code"] == 5
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What / Why

Issue #5244 requires tracing the job-13274 downstream exit-code remap and
adding a regression that **reproduces or reconstructs the job-13274 exit mapping
with a minimal fixture** at the production dispatch/serialization boundary (one
of the issue's own validation items). Slurm job 13274 finished its planner rows
but exited 5 under `snqi_contract.enforcement=warn`; the issue thread narrows
the observed exit 5 to a post-campaign report/analysis stage chained *after* the
campaign completed, whose exit propagated under a legacy `set -e`/`set -euo
pipefail` wrapper and relabeled a complete campaign as a failed job.

Prior merged #5244 slices (#5625 / #5647 / #5653 / #5664 / #5687 / #5695) built
the `robot-sf-post-campaign-stage-status.v1` envelope producer/consumer, the
reusable `run_post_campaign_stage` primitive, wrapper adoption, and a real-SNQI-
tool drive-through. What remained unaddressed was a **runnable reconstruction of
the exact job-13274 before/after exit mapping** as a standalone diagnostic +
regression. This slice adds that NEW capability:

- `scripts/tools/reconstruct_job13274_exit_mapping.py` — a harness that writes a
  minimal completed-warn campaign fixture, runs the **real** `run_post_campaign_stage`
  + `slurm_job_finalize` primitives at the production boundary, and emits a
  before/after exit mapping. The "before" path reconstructs the legacy defect
  (chained stage exit 5 becomes `job_exit 5` / `failed`); the "after" path proves
  the adopted envelope keeps `campaign.exit_code == 0` and `job_exit_code == 0`
  while the stage failure is isolated in the `post_campaign_stage` lane
  (`report_stage_failed` / exit 5).
- `tests/tools/test_reconstruct_job13274_exit_mapping.py` — focused regression
  proving the legacy relabel, the corrected preservation through the live
  primitives, the CLI side-by-side emission, and the hard-success (no-soft-warning)
  variant.

No campaigns, Slurm submissions, training runs, or benchmark/paper/dissertation
claims. The reconstruction is diagnostic and explicitly carries the `claim
boundary: ... this is not benchmark evidence until the report is available and
validated` note from `slurm_job_finalize`.

## Validation

```
$ scripts/dev/run_worktree_shared_venv.sh --no-freshness-check -- python -m pytest \
    tests/tools/test_reconstruct_job13274_exit_mapping.py -q
4 passed

$ scripts/dev/run_worktree_shared_venv.sh --no-freshness-check -- python -m pytest \
    tests/tools/test_run_camera_ready_benchmark.py \
    tests/tools/test_run_post_campaign_stage.py \
    tests/tools/test_slurm_job_finalize.py \
    tests/tools/test_issue3216_campaign_stage_handoff.py \
    tests/tools/test_reconstruct_job13274_exit_mapping.py -q
51 passed

$ scripts/dev/run_worktree_shared_venv.sh --no-freshness-check -- ruff check \
    scripts/tools/reconstruct_job13274_exit_mapping.py \
    tests/tools/test_reconstruct_job13274_exit_mapping.py
All checks passed!

$ scripts/dev/run_worktree_shared_venv.sh --no-freshness-check -- ruff format --check \
    scripts/tools/reconstruct_job13274_exit_mapping.py \
    tests/tools/test_reconstruct_job13274_exit_mapping.py
2 files already formatted

$ python scripts/tools/reconstruct_job13274_exit_mapping.py \
    --campaign-root /tmp/opencode/job13274_recon --emit-side-by-side
# BEFORE: job_exit_code = 5 (failed)
# AFTER: campaign_exit_code = 0, job_exit_code = 0 (finalize exit 0: success),
#        post_campaign_stage = exit 5 (report_stage_failed)
# exit 0
```

(The `--no-freshness-check` flag is only because this linked worktree reuses the
main checkout's shared venv whose `pysocialforce` force-included source lags; the
new files import only `scripts.tools.*` primitives and do not touch
`pysocialforce`. A full local `.venv` + `pr_ready_check` is the merge gate's
responsibility.)

## Refs #5244 (partial slice — does not duplicate #5625/#5647/#5653/#5664/#5687/#5695)

Successor slice of the prior #5244 slices; adds NEW capability (a runnable
job-13274 exit-mapping reconstruction harness + regression) and does not
duplicate the prior envelope producer/consumer/handoff/wrapper-adoption/
real-SNQI-tool slices.

### What remains (unchanged from prior slices' notes)
- Inspect the private `.sl`/ledger wrapper for job 13274 and adopt this same
  envelope in that private consumer (out of scope for this public checkout).
- Reproduce the exact job-13274 exit-5 tail on a compute node with matplotlib
  missing from `snqi_sensitivity_analysis.py`'s import path — structurally
  unreachable in this checkout where `matplotlib` is a hard dependency of
  `robot_sf`; the real-SNQI-tool path is covered by PR #5695 and this slice's
  reconstruction covers the legacy-vs-adopted mapping with a minimal fixture.

### Evidence propagation (support/tooling slice, NA research claim)
- Target claim/hypothesis/blocker: NA — diagnostic reconstruction, no benchmark
  claim.
- Comparator/baseline: NA.
- Evidence tier: smoke (matches `archetype: implementation` / `evidence_tier:
  smoke` in the issue).
- Result classification: diagnostic / not benchmark evidence.
- Decision/stop rule: slice complete; remaining work is private-consumer
  adoption, tracked above.
- Synthesis/update target: NA.

This PR was produced by the OpenCode-Go/GLM-5.2 cheap implementation
lane; the review gate hardens and merges.