### PR TITLE
Issue #5244: harden job-13274 reconstruction artifact + exit validation (cheap-lane worker)

### DIFF
--- a/scripts/tools/reconstruct_job13274_exit_mapping.py
+++ b/scripts/tools/reconstruct_job13274_exit_mapping.py
@@ -43,10 +43,17 @@ from scripts.tools import run_post_campaign_stage, slurm_job_finalize
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-REPORT_REQUIRED_ARTIFACTS = (
-    "reports/headline_rows.json",
-    "reports/result.json",
-)
+
+def _validate_stage_exit_code(value: int) -> int:
+    """Reject exit codes outside the shell range before any fixture is produced.
+
+    The production post-campaign boundary accepts only shell exit codes ``0..255``;
+    the harness must fail closed on an impossible input instead of letting a nested
+    production parser raise after fixtures have already been written.
+    """
+    if not 0 <= value <= 255:
+        raise ValueError(f"--stage-exit-code must be a shell exit code in 0..255, got {value}")
+    return value
 
 
 def _write_completed_campaign_fixture(campaign_root: Path, *, soft_warning: bool) -> Path:
@@ -141,7 +148,7 @@ def reconstruct_after_fix(
             "--job-state",
             "COMPLETED",
             "--expected-artifact",
-            str(envelope_path),
+            str(summary_path),
             "--post-campaign-stage-status",
             str(envelope_path),
             "--output",
@@ -213,6 +220,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Exit code of the chained post-campaign stage to reproduce (job-13274: 5).",
     )
     parser.add_argument(
+        "--campaign-exit-code",
+        type=int,
+        default=0,
+        help="Exit code of the campaign lane; nonzero models a hard-failed campaign.",
+    )
+    parser.add_argument(
         "--no-soft-warning",
         action="store_true",
         help="Fixture a campaign without the soft contract warning (hard-success variant).",
@@ -223,6 +236,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Print the human-readable before/after exit mapping for the reproduced trace.",
     )
     args = parser.parse_args(list(argv) if argv is not None else None)
+    _validate_stage_exit_code(args.stage_exit_code)
+    _validate_stage_exit_code(args.campaign_exit_code)
 
     campaign_root = args.campaign_root
     soft_warning = not args.no_soft_warning
@@ -232,7 +247,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     after = reconstruct_after_fix(
         summary_path,
         campaign_root,
-        campaign_exit_code=0,
+        campaign_exit_code=args.campaign_exit_code,
         stage_exit_code=args.stage_exit_code,
     )
 
@@ -241,9 +256,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     else:
         print(json.dumps({"before": before, "after": after}, indent=2, sort_keys=True))
 
-    # The harness exits 0 when the corrected boundary preserves the campaign exit 0
-    # and isolates the stage failure, proving the reproduction is actionable.
-    return 0 if after["job_exit_code"] == 0 else 1
+    # The harness mirrors the campaign lane: exit 0 when the campaign completed (the
+    # corrected boundary preserves that lane and isolates any stage failure), nonzero
+    # when the campaign itself failed. A hard-failed campaign must stay nonzero.
+    return after["job_exit_code"]
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_reconstruct_job13274_exit_mapping.py
+++ b/tests/tools/test_reconstruct_job13274_exit_mapping.py
@@ -16,6 +16,12 @@ failure is isolated in its own lane and the legacy mapping is reconstructed for
 contrast. This is the issue's own validation item "reproduce or reconstruct the
 job-13274 exit mapping with a minimal fixture" and uses the production
 dispatch/serialization boundary, not only a synthetic returned payload.
+
+This module also hardens the reconstruction harness per follow-up issue #5702:
+the finalizer must receive the campaign summary as the expected campaign artifact
+and the status envelope separately, the harness must reject exit codes outside
+``0..255`` before producing fixtures, and a hard (nonzero) campaign exit must stay
+nonzero while the post-campaign stage failure remains isolated.
 """
 
 from __future__ import annotations
@@ -72,33 +78,38 @@ class TestJob13274ExitMappingReconstruction:
         assert before["legacy_classification"] == "failed"
 
     def test_after_fix_preserves_campaign_exit_zero_through_production_boundary(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+        self, tmp_path: Path, capsys
     ) -> None:
         """The adopted boundary keeps job exit 0 while isolating the stage exit 5.
 
         Drives the real reconstruction harness (which runs the live
         ``run_post_campaign_stage`` + ``slurm_job_finalize`` primitives) so the
