### PR TITLE
Issue #5307: calibration-sweep reliability curve over risk budget (cheap-lane worker)

### DIFF
--- a/configs/algos/chance_constrained_mpc_calibration_sweep_diagnostic.yaml
+++ b/configs/algos/chance_constrained_mpc_calibration_sweep_diagnostic.yaml
@@ -1,0 +1,67 @@
+# Calibration-sweep diagnostic slice for issue #5307 (cheap-lane successor slice).
+#
+# PR #5322 delivered the chance-constrained MPC control law (marginal +
+# joint_horizon Boole bounds). PR #5662 added the surrogate constant_velocity_gmm
+# provider and a *single-point* realized-risk calibration self-check. PR #5693
+# added the CVaR/tail-risk (Arm 4 branch 2) formulation. PR #5715 added the
+# minimal learned-GMM predictor scaffold.
+#
+# Issue #5307's primary measure is realized collision-risk CALIBRATION (claimed
+# vs. observed). Calibration is a *curve* over the risk budget, not a single
+# point. This config makes that curve CPU-reproducible TODAY: it sweeps
+# max_collision_risk across four budgets and across all three
+# chance-constraint formulations (marginal per-time-step, joint_horizon Boole
+# union bound, cvar_tail Conditional Value-at-Risk tail-risk) over matched
+# constant-velocity scenarios, and surfaces the issue's pre-registered stop-rule
+# observables (solver compute time vs the MPC control period, and zero-progress
+# freezing at the tightest budget) as inspection signals.
+#
+# This is NOT a calibrated forecast and NOT a benchmark claim, and it is NOT a
+# matched-arm benchmark comparison (those need the learned #2844 predictor and
+# the ops-queue campaign). The calibration_sweep sub-key is consumed by
+# build_calibration_sweep_config; everything else is the base chance-constrained
+# MPC adapter config inherited from the prior diagnostic configs.
+allow_testing_algorithms: true
+predictor_backend: constant_velocity_gmm
+allow_predictor_fallback: false
+gmm_mode_count: 1
+max_linear_speed: 0.9
+max_angular_speed: 1.1
+horizon_steps: 6
+rollout_dt: 0.25
+goal_tolerance: 0.25
+waypoint_switch_distance: 0.75
+path_goal_weight: 1.5
+terminal_goal_weight: 5.0
+heading_weight: 0.5
+control_effort_weight: 0.05
+smoothness_weight: 0.2
+pedestrian_safety_margin: 0.35
+static_obstacle_soft_weight: 1.0
+solver_ftol: 0.001
+solver_max_iterations: 40
+warm_start: true
+fallback_to_stop: true
+chance_constraint_formulation: marginal
+max_collision_risk: 0.05
+radial_quadrature_order: 6
+angular_quadrature_order: 16
+calibration_sweep:
+  # Risk budgets (max_collision_risk) swept left-to-right. The same RNG seed
+  # replays identical scenarios at every budget so claimed-vs-observed pairs are
+  # directly comparable. Defaults to (0.01, 0.05, 0.10, 0.20).
+  risk_budgets: [0.05, 0.10, 0.20]
+  # Formulations compared at matched budgets.
+  formulations: ["marginal", "joint_horizon", "cvar_tail"]
+  scenario:
+    # CPU-light reproducible grid (diagnostic self-consistency only; not a
+    # benchmark sample size). At 3 episodes x 6 steps x 3 budgets x 3
+    # formulations the full sweep completes in well under a minute on CPU.
+    num_episodes: 3
+    steps_per_episode: 6
+    dt: 0.25
+    num_pedestrians: 2
+    robot_goal_distance_m: 6.0
+    spawn_radius_m: 4.0
+    max_ped_speed_mps: 0.7
+    collision_radius_m: 0.85

--- a/robot_sf/planner/chance_constrained_mpc_provider.py
+++ b/robot_sf/planner/chance_constrained_mpc_provider.py
@@ -30,14 +30,17 @@ container is reused for every forecast this module emits.
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from dataclasses import dataclass, field
+from itertools import pairwise
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 from robot_sf.planner.chance_constrained_mpc import GaussianMixturePedestrianForecast
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from robot_sf.planner.chance_constrained_mpc import ChanceConstrainedMPCPlannerAdapter
 
 
@@ -426,8 +429,280 @@ def realized_collision_risk_calibration(
     }
 
 
