### PR TITLE
Issue #5326: add SLURM submission wrapper and config validation tests (cheap-lane worker)

### DIFF
--- a/scripts/benchmark/submit_issue_5326_campaign.sh
+++ b/scripts/benchmark/submit_issue_5326_campaign.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# SLURM submission wrapper for issue #5326 temporal-robustness objective comparison.
+# This script submits the matched-budget campaign comparing temporal_robustness vs worst_case_snqi.
+#
+# Usage:
+#   ./scripts/benchmark/submit_issue_5326_campaign.sh [--dry-run]
+#
+# Prerequisites:
+#   - PR #5325 merged (temporal_robustness objective available)
+#   - PR #5714 merged (CMA-ES sampler wired)
+#   - SLURM access on cluster
+#
+# Campaign contract:
+#   - Objectives: worst_case_snqi, temporal_robustness
+#   - Budgets: 16, 32, 64 (Package-B grid)
+#   - Seeds: 1101, 2202, 3303
+#   - Samplers: random, coordinate, optuna
+#   - Output: output/adversarial/issue_5326_objective_comparison/
+
+set -euo pipefail
+
+DRY_RUN="${1:-}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CONFIG_PATH="${REPO_ROOT}/configs/adversarial/issue_5326_objective_comparison.yaml"
+OUTPUT_DIR="${REPO_ROOT}/output/adversarial/issue_5326_objective_comparison"
+RUNNER="${REPO_ROOT}/scripts/tools/compare_adversarial_samplers.py"
+
+if [[ ! -f "${CONFIG_PATH}" ]]; then
+    echo "ERROR: Config not found: ${CONFIG_PATH}" >&2
+    exit 1
+fi
+
+if [[ ! -f "${RUNNER}" ]]; then
+    echo "ERROR: Runner script not found: ${RUNNER}" >&2
+    exit 1
+fi
+
+# SLURM parameters tuned for adversarial search campaigns
+# Each job runs one objective-sampler-budget-seed combination
+SLURM_TIME="4:00:00"
+SLURM_MEM="8G"
+SLURM_CPUS="4"
+SLURM_PARTITION="gpu"
+
+COMMAND=(
+    "uv" "run" "python" "${RUNNER}"
+    "--objective" "worst_case_snqi"
+    "--objective" "temporal_robustness"
+    "--package-b-budget-grid"
+    "--seed" "1101" "--seed" "2202" "--seed" "3303"
+    "--output-dir" "${OUTPUT_DIR}"
+    "--out-json" "${OUTPUT_DIR}/report.json"
+)
+
+if [[ -n "${DRY_RUN}" ]]; then
+    echo "=== DRY RUN MODE ==="
+    echo "Config: ${CONFIG_PATH}"
+    echo "Output: ${OUTPUT_DIR}"
+    echo "Command:"
+    printf '  %s\n' "${COMMAND[@]}"
+    echo ""
+    echo "To submit, run without --dry-run:"
+    echo "  ./scripts/benchmark/submit_issue_5326_campaign.sh"
+    exit 0
+fi
+
+# Submit as SLURM job array
+# Each array element handles one objective-sampler-budget-seed tuple
+# For simplicity, submit as single job that runs full grid
+sbatch <<SLURM_EOF
+#!/bin/bash
+#SBATCH --job-name=issue_5326_obj_cmp
+#SBATCH --partition=${SLURM_PARTITION}
+#SBATCH --time=${SLURM_TIME}
+#SBATCH --mem=${SLURM_MEM}
+#SBATCH --cpus-per-task=${SLURM_CPUS}
+#SBATCH --output=${OUTPUT_DIR}/slurm-%j.out
+#SBATCH --error=${OUTPUT_DIR}/slurm-%j.err
+
+set -euo pipefail
+cd "${REPO_ROOT}"
+source .venv/bin/activate
+echo "Starting issue #5326 objective comparison campaign"
+echo "Config: ${CONFIG_PATH}"
+echo "Output: ${OUTPUT_DIR}"
+echo "Started at: \$(date -Iseconds)"
+
+"${COMMAND[@]}"
+
+echo "Completed at: \$(date -Iseconds)"
+SLURM_EOF
+
+echo "Submitted SLURM job for issue #5326 campaign"
+echo "Output directory: ${OUTPUT_DIR}"
+echo "Monitor with: sbatch --qos=debug --wrap 'squeue -u \$USER -o \"%.10i %.9P %.20j %.8T %.10M %.8l %.6D %.20S\"'"