-        completed-warn campaign is not relabeled by the downstream stage.
+        completed-warn campaign is not relabeled by the downstream stage. The
+        finalizer receives the campaign summary as the expected campaign artifact and
+        the status envelope as a separate required artifact (issue #5702).
         """
-        summary = self._completed_campaign_summary(tmp_path, soft_warning=True)
+        self._completed_campaign_summary(tmp_path, soft_warning=True)
         campaign_root = tmp_path / "cid"
 
-        monkeypatch.setattr(sys, "argv", ["reconstruct_job13274_exit_mapping.py"])
-        after = reconstruct_job13274_exit_mapping.reconstruct_after_fix(
-            summary,
-            campaign_root,
-            campaign_exit_code=0,
-            stage_exit_code=5,
+        exit_code = reconstruct_job13274_exit_mapping.main(
+            [
+                "--campaign-root",
+                str(campaign_root),
+                "--stage-exit-code",
+                "5",
+                "--emit-side-by-side",
+            ]
         )
+        assert exit_code == 0
 
-        assert after["envelope_schema"] == "robot-sf-post-campaign-stage-status.v1"
-        assert after["campaign_exit_code"] == 0
-        assert after["job_exit_code"] == 0
-        assert after["finalize_exit"] == 0
-        assert after["finalize_classification"] == "success"
-        assert after["post_campaign_stage_exit_code"] == 5
-        assert after["post_campaign_stage_status"] == "report_stage_failed"
-        assert "not benchmark evidence" in after["claim_boundary"].lower()
+        finalize_output = campaign_root / "finalize.json"
+        report = json.loads(finalize_output.read_text(encoding="utf-8"))
+        assert report["classification"] == "success"
+        envelope = report["exit_code_lanes"]
+        assert envelope["job_exit_code"] == 0
+        assert envelope["campaign"]["exit_code"] == 0
+        assert envelope["post_campaign_stage"]["exit_code"] == 5
+        assert "not benchmark evidence" in report["claim_boundary"].lower()
 
     def test_reconstruction_cli_emits_side_by_side(self, tmp_path: Path, capsys) -> None:
         """The runnable harness reproduces the scenario and prints the mapping."""
@@ -151,6 +162,58 @@ class TestJob13274ExitMappingReconstruction:
         assert envelope["campaign"]["soft_contract_warning"] is False
         assert envelope["job_exit_code"] == 0
         assert envelope["post_campaign_stage"]["exit_code"] == 5
+
+    def test_hard_campaign_exit_stays_nonzero_while_stage_failure_isolated(
+        self, tmp_path: Path
+    ) -> None:
+        """A hard (nonzero) campaign exit must remain nonzero through the boundary.
+
+        The post-campaign stage may also fail, but the harness must never mask the
+        campaign failure: ``job_exit_code`` follows the campaign lane, so a failed
+        campaign stays failed (regression guard from issue #5702).
+        """
+        self._completed_campaign_summary(tmp_path, soft_warning=False)
+        campaign_root = tmp_path / "cid"
+
+        exit_code = reconstruct_job13274_exit_mapping.main(
+            [
+                "--campaign-root",
+                str(campaign_root),
+                "--campaign-exit-code",
+                "3",
+                "--stage-exit-code",
+                "5",
+            ]
+        )
+        assert exit_code == 3
+
+        finalize_output = campaign_root / "finalize.json"
+        report = json.loads(finalize_output.read_text(encoding="utf-8"))
+        assert report["classification"] == "failed"
+        envelope = report["exit_code_lanes"]
+        assert envelope["job_exit_code"] == 3
+        assert envelope["campaign"]["exit_code"] == 3
+        assert envelope["post_campaign_stage"]["exit_code"] == 5
+
+    def test_invalid_stage_exit_code_rejected_before_fixture_creation(self, tmp_path: Path) -> None:
+        """Exit codes outside ``0..255`` must fail closed at the harness boundary.
+
+        The production boundary accepts only shell exit codes; the harness must reject
+        an impossible value (e.g. 256) before writing any fixture, rather than letting a
+        nested production parser raise mid-run (issue #5702).
+        """
+        campaign_root = tmp_path / "cid"
+        with pytest.raises(ValueError, match=r"0\.\.255"):
+            reconstruct_job13274_exit_mapping.main(
+                [
+                    "--campaign-root",
+                    str(campaign_root),
+                    "--stage-exit-code",
+                    "256",
+                ]
+            )
+        # No fixture output should have been produced.
+        assert not (campaign_root / "reports" / "campaign_summary.json").exists()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What / Why

This PR hardens the job-13274 exit-mapping reconstruction harness (issue #5244)
to close the two concrete gaps the gate review of merged PR #5698 flagged in
follow-up issue #5702. The harness drives the **adopted** production boundary
(the `robot-sf-post-campaign-stage-status.v1` envelope plus `run_post_campaign_stage`
and `slurm_job_finalize`); this change makes that harness faithful to the real
finalizer contract and fail-closed on impossible inputs.

Changes in `scripts/tools/reconstruct_job13274_exit_mapping.py`:
- Removed the dead `REPORT_REQUIRED_ARTIFACTS` declaration; the finalizer now
  receives the **campaign summary** as the expected campaign artifact and the
  **status envelope** as a separate required artifact (correct artifact role
  modeling).
- Added `_validate_stage_exit_code` so `--stage-exit-code` / `--campaign-exit-code`
  are rejected outside the shell range `0..255` **before** any fixture is written
  (prevents a misleading diagnostic that accepts an impossible exit code).
- The harness now models a **hard (nonzero) campaign exit**, preserving it through
  the boundary while still isolating the post-campaign stage failure.

**Successor statement:** This is a successor slice to issue #5702. It does **not**
duplicate prior merged PRs #5698, #5653, #5625, #5647, or #5664, which introduced
the envelope, the reusable stage runner, and the camera-ready/launcher adoption
that the harness now exercises. It adds new capability: the gate-hardened artifact
wiring and the shell-range fail-closed validation.

## Validation

`PYTHONPATH=. python -m pytest tests/tools/test_reconstruct_job13274_exit_mapping.py -q` → **6 passed**.

Ruff check + format: both pass on the two touched files.

CLI smoke tests:
- `--stage-exit-code 5` → job_exit_code 0, post-campaign stage isolated at exit 5, classification `success`.
- `--stage-exit-code 256` → fails closed with `ValueError: --stage-exit-code must be a shell exit code in 0..255, got 256`; no fixture written.
- `--campaign-exit-code 3 --stage-exit-code 5` → classification `failed`, job exit code 3 preserved (stage failure still isolated).

The focused regression suite covers the corrected warn-stage path, the hard-campaign
exit path, and the invalid-input rejection deterministically.

## Scope

- In scope (per #5702): artifact wiring, shell-range validation, hard-campaign exit, focused tests.
- Out of scope (remains on parent #5244): the private scheduler/ledger consumer
  trace and the full job-13274 compute-node trace.

Refs #5244
Refs #5702

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.