+@dataclass(frozen=True)
+class CalibrationSweep:
+    """Risk-budget grid for the calibration-sweep reliability curve.
+
+    Issue #5307's primary measure is realized collision-risk CALIBRATION
+    (claimed vs. observed). Calibration is inherently a *curve* over the risk
+    budget the planner is allowed to claim, not a single point: a well-built
+    chance-constraint control law should observe a collision frequency that
+    tracks the claimed ``max_collision_risk`` as that budget is swept, and the
+    curve should be monotone non-decreasing (loosening the bound admits more
+    risk). This dataclass holds the configuration of that sweep.
+
+    The closed-loop scenarios at every budget point come from the same RNG seed,
+    so each point replays identical pedestrian spawn/motion sequences
+    (apples-to-apples across risk budgets and across chance-constraint
+    formulations).
+    """
+
+    risk_budgets: tuple[float, ...] = (0.01, 0.05, 0.10, 0.20)
+    formulations: tuple[str, ...] = ("marginal",)
+    scenario: CalibrationScenario = field(default_factory=CalibrationScenario)
+
+
+def _is_nondecreasing(values: list[float], *, atol: float = 1e-9) -> bool:
+    """True when ``values`` is monotone non-decreasing within ``atol``.
+
+    Returns:
+        ``True`` when every successive pair is non-decreasing within ``atol``.
+    """
+
+    for a, b in pairwise(values):
+        if b < a - atol:
+            return False
+    return True
+
+
+def realized_collision_risk_calibration_sweep(
+    base_algo_config: dict[str, Any] | None,
+    sweep: CalibrationSweep | None = None,
+    *,
+    adapter_builder: Callable[[dict[str, Any]], ChanceConstrainedMPCPlannerAdapter] | None = None,
+    seed: int = 0,
+) -> dict[str, object]:
+    """Issue #5307 primary measure as a calibration *curve* over the risk budget.
+
+    Sweeps ``max_collision_risk`` across a configurable budget grid and, for
+    each budget, across the requested chance-constraint formulations
+    (``marginal``, ``joint_horizon`` Boole-union bound, or ``cvar_tail``
+    Conditional Value-at-Risk tail-risk). At every grid point the planner is
+    rebuilt with the patched ``max_collision_risk`` / formulation and rolled
+    out through :func:`realized_collision_risk_calibration` over the *same*
+    matched-constant-velocity scenarios (same ``seed``), so the
+    claimed-vs-observed pairs are directly comparable across the budget and
+    across formulations.
+
+    The routine assembles the claimed-vs-observed reliability curve plus a
+    per-formulation reliability summary. The summary surfaces the issue's
+    pre-registered stop-rule *observables*: the per-step compute time against
+    the MPC control period (``stop if the solver cannot meet the control
+    period``) and the freeze rate at the tightest risk budget (``stop if
+    safety gains come with the zero-progress behavior already observed for
+    stream_gap``). These are exposed as observables for inspection, not as a
+    gate verdict: the cheap-lane slice does not make a campaign-routing
+    decision.
+
+    This slice is CPU-runnable today over the surrogate
+    ``constant_velocity_gmm`` provider. It is an API/self-consistency
+    diagnostic under matched surrogate dynamics and is **not** a benchmark
+    calibration result: replacing the surrogate with the learned ``#2844``
+    predictor is required before any matched-arm benchmark calibration claim.
+
+    Args:
+        base_algo_config: Base YAML-style config mapping for the chance
+            constrained MPC adapter. ``max_collision_risk`` and
+            ``chance_constraint_formulation`` are overridden per grid point.
+        sweep: :class:`CalibrationSweep` controlling the risk-budget grid, the
+            formulations to compare, and the closed-loop scenario. Defaults to a
+            single-formulation four-point grid over :class:`CalibrationScenario`.
+        adapter_builder: Callable that builds the planner from a config mapping;
+            defaults to lazily-imported
+            :func:`build_chance_constrained_mpc_adapter`. Injected for testability.
+        seed: RNG seed shared across every grid point so the same scenario
+            sequence replays at every budget and formulation.
+
+    Returns:
+        Mapping with ``sweep`` (grid + seed + scenario provenance), ``points``
+        (flat list of per-budget-per-formulation calibration records), ``points_by_formulation``
+        (grouped), and ``reliability_summary`` (per-formulation curve statistics and
+        stop-rule observables). A ``claim_boundary`` marks the diagnostic scope.
+
+    Raises:
+        ValueError: If the budget grid is empty, any budget is outside ``(0, 1)``,
+            the formulation list is empty, or a formulation is not one of
+            ``marginal``/``joint_horizon``/``cvar_tail``.
+    """
+
+    sweep = sweep or CalibrationSweep()
+    if adapter_builder is None:
+        from robot_sf.planner.chance_constrained_mpc import (  # noqa: PLC0415
+            build_chance_constrained_mpc_adapter,
+        )
+
+        adapter_builder = build_chance_constrained_mpc_adapter
+
+    budgets: tuple[float, ...] = tuple(float(b) for b in sweep.risk_budgets)
+    if not budgets:
+        raise ValueError("CalibrationSweep.risk_budgets must be non-empty")
+    if not all(0.0 < b < 1.0 for b in budgets):
+        raise ValueError("CalibrationSweep.risk_budgets must lie in (0, 1)")
+
+    valid_formulations = {"marginal", "joint_horizon", "cvar_tail"}
+    formulations = tuple(str(f) for f in sweep.formulations)
+    if not formulations:
+        raise ValueError("CalibrationSweep.formulations must be non-empty")
+    unsupported = [f for f in formulations if f not in valid_formulations]
+    if unsupported:
+        raise ValueError(
+            f"Unsupported formulation(s) {unsupported!r}; "
+            f"expected one of {sorted(valid_formulations)}"
+        )
+
+    base = dict(base_algo_config or {})
+    base.setdefault("predictor_backend", "constant_velocity_gmm")
+
+    scenario = sweep.scenario
+    control_period_ms = float(scenario.dt) * 1000.0
+
+    points_by_formulation: dict[str, list[dict[str, Any]]] = {}
+    for formulation in formulations:
+        points: list[dict[str, Any]] = []
+        for budget in budgets:
+            cfg = dict(base)
+            cfg["max_collision_risk"] = float(budget)
+            cfg["chance_constraint_formulation"] = formulation
+            planner = adapter_builder(cfg)
+            result = realized_collision_risk_calibration(planner, scenario, seed=seed)
+            point = {
+                "formulation": formulation,
+                "claimed_risk": float(budget),
+                "observed_collision_rate": float(result["observed_collision_rate"]),
+                "calibration_error": float(result["calibration_error"]),
+                "freeze_rate": float(result["freeze_rate"]),
+                "infeasible_rate": float(result["infeasible_rate"]),
+                "completion_rate": float(result["completion_rate"]),
+                "mean_tail_clearance_m": float(result["mean_tail_clearance_m"]),
+                "mean_compute_time_ms": float(result["mean_compute_time_ms"]),
+                "sample_count": float(result["sample_count"]),
+            }
+            points.append(point)
+        points_by_formulation[formulation] = points
+
+    reliability_summary: dict[str, dict[str, Any]] = {}
+    for formulation, points in points_by_formulation.items():
+        abs_errors = [abs(float(p["calibration_error"])) for p in points]
+        observed = [float(p["observed_collision_rate"]) for p in points]
+        compute_times = [float(p["mean_compute_time_ms"]) for p in points]
+        freeze_rates = [float(p["freeze_rate"]) for p in points]
+        # The tightest (lowest) budget sits first because budgets sweep small->large.
+        freeze_at_tightest = freeze_rates[0] if freeze_rates else 0.0
+        reliability_summary[formulation] = {
+            "mean_abs_calibration_error": float(np.mean(abs_errors))
+            if abs_errors
+            else float("nan"),
+            "max_abs_calibration_error": float(np.max(abs_errors)) if abs_errors else float("nan"),
+            # A well-calibrated risk bound should make observed collision rate
+            # rise with the claimed budget; a non-monotone curve, beyond
+            # sparse-sample noise, signals that the bound is not translating to
+            # realized risk (a calibration defect the issue asks to surface).
+            "observed_monotone_non_decreasing_in_claimed": bool(_is_nondecreasing(observed)),
+            # Issue #5307 pre-registered stop rules, surfaced as observables
+            # (not a routing decision): compute time vs the MPC control period,
+            # and zero-progress freeze at the tightest budget.
+            "control_period_ms": float(control_period_ms),
+            "max_per_step_compute_time_ms": float(np.max(compute_times))
+            if compute_times
+            else float("nan"),
+            "compute_exceeds_control_period": bool(
+                bool(compute_times) and float(np.max(compute_times)) > control_period_ms
+            ),
+            "freeze_rate_at_tightest_budget": float(freeze_at_tightest),
+        }
+
+    all_points = [p for pts in points_by_formulation.values() for p in pts]
+    return {
+        "sweep": {
+            "risk_budgets": list(budgets),
+            "formulations": list(formulations),
+            "seed": int(seed),
+            "scenario": {
+                "num_episodes": int(scenario.num_episodes),
+                "steps_per_episode": int(scenario.steps_per_episode),
+                "dt": float(scenario.dt),
+                "num_pedestrians": int(scenario.num_pedestrians),
+                "robot_goal_distance_m": float(scenario.robot_goal_distance_m),
+                "spawn_radius_m": float(scenario.spawn_radius_m),
+                "max_ped_speed_mps": float(scenario.max_ped_speed_mps),
+                "collision_radius_m": float(scenario.collision_radius_m),
+            },
+        },
+        "points": all_points,
+        "points_by_formulation": points_by_formulation,
+        "reliability_summary": reliability_summary,
+        "claim_boundary": (
+            "closed-loop self-consistency calibration curve under matched "
+            "constant-velocity surrogate dynamics; not a matched-arm benchmark "
+            "calibration result and makes no planner-value or real-world risk "
+            "claim; replace the surrogate with the learned #2844 predictor and "
+            "run the ops-queue campaign before any benchmark-facing calibration "
+            "or planner-superiority claim"
+        ),
+    }
+
+
+def build_calibration_sweep_config(
+    raw: dict[str, Any] | None,
+) -> tuple[dict[str, Any], CalibrationSweep]:
+    """Split a sweep YAML into the base adapter config and the sweep grid.
+
+    The config-first reproducibility contract (``configs/`` carries stable
+    experiments) is kept by letting a single YAML describe both the base
+    chance-constrained MPC settings and the calibration-sweep grid. The
+    optional ``calibration_sweep`` mapping carries ``risk_budgets`` and
+    ``formulations``; everything else is forwarded as the base ``algo`` config.
+
+    Args:
+        raw: Parsed YAML mapping. If ``calibration_sweep`` is absent the default
+            :class:`CalibrationSweep` is used and the whole mapping is treated
+            as the base config.
+
+    Returns:
+        ``(base_algo_config, sweep)``: the base adapter config (with the
+        ``calibration_sweep`` sub-key removed) and the parsed sweep grid.
+    """
+
+    src = dict(raw or {})
+    sweep_raw = src.pop("calibration_sweep", None) or {}
+    budgets_raw = sweep_raw.get("risk_budgets")
+    if budgets_raw is None:
+        risk_budgets: tuple[float, ...] = CalibrationSweep().risk_budgets
+    else:
+        risk_budgets = tuple(float(b) for b in budgets_raw)
+    formulations_raw = sweep_raw.get("formulations")
+    if formulations_raw is None:
+        formulations: tuple[str, ...] = CalibrationSweep().formulations
+    else:
+        formulations = tuple(str(f) for f in formulations_raw)
+    scenario_raw = sweep_raw.get("scenario") or {}
+    scenario_kwargs: dict[str, Any] = {}
+    for key in (
+        "num_episodes",
+        "steps_per_episode",
+        "dt",
+        "num_pedestrians",
+        "robot_goal_distance_m",
+        "spawn_radius_m",
+        "max_ped_speed_mps",
+        "collision_radius_m",
+    ):
+        if key in scenario_raw:
+            scenario_kwargs[key] = scenario_raw[key]
+    scenario = CalibrationScenario(**scenario_kwargs)  # type: ignore[arg-type]
+    sweep = CalibrationSweep(
+        risk_budgets=risk_budgets,
+        formulations=formulations,
+        scenario=scenario,
+    )
+    return src, sweep
+
+
 __all__ = [
+    "CalibrationSweep",
     "ConstantVelocityGmmPredictor",
+    "build_calibration_sweep_config",
     "build_constant_velocity_gmm_forecast",
     "realized_collision_risk_calibration",
+    "realized_collision_risk_calibration_sweep",
 ]

