### PR TITLE
Issue #5326: fix canonical-command test to prove durable-table artifact (cheap-lane worker)

### DIFF
--- a/tests/benchmark/test_adversarial_package_b_manifest_run.py
+++ b/tests/benchmark/test_adversarial_package_b_manifest_run.py
@@ -238,11 +238,17 @@ def test_issue_5326_canonical_example_command_emits_durable_table(tmp_path: Path
     copy and asserts both the JSON report and the markdown table are written with both
     objectives, the stop-rule decision, and signed-property annotations.
     """
-    # 5326 manifest reuses the same scenario/search-space/template assets as 3079.
-    shutil.copy2(
-        REPO_ROOT / "configs/adversarial/issue_5326_objective_comparison.yaml",
-        tmp_path / "configs/adversarial/issue_5326_objective_comparison.yaml",
-    )
+    # 5326 manifest references scenario-template / search-space assets relative to
+    # --repo-root; stage a repo-shaped fixture so the canonical command runs CPU-synthetic.
+    for relative_path in (
+        "configs/adversarial/issue_5326_objective_comparison.yaml",
+        "configs/adversarial/crossing_ttc_space.yaml",
+        "configs/scenarios/templates/crossing_ttc.yaml",
+    ):
+        source = REPO_ROOT / relative_path
+        target = tmp_path / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
     report_json = tmp_path / "out/report.json"
     table_md = tmp_path / "out/comparison_table.md"
 
@@ -253,6 +259,7 @@ def test_issue_5326_canonical_example_command_emits_durable_table(tmp_path: Path
         "configs/adversarial/issue_5326_objective_comparison.yaml",
         "--repo-root",
         str(tmp_path),
+        "--synthetic",
         "--out-json",
         str(report_json),
         "--out-md",


### PR DESCRIPTION
## What / Why

Issue #5326 asks for a durable comparison table (exclusions, failures, stop-rule) recording the
signed `temporal_robustness` objective vs the `worst_case_snqi` baseline under matched
simulator-call budgets. Prior merged slices built the infrastructure (PR #5333 config/runner,
#5700 durable-table renderer + orchestrator `--out-md` threading). The committed canonical-command
test `test_issue_5326_canonical_example_command_emits_durable_table` was **red on main**: it copied
the 5326 manifest to a path with no parent directory, never staged the `scenario_template` /
`search_space` assets the manifest references, and omitted `--synthetic` (so it would launch real
benchmark campaigns — out of cheap-lane scope). The test therefore never exercised the canonical
command and never proved the durable-table DoD item.

This PR fixes that test so it actually runs the committed canonical command CPU-synthetic and
asserts the JSON report + durable markdown table are produced for both objectives. **New
capability/proof, not a duplicate of prior PRs**: prior PRs added the runner capability; this proves
the committed canonical command emits the artifact end-to-end.

## Slice implemented

- `tests/benchmark/test_adversarial_package_b_manifest_run.py::test_issue_5326_canonical_example_command_emits_durable_table`:
  - Stages a repo-shaped fixture (`issue_5326_objective_comparison.yaml`, `crossing_ttc_space.yaml`,
    `crossing_ttc.yaml` template) so `--repo-root` resolution succeeds.
  - Runs with `--synthetic` (CPU, no benchmark campaigns) on the full 54-cell matrix
    (2 objectives x 3 samplers x 3 budgets x 3 seeds).
  - Asserts `report.json` + `comparison_table.md` are written, both objectives present, 54 rows,
    stop-rule present, signed-property annotations (baseline shows none).

## Validation

- `uv run pytest tests/benchmark/test_adversarial_package_b_manifest_run.py` → 12 passed
  (fixed test: 5.6s synthetic; full file 26.7s).
- `uv run ruff check` + `ruff format --check` on changed file → clean.

## Successor statement

Successor slice (requires SLURM-capable worker — out of cheap-lane scope): the full matched-budget
campaign with certification, replay, and independent-seed confirmation for random/TPE/CMA-ES-class
search, plus held-out-family yield and the durable **benchmark-tier** stop-rule comparison table.
This PR closes/validates the CPU-achievable durable-table DoD item only.

Refs #5326

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved coverage and reliability for the comparison workflow.
  - Tests now include all required repository assets when creating temporary test environments.
  - Added CPU-synthetic execution coverage to validate comparison behavior in environments without specialized hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->