### PR TITLE
Issue #4981: extend social-force GIL-release and Numba nogil to batch-lidar path and remaining force kernels (cheap-lane worker)

### DIFF
--- a/fast-pysf/pysocialforce/forces.py
+++ b/fast-pysf/pysocialforce/forces.py
@@ -732,7 +732,7 @@ class GroupRepulsiveForce:
         return forces * self.config.factor
 
 
-@njit(fastmath=True)
+@njit(fastmath=True, nogil=True)
 def group_repulsive_force(member_pos: np.ndarray, threshold: float) -> np.ndarray:
     """Compute intra-group repulsive forces for one pedestrian group.
 
@@ -808,7 +808,7 @@ class GroupGazeForceAlt:
         return forces * self.config.factor
 
 
-@njit(fastmath=True)
+@njit(fastmath=True, nogil=True)
 def group_gaze_force(
     member_pos: np.ndarray, member_directions: np.ndarray, member_dist: np.ndarray
 ) -> np.ndarray:
@@ -884,7 +884,7 @@ def vec_len_2d(vec_x: float, vec_y: float) -> float:
     return (vec_x**2 + vec_y**2) ** 0.5
 
 
-@njit
+@njit(nogil=True)
 def normalize(vecs: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Normalize an (n, 2) array of vectors.
 
@@ -907,7 +907,7 @@ def normalize(vecs: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     return unit_vecs, vec_lengths
 
 
-@njit
+@njit(nogil=True)
 def desired_directions(state: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Compute desired directions and distances for each pedestrian.
 
@@ -953,7 +953,7 @@ def each_diff(vecs: np.ndarray, keepdims=False) -> np.ndarray:
     return diff
 
 
-@njit
+@njit(nogil=True)
 def centroid(vecs: np.ndarray) -> tuple[float, float]:
     """
     Compute the centroid of a set of points in 2D space.

--- a/robot_sf/training/threaded_vec_env.py
+++ b/robot_sf/training/threaded_vec_env.py
@@ -175,6 +175,10 @@ class ThreadedVecEnv(DummyVecEnv):
     def _step_env(self, env_idx: int, env: gym.Env, action: np.ndarray) -> Any:
         """Step one environment with its optional coordinated LiDAR binding.
 
+        The GIL-releasing social-force context is always active so that Numba
+        kernels in the step hot path run without the GIL regardless of whether
+        cross-environment LiDAR batching is also enabled.
+
         Returns:
             The Gymnasium step transition emitted by ``env``.
         """
@@ -182,12 +186,13 @@ class ThreadedVecEnv(DummyVecEnv):
         if coordinator is None:
             with social_force_gil_releasing_context():
                 return env.step(action)
-        try:
-            with lidar_batch_context(coordinator, env_idx):
-                return env.step(action)
-        except BaseException as exc:
-            coordinator.abort(exc)
-            raise
+        with social_force_gil_releasing_context():
+            try:
+                with lidar_batch_context(coordinator, env_idx):
+                    return env.step(action)
+            except BaseException as exc:
+                coordinator.abort(exc)
+                raise
 
     def _ensure_no_pending_step(self, operation: str) -> None:
         """Reject operations that would race an outstanding asynchronous step."""

--- a/tests/training/test_threaded_vec_env.py
+++ b/tests/training/test_threaded_vec_env.py
@@ -130,8 +130,8 @@ def test_threaded_vec_env_steps_sibling_environments_concurrently() -> None:
         vec_env.close()
 
 
-def test_threaded_vec_env_scopes_gil_releasing_forces_to_plain_mode(monkeypatch) -> None:
-    """Plain threaded steps opt in, while coordinated LiDAR steps retain their own schedule."""
+def test_threaded_vec_env_applies_gil_releasing_forces_in_all_modes(monkeypatch) -> None:
+    """Both plain and coordinated LiDAR modes enable the GIL-releasing social-force context."""
     context_entries: list[None] = []
 
     @contextmanager
@@ -167,7 +167,7 @@ def test_threaded_vec_env_scopes_gil_releasing_forces_to_plain_mode(monkeypatch)
         batch_env.step(np.zeros((2, 1), dtype=np.float32))
     finally:
         batch_env.close()
-    assert context_entries == []
+    assert len(context_entries) == 2
 
 
 def test_threaded_vec_env_preserves_sb3_terminal_observation_and_auto_reset() -> None:


### PR DESCRIPTION
## Summary

This PR delivers an optimization slice for the in-process rollout hot path under `#4981`.

### What / Why

1. **Batch-lidar GIL-release fix:** The `ThreadedVecEnv._step_env` method applied `social_force_gil_releasing_context()` only in the non-batch path (`batch_lidar=False`). When `batch_lidar=True`, the cross-environment LiDAR batching was active but the GIL-releasing social-force kernel was *not* used. This meant the `threaded_lidar_batch` mode was missing the Numba GIL-release benefit during social-force computation — the heaviest O(N²) kernel in the step hot path. The fix wraps both paths with the GIL-releasing context.

2. **Numba `nogil=True` for remaining force kernels:** Added `nogil=True` to `normalize`, `desired_directions`, `group_repulsive_force`, `group_gaze_force`, and `centroid` in `fast-pysf/pysocialforce/forces.py`. These are called from Python force-computation classes (`DesiredForce.__call__`, `GroupRepulsiveForce.__call__`, `GroupGazeForceAlt.__call__`, `GroupCoherenceForceAlt.__call__`) and now release the GIL during concurrent threaded execution.

### Validation

All focused and training test suites pass:

```
# Training tests (709 passed)
pytest tests/training/ -v
========================= 709 passed in 79.56s =========================

# Fast-pysf tests (39 passed)
pytest fast-pysf/tests/ -v
============================== 39 passed in 8.39s ==============================

# Threaded VecEnv tests (10 passed)
pytest tests/training/test_threaded_vec_env.py tests/training/test_vector_env_matrix.py -v
============================= 10 passed in 37.63s ==============================

# VecEnv throughput acceptance tests (12 passed)
pytest tests/validation/test_run_issue_4981_vecenv_throughput_acceptance.py -v
============================== 12 passed in 1.94s ==============================

# Worker-mode throughput tests (35 passed)
pytest tests/validation/test_run_vecenv_worker_mode_throughput.py -v
============================== 35 passed in 4.91s ==============================
```

Ruff check and format pass cleanly on all changed files.

### Successor Statement

This PR is a successor slice for `#4981`. It does not duplicate the prior VecEnv, LiDAR-batching, comparator, plain-threaded social-force GIL-release, or fast-deepcopy slices. The strict `>3x` acceptance criterion remains open and requires a current-head adjudication run.

Refs #4981

This PR was produced by the Pi-harness/SAIA-DeepSeek-v4-Flash cheap implementation lane; the review gate hardens and merges.