--- a/tests/planner/test_chance_constrained_mpc_provider.py
+++ b/tests/planner/test_chance_constrained_mpc_provider.py
@@ -28,10 +28,13 @@ from robot_sf.planner.chance_constrained_mpc import (
 )
 from robot_sf.planner.chance_constrained_mpc_provider import (
     CalibrationScenario,
+    CalibrationSweep,
     ConstantVelocityGmmPredictor,
     _min_robot_pedestrian_clearance,
+    build_calibration_sweep_config,
     build_constant_velocity_gmm_forecast,
     realized_collision_risk_calibration,
+    realized_collision_risk_calibration_sweep,
 )
 
 
@@ -295,3 +298,187 @@ def test_calibration_integrates_robot_command_and_declared_collision_radius() ->
     assert _min_robot_pedestrian_clearance(observation, collision_radius_m=0.5) == pytest.approx(
         0.3
     )
+
+
+def _light_sweep() -> tuple[dict, CalibrationSweep]:
+    """Compact sweep config used by the calibration-curve tests."""
+
+    base_algo_config = {
+        "predictor_backend": "constant_velocity_gmm",
+        "horizon_steps": 6,
+        "solver_max_iterations": 20,
+    }
+    sweep = CalibrationSweep(
+        risk_budgets=(0.05, 0.10, 0.20),
+        formulations=("marginal",),
+        scenario=CalibrationScenario(num_episodes=3, steps_per_episode=6, num_pedestrians=2),
+    )
+    return base_algo_config, sweep
+
+
+def test_calibration_sweep_returns_claimed_vs_observed_curve_across_budgets() -> None:
+    """Issue #5307 primary measure as a *curve*: pair claimed risk with observed.
+
+    The sweep rebuilds the planner per risk budget and rolls out over the same
+    matched scenarios (shared seed), assembling one claimed-vs-observed record
+    per budget point. This is the calibration reliability curve, not a single
+    point, and is new capability relative to the single-point PR #5662 harness.
+    """
+
+    base_algo_config, sweep = _light_sweep()
+    result = realized_collision_risk_calibration_sweep(base_algo_config, sweep, seed=1)
+    assert result["sweep"]["risk_budgets"] == [0.05, 0.10, 0.20]
+    assert result["sweep"]["formulations"] == ["marginal"]
+    assert result["sweep"]["seed"] == 1
+    points = result["points"]
+    assert len(points) == 3
+    claimed = [p["claimed_risk"] for p in points]
+    assert claimed == [0.05, 0.10, 0.20]
+    for point, budget in zip(points, sweep.risk_budgets, strict=True):
+        assert point["formulation"] == "marginal"
+        assert point["claimed_risk"] == pytest.approx(float(budget))
+        # calibration_error is the issue's primary measure: observed - claimed.
+        assert point["calibration_error"] == pytest.approx(
+            point["observed_collision_rate"] - point["claimed_risk"]
+        )
+        assert 0.0 <= point["observed_collision_rate"] <= 1.0
+        assert 0.0 <= point["freeze_rate"] <= 1.0
+        assert 0.0 <= point["infeasible_rate"] <= 1.0
+        assert 0.0 <= point["completion_rate"] <= 1.0
+        assert point["sample_count"] == pytest.approx(float(sweep.scenario.num_episodes))
+
+
+def test_calibration_sweep_compares_formulations_at_matched_budgets() -> None:
+    """All three chance-constraint formulations compare at matched budgets."""
+
+    base_algo_config, sweep = _light_sweep()
+    sweep = CalibrationSweep(
+        risk_budgets=sweep.risk_budgets,
+        formulations=("marginal", "joint_horizon", "cvar_tail"),
+        scenario=sweep.scenario,
+    )
+    result = realized_collision_risk_calibration_sweep(base_algo_config, sweep, seed=2)
+    by_formulation = result["points_by_formulation"]
+    assert set(by_formulation) == {"marginal", "joint_horizon", "cvar_tail"}
+    assert len(result["points"]) == 3 * 3
+    # Each formulation has one point per budget, grouped in budget order.
+    for formulation, points in by_formulation.items():
+        assert [p["claimed_risk"] for p in points] == [0.05, 0.10, 0.20]
+        assert all(p["formulation"] == formulation for p in points)
+
+
+def test_calibration_sweep_replays_same_scenarios_across_budgets() -> None:
+    """A shared seed replays identical scenarios across budgets (apples-to-apples).
+
+    Because every budget point re-seeds its closed-loop RNG with the same seed,
+    two sweeps over the same budgets and seed must reproduce the exact observed
+    curve, and the underlying single-point harness at matched budget/seed must
+    match the sweep point. This is the reproducibility contract that makes the
+    claimed-vs-observed curve directly comparable across budgets.
+    """
+
+    base_algo_config, sweep = _light_sweep()
+    first = realized_collision_risk_calibration_sweep(base_algo_config, sweep, seed=11)
+    second = realized_collision_risk_calibration_sweep(base_algo_config, sweep, seed=11)
+    first_observed = [p["observed_collision_rate"] for p in first["points"]]
+    second_observed = [p["observed_collision_rate"] for p in second["points"]]
+    assert first_observed == second_observed
+
+    # The sweep point at a given budget must equal a direct single-point run.
+    adapter = build_chance_constrained_mpc_adapter(
+        {
+            **base_algo_config,
+            "max_collision_risk": sweep.risk_budgets[1],
+            "chance_constraint_formulation": "marginal",
+        }
+    )
+    direct = realized_collision_risk_calibration(adapter, sweep.scenario, seed=11)
+    sweep_point = first["points_by_formulation"]["marginal"][1]
+    assert sweep_point["observed_collision_rate"] == pytest.approx(
+        direct["observed_collision_rate"]
+    )
+    assert sweep_point["calibration_error"] == pytest.approx(direct["calibration_error"])
+
+
+def test_calibration_sweep_reliability_summary_reports_stop_rule_observables() -> None:
+    """The issue's pre-registered stop rules surface as observables per formulation.
+
+    The summary reports whether observed collision rate rises monotonically with
+    the claimed risk budget (a reliability/curve-defect signal), the per-step
+    compute time against the MPC control period (``stop if the solver cannot meet
+    the control period``), and the freeze rate at the tightest budget
+    (``stop if safety gains come with the zero-progress behavior seen for
+    stream_gap``). These are inspection observables, not a routing verdict.
+    """
+
+    base_algo_config, sweep = _light_sweep()
+    result = realized_collision_risk_calibration_sweep(base_algo_config, sweep, seed=3)
+    summary = result["reliability_summary"]["marginal"]
+    assert isinstance(summary["observed_monotone_non_decreasing_in_claimed"], bool)
+    assert summary["control_period_ms"] == pytest.approx(float(sweep.scenario.dt) * 1000.0)
+    assert 0.0 <= summary["max_abs_calibration_error"] <= 1.0
+    assert summary["max_per_step_compute_time_ms"] >= 0.0
+    assert isinstance(summary["compute_exceeds_control_period"], bool)
+    assert summary["freeze_rate_at_tightest_budget"] >= 0.0
+
+
+def test_calibration_sweep_rejects_invalid_budgets_and_formulations() -> None:
+    """The sweep grid validates budget range and formulation names up front."""
+
+    base_algo_config, _ = _light_sweep()
+    bad_budgets = CalibrationSweep(
+        risk_budgets=(0.0, 0.5),
+        formulations=("marginal",),
+    )
+    with pytest.raises(ValueError, match="risk_budgets must lie in"):
+        realized_collision_risk_calibration_sweep(base_algo_config, bad_budgets, seed=0)
+
+    empty_budgets = CalibrationSweep(
+        risk_budgets=(),
+        formulations=("marginal",),
+    )
+    with pytest.raises(ValueError, match="risk_budgets must be non-empty"):
+        realized_collision_risk_calibration_sweep(base_algo_config, empty_budgets, seed=0)
+
+    bad_formulations = CalibrationSweep(
+        risk_budgets=(0.05, 0.10),
+        formulations=("not_a_formulation",),
+    )
+    with pytest.raises(ValueError, match="Unsupported formulation"):
+        realized_collision_risk_calibration_sweep(base_algo_config, bad_formulations, seed=0)
+
+
+def test_calibration_sweep_yaml_config_runs_end_to_end() -> None:
+    """The shipped sweep config parses into base+grid and produces a finite curve."""
+
+    config_path = (
+        Path(__file__).resolve().parents[2]
+        / "configs"
+        / "algos"
+        / "chance_constrained_mpc_calibration_sweep_diagnostic.yaml"
+    )
+    base, sweep = build_calibration_sweep_config(yaml.safe_load(config_path.read_text()))
+    assert base["predictor_backend"] == "constant_velocity_gmm"
+    assert "calibration_sweep" not in base
+    assert sweep.risk_budgets == (0.05, 0.10, 0.20)
+    assert sweep.formulations == ("marginal", "joint_horizon", "cvar_tail")
+
+    result = realized_collision_risk_calibration_sweep(base, sweep, seed=0)
+    assert len(result["points"]) == 3 * 3
+    for point in result["points"]:
+        assert np.isfinite(point["observed_collision_rate"])
+        assert np.isfinite(point["mean_compute_time_ms"])
+    assert set(result["reliability_summary"]) == {
+        "marginal",
+        "joint_horizon",
+        "cvar_tail",
+    }
+
+
+def test_build_calibration_sweep_config_defaults_when_subkey_absent() -> None:
+    """Without a calibration_sweep sub-key the grid falls back to defaults."""
+
+    base, sweep = build_calibration_sweep_config({"predictor_backend": "constant_velocity_gmm"})
+    assert base == {"predictor_backend": "constant_velocity_gmm"}
+    assert sweep.risk_budgets == CalibrationSweep().risk_budgets
+    assert sweep.formulations == CalibrationSweep().formulations


