### PR TITLE
Issue #5729: docs-only fix for gh issue view --comments friction (cheap-lane worker)

### DIFF
--- a/docs/context/issue_1076_amv_paper_defense_backlog.md
+++ b/docs/context/issue_1076_amv_paper_defense_backlog.md
@@ -93,7 +93,7 @@ should not be conflated with the current AMV paper-defense evidence path.
 Checked on 2026-05-09:
 
 ```bash
-rtk gh issue view 1076 --comments --json number,title,body,comments,labels,state,url
+rtk uv run python scripts/dev/gh_issue_rest.py view 1076 --json number title body comments labels state url --repo ll7/robot_sf_ll7
 rtk bash -lc 'for i in $(seq 1077 1092); do gh issue view "$i" --json number,title,body,url | jq -r "[.number, .title, .url, ((.body // \"\") | if test(\"#1076\\\\b\") then \"links-1076\" else \"missing-1076-link\" end)] | @tsv"; done'
 ```
 

--- a/docs/context/issue_2620_oracle_artifact_access.md
+++ b/docs/context/issue_2620_oracle_artifact_access.md
@@ -101,9 +101,9 @@ jq '{artifact_classification, split_leakage_check, analysis, jobs: [.jobs[] | {j
 ```bash
 rg -n 'issue_1397_oracle_imitation_v1|issue1470|oracle-imitation|wandb-artifact://|artifact://|s3://|gs://|hf://|huggingface|W&B|wandb' \
   docs configs robot_sf scripts tests
-gh issue view 2441 --comments --json body,comments,url,state,title
-gh issue view 1470 --comments --json body,comments,url,state,title
-gh issue view 1496 --comments --json body,comments,url,state,title
+uv run python scripts/dev/gh_issue_rest.py view 2441 --json body comments url state title --repo ll7/robot_sf_ll7
+uv run python scripts/dev/gh_issue_rest.py view 1470 --json body comments url state title --repo ll7/robot_sf_ll7
+uv run python scripts/dev/gh_issue_rest.py view 1496 --json body comments url state title --repo ll7/robot_sf_ll7
 ```
 
 Result: tracked compact evidence and issue comments preserve checksums and split routing, but

--- a/docs/context/issue_713_batch_first_issue_workflow.md
+++ b/docs/context/issue_713_batch_first_issue_workflow.md
@@ -57,26 +57,26 @@ Git command can answer the same question.
 
 ### Issue-with-comments helper
 
