### PR TITLE
Issue #5702: harden job-13274 reconstruction artifact and exit validation (cheap-lane worker)

### DIFF
--- a/scripts/tools/reconstruct_job13274_exit_mapping.py
+++ b/scripts/tools/reconstruct_job13274_exit_mapping.py
@@ -43,10 +43,19 @@ from scripts.tools import run_post_campaign_stage, slurm_job_finalize
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-REPORT_REQUIRED_ARTIFACTS = (
-    "reports/headline_rows.json",
-    "reports/result.json",
-)
+
+def _exit_code(value: str) -> int:
+    """Parse a portable shell exit code at the harness boundary.
+
+    The production boundary (``run_post_campaign_stage`` /
+    ``record_post_campaign_stage_status``) accepts only shell exit codes
+    ``0..255``. The reconstruction must reject impossible values before it
+    writes any fixture output so the diagnostic never runs a misleading case.
+    """
+    parsed = int(value)
+    if not 0 <= parsed <= 255:
+        raise argparse.ArgumentTypeError("exit code must be between 0 and 255")
+    return parsed
 
 
 def _write_completed_campaign_fixture(campaign_root: Path, *, soft_warning: bool) -> Path:
@@ -141,7 +150,7 @@ def reconstruct_after_fix(
             "--job-state",
             "COMPLETED",
             "--expected-artifact",
-            str(envelope_path),
+            str(summary_path),
             "--post-campaign-stage-status",
             str(envelope_path),
             "--output",
@@ -208,9 +217,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     parser.add_argument(
         "--stage-exit-code",
-        type=int,
+        type=_exit_code,
         default=5,
-        help="Exit code of the chained post-campaign stage to reproduce (job-13274: 5).",
+        help="Exit code of the chained post-campaign stage to reproduce (job-13274: 5); shell range 0..255.",
     )
     parser.add_argument(
         "--no-soft-warning",

--- a/tests/tools/test_reconstruct_job13274_exit_mapping.py
+++ b/tests/tools/test_reconstruct_job13274_exit_mapping.py
@@ -170,6 +170,7 @@ class TestJob13274ExitMappingReconstruction:
                 ]
             )
         assert exc_info.value.code == 2
+        assert not campaign_root.exists()
 
     def test_after_fix_finalizer_expects_campaign_summary_as_artifact(self, tmp_path: Path) -> None:
         """The finalizer receives the campaign summary as the campaign artifact.

--- a/tests/tools/test_reconstruct_job13274_exit_mapping.py
+++ b/tests/tools/test_reconstruct_job13274_exit_mapping.py
@@ -152,6 +152,79 @@ class TestJob13274ExitMappingReconstruction:
         assert envelope["job_exit_code"] == 0
         assert envelope["post_campaign_stage"]["exit_code"] == 5
 
+    def test_cli_rejects_out_of_range_stage_exit_code(self, tmp_path: Path) -> None:
+        """The harness boundary rejects impossible shell exit codes before any output.
+
+        The reproduction in issue #5702 shows the merged head accepted an integer
+        such as 256 at its own parser and only failed later inside the nested
+        production parser. The harness must reject it at the CLI boundary.
+        """
+        campaign_root = tmp_path / "cid"
+        with pytest.raises(SystemExit) as exc_info:
+            reconstruct_job13274_exit_mapping.main(
+                [
+                    "--campaign-root",
+                    str(campaign_root),
+                    "--stage-exit-code",
+                    "256",
+                ]
+            )
+        assert exc_info.value.code == 2
+
+    def test_after_fix_finalizer_expects_campaign_summary_as_artifact(self, tmp_path: Path) -> None:
+        """The finalizer receives the campaign summary as the campaign artifact.
+
+        Issue #5702 gap 1: the finalizer's required-artifact check must represent
+        the campaign summary/report boundary, not only the status envelope.
+        """
+        summary = self._completed_campaign_summary(tmp_path, soft_warning=True)
+        campaign_root = tmp_path / "cid"
+        after = reconstruct_job13274_exit_mapping.reconstruct_after_fix(
+            summary,
+            campaign_root,
+            campaign_exit_code=0,
+            stage_exit_code=5,
+        )
+        assert after["campaign_exit_code"] == 0
+        assert after["job_exit_code"] == 0
+        # The report must record the campaign summary as a required expected artifact
+        # and the status envelope separately, so artifact loading is observable.
+        report_path = campaign_root / "finalize.json"
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        artifact_paths = {artifact["path"] for artifact in report["artifacts"]}
+        assert summary.resolve().as_posix() in artifact_paths
+        stage_artifact = next(
+            artifact
+            for artifact in report["artifacts"]
+            if artifact["role"] == "post_campaign_stage_status"
+        )
+        assert stage_artifact["exists"] is True
+        assert report["post_campaign_stage_status"]["load_status"] == "loaded"
+
+    def test_hard_campaign_exit_preserved_through_production_boundary(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A genuinely failed campaign exit is preserved, not relabeled by the stage.
+
+        Hard-campaign-exit regression for issue #5702: a nonzero campaign exit must
+        stay the job exit code and classify the run as failed, while a coincident
+        stage failure does not hide the campaign failure behind a success.
+        """
+        summary = self._completed_campaign_summary(tmp_path, soft_warning=True)
+        campaign_root = tmp_path / "cid"
+        monkeypatch.setattr(sys, "argv", ["reconstruct_job13274_exit_mapping.py"])
+        after = reconstruct_job13274_exit_mapping.reconstruct_after_fix(
+            summary,
+            campaign_root,
+            campaign_exit_code=3,
+            stage_exit_code=5,
+        )
+        assert after["campaign_exit_code"] == 3
+        assert after["job_exit_code"] == 3
+        assert after["post_campaign_stage_exit_code"] == 5
+        assert after["finalize_classification"] == "failed"
+        assert "benchmark evidence" in after["claim_boundary"].lower()
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Hardens the job-13274 reconstruction harness (`scripts/tools/reconstruct_job13274_exit_mapping.py`) for the two gate-review gaps found on merged PR #5698 (gate findings comment on #5698):

