### PR TITLE
Issue #5724: skip triton preload on conflicting modules (cheap-lane worker)

### DIFF
--- a/robot_sf/common/seed.py
+++ b/robot_sf/common/seed.py
@@ -72,6 +72,9 @@ def _configure_torch_213_runtime() -> bool:
             return False
         if not str(version).split("+", 1)[0].startswith("2.13.0"):
             return False
+        if any(m in sys.modules for m in ("tensorflow", "tensorboard", "keras")):
+            os.environ["TORCH_COMPILE_DISABLE"] = "1"
+            return True
         try:
             importlib.import_module("triton")
         except ImportError:  # pragma: no cover - triton is optional on CPU-only installs

--- a/tests/test_seed_utils.py
+++ b/tests/test_seed_utils.py
@@ -85,6 +85,8 @@ def test_torch_213_runtime_guard_disables_compile_wrapper(monkeypatch):
     """Guard the optimizer path that segfaults with Torch 2.13 on Python 3.12+."""
     monkeypatch.setattr(sys, "version_info", (3, 13))
     monkeypatch.setattr(seed_module, "package_version", lambda _name: "2.13.0+cpu")
+    for module_name in ("tensorflow", "tensorboard", "keras"):
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
     imported: list[str] = []
     monkeypatch.setattr(
         seed_module.importlib,
@@ -108,8 +110,11 @@ def test_torch_213_runtime_guard_is_limited_to_supported_versions(monkeypatch):
     assert os.environ["TORCH_COMPILE_DISABLE"] == "0"
 
 
-def test_torch_213_runtime_guard_skips_triton_when_conflicting_modules_imported(monkeypatch):
-    """Guard skips importing triton when conflicting modules (tensorflow, tensorboard, keras) are present in sys.modules."""
+@pytest.mark.parametrize("conflicting_module", ("tensorflow", "tensorboard", "keras"))
+def test_torch_213_runtime_guard_skips_triton_when_conflicting_modules_imported(
+    monkeypatch, conflicting_module
+):
+    """Skip Triton when a conflicting module is already present in sys.modules."""
     monkeypatch.setattr(sys, "version_info", (3, 13))
     monkeypatch.setattr(seed_module, "package_version", lambda _name: "2.13.0+cpu")
     imported: list[str] = []
@@ -120,9 +125,9 @@ def test_torch_213_runtime_guard_skips_triton_when_conflicting_modules_imported(
     )
     monkeypatch.setenv("TORCH_COMPILE_DISABLE", "0")
 
-    # Temporarily inject 'tensorflow' into sys.modules
+    # Temporarily inject one conflicting top-level module into sys.modules.
     with monkeypatch.context() as ctx:
-        ctx.setitem(sys.modules, "tensorflow", object())
+        ctx.setitem(sys.modules, conflicting_module, object())
         assert seed_module._configure_torch_213_runtime()
         # Should not have tried to import 'triton'
         assert imported == []

--- a/tests/test_seed_utils.py
+++ b/tests/test_seed_utils.py
@@ -108,6 +108,27 @@ def test_torch_213_runtime_guard_is_limited_to_supported_versions(monkeypatch):
     assert os.environ["TORCH_COMPILE_DISABLE"] == "0"
 
 
+def test_torch_213_runtime_guard_skips_triton_when_conflicting_modules_imported(monkeypatch):
+    """Guard skips importing triton when conflicting modules (tensorflow, tensorboard, keras) are present in sys.modules."""
+    monkeypatch.setattr(sys, "version_info", (3, 13))
+    monkeypatch.setattr(seed_module, "package_version", lambda _name: "2.13.0+cpu")
+    imported: list[str] = []
+    monkeypatch.setattr(
+        seed_module.importlib,
+        "import_module",
+        lambda name: imported.append(name) or object(),
+    )
+    monkeypatch.setenv("TORCH_COMPILE_DISABLE", "0")
+
+    # Temporarily inject 'tensorflow' into sys.modules
+    with monkeypatch.context() as ctx:
+        ctx.setitem(sys.modules, "tensorflow", object())
+        assert seed_module._configure_torch_213_runtime()
+        # Should not have tried to import 'triton'
+        assert imported == []
+        assert os.environ["TORCH_COMPILE_DISABLE"] == "1"
+
+
 def test_torch_optional_behavior():
     """TODO docstring. Document this function."""
     torch = _import_torch()


### PR DESCRIPTION
## What/Why

When running tests or scripts that load `stable_baselines3` (which under the hood imports `tensorflow`/`tensorboard`), the subsequent import of `triton` in `_configure_torch_213_runtime()` causes a segmentation fault (`signal 11`, exit code 139) on CPU-only/stub CUDA configurations. This happens because TensorFlow and Triton load conflicting CUDA/stub library symbols when TensorFlow is initialized first.

To address this, we added a compatibility guard in `robot_sf/common/seed.py` that checks `sys.modules` for conflicting modules (`tensorflow`, `tensorboard`, `keras`). If any of these are present, we set `TORCH_COMPILE_DISABLE=1` and skip the `triton` import. Since `triton` compilation is only used for GPU target compiling, this check safely bypasses the crashing preload path on CPU environments while preserving the compile-disable behavior.

## Validation Output

### Pytest Execution

```text
$ uv run pytest tests/training/test_train_ppo_mamba_config_issue_4014.py
============================= test session starts ==============================
...
tests/training/test_train_ppo_mamba_config_issue_4014.py ...             [100%]
============================== 3 passed in 6.73s ===============================

$ uv run pytest tests/test_seed_utils.py
============================= test session starts ==============================
...
tests/test_seed_utils.py .........                                       [100%]
============================== 9 passed in 0.79s ===============================
```

### Ruff Validation

```text
$ uv run ruff check robot_sf/common/seed.py tests/test_seed_utils.py
All checks passed!

$ uv run ruff format --check robot_sf/common/seed.py tests/test_seed_utils.py
2 files already formatted
```

## Successor Statement

This PR is a successor slice that does not duplicate prior work and fully resolves issue #5724 by implementing the safety check for conflicting modules to skip preloading triton, and adding a regression test case.

---

This PR was produced by the agy/Gemini-3.5-Flash cheap implementation lane; the review gate hardens and merges.

Closes #5724
