### PR TITLE
fix: align issue-3216 wrapper fixture argv boundary (#5725)

### DIFF
--- a/tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py
@@ -617,24 +617,6 @@ case "${1:-}" in
     ;;
   scripts/tools/run_post_campaign_stage.py)
     _original_args=("$@")
-    stage_campaign=""
-    shift 2
-    while [ "${1:-}" != "--stage-command" ] && [ "$#" -gt 0 ]; do
-      case "${1:-}" in
-        --campaign-summary) shift 2 ;;
-        --campaign-exit-code) shift 2 ;;
-        --stage-name) shift 2 ;;
-        --output) shift 2 ;;
-        *) shift ;;
-      esac
-    done
-    shift
-    while [ "$#" -gt 0 ]; do
-      case "${1:-}" in
-        --campaign) stage_campaign="$2"; shift 2 ;;
-        *) shift ;;
-      esac
-    done
     if [ "${STATUS_RECORDER_EXIT:-0}" -ne 0 ]; then
       exit "$STATUS_RECORDER_EXIT"
     fi
@@ -759,8 +741,6 @@ JSON
     ;;
   scripts/tools/run_post_campaign_stage.py)
     _orig_args=("$@")
-    shift 2
-    export PYTHONPATH="$(pwd):${PYTHONPATH:-}"
     exec python "${_orig_args[@]}"
     ;;
   *) exit 98 ;;


### PR DESCRIPTION
## Reviewer-critical summary

- What changed: removed dead `shift`-based parsing from both issue-3216 `uv` fixture branches so the original argv reaches `run_post_campaign_stage.py` unchanged.
- Why now: the fixture must preserve the production `--stage-command` boundary; otherwise the stage command's `--campaign` token can be treated as an unsupported stage-runner option.
- Claim boundary: this is a test-fixture contract cleanup only; production wrapper behavior and benchmark metric semantics are unchanged.
- Required validation: the complete issue-3216 test file passes (25 tests), and Ruff plus `git diff --check` pass.
- Remaining blocker: the broader readiness gate is blocked by pre-existing optional-import snapshot drift tracked in [#5718](https://github.com/ll7/robot_sf_ll7/issues/5718), outside this PR's changed files.

## Contract delta

- New schema fields: none.
- New fail-closed blockers: none.
- Compatibility impact: test-only. The fixture now delegates argument-boundary handling to `run_post_campaign_stage.py` and no longer reparses the nested stage command.

Closes #5725

## Scope and evidence

Issue: https://github.com/ll7/robot_sf_ll7/issues/5725

This is the smallest reversible implementation of the issue-3216 wrapper-fixture contract identified in the merged #5717 review: preserve the full production argv and remove unused fixture-side parsing. The two affected parametrized wrapper paths retain coverage for successful envelope writing and status-recorder failure.

Validation results:

- `uv run pytest tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py -q` — exit 0, 25 passed.
- `uv run ruff check tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py` — exit 0.
- `git diff --check` — exit 0.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — exit 1 after 2,428 tests passed; unchanged base-sensitive inventory reports `ModuleNotFoundError: snapshot=6 observed=7`, already tracked by #5718. The focused issue-3216 tests pass independently after this gate result.

No issue comment was posted because this execution is explicitly unauthorized to comment on issues or PRs; this PR is the durable state handoff. Friction found during implementation is tracked in [#5729](https://github.com/ll7/robot_sf_ll7/issues/5729).

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

<details>
<summary>Governance appendix</summary>

Research result guidance: NA — this PR changes only a benchmark test fixture and makes no research, metric, or paper-facing claim.

Artifact handling: no generated benchmark artifacts or model files were added; readiness logs remain in the worktree-local/common Git-dir agent-run area.

Downstream propagation: not applicable because no benchmark result, schema, model provenance, registry, or paper-facing surface changed.

</details>