### PR DESCRIPTION
### Reviewer-critical summary

**Successor slice.** PR #5662 delivered issue #5307's primary measure — realized
collision-risk CALIBRATION (claimed vs. observed) — as a **single-point** reading
(`realized_collision_risk_calibration`). PR #5693 added the `cvar_tail` Arm 4
formulation. PR #5715 added the minimal learned-GMM predictor scaffold. The
issue's remaining open items (matched-arm benchmark comparison, cross-arm
calibration evidence, trained-model integration) all require the learned #2844
predictor and an ops-queue campaign — genuinely outside a single CPU
implementation session.

This slice adds **NEW capability** that does not duplicate any prior PR: it
realizes the primary measure as a **calibration *curve*** over the risk budget
rather than a single point, which is what "calibration" actually is.

**Does not duplicate:**
- PR #5322: `marginal` + `joint_horizon` control law + `GaussianMixturePedestrianPredictor` boundary.
- PR #5662: surrogate `constant_velocity_gmm` provider + **single-point** `realized_collision_risk_calibration` harness.
- PR #5693: `cvar_tail` (Arm 4 branch 2) formulation.
- PR #5715: minimal `learned_gmm` predictor scaffold.
- **This PR:** calibration-sweep reliability curve over the risk budget, across budget grid and across all three formulations, with the issue's pre-registered stop-rule observables surfaced per formulation.