-`gh issue view <number> --comments` fails on some GitHub CLI versions because it requests the
-deprecated classic-Projects GraphQL field `repository.issue.projectCards` (issue #5021). Autonomous
-workflows that must read an issue together with its comment thread should use the shared helper:
+`gh issue view <number> --comments` fails on GitHub CLI 2.45.x (Ubuntu noble) because it requests
+the deprecated classic-Projects GraphQL field `repository.issue.projectCards` (issue #5021, #5729).
+Use the shared helper for all issue-with-comments reads in autonomous workflows:
 
 ```bash
-# preferred complete read: native CLI first, targeted REST fallback
+# preferred complete read: REST-backed, works on all CLI versions
 uv run python scripts/dev/gh_issue_rest.py thread <number> --repo ll7/robot_sf_ll7
 
 # explicit REST and normalized JSON fields for machine consumers
-uv run python scripts/dev/gh_issue_rest.py view <number> --json number title state url labels
+uv run python scripts/dev/gh_issue_rest.py view <number> --json number title state url labels comments
 
 # library use for Python callers
 from scripts.dev.gh_issue_rest import fetch_issue_with_comments
 payload = fetch_issue_with_comments(<number>)
 ```
 
-The `thread` command preserves successful native output. It falls back only when stderr names the
-known `repository.issue.projectCards` field; authentication, authorization, and other failures stay
-visible instead of being masked. The REST path preserves API comment order, paginates comments, and
-fails closed when a thread exceeds the page budget. The `view` command remains REST-only and
+The `thread` command tries native `gh issue view` first and falls back to paginated REST only for
+the known `repository.issue.projectCards` failure; authentication, authorization, and other failures
+stay visible instead of being masked. The REST path preserves API comment order, paginates comments,
+and fails closed when a thread exceeds the page budget. The `view` command is REST-only and
 normalizes `state`/`url` for `gh issue view --json` consumers.
 
 ## Project #5 Cache

--- a/docs/context/slurm_job_discovery_2026-05-31.md
+++ b/docs/context/slurm_job_discovery_2026-05-31.md
@@ -21,7 +21,7 @@ squeue --me --format='%i %j %T %P %Q %y %b %M %l %S %R'
 sacct -u "$USER" --starttime now-7days --format=JobID,JobName%28,State,ExitCode,Partition,Elapsed,Start,End -P
 gh issue list --repo ll7/robot_sf_ll7 --state open --label slurm --limit 100 --json number,title,labels,updatedAt,url
 gh issue list --repo ll7/robot_sf_ll7 --state open --search 'label:"resource:slurm" -label:"state:blocked"' --limit 100 --json number,title,labels,updatedAt,url
-gh issue view <issue> --repo ll7/robot_sf_ll7 --comments --json number,title,body,comments,labels,state,url
+uv run python scripts/dev/gh_issue_rest.py view <issue> --json number title body comments labels state url --repo ll7/robot_sf_ll7
 ```
 
 Live state:

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -555,18 +555,18 @@ When issue or PR text needs to classify proof strength, use the
 [artifact evidence vocabulary](context/artifact_evidence_vocabulary.md) so local `output/` paths are
 not promoted into durable benchmark or paper-facing claims.
 
-#### Issue-reading fallback
+#### Issue-reading with comments (REST-backed)
 
-`gh issue view <number> --comments` can fail on some GitHub CLI versions with a
-`repository.issue.projectCards` GraphQL deprecation error. Use the targeted REST
-fallback (see issues #5186 and #5188):
+`gh issue view <number> --comments` fails on GitHub CLI 2.45.x (Ubuntu noble) with a
+`repository.issue.projectCards` GraphQL deprecation error (issue #5729). Use the
+REST-backed helpers for all issue-with-comments reads:
 
 ```bash
-# Drop-in shell wrapper (tries native CLI first, falls back to REST on projectCards):
-bash scripts/dev/gh_issue_view.sh <number> --repo ll7/robot_sf_ll7
-
-# Direct REST helper (same fallback logic, more options):
+# Preferred: complete thread read with native-first fallback
 uv run python scripts/dev/gh_issue_rest.py thread <number> --repo ll7/robot_sf_ll7
+
+# Shell wrapper (same logic, concise invocation):
+bash scripts/dev/gh_issue_view.sh <number> --repo ll7/robot_sf_ll7
 
 # Explicit REST read with normalized fields (stable JSON output shape):
 uv run python scripts/dev/gh_issue_rest.py view <number> --repo ll7/robot_sf_ll7 --comments
@@ -574,9 +574,8 @@ uv run python scripts/dev/gh_issue_rest.py view <number> --json number title sta
 ```
 
 All issue-delivery skills (`gh-issue-autopilot`, `gh-issue-clarifier`,
-`goal-issue-implementation`, etc.) already route to `gh_issue_rest.py thread` when
-`gh issue view --comments` fails; see
-`docs/context/issue_713_batch_first_issue_workflow.md` for the full command reference.
+`goal-issue-implementation`, etc.) use `gh_issue_rest.py thread` as the primary path;
+see `docs/context/issue_713_batch_first_issue_workflow.md` for the full command reference.
 
 For GitHub issue batches and Project #5 updates, follow the batch-first workflow note:
 


### PR DESCRIPTION
## What/Why

This fixes the friction tracked in #5729 where `gh issue view --comments` fails on GitHub CLI 2.45.x (Ubuntu noble) due to the deprecated `repository.issue.projectCards` GraphQL field.

The repository already has working REST-backed helpers (`scripts/dev/gh_issue_rest.py` and `scripts/dev/gh_issue_view.sh`), but several documentation surfaces still showed the broken native command as an example. This PR updates those examples to use the working REST path as the **primary** recommendation, not just a fallback.

## Changes

- **docs/context/issue_2620_oracle_artifact_access.md**: Updated example commands to use `gh_issue_rest.py view`.
- **docs/context/slurm_job_discovery_2026-05-31.md**: Updated example command to use `gh_issue_rest.py view`.
- **docs/context/issue_1076_amv_paper_defense_backlog.md**: Updated example command to use `gh_issue_rest.py view`.
- **docs/context/issue_713_batch_first_issue_workflow.md**: Clarified that REST is the primary path on affected CLI versions.
- **docs/dev_guide.md**: Renamed section to "Issue-reading with comments (REST-backed)" and presented REST helpers as the recommended approach.

## Validation

- Existing tests pass: `uv run pytest tests/dev/test_gh_issue_rest.py -v` (26 tests).
- Updated commands verified against issue #5729 itself:
  ```
  uv run python scripts/dev/gh_issue_rest.py view 5729 --json number title state url labels comments --repo ll7/robot_sf_ll7
  ```
- Ruff check passes on changed files (docs-only, no Python changes).

## Scope

This is a **docs-only** fix. The underlying `gh_issue_rest.py` implementation and tests are unchanged. No benchmark, metric, schema, or paper-facing claims are affected.

Closes #5729

---

This PR was produced by the SAIA/Qwen3.5-397B-A17B cheap implementation lane; the review gate hardens and merges.