### PR TITLE
Issue #5244: ledger adopts post-campaign exit-code envelope (cheap-lane worker)

### DIFF
--- a/scripts/tools/reconcile_slurm_evidence.py
+++ b/scripts/tools/reconcile_slurm_evidence.py
@@ -188,7 +188,9 @@ class FinalizerReport:
     claim_boundary: str | None
     durable_pointer: str | None
     output_pointers: tuple[str, ...]
-    source_path: str
+    exit_code_lanes: dict[str, Any] | None = None
+    post_campaign_stage_status: dict[str, Any] | None = None
+    source_path: str = ""
 
 
 @dataclass(frozen=True)
@@ -428,6 +430,53 @@ def _extract_finalizer_output_pointers(payload: dict[str, Any]) -> tuple[str, ..
     return tuple(sorted(set(pointers)))
 
 
+def _extract_exit_code_lanes(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Adopt the #5244 separated campaign/post-campaign exit lanes from a finalizer.
+
+    The ``robot-sf-slurm-job-finalization.v1`` report carries ``exit_code_lanes`` when a
+    ``post_campaign_stage_status`` envelope was supplied to the finalizer. The ledger must
+    consume these lanes rather than re-deriving status from the overall ``classification``
+    alone: a job whose campaign lane completed (exit 0) but whose post-campaign report stage
+    failed (e.g. the job-13274 exit-5 candidate) is a ``warn_success`` with an isolated
+    ``report_stage_failed`` lane, not a flat failure.
+    """
+    lanes = payload.get("exit_code_lanes")
+    if not isinstance(lanes, dict):
+        return None
+    campaign = lanes.get("campaign")
+    stage = lanes.get("post_campaign_stage")
+    job_exit_code = lanes.get("job_exit_code")
+    if not isinstance(campaign, dict) or not isinstance(stage, dict):
+        return None
+    if not isinstance(job_exit_code, int):
+        return None
+    return {
+        "campaign": {
+            "status": campaign.get("status"),
+            "exit_code": campaign.get("exit_code"),
+            "soft_contract_warning": campaign.get("soft_contract_warning", False),
+        },
+        "post_campaign_stage": {
+            "name": stage.get("name"),
+            "status": stage.get("status"),
+            "exit_code": stage.get("exit_code"),
+        },
+        "job_exit_code": job_exit_code,
+    }
+
+
+def _extract_post_campaign_stage_status(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Carry the finalizer's envelope-load metadata without re-reading the file."""
+    status = payload.get("post_campaign_stage_status")
+    if not isinstance(status, dict):
+        return None
+    return {
+        "path": status.get("path"),
+        "load_status": status.get("load_status"),
+        "error": status.get("error"),
+    }
+
+
 def _has_checksum(payload: dict[str, Any]) -> bool:
     """Return whether the payload row carries at least one checksum/checksum-like field."""
     for key in payload.keys():
@@ -483,6 +532,8 @@ def _load_finalizer_report(path: Path) -> list[FinalizerReport]:
             claim_boundary=_extract_claim_boundary(payload),
             durable_pointer=_extract_finalizer_durable_pointer(payload),
             output_pointers=_extract_finalizer_output_pointers(payload),
+            exit_code_lanes=_extract_exit_code_lanes(payload),
+            post_campaign_stage_status=_extract_post_campaign_stage_status(payload),
             source_path=str(path),
         )
     ]
@@ -652,7 +703,20 @@ def _load_evidence_from_path(path: Path) -> list[EvidenceRow]:
 def _infer_finalizer_issue_transition(
     finalizer: FinalizerReport, *, queue_status: str | None
 ) -> str:
-    """Infer issue transition target status from finalizer status and durability."""
+    """Infer issue transition target status from finalizer status and durability.
+
+    Issue #5244: when a finalizer adopted the post-campaign status envelope, a job whose
+    campaign lane completed (exit 0) but whose post-campaign report stage failed (the
+    job-13274 exit-5 candidate) is a ``warn_success`` — the rows stay usable for diagnosis
+    but are not promoted as benchmark evidence. This lane is read from ``exit_code_lanes``
+    so the ledger never relabels a completed campaign as a flat failure.
+    """
+    lanes = finalizer.exit_code_lanes
+    if lanes is not None:
+        campaign = lanes.get("campaign") or {}
+        stage = lanes.get("post_campaign_stage") or {}
+        if campaign.get("exit_code") == 0 and stage.get("exit_code") not in (0, None):
+            return "warn_success"
     if finalizer.classification == "success":
         if finalizer.artifact_status == "all_required_present":
             if finalizer.durable_pointer:
@@ -807,6 +871,30 @@ def _finalizer_rows_from_payloads(  # noqa: C901, PLR0912, PLR0915
         if not finalizer.output_pointers:
             warnings.append(f"finalizer job {finalizer.job_id}: no output pointers found")
 
+        if finalizer.exit_code_lanes is not None:
+            lanes = finalizer.exit_code_lanes
+            campaign = lanes.get("campaign") or {}
+            job_exit = lanes.get("job_exit_code")
+            if campaign.get("exit_code") != job_exit:
+                # The envelope contract requires job_exit_code == campaign.exit_code; a
+                # violated invariant means a downstream layer remapped the campaign exit and
+                # must not be trusted by the ledger.
+                warnings.append(
+                    f"finalizer job {finalizer.job_id}: envelope invariant violated "
+                    f"(job_exit_code={job_exit} != campaign.exit_code={campaign.get('exit_code')})"
+                )
+            if campaign.get("exit_code") != 0 and finalizer.classification != "failed":
+                warnings.append(
+                    f"finalizer job {finalizer.job_id}: envelope reports a failed campaign "
+                    f"(exit {campaign.get('exit_code')}) but classification is "
+                    f"'{finalizer.classification}'; treat as failed"
+                )
+
+        report_stage_status = (
+            finalizer.exit_code_lanes.get("post_campaign_stage", {}).get("status")
+            if finalizer.exit_code_lanes is not None
+            else None
+        )
         rows.append(
             {
                 "issue": finalizer.issue_number,
@@ -827,6 +915,9 @@ def _finalizer_rows_from_payloads(  # noqa: C901, PLR0912, PLR0915
                 "claim_boundary": finalizer.claim_boundary,
                 "durable_pointer": finalizer.durable_pointer,
                 "output_pointers": list(finalizer.output_pointers),
+                "exit_code_lanes": finalizer.exit_code_lanes,
+                "post_campaign_stage_status": finalizer.post_campaign_stage_status,
+                "report_stage_status": report_stage_status,
                 "issue_transition": {
                     "from": issue_transition_from,
                     "to": issue_transition_to,

--- a/tests/tools/test_reconcile_slurm_evidence.py
+++ b/tests/tools/test_reconcile_slurm_evidence.py
@@ -668,3 +668,180 @@ def test_missing_finalizer_manifest_mapping_is_reported(tmp_path: Path) -> None:
     assert any(
         "no manifest row for queue/seed linkage" in error for error in report["errors"]
     ) or any("issue 2656 not in queue" in error for error in report["warnings"])
+
+
+def test_finalizer_envelope_warn_success_isolated_report_stage(tmp_path: Path) -> None:
+    """Issue #5244: the ledger must adopt the post-campaign exit-code envelope.
+
+    A job whose campaign completed (exit 0) under ``snqi_contract.enforcement=warn`` but
+    whose post-campaign report stage failed (the job-13274 exit-5 candidate) must surface as
+    ``warn_success`` with an isolated ``report_stage_failed`` lane, not as a flat failure. The
+    envelope's campaign lane must be preserved and the downstream ``job_exit_code`` must equal
+    it.
+    """
+    payload = _queue_payload()
+    payload["entries"][0]["id"] = "issue-2656-example"
+    payload["entries"][0]["seeds"] = [201]
+    payload["entries"][0]["issue"] = 2656
+    queue_path = tmp_path / "experiments" / "submission_queue.yaml"
+    _write_yaml(queue_path, payload)
+
+    manifest_path = tmp_path / "manifests" / "one.yaml"
+    _write_yaml(
+        manifest_path,
+        _manifest_payload(
+            queue_id="issue-2656-example",
+            status="completed",
+            seeds=[201],
+            slurm_job_id=13274,
+            exp_id="exp-finalizer",
+        ),
+    )
+
+    finalizer = tmp_path / "evidence" / "finalization_13274.json"
+    _write_json(
+        finalizer,
+        {
+            "schema_version": "robot-sf-slurm-job-finalization.v1",
+            "issue_number": 2656,
+            "job_id": "13274",
+            "job_state": "COMPLETED",
+            "classification": "success",
+            "artifact_status": "all_required_present",
+            "artifacts": [
+                {
+                    "path": "output/slurm/job-13274/campaign_summary.json",
+                    "artifact_uri": "wandb-artifact://robot-sf/finalizer/job-13274:latest",
+                    "exists": True,
+                    "required": True,
+                    "kind": "file",
+                    "sha256": "deadbeef",
+                    "size_bytes": 1,
+                }
+            ],
+            "claim_boundary": (
+                "Campaign execution completed with exit 0, but the post-campaign report "
+                "stage failed with exit 5; this is not benchmark evidence until the report "
+                "is available and validated."
+            ),
+            "exit_code_lanes": {
+                "campaign": {
+                    "status": "completed",
+                    "exit_code": 0,
+                    "soft_contract_warning": True,
+                },
+                "post_campaign_stage": {
+                    "name": "headline_ci_rank_stability_report",
+                    "status": "report_stage_failed",
+                    "exit_code": 5,
+                },
+                "job_exit_code": 0,
+            },
+            "post_campaign_stage_status": {
+                "path": "output/slurm/job-13274/reports/post_campaign_stage_status.json",
+                "load_status": "loaded",
+            },
+            "durable_uri": "wandb-artifact://robot-sf/finalizer/job-13274:latest",
+        },
+    )
+
+    evidence = tmp_path / "evidence" / "seed_summary.csv"
+    _write_csv(
+        evidence,
+        ["queue_id", "seed", "job_id", "wandb_url", "claim_boundary", "run_summary_sha256"],
+        [
+            {
+                "queue_id": "issue-2656-example",
+                "seed": "201",
+                "job_id": "13274",
+                "wandb_url": "wandb-artifact://robot-sf/finalizer/job-13274:latest",
+                "claim_boundary": "warn_success_diagnostic",
+                "run_summary_sha256": "0123456789abcdef0123456789abcdef",
+            }
+        ],
+    )
+
+    report = reconcile_slurm_evidence.reconcile(
+        queue_path=queue_path,
+        submission_manifests=[manifest_path],
+        evidence_root=tmp_path / "evidence",
+        finalizer_manifests=[finalizer],
+    )
+
+    assert report["errors"] == []
+    bridge_row = report["finalizer_bridge"]["rows"][0]
+    assert bridge_row["job_id"] == "13274"
+    assert bridge_row["issue_transition"]["to"] == "warn_success"
+    assert bridge_row["report_stage_status"] == "report_stage_failed"
+    lanes = bridge_row["exit_code_lanes"]
+    assert lanes["campaign"]["exit_code"] == 0
+    assert lanes["campaign"]["soft_contract_warning"] is True
+    assert lanes["post_campaign_stage"]["exit_code"] == 5
+    assert lanes["job_exit_code"] == 0
+    assert bridge_row["post_campaign_stage_status"]["load_status"] == "loaded"
+
+
+def test_finalizer_envelope_failed_campaign_not_relabeled_as_success(tmp_path: Path) -> None:
+    """Issue #5244: a hard-failed campaign lane must keep the finalizer classification failed."""
+    payload = _queue_payload()
+    payload["entries"][0]["id"] = "issue-2656-example"
+    payload["entries"][0]["seeds"] = [202]
+    payload["entries"][0]["issue"] = 2656
+    queue_path = tmp_path / "experiments" / "submission_queue.yaml"
+    _write_yaml(queue_path, payload)
+
+    manifest_path = tmp_path / "manifests" / "one.yaml"
+    _write_yaml(
+        manifest_path,
+        _manifest_payload(
+            queue_id="issue-2656-example",
+            status="completed",
+            seeds=[202],
+            slurm_job_id=13275,
+            exp_id="exp-finalizer",
+        ),
+    )
+
+    finalizer = tmp_path / "evidence" / "finalization_13275.json"
+    _write_json(
+        finalizer,
+        {
+            "schema_version": "robot-sf-slurm-job-finalization.v1",
+            "issue_number": 2656,
+            "job_id": "13275",
+            "job_state": "COMPLETED",
+            "classification": "failed",
+            "artifact_status": "all_required_present",
+            "artifacts": [
+                {
+                    "path": "output/slurm/job-13275/campaign_summary.json",
+                    "exists": True,
+                    "required": True,
+                    "kind": "file",
+                    "sha256": "deadbeef",
+                    "size_bytes": 1,
+                }
+            ],
+            "exit_code_lanes": {
+                "campaign": {"status": "failed", "exit_code": 3, "soft_contract_warning": False},
+                "post_campaign_stage": {
+                    "name": "headline_ci_rank_stability_report",
+                    "status": "report_stage_failed",
+                    "exit_code": 5,
+                },
+                "job_exit_code": 3,
+            },
+        },
+    )
+
+    report = reconcile_slurm_evidence.reconcile(
+        queue_path=queue_path,
+        submission_manifests=[manifest_path],
+        evidence_root=tmp_path / "evidence",
+        finalizer_manifests=[finalizer],
+    )
+
+    bridge_row = report["finalizer_bridge"]["rows"][0]
+    assert bridge_row["issue_transition"]["to"] == "failed"
+    assert bridge_row["exit_code_lanes"]["campaign"]["exit_code"] == 3
+    assert bridge_row["exit_code_lanes"]["job_exit_code"] == 3


### PR DESCRIPTION
## What / Why

Issue #5244 traces the downstream exit-code remapping for soft SNQI warnings.
Prior merged PRs (#5625, #5647, #5653, #5664, #5698, #5705) built the
`robot-sf-post-campaign-stage-status.v1` envelope, the reusable stage runner, the
camera-ready/launcher adoption, the finalizer adoption, and the job-13274
reconstruction harness. The latest thread (2026-07-15) names the **remaining** open
gap as: *"inspect the private scheduler/ledger path and job-13274 trace, adopt the
envelope in production, and add the production-boundary regression."*

This slice closes the **ledger consumer** part of that gap: `slurm_job_finalize`
already emits `exit_code_lanes` from the envelope, but the ledger/reconciler
(`reconcile_slurm_evidence.py`) ignored those separated lanes and would re-derive
status from the flat `classification` alone. Now the ledger adopts the envelope.

### Changes (artifact-first)
- `reconcile_slurm_evidence._load_finalizer_report` adopts `exit_code_lanes` and
  `post_campaign_stage_status` from each finalizer report.
- The finalizer bridge row now surfaces `exit_code_lanes`, `report_stage_status`,
  and the envelope load status.
- A job whose campaign completed (exit 0) under `snqi_contract.enforcement=warn` but
  whose post-campaign report stage failed (the job-13274 exit-5 candidate) is
  classified **`warn_success`** with an isolated `report_stage_failed` lane — not a
  flat failure. The campaign lane is preserved and `job_exit_code` equals it.
- A hard-failed campaign lane (e.g. exit 3) keeps the finalizer `failed`
  classification; it is never relabeled as success by the report stage.
- Guards flag envelope-invariant violations (`job_exit_code != campaign.exit_code`)
  and a failed-campaign lane contradicting a `success` classification.

### Successor statement
This is a successor slice to issue #5244. It does **not** duplicate prior merged
PRs #5625, #5647, #5653, #5664, #5698, #5705 (which built the envelope, stage
runner, launcher/finalizer adoption, and reconstruction harness). It adds **new
capability**: the ledger consumer adopting the envelope. What remains on the parent
issue: the full job-13274 **compute-node** trace is a private-ops investigation that
requires node access and is out of scope for this cheap-lane slice.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh --no-freshness-check -- python -m pytest tests/tools/test_reconcile_slurm_evidence.py -q` → **15 passed**.
- Full related packet: `tests/tools/{test_reconcile_slurm_evidence,test_reconstruct_job13274_exit_mapping,test_slurm_job_finalize,test_run_post_campaign_stage}.py` → **49 passed**.
- `uv run ruff check` + `ruff format --check` on both changed files → all passed.

New regression tests:
- `test_finalizer_envelope_warn_success_isolated_report_stage`: job-13274-style
  completed campaign + report-stage exit 5 → `warn_success`, isolated lane,
  `job_exit_code == 0`.
- `test_finalizer_envelope_failed_campaign_not_relabeled_as_success`: hard campaign
  exit 3 + report-stage fail → `failed`, campaign lane preserved.

## Scope
- In scope (per remaining #5244 thread): adopt the envelope in the ledger consumer + production-boundary regression.
- Out of scope (remains on parent #5244): the private compute-node trace of job 13274.

Refs #5244

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.