### What changed

- `robot_sf/planner/chance_constrained_mpc_provider.py`:
  - New `CalibrationSweep` dataclass: risk-budget grid + formulations + scenario.
  - `realized_collision_risk_calibration_sweep`: sweeps `max_collision_risk`
    across a configurable budget grid and across
    `marginal` / `joint_horizon` / `cvar_tail`. At every grid point the planner
    is rebuilt with the patched config and rolled out through the existing
    `realized_collision_risk_calibration` over the **same** matched scenarios
    (shared `seed`), so claimed-vs-observed pairs are directly comparable across
    budgets and across formulations. Assembles the claimed-vs-observed
    reliability curve plus a per-formulation reliability summary.
  - The reliability summary surfaces issue #5307's **pre-registered stop-rule
    observables** as inspection signals (not a routing verdict): per-step
    compute time vs the MPC control period (`stop if the solver cannot meet the
    control period`) and the freeze rate at the tightest budget (`stop if safety
    gains come with the zero-progress behavior already observed for stream_gap`),
    plus `observed_monotone_non_decreasing_in_claimed` (a well-calibrated bound
    should make observed collision rate rise with the claimed budget) and
    mean/max abs calibration error.
  - `build_calibration_sweep_config`: config-first helper that splits a single
    YAML into the base adapter config and the `CalibrationSweep` grid.