--- a/scripts/benchmark/submit_issue_5326_campaign.sh
+++ b/scripts/benchmark/submit_issue_5326_campaign.sh
@@ -19,11 +19,22 @@
 
 set -euo pipefail
 
-DRY_RUN="${1:-}"
+if [[ "$#" -gt 1 || ( "$#" -eq 1 && "$1" != "--dry-run" ) ]]; then
+    echo "Usage: $0 [--dry-run]" >&2
+    exit 2
+fi
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+    DRY_RUN=true
+fi
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 CONFIG_PATH="${REPO_ROOT}/configs/adversarial/issue_5326_objective_comparison.yaml"
 OUTPUT_DIR="${REPO_ROOT}/output/adversarial/issue_5326_objective_comparison"
 RUNNER="${REPO_ROOT}/scripts/tools/compare_adversarial_samplers.py"
+
+cd "${REPO_ROOT}"
 
 if [[ ! -f "${CONFIG_PATH}" ]]; then
     echo "ERROR: Config not found: ${CONFIG_PATH}" >&2
@@ -36,7 +47,6 @@ if [[ ! -f "${RUNNER}" ]]; then
 fi
 
 # SLURM parameters tuned for adversarial search campaigns
-# Each job runs one objective-sampler-budget-seed combination
 SLURM_TIME="4:00:00"
 SLURM_MEM="8G"
 SLURM_CPUS="4"
@@ -44,15 +54,15 @@ SLURM_PARTITION="gpu"
 
 COMMAND=(
     "uv" "run" "python" "${RUNNER}"
-    "--objective" "worst_case_snqi"
-    "--objective" "temporal_robustness"
-    "--package-b-budget-grid"
-    "--seed" "1101" "--seed" "2202" "--seed" "3303"
-    "--output-dir" "${OUTPUT_DIR}"
+    "--manifest" "${CONFIG_PATH}"
+    "--repo-root" "${REPO_ROOT}"
     "--out-json" "${OUTPUT_DIR}/report.json"
+    "--out-md" "${OUTPUT_DIR}/comparison_table.md"
 )
 
-if [[ -n "${DRY_RUN}" ]]; then
+printf -v COMMAND_TEXT '%q ' "${COMMAND[@]}"
+
+if [[ "${DRY_RUN}" == true ]]; then
     echo "=== DRY RUN MODE ==="
     echo "Config: ${CONFIG_PATH}"
     echo "Output: ${OUTPUT_DIR}"
@@ -64,9 +74,9 @@ if [[ -n "${DRY_RUN}" ]]; then
     exit 0
 fi
 
-# Submit as SLURM job array
-# Each array element handles one objective-sampler-budget-seed tuple
-# For simplicity, submit as single job that runs full grid
+mkdir -p "${OUTPUT_DIR}"
+
+# Submit one SLURM job that runs the full objective/sampler/budget/seed grid.
 sbatch <<SLURM_EOF
 #!/bin/bash
 #SBATCH --job-name=issue_5326_obj_cmp
@@ -85,7 +95,7 @@ echo "Config: ${CONFIG_PATH}"
 echo "Output: ${OUTPUT_DIR}"
 echo "Started at: \$(date -Iseconds)"
 
-"${COMMAND[@]}"
+${COMMAND_TEXT}
 
 echo "Completed at: \$(date -Iseconds)"
 SLURM_EOF

