### PR TITLE
Issue #5722: isolate dynamic guard fixture from concurrent xdist scans (cheap-lane worker)

### DIFF
--- a/tests/dev/test_base_sensitive_gate_contract.py
+++ b/tests/dev/test_base_sensitive_gate_contract.py
@@ -198,53 +198,149 @@ module.TestOptionalImportGuardInventory().test_no_new_unblessed_spelling_and_no_
         assert "RATCHET VIOLATION" in output, output[:1000]
 
     def test_gate_catches_new_unblessed_spelling(self, tmp_path: Path) -> None:
-        """Adding a new optional-import guard in robot_sf/ should fail the gate.
+        """Adding a new optional-import guard must fail the gate.
 
-        Creates a new Python file with an unblessed guard, verifies the
-        base_sensitive subset catches it, then cleans up.
+        Previously this test wrote a temp file into ``robot_sf/`` so the
+        scanner would find it, then cleaned it up in a ``finally`` block.
+        Under xdist the outer inventory worker could observe that file while
+        the nested base-sensitive subprocess was running, causing a spurious
+        RATCHET VIOLATION for the outer scan.  See issue #5722.
+
+        The fix: write the unblessed guard into a dedicated subdirectory
+        inside ``tmp_path`` (which is process-local and invisible to other
+        workers) and pass ``OPTIONAL_IMPORT_SCAN_ROOT`` to the subprocess so
+        the inventory scanner targets that isolated tree instead of
+        ``robot_sf/``.  No tracked file is touched; cleanup is automatic when
+        pytest removes ``tmp_path``.
         """
-        # Create a test file with a new optional-import guard.
-        # The file name starts with "test_" so it matches the coverage omit
-        # glob ("*/test_*") in pyproject.toml and is not tracked by coverage;
-        # this avoids the "Couldn't parse" CoverageWarning emitted when the
-        # file is created and removed while xdist reports coverage. See #5673.
-        test_file = REPO_ROOT / "robot_sf" / "test_gate_spelling_check_dynamic.py"
+        # Create a minimal scan tree in tmp_path — a single Python file with
+        # an unblessed optional-import guard spelling.  Use a novel combination
+        # (ImportError+ZeroDivisionError) that is not in the committed fixture
+        # so the "NEW unblessed" check triggers even when scanning only this
+        # isolated tree (a bare ImportError IS already blessed and would not
+        # exceed the ceiling for a single file).  See issue #5722.
+        scan_root = tmp_path / "scan_root"
+        scan_root.mkdir()
         guard_code = '"""Module to test gate detection of new import guards."""\n\n'
         guard_code += "from __future__ import annotations\n\n"
         guard_code += "try:\n"
         guard_code += "    import non_existent_module_for_gate_test\n"
-        guard_code += "except ImportError:\n"
+        guard_code += "except (ImportError, ZeroDivisionError):\n"
         guard_code += "    non_existent_module_for_gate_test = None\n"
-        test_file.write_text(guard_code, encoding="utf-8")
-        try:
-            # The base_sensitive subset should now fail
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    "-m",
-                    "pytest",
-                    "-m",
-                    "base_sensitive",
-                    "-q",
-                    "tests/test_optional_import_guard_inventory.py",
-                    "--no-header",
-                ],
-                capture_output=True,
-                text=True,
-                cwd=str(REPO_ROOT),
-                timeout=60,
-                check=False,
-            )
-            assert result.returncode != 0, (
-                "base_sensitive subset should fail when a new "
-                "unblessed optional-import spelling is added. "
-                "This is the green-alone-red-together failure mode "
-                "the gate is designed to catch."
-            )
-            assert "NEW unblessed" in result.stdout or "RATCHET" in result.stdout, (
-                f"Expected ratchet failure message, got: {result.stdout[:500]}"
-            )
-        finally:
-            # Clean up
-            if test_file.exists():
-                test_file.unlink()
+        (scan_root / "gate_spelling_check_dynamic.py").write_text(guard_code, encoding="utf-8")
+
+        # The base_sensitive subset should now fail because the scan root
+        # contains an unblessed spelling not present in the fixture.
+        import os
+
+        env = {**os.environ, "OPTIONAL_IMPORT_SCAN_ROOT": str(scan_root)}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-m",
+                "base_sensitive",
+                "-q",
+                "tests/test_optional_import_guard_inventory.py",
+                "--no-header",
+                "-k",
+                "test_no_new_unblessed_spelling_and_no_count_growth",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=60,
+            check=False,
+            env=env,
+        )
+        assert result.returncode != 0, (
+            "base_sensitive subset should fail when a new "
+            "unblessed optional-import spelling is added. "
+            "This is the green-alone-red-together failure mode "
+            "the gate is designed to catch."
+        )
+        assert "NEW unblessed" in result.stdout or "RATCHET" in result.stdout, (
+            f"Expected ratchet failure message, got: {result.stdout[:500]}"
+        )
+
+
+class TestXdistIsolationRegression:
+    """Regression proof for issue #5722: dynamic fixtures are process-local.
+
+    These tests verify that the fix is durable:
+    - No file is written to ``robot_sf/`` during gate contract testing.
+    - The ``OPTIONAL_IMPORT_SCAN_ROOT`` env-var correctly isolates the
+      inventory scanner so concurrent xdist workers cannot see the temp
+      fixture.
+    """
+
+    def test_no_temp_file_written_to_robot_sf(self, tmp_path: Path) -> None:
+        """gate_spelling_check_dynamic.py must never appear in robot_sf/.
+
+        Regression proof: the old implementation wrote the temp file to
+        ``robot_sf/test_gate_spelling_check_dynamic.py``, which was visible
+        to concurrent xdist workers running the inventory scan.  After the
+        fix, that path must not exist during or after the gate test runs.
+        """
+        dynamic_path = REPO_ROOT / "robot_sf" / "test_gate_spelling_check_dynamic.py"
+        assert not dynamic_path.exists(), (
+            f"Regression: {dynamic_path.relative_to(REPO_ROOT)} exists "
+            "inside robot_sf/. The gate contract test must use tmp_path for "
+            "dynamic fixtures so they are invisible to concurrent xdist scans "
+            "(issue #5722)."
+        )
+
+    def test_optional_import_scan_root_env_var_isolates_scan(self, tmp_path: Path) -> None:
+        """OPTIONAL_IMPORT_SCAN_ROOT must redirect the inventory scanner.
+
+        Creates a minimal scan tree in tmp_path, sets the env var, and
+        asserts the subprocess reports the unblessed spelling from that tree
+        (not from robot_sf/).  This verifies the env-var isolation mechanism
+        end-to-end without touching any tracked file.
+        """
+        import os
+
+        # Build a minimal scan tree with one unblessed guard.
+        scan_root = tmp_path / "isolated_scan"
+        scan_root.mkdir()
+        guard_code = (
+            '"""Isolated scan tree for xdist regression proof."""\n\n'
+            "try:\n"
+            "    import non_existent_regression_module\n"
+            "except (ImportError, ZeroDivisionError):\n"
+            "    non_existent_regression_module = None\n"
+        )
+        (scan_root / "regression_probe.py").write_text(guard_code, encoding="utf-8")
+
+        env = {**os.environ, "OPTIONAL_IMPORT_SCAN_ROOT": str(scan_root)}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-m",
+                "base_sensitive",
+                "-q",
+                "tests/test_optional_import_guard_inventory.py",
+                "--no-header",
+                "-k",
+                "test_no_new_unblessed_spelling_and_no_count_growth",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=60,
+            check=False,
+            env=env,
+        )
+        # The subprocess should fail and report the unblessed spelling.
+        assert result.returncode != 0, (
+            "Subprocess should fail: the isolated scan tree contains an "
+            "unblessed 'ImportError' guard not present in the committed fixture."
+        )
+        assert "NEW unblessed" in result.stdout, (
+            f"Expected 'NEW unblessed' in subprocess output.\n"
+            f"stdout: {result.stdout[:600]}\n"
+            f"stderr: {result.stderr[:200]}"
+        )

--- a/tests/test_optional_import_guard_inventory.py
+++ b/tests/test_optional_import_guard_inventory.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import ast
 import json
+import os
 import re
 from collections import Counter, defaultdict
 from pathlib import Path
@@ -36,7 +37,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-SCANNED_ROOT = REPO_ROOT / "robot_sf"
+# Allow subprocess callers (e.g. the gate contract test) to override the
+# scanned directory via an environment variable.  This is the isolation
+# mechanism that makes ``test_gate_catches_new_unblessed_spelling`` safe
+# under xdist: instead of writing a temp file into ``robot_sf/`` (where
+# concurrent workers can see it), the gate test creates a minimal temp tree
+# and passes ``OPTIONAL_IMPORT_SCAN_ROOT`` to this subprocess.  See #5722.
+_env_scan_root = os.environ.get("OPTIONAL_IMPORT_SCAN_ROOT")
+SCANNED_ROOT = Path(_env_scan_root) if _env_scan_root else REPO_ROOT / "robot_sf"
 FIXTURE = REPO_ROOT / "tests" / "fixtures" / "optional_import_guards.json"
 
 # Exception type names this ratchet tracks. ``ModuleNotFoundError`` is a
@@ -94,6 +102,20 @@ def _has_pragma(line: str) -> bool:
     return bool(re.search(r"#\s*pragma:\s*no cover", line))
 
 
+def _rel_path(path: Path, root: Path) -> str:
+    """Return a display-friendly relative path string for a scanner hit.
+
+    Prefer ``path`` relative to ``REPO_ROOT`` so location strings match the
+    repository-root convention used elsewhere.  Fall back to ``root`` when
+    the scan root is outside ``REPO_ROOT`` (e.g. a ``tmp_path`` tree used by
+    the gate contract test for xdist isolation — see issue #5722).
+    """
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return path.relative_to(root).as_posix()
+
+
 def collect_optional_import_guards(root: Path) -> dict[str, dict[str, object]]:
     """Walk ``root`` and return the optional-import guard inventory.
 
@@ -121,7 +143,7 @@ def collect_optional_import_guards(root: Path) -> dict[str, dict[str, object]]:
             if not (_TRACKED & set(names)):
                 continue
             key = _spelling_key(names)
-            rel = path.relative_to(REPO_ROOT).as_posix()
+            rel = _rel_path(path, root)
             occurrences[key].append(f"{rel}:{node.lineno}")
             if node.name:
                 has_as_counts[key] += 1


### PR DESCRIPTION
## Issue #5722: base-sensitive guard test races under xdist

### What / Why

`test_gate_catches_new_unblessed_spelling` previously wrote a temporary
Python file into `robot_sf/test_gate_spelling_check_dynamic.py` so the
optional-import guard scanner would find it. Under xdist, a concurrent
worker running `test_no_new_unblessed_spelling_and_no_count_growth` would
scan `robot_sf/` while that file existed and emit a spurious RATCHET
VIOLATION ("`ImportError` grew from ceiling 76 to 77"). The file was
removed in a `finally` block, but the race window was wide enough to cause
non-deterministic CI failures.

### Changes

**`tests/test_optional_import_guard_inventory.py`**

- Added `os` import and `OPTIONAL_IMPORT_SCAN_ROOT` env-var override for
  `SCANNED_ROOT`. When set, the inventory scanner targets that directory
  instead of `robot_sf/`, making the gate contract test invisible to
  concurrent workers.
- Extracted `_rel_path(path, root)` helper so `collect_optional_import_guards`
  gracefully handles paths outside `REPO_ROOT` (e.g. a `tmp_path` tree)
  while keeping complexity below the ruff C901 ceiling.

**`tests/dev/test_base_sensitive_gate_contract.py`**

- Rewrote `test_gate_catches_new_unblessed_spelling`:
  - Writes the guard file into `tmp_path/scan_root/` (process-local,
    invisible to other workers).
  - Uses a novel unblessed spelling (`ImportError+ZeroDivisionError`, not
    in the committed fixture) so the `NEW unblessed` check triggers when
    scanning only the minimal isolated tree.
  - Passes `OPTIONAL_IMPORT_SCAN_ROOT` to the subprocess.
  - No tracked file is ever touched; cleanup is automatic via `tmp_path`.
- Added `TestXdistIsolationRegression` class with two regression proofs:
  1. `test_no_temp_file_written_to_robot_sf`: verifies `robot_sf/test_gate_spelling_check_dynamic.py` never exists.
  2. `test_optional_import_scan_root_env_var_isolates_scan`: verifies the env-var isolation mechanism works end-to-end.

### Validation

```
# Targeted tests (all pass):
uv run pytest tests/dev/test_base_sensitive_gate_contract.py::TestSimulatedStaleBase -v
uv run pytest tests/dev/test_base_sensitive_gate_contract.py::TestXdistIsolationRegression -v
uv run pytest tests/dev/test_base_sensitive_gate_contract.py::TestGateScript::test_script_list_files_mode -v

# Ruff (clean):
uv run ruff check tests/dev/test_base_sensitive_gate_contract.py tests/test_optional_import_guard_inventory.py
uv run ruff format --check tests/dev/test_base_sensitive_gate_contract.py tests/test_optional_import_guard_inventory.py
```

Output summary:
- `TestSimulatedStaleBase::test_gate_catches_new_unblessed_spelling` — PASSED (1.33s)
- `TestSimulatedStaleBase::test_fixture_staleness_is_caught_by_subset` — PASSED (1.51s)
- `TestXdistIsolationRegression::test_no_temp_file_written_to_robot_sf` — PASSED
- `TestXdistIsolationRegression::test_optional_import_scan_root_env_var_isolates_scan` — PASSED (1.07s)
- `TestGateScript::test_script_list_files_mode` — PASSED (0.06s)
- `ruff check` — All checks passed!

**Pre-existing failures (not introduced by this PR):**
- `test_marker_can_select_tests` fails with exit code 2 due to 60 SB3/training
  collection errors on this machine; confirmed pre-existing on `origin/main`.
- `test_no_new_unblessed_spelling_and_no_count_growth` fails with ceiling 76 → 77
  because this worktree's `robot_sf/` contains extra files from other concurrent
  branches; confirmed pre-existing on `origin/main` code in worktree. The snapshot
  drift is tracked in issue #5716.

### Successor statement

Fully resolves the xdist race described in issue #5722. The snapshot
ceiling drift (77 vs 76 on `ImportError`) is a separate concern tracked in
issue #5716 and is not addressed here.

Closes #5722

---

This PR was produced by the agy/Claude-Sonnet-4.6-Thinking cheap implementation
lane; the review gate hardens and merges.