- `configs/algos/chance_constrained_mpc_calibration_sweep_diagnostic.yaml`:
  reproducible CPU diagnostic config exercising the sweep over three budgets ×
  three formulations on a CPU-light scenario grid.
- `tests/planner/test_chance_constrained_mpc_provider.py`: 7 new focused tests
  (curve-across-budgets, cross-formulation comparison, same-scenario replay
  reproducibility + sweep-point-equals-single-point, stop-rule observables,
  invalid budget/formulation validation, YAML parse + end-to-end run, config
  default fallback).

### Why now

The claimed-vs-observed calibration *curve* across the risk budget is the
substantive realization of issue #5307's primary measure, and it is achievable on
CPU today over the PR #5662 surrogate `constant_velocity_gmm` provider without
waiting for #2844. A single-point reading under-determines calibration: it
cannot show whether observed collision frequency tracks the claimed bound as the
budget is loosened, nor whether the curve is monotone. The sweep fills that gap
as an artifact (a reliability curve), not as another readiness/decision/checker
packet.

### Validation Output

New focused sweep tests (`-k "sweep or build_calibration"`):
```
tests/planner/test_chance_constrained_mpc_provider.py ........................ 7 passed in 60.46s
```
All under the 20s soft threshold; YAML end-to-end at 18.54s.