--- a/tests/adversarial/test_issue_5326_config.py
+++ b/tests/adversarial/test_issue_5326_config.py
@@ -1,0 +1,198 @@
+"""Validation tests for issue #5326 temporal-robustness objective comparison config.
+
+These tests verify the config and runner work correctly in synthetic mode.
+They do NOT run actual campaigns - that requires SLURM and is out of scope for CPU validation.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+class TestIssue5326ConfigValidation:
+    """Validate issue #5326 objective comparison configuration."""
+
+    @pytest.fixture
+    def repo_root(self) -> Path:
+        """Return repository root path."""
+        return Path(__file__).resolve().parents[2]
+
+    @pytest.fixture
+    def config_path(self, repo_root: Path) -> Path:
+        """Return path to issue #5326 config file."""
+        return repo_root / "configs" / "adversarial" / "issue_5326_objective_comparison.yaml"
+
+    @pytest.fixture
+    def runner_path(self, repo_root: Path) -> Path:
+        """Return path to comparison runner script."""
+        return repo_root / "scripts" / "tools" / "compare_adversarial_samplers.py"
+
+    def test_config_file_exists(self, config_path: Path) -> None:
+        """Verify the issue #5326 config file exists."""
+        assert config_path.exists(), f"Config not found: {config_path}"
+
+    def test_config_yaml_valid(self, config_path: Path) -> None:
+        """Verify the config YAML is parseable."""
+        import yaml
+
+        with config_path.open("r", encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+
+        assert config is not None
+        assert "schema_version" in config
+        assert config["issue"] == 5326
+        assert "objectives" in config
+        assert "worst_case_snqi" in config["objectives"]
+        assert "temporal_robustness" in config["objectives"]
+        assert "budget_grid" in config
+        assert config["budget_grid"] == [16, 32, 64]
+        assert "repeated_seeds" in config
+        assert config["repeated_seeds"] == [1101, 2202, 3303]
+
+    def test_runner_script_exists(self, runner_path: Path) -> None:
+        """Verify the comparison runner script exists."""
+        assert runner_path.exists(), f"Runner not found: {runner_path}"
+
+    def test_temporal_robustness_objective_registered(self, repo_root: Path) -> None:
+        """Verify temporal_robustness objective is registered and importable."""
+        from robot_sf.adversarial.objectives import get_objective
+
+        obj = get_objective("temporal_robustness")
+        assert obj is not None
+        assert callable(obj)
+
+    def test_synthetic_smoke_single_objective(self, repo_root: Path, runner_path: Path) -> None:
+        """Run a minimal synthetic smoke test with one objective.
+
+        This validates the runner can execute with the temporal_robustness objective
+        without running actual campaign episodes. Uses synthetic evaluator for speed.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "output"
+            output_json = Path(tmpdir) / "report.json"
+
+            cmd = [
+                "uv",
+                "run",
+                "python",
+                str(runner_path),
+                "--objective",
+                "temporal_robustness",
+                "--budget",
+                "2",
+                "--seed",
+                "42",
+                "--sampler",
+                "random",
+                "--output-dir",
+                str(output_dir),
+                "--out-json",
+                str(output_json),
+                "--synthetic",
+            ]
+
+            result = subprocess.run(
+                cmd,
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+
+            assert result.returncode == 0, f"Runner failed: {result.stderr}"
+            assert output_json.exists(), "Output JSON not written"
+
+            with output_json.open("r", encoding="utf-8") as f:
+                report = json.load(f)
+
+            assert report["schema_version"] == "adversarial-sampler-comparison.v3"
+            assert "temporal_robustness" in report["objectives"]
+            assert len(report["rows"]) == 1
+            row = report["rows"][0]
+            assert row["objective"] == "temporal_robustness"
+            assert row["sampler"] == "random"
+            assert row["budget"] == 2
+
+    def test_synthetic_smoke_both_objectives(self, repo_root: Path, runner_path: Path) -> None:
+        """Run synthetic smoke test comparing both objectives.
+
+        Validates the multi-objective comparison path works.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "output"
+            output_json = Path(tmpdir) / "report.json"
+
+            cmd = [
+                "uv",
+                "run",
+                "python",
+                str(runner_path),
+                "--objective",
+                "worst_case_snqi",
+                "--objective",
+                "temporal_robustness",
+                "--budget",
+                "2",
+                "--seed",
+                "42",
+                "--sampler",
+                "random",
+                "--output-dir",
+                str(output_dir),
+                "--out-json",
+                str(output_json),
+                "--synthetic",
+            ]
+
+            result = subprocess.run(
+                cmd,
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+
+            assert result.returncode == 0, f"Runner failed: {result.stderr}"
+            assert output_json.exists(), "Output JSON not written"
+
+            with output_json.open("r", encoding="utf-8") as f:
+                report = json.load(f)
+
+            assert len(report["rows"]) == 2
+            objectives = {row["objective"] for row in report["rows"]}
+            assert objectives == {"worst_case_snqi", "temporal_robustness"}
+
+    def test_submission_script_exists(self, repo_root: Path) -> None:
+        """Verify the SLURM submission wrapper script exists."""
+        submission_script = repo_root / "scripts" / "benchmark" / "submit_issue_5326_campaign.sh"
+        assert submission_script.exists(), f"Submission script not found: {submission_script}"
+
+    def test_submission_script_executable(self, repo_root: Path) -> None:
+        """Verify the submission script is executable."""
+        submission_script = repo_root / "scripts" / "benchmark" / "submit_issue_5326_campaign.sh"
+        assert submission_script.stat().st_mode & 0o111, "Submission script not executable"
+
+    def test_submission_script_dry_run(self, repo_root: Path) -> None:
+        """Verify the submission script dry-run mode works."""
+        submission_script = repo_root / "scripts" / "benchmark" / "submit_issue_5326_campaign.sh"
+
+        result = subprocess.run(
+            [str(submission_script), "--dry-run"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+        assert "DRY RUN MODE" in result.stdout
+        assert "temporal_robustness" in result.stdout
+        assert "worst_case_snqi" in result.stdout

--- a/tests/adversarial/test_issue_5326_config.py
+++ b/tests/adversarial/test_issue_5326_config.py
@@ -194,5 +194,24 @@ class TestIssue5326ConfigValidation:
 
         assert result.returncode == 0, f"Script failed: {result.stderr}"
         assert "DRY RUN MODE" in result.stdout
-        assert "temporal_robustness" in result.stdout
-        assert "worst_case_snqi" in result.stdout
+        assert "--manifest" in result.stdout
+        assert str(repo_root / "configs/adversarial/issue_5326_objective_comparison.yaml") in (
+            result.stdout
+        )
+        assert "--out-md" in result.stdout
+
+    def test_submission_script_rejects_unknown_argument(self, repo_root: Path) -> None:
+        """Verify typos cannot silently turn a real submission into a dry run."""
+        submission_script = repo_root / "scripts" / "benchmark" / "submit_issue_5326_campaign.sh"
+
+        result = subprocess.run(
+            [str(submission_script), "--not-a-real-option"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+
+        assert result.returncode == 2
+        assert "Usage:" in result.stderr


### PR DESCRIPTION
## What/Why

This PR adds the missing infrastructure to execute the issue #5326 matched-budget temporal-robustness objective comparison campaign:

- **scripts/benchmark/submit_issue_5326_campaign.sh**: SLURM submission wrapper that runs the full objective comparison (temporal_robustness vs worst_case_snqi) across Package-B budgets (16, 32, 64), repeated seeds (1101, 2202, 3303), and samplers (random, coordinate, optuna, CMA-ES-class)
- **tests/adversarial/test_issue_5326_config.py**: validation tests that verify the config, runner, and submission script work correctly with synthetic evaluator

This is the final infrastructure piece before campaign execution. The campaign itself requires a SLURM-capable worker and is out of scope for cheap-lane.

## Validation

Ran CPU-level validation tests in synthetic mode:

```
tests/adversarial/test_issue_5326_config.py::TestIssue5326ConfigValidation::test_config_file_exists PASSED
tests/adversarial/test_issue_5326_config.py::TestIssue5326ConfigValidation::test_config_yaml_valid PASSED
tests/adversarial/test_issue_5326_config.py::TestIssue5326ConfigValidation::test_runner_script_exists PASSED
tests/adversarial/test_issue_5326_config.py::TestIssue5326ConfigValidation::test_temporal_robustness_objective_registered PASSED
tests/adversarial/test_issue_5326_config.py::TestIssue5326ConfigValidation::test_synthetic_smoke_single_objective PASSED
tests/adversarial/test_issue_5326_config.py::TestIssue5326ConfigValidation::test_synthetic_smoke_both_objectives PASSED
tests/adversarial/test_issue_5326_config.py::TestIssue5326ConfigValidation::test_submission_script_exists PASSED
tests/adversarial/test_issue_5326_config.py::TestIssue5326ConfigValidation::test_submission_script_executable PASSED
tests/adversarial/test_issue_5326_config.py::TestIssue5326ConfigValidation::test_submission_script_dry_run PASSED
```

Ruff check passed on all changed Python files.

## Successor Statement

**This PR does NOT run the actual campaign** - that requires SLURM execution and is explicitly out of scope for cheap-lane workers per the issue's blocked comments. A SLURM-capable worker should:

1. Run `./scripts/benchmark/submit_issue_5326_campaign.sh` (without --dry-run) on a cluster
2. Wait for campaign completion
3. Verify certification/replay/independent-seed confirmation outcomes
4. Produce the durable stop-rule comparison table

Refs #5326

---

This PR was produced by the SAIA/Qwen3.5-397B-A17B cheap implementation lane; the review gate hardens and merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line workflow for submitting objective-comparison benchmark campaigns to SLURM.
  * Added dry-run support to preview submission details without launching a job.
  * Added validation for required configuration and runner files.
  * Added CPU-only synthetic execution checks and structured comparison reports.

* **Tests**
  * Added coverage for configuration validity, objective registration, report contents, submission behavior, dry-run output, and invalid arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->