1. **Artifact wiring (gap 1):** `reconstruct_after_fix()` previously passed only `post_campaign_stage_status.json` as the finalizer's `--expected-artifact`, so the required-artifact check never represented the campaign summary/report boundary. The finalizer now receives the campaign summary as the required campaign artifact and the status envelope as a separate required artifact. The dead `REPORT_REQUIRED_ARTIFACTS` declaration was removed.
2. **Exit-code range (gap 2):** the harness CLI accepted arbitrary integers for `--stage-exit-code` and only failed later inside the nested production parser. It now rejects values outside `0..255` at the harness boundary via a portable `_exit_code` adapter, before any fixture output is written.

## Why

The harness must model the production finalizer contract (campaign summary + status envelope as distinct required artifacts) and must never run a misleading case with an impossible shell exit code. This preserves the fail-closed `not benchmark evidence` boundary; no benchmark or paper-facing claim is introduced.

## What changed

- `scripts/tools/reconstruct_job13274_exit_mapping.py`: `--stage-exit-code` validated to `0..255`; `reconstruct_after_fix()` passes `summary_path` as the expected campaign artifact alongside the status envelope; removed dead `REPORT_REQUIRED_ARTIFACTS`.
- `tests/tools/test_reconstruct_job13274_exit_mapping.py`: added artifact-loading assertion, hard-campaign-exit regression (nonzero campaign exit preserved as `job_exit_code` and classified `failed`), and invalid-input rejection test (`--stage-exit-code 256` exits `2`).

## Validation

```
$ bash scripts/dev/run_worktree_shared_venv.sh --no-freshness-check -- python -m pytest tests/tools/test_reconstruct_job13274_exit_mapping.py -q
7 passed in 1.12s

$ bash scripts/dev/run_worktree_shared_venv.sh --no-freshness-check -- ruff check scripts/tools/reconstruct_job13274_exit_mapping.py tests/tools/test_reconstruct_job13274_exit_mapping.py
All checks passed!
$ bash scripts/dev/run_worktree_shared_venv.sh --no-freshness-check -- ruff format --check ...
2 files already formatted
```

## Successor statement

This PR fully resolves issue #5702 (both gate gaps + regressions). It does not duplicate PR #5698: it adds NEW hardening (corrected expected-artifact wiring and shell exit-code range validation at the harness boundary) on top of the already-merged reconstruction. No remaining work.

## Claim boundary

No benchmark, metric, schema, or paper-facing claim is introduced. The reconstruction preserves `job_exit_code == campaign.exit_code` and the explicit `not benchmark evidence` claim boundary when the report stage fails.

Closes #5702

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.