Full provider test file (12 existing + 7 new), all passing, all under soft 20s:
```
tests/planner/test_chance_constrained_mpc_provider.py .................. 19 passed in 101.82s
  slowest: test_calibration_sweep_yaml_config_runs_end_to_end 18.54s
           test_calibration_is_reproducible_under_fixed_seed 17.80s
           test_calibration_closes_loop_over_the_planners_claimed_risk 15.11s
           test_calibration_sweep_compares_formulations_at_matched_budgets 14.78s
```

Neighbor test files unchanged behavior:
```
tests/planner/test_chance_constrained_mpc.py .............................. 18 passed in 2.43s
tests/planner/test_learned_gmm_predictor.py + test_chance_constrained_mpc.py 51 passed in 4.40s
```

Lint/format clean on all changed files:
```
ruff check robot_sf/planner/chance_constrained_mpc_provider.py tests/planner/test_chance_constrained_mpc_provider.py
=> All checks passed!
ruff format --check <changed files>
=> already formatted
```

Validation was run in a fresh worktree-local `.venv` bootstrapped per AGENTS.md
(`uv venv .venv && uv sync --all-extras`); the shared-venv path failed because
the main checkout's editable install pins `robot_sf` to an older commit than
this worktree's head, so conftest collection broke. The local `.venv` imports
the worktree's own `robot_sf` (verified).

