### PR TITLE
Issue #5409: guarded-PPO availability preflight (cheap-lane worker)

### DIFF
--- a/scripts/benchmark/check_guarded_ppo_availability_issue_5409.py
+++ b/scripts/benchmark/check_guarded_ppo_availability_issue_5409.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""CPU-only guarded-PPO availability preflight for issue #5409 horizon ablation.
+
+Plain-language summary: the issue #5409 roster-matched horizon ablation configs
+(`configs/benchmarks/issue_5409_horizon_ablation_h500.yaml` and the h600 twin)
+declare the `guarded_ppo` arm with `availability_gate: dependency_gated` and
+`fail_closed_reason: guarded_ppo_checkpoint_observation_contract_missing`. That
+flag is a conservative *claim of unavailability*, not proof. This preflight
+resolves the two dependencies that flag actually refers to, using the
+repository's existing CPU-only infrastructure:
+
+1. the arm checkpoint (`model_id` in the algo_config), resolved through
+   `robot_sf.benchmark.campaign_checkpoint_preflight` (network-free cheap mode);
+2. the learned-checkpoint observation contract, resolved through
+   `robot_sf.benchmark.algorithm_metadata.resolve_learned_checkpoint_observation_contract`.
+
+When both resolve, the arm is AVAILABLE and the `fail_closed_reason` no longer
+applies; when either is missing this reports exactly which dependency is absent
+and keeps the arm classified `not_available`. The preflight stages nothing,
+downloads nothing, executes no episode, and submits no campaign, so it is safe
+to run on any CPU node without the #4826 GPU-lifecycle gate.
+
+Exit codes are branchable for a submit wrapper:
+    0 -- the guarded_ppo arm is available (both dependencies resolve).
+    1 -- the guarded_ppo arm is not available (a dependency is missing).
+    2 -- the config could not be loaded or has no guarded_ppo arm.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from robot_sf.benchmark.algorithm_metadata import (
+    canonical_algorithm_name,
+    resolve_learned_checkpoint_observation_contract,
+)
+from robot_sf.benchmark.camera_ready_campaign import load_campaign_config
+from robot_sf.benchmark.campaign_checkpoint_preflight import (
+    CampaignCheckpointPreflightError,
+    iter_campaign_arm_checkpoint_references,
+    resolve_arm_checkpoint,
+)
+
+EXIT_AVAILABLE = 0
+EXIT_NOT_AVAILABLE = 1
+EXIT_CONFIG_ERROR = 2
+
+GUARDED_PPO_ALGO = "guarded_ppo"
+
+
+def _find_guarded_ppo_planner(cfg: Any) -> Any | None:
+    """Return the first enabled guarded_ppo planner spec in a loaded campaign config."""
+    for planner in cfg.planners:
+        if planner.enabled and canonical_algorithm_name(planner.algo) == GUARDED_PPO_ALGO:
+            return planner
+    return None
+
+
+def _checkpoint_resolution(
+    cfg: Any, planner_key: str, *, registry_path: Path | None
+) -> dict[str, Any]:
+    """Resolve the guarded_ppo arm checkpoints in network-free cheap mode."""
+    references = [
+        ref
+        for ref in iter_campaign_arm_checkpoint_references(cfg)
+        if ref.planner_key == planner_key
+    ]
+    if not references:
+        return {
+            "checked": 0,
+            "resolvable": True,
+            "status": "no_checkpoint_declared",
+            "references": [],
+        }
+    resolutions = [
+        resolve_arm_checkpoint(ref, stage=False, registry_path=registry_path) for ref in references
+    ]
+    return {
+        "checked": len(resolutions),
+        "resolvable": all(r.resolvable for r in resolutions),
+        "status": "ok" if all(r.resolvable for r in resolutions) else "unresolved",
+        "references": [
+            {
+                "kind": r.reference.kind,
+                "value": r.reference.value,
+                "status": r.status,
+                "detail": r.detail,
+            }
+            for r in resolutions
+        ],
+    }
+
+
+def _observation_contract_resolution(planner: Any) -> dict[str, Any]:
+    """Resolve the guarded_ppo learned-checkpoint observation contract."""
+    from robot_sf.benchmark.camera_ready._config_types import PlannerSpec
+
+    algo_config: dict[str, Any] = {}
+    if isinstance(planner, PlannerSpec) and planner.algo_config_path is not None:
+        import yaml
+
+        path = Path(planner.algo_config_path)
+        if path.is_file():
+            algo_config = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    try:
+        contract = resolve_learned_checkpoint_observation_contract(planner.algo, algo_config)
+    except (ValueError, KeyError, TypeError, FileNotFoundError) as exc:
+        return {
+            "resolvable": False,
+            "status": "error",
+            "active_observation_mode": None,
+            "metadata_source": None,
+            "detail": f"{type(exc).__name__}: {exc}",
+        }
+    return {
+        "resolvable": contract.get("status") not in ("error", "missing"),
+        "status": contract.get("status"),
+        "active_observation_mode": contract.get("active_observation_mode"),
+        "metadata_source": contract.get("metadata_source"),
+        "detail": "observation contract resolved",
+    }
+
+
+def _readiness_tier(planner: Any) -> dict[str, Any]:
+    """Return the guarded_ppo algorithm readiness tier without importing heavy deps."""
+    from robot_sf.benchmark.algorithm_readiness import get_algorithm_readiness
+
+    readiness = get_algorithm_readiness(planner.algo)
+    if readiness is None:
+        return {"canonical_name": planner.algo, "tier": "unknown"}
+    return {"canonical_name": readiness.canonical_name, "tier": readiness.tier}
+
+
+def check_guarded_ppo_availability(
+    config_path: str | Path,
+    *,
+    registry_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Compute the guarded_ppo availability verdict for a campaign config.
+
+    Args:
+        config_path: Path to a camera-ready campaign config YAML that may contain
+            a guarded_ppo arm (declared via `availability_gate: dependency_gated`).
+        registry_path: Optional model-registry path override (useful for tests).
+
+    Returns:
+        dict[str, Any]: Structured verdict with ``available`` boolean, the resolved
+        checkpoint and observation-contract status, the declared availability gate,
+        and the actionable ``fail_closed_reason`` (carried from the config, retained
+        when the arm is not available).
+
+    Raises:
+        FileNotFoundError / TypeError / ValueError: When the config cannot be loaded.
+    """
+    cfg = load_campaign_config(Path(config_path))
+    planner = _find_guarded_ppo_planner(cfg)
+    if planner is None:
+        return {
+            "config": str(config_path),
+            "present": False,
+            "available": False,
+            "reason": "no enabled guarded_ppo planner arm found in config",
+        }
+
+    checkpoint = _checkpoint_resolution(
+        cfg,
+        planner.key,
+        registry_path=Path(registry_path) if registry_path else None,
+    )
+    observation = _observation_contract_resolution(planner)
+    readiness = _readiness_tier(planner)
+
+    available = bool(checkpoint["resolvable"] and observation["resolvable"])
+
+    missing: list[str] = []
+    if not checkpoint["resolvable"]:
+        missing.append("checkpoint")
+    if not observation["resolvable"]:
+        missing.append("observation_contract")
+
+    fail_closed_reason = str(getattr(planner, "fail_closed_reason", "") or "").strip()
+
+    return {
+        "config": str(config_path),
+        "present": True,
+        "available": available,
+        "planner_key": planner.key,
+        "algo": planner.algo,
+        "declared_availability_gate": getattr(planner, "availability_gate", None),
+        "declared_fail_closed_reason": fail_closed_reason or None,
+        "readiness": readiness,
+        "checkpoint": checkpoint,
+        "observation_contract": observation,
+        "remaining_missing_dependencies": missing,
+        "verdict": (
+            "available"
+            if available
+            else "not_available" + (f": missing {missing}" if missing else "")
+        ),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the guarded-PPO availability preflight CLI."""
+    parser = argparse.ArgumentParser(
+        description="CPU-only guarded-PPO availability preflight for issue #5409.",
+    )
+    parser.add_argument(
+        "--config",
+        required=True,
+        type=Path,
+        help="Path to a camera-ready campaign config YAML (e.g. the issue #5409 h500/h600 config).",
+    )
+    parser.add_argument(
+        "--registry-path",
+        type=Path,
+        default=None,
+        help="Optional model-registry path override.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the availability verdict as JSON on stdout.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.config.is_file():
+        print(f"error: campaign config not found: {args.config}", file=sys.stderr)
+        return EXIT_CONFIG_ERROR
+
+    try:
+        verdict = check_guarded_ppo_availability(
+            args.config,
+            registry_path=args.registry_path,
+        )
+    except (FileNotFoundError, TypeError, ValueError, CampaignCheckpointPreflightError) as exc:
+        print(f"error: could not evaluate {args.config}: {exc}", file=sys.stderr)
+        return EXIT_CONFIG_ERROR
+
+    if not verdict["present"]:
+        print(f"NOT AVAILABLE: {verdict['reason']}", file=sys.stderr)
+        if args.json:
+            print(json.dumps(verdict, indent=2))
+        return EXIT_CONFIG_ERROR
+
+    if verdict["available"]:
+        if args.json:
+            print(json.dumps(verdict, indent=2))
+        else:
+            logger.info(
+                "guarded_ppo arm AVAILABLE: checkpoint + observation contract both resolve "
+                f"({verdict['checkpoint']['status']}, {verdict['observation_contract']['status']})"
+            )
+            print(
+                f"AVAILABLE: guarded_ppo arm in {args.config} is runnable "
+                "(checkpoint and observation contract resolve; "
+                f"readiness tier={verdict['readiness']['tier']})."
+            )
+        return EXIT_AVAILABLE
+
+    if args.json:
+        print(json.dumps(verdict, indent=2))
+    else:
+        missing = ", ".join(verdict["remaining_missing_dependencies"])
+        declared = verdict["declared_fail_closed_reason"] or "unspecified"
+        print(
+            f"NOT AVAILABLE: guarded_ppo arm in {args.config} missing {missing}. "
+            f"Declared fail_closed_reason='{declared}' still applies.",
+            file=sys.stderr,
+        )
+    return EXIT_NOT_AVAILABLE
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_check_guarded_ppo_availability_issue_5409.py
+++ b/tests/benchmark/test_check_guarded_ppo_availability_issue_5409.py
@@ -1,0 +1,256 @@
+"""Tests for the issue #5409 guarded-PPO availability preflight.
+
+CPU-only and network-free. The preflight reuses the repository's existing
+checkpoint-resolution and observation-contract machinery, so these tests verify
+the *wiring* (a guarded_ppo arm is detected, its two declared dependencies are
+resolved, and the available/not-available verdict is derived correctly) without
+running any campaign or touching the network.
+
+The real issue #5409 configs are exercised where present; synthetic fixtures
+cover the missing-dependency and absent-arm branches.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = REPO_ROOT / "scripts/benchmark/check_guarded_ppo_availability_issue_5409.py"
+_H500_CONFIG = REPO_ROOT / "configs/benchmarks/issue_5409_horizon_ablation_h500.yaml"
+_H600_CONFIG = REPO_ROOT / "configs/benchmarks/issue_5409_horizon_ablation_h600.yaml"
+
+
+def _load_script_module():
+    """Load the preflight script as a module for testing."""
+    spec = importlib.util.spec_from_file_location(
+        "check_guarded_ppo_availability_issue_5409", _SCRIPT_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["check_guarded_ppo_availability_issue_5409"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_script_module()
+check_guarded_ppo_availability = _mod.check_guarded_ppo_availability
+EXIT_AVAILABLE = _mod.EXIT_AVAILABLE
+EXIT_NOT_AVAILABLE = _mod.EXIT_NOT_AVAILABLE
+EXIT_CONFIG_ERROR = _mod.EXIT_CONFIG_ERROR
+
+
+def _write_guarded_ppo_config(
+    tmp_path: Path, *, with_checkpoint: bool, with_contract: bool
+) -> Path:
+    """Write a minimal campaign config with a guarded_ppo arm and dependencies toggled."""
+    registry_path = tmp_path / "registry.yaml"
+    if with_checkpoint:
+        registry_payload = {
+            "version": 1,
+            "models": [
+                {
+                    "model_id": "guarded_ckpt",
+                    "local_path": str(tmp_path / "guarded_ckpt-model.zip"),
+                }
+            ],
+        }
+    else:
+        registry_payload = {"version": 1, "models": []}
+    registry_path.write_text(yaml.safe_dump(registry_payload), encoding="utf-8")
+
+    algo_cfg = tmp_path / "guarded_ppo.yaml"
+    if with_contract:
+        algo_payload = {
+            "model_id": "guarded_ckpt",
+            "benchmark_promotion": {
+                "observation_level": "tracked_agents_no_noise",
+                "observation_mode": "dict",
+            },
+        }
+    else:
+        algo_payload = {"model_id": "guarded_ckpt"}
+    algo_cfg.write_text(yaml.safe_dump(algo_payload), encoding="utf-8")
+
+    (tmp_path / "guarded_ckpt-model.zip").write_text("dummy", encoding="utf-8")
+
+    config = tmp_path / "campaign.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "name": "guarded_test",
+                "scenario_matrix": "configs/scenarios/classic_interactions_francis2023.yaml",
+                "horizon": 500,
+                "planners": [
+                    {
+                        "key": "goal",
+                        "algo": "goal",
+                        "planner_group": "core",
+                        "benchmark_profile": "baseline-safe",
+                    },
+                    {
+                        "key": "guarded_ppo",
+                        "algo": "guarded_ppo",
+                        "planner_group": "experimental",
+                        "benchmark_profile": "experimental",
+                        "algo_config": str(algo_cfg),
+                        "availability_gate": "dependency_gated",
+                        "fail_closed_reason": (
+                            "guarded_ppo_checkpoint_observation_contract_missing"
+                        ),
+                    },
+                ],
+                "seed_policy": {
+                    "mode": "seed-set",
+                    "seed_set": "eval",
+                    "seed_sets_path": "configs/benchmarks/seed_sets_v1.yaml",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return config
+
+
+class TestGuardedPpoAvailability:
+    """Verdict derivation for the guarded_ppo arm."""
+
+    def test_arm_present_and_available_when_both_deps_resolve(self, tmp_path: Path) -> None:
+        config = _write_guarded_ppo_config(tmp_path, with_checkpoint=True, with_contract=True)
+        verdict = check_guarded_ppo_availability(config, registry_path=tmp_path / "registry.yaml")
+        assert verdict["present"] is True
+        assert verdict["available"] is True
+        assert verdict["remaining_missing_dependencies"] == []
+        assert verdict["verdict"] == "available"
+
+    def test_not_available_when_checkpoint_missing(self, tmp_path: Path) -> None:
+        registry_path = tmp_path / "registry.yaml"
+        registry_path.write_text(yaml.safe_dump({"version": 1, "models": []}), encoding="utf-8")
+        algo_cfg = tmp_path / "guarded_ppo.yaml"
+        algo_cfg.write_text(
+            yaml.safe_dump(
+                {
+                    "model_id": "guarded_ckpt",
+                    "benchmark_promotion": {
+                        "observation_level": "tracked_agents_no_noise",
+                        "observation_mode": "dict",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        config = tmp_path / "campaign.yaml"
+        config.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "guarded_test",
+                    "scenario_matrix": "configs/scenarios/classic_interactions_francis2023.yaml",
+                    "horizon": 500,
+                    "planners": [
+                        {
+                            "key": "guarded_ppo",
+                            "algo": "guarded_ppo",
+                            "planner_group": "experimental",
+                            "benchmark_profile": "experimental",
+                            "algo_config": str(algo_cfg),
+                            "availability_gate": "dependency_gated",
+                            "fail_closed_reason": (
+                                "guarded_ppo_checkpoint_observation_contract_missing"
+                            ),
+                        },
+                    ],
+                    "seed_policy": {
+                        "mode": "seed-set",
+                        "seed_set": "eval",
+                        "seed_sets_path": "configs/benchmarks/seed_sets_v1.yaml",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        verdict = check_guarded_ppo_availability(config, registry_path=registry_path)
+        assert verdict["available"] is False
+        assert "checkpoint" in verdict["remaining_missing_dependencies"]
+        assert verdict["declared_fail_closed_reason"] == (
+            "guarded_ppo_checkpoint_observation_contract_missing"
+        )
+
+    def test_absent_arm_reports_present_false(self, tmp_path: Path) -> None:
+        config = tmp_path / "campaign.yaml"
+        config.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "no_guarded",
+                    "scenario_matrix": "configs/scenarios/classic_interactions_francis2023.yaml",
+                    "horizon": 500,
+                    "planners": [
+                        {
+                            "key": "goal",
+                            "algo": "goal",
+                            "planner_group": "core",
+                            "benchmark_profile": "baseline-safe",
+                        },
+                    ],
+                    "seed_policy": {
+                        "mode": "seed-set",
+                        "seed_set": "eval",
+                        "seed_sets_path": "configs/benchmarks/seed_sets_v1.yaml",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        verdict = check_guarded_ppo_availability(config)
+        assert verdict["present"] is False
+        assert verdict["available"] is False
+
+
+class TestActualIssue5409Configs:
+    """Exercise the real issue #5409 ablation configs where present."""
+
+    def test_h500_guarded_ppo_arm_resolves_available(self) -> None:
+        if not _H500_CONFIG.exists():
+            pytest.skip("issue #5409 h500 config not present in this checkout")
+        verdict = check_guarded_ppo_availability(_H500_CONFIG)
+        assert verdict["present"] is True
+        assert verdict["planner_key"] == "guarded_ppo"
+        assert verdict["available"] is True
+        assert verdict["checkpoint"]["resolvable"] is True
+        assert verdict["observation_contract"]["resolvable"] is True
+
+    def test_h600_guarded_ppo_arm_resolves_available(self) -> None:
+        if not _H600_CONFIG.exists():
+            pytest.skip("issue #5409 h600 config not present in this checkout")
+        verdict = check_guarded_ppo_availability(_H600_CONFIG)
+        assert verdict["present"] is True
+        assert verdict["available"] is True
+
+
+class TestCliExitCodes:
+    """Exit-code contract for the submit wrapper."""
+
+    def test_available_exit_zero(self, tmp_path: Path) -> None:
+        config = _write_guarded_ppo_config(tmp_path, with_checkpoint=True, with_contract=True)
+        exit_code = _mod.main(
+            ["--config", str(config), "--registry-path", str(tmp_path / "registry.yaml")]
+        )
+        assert exit_code == EXIT_AVAILABLE
+
+    def test_not_available_exit_one(self, tmp_path: Path) -> None:
+        config = _write_guarded_ppo_config(tmp_path, with_checkpoint=False, with_contract=True)
+        exit_code = _mod.main(
+            [
+                "--config",
+                str(config),
+                "--registry-path",
+                str(tmp_path / "registry.yaml"),
+            ]
+        )
+        assert exit_code == EXIT_NOT_AVAILABLE
+
+    def test_missing_config_exit_two(self, tmp_path: Path) -> None:
+        exit_code = _mod.main(["--config", str(tmp_path / "missing.yaml")])
+        assert exit_code == EXIT_CONFIG_ERROR


### PR DESCRIPTION
## What / why

Issue #5409 is the **roster-matched, seed-matched horizon ablation** (h500 vs h600, everything
constant but horizon). PR #5422 already landed the paired configs
(`configs/benchmarks/issue_5409_horizon_ablation_h500.yaml` / `_h600.yaml`) and the fail-closed
`validate_horizon_ablation_pair.py` validator. The issue thread's **Remaining** item is the
**guarded-PPO availability preflight**: the `guarded_ppo` arm in both configs is declared
`availability_gate: dependency_gated` with `fail_closed_reason: guarded_ppo_checkpoint_observation_contract_missing`.
That flag is a *conservative claim of unavailability*, not proof.

This PR adds a CPU-only, network-free preflight
(`scripts/benchmark/check_guarded_ppo_availability_issue_5409.py`) that resolves the two
dependencies that flag actually refers to, using the repository's existing infrastructure:

1. the arm checkpoint (`model_id` in the algo_config), via
   `robot_sf.benchmark.campaign_checkpoint_preflight` in cheap (network-free) mode;
2. the learned-checkpoint observation contract, via
   `robot_sf.benchmark.algorithm_metadata.resolve_learned_checkpoint_observation_contract`.

When both resolve, the arm is **AVAILABLE** and the `fail_closed_reason` no longer applies; when
either is missing the arm is classified `not_available` with the specific missing dependency named.

## Successor statement

Successor slice to PR #5422 (which landed config + pair validator only). Does **not** duplicate
PR #5422: that PR validated the two configs *form* a valid horizon ablation pair; this PR validates
the `guarded_ppo` arm *availability* claim that those configs left fail-closed. No new benchmark
config, no duplication of the pair validator.

## Validation output

`uv run pytest tests/benchmark/test_check_guarded_ppo_availability_issue_5409.py -q` → **8 passed**.

Real #5409 configs exercised (CPU-only, no network):
- h500 `guarded_ppo` arm: checkpoint `resolvable=True`, observation contract `status=metadata_resolved`
  (`active_observation_mode=socnav_state`), verdict **available**.
- h600 `guarded_ppo` arm: same, verdict **available**.

`uv run ruff check` + `ruff format` pass on both new files.

Manual CLI check on the real h500 config returns exit code 0 (AVAILABLE); synthetic fixtures cover
the not-available (checkpoint missing) and absent-arm branches with exit codes 1 and 2.

## What remains (not done in this cheap-lane PR)

- **Campaign execution** for both horizons (h500 + h600) and producing the actual benchmark rows
  that answer "does horizon change planner conclusions?".
- The GPU-lifecycle acceptance evidence is recorded in #4826; campaign submission still requires the `--stage` checkpoint staging (`scripts/benchmark/preflight_campaign_checkpoints.py --stage`) before `sbatch`.

This PR only hardens the availability preflight (the remaining named item) and is diagnostic-only;
it makes no benchmark, paper, or dissertation claim.

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

Refs #5409