### Claim Boundary

Diagnostic / self-consistency only, under matched constant-velocity **surrogate**
dynamics. This is explicitly **NOT** a matched-arm benchmark calibration result
and makes **no** planner-value or real-world risk claim. The surrogate is not a
calibrated forecast. Replacing the surrogate with the learned #2844 predictor and
running the ops-queue campaign is required before any benchmark-facing
calibration or planner-superiority claim. The stop-rule observables in the
reliability summary are inspection signals, not a campaign-routing decision.

### Remaining Tasks (tracked, not closed by this PR; do not close #5307)

- Matched-arm benchmark comparison campaign — parent issue #5307; needs #2844 + ops queue.
- Full cross-arm calibration evidence (vs. CV / deterministic-envelope arms 1-2) — parent issue #5307; needs #2844 + ops queue.
- Trained-model integration — depends on issue #2844.

This PR was produced by the OpenCode-Go/GLM-5.2 cheap implementation lane; the review gate hardens and merges.

Refs #5307. Successor slice: calibration-sweep reliability curve over the risk budget; does not duplicate PR #5322, #5662, #5693, or #5715.

### Artifact / output handling

`output/`: NA — no campaign, no SLURM, no training, no benchmark artifacts
produced; the only generated outputs are in-test in-memory calibration result
dicts. Nothing to promote to durable storage. Downstream propagation: NA
(diagnostic-only slice, no research claim).


### Gate follow-up

The gate records the diagnostic risk/observation units explicitly: the configured planner risk budget is per horizon while the current observed rate is episode-level. This is not benchmark calibration evidence; alignment is tracked in [follow-up issue #5737](https://github.com/ll7/robot_sf_ll7/issues/5737).

Refs #5737.