### PR TITLE
Issue #5743: Optimize calibration provider test duration under threshold (cheap-lane worker)

### DIFF
--- a/tests/planner/test_chance_constrained_mpc_provider.py
+++ b/tests/planner/test_chance_constrained_mpc_provider.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import numpy as np
 import pytest
@@ -36,6 +37,32 @@ from robot_sf.planner.chance_constrained_mpc_provider import (
     realized_collision_risk_calibration,
     realized_collision_risk_calibration_sweep,
 )
+
+
+class MockPlanner:
+    """Deterministic, CPU-light mock planner for provider calibration contract tests."""
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        """Initialize the mock planner with basic configuration mapping."""
+        self.config = SimpleNamespace(
+            rollout_dt=float(config.get("rollout_dt", 0.25)),
+            chance_constraint_formulation=str(
+                config.get("chance_constraint_formulation", "marginal")
+            ),
+            max_collision_risk=float(config.get("max_collision_risk", 0.05)),
+        )
+        self.claimed_risk = float(self.config.max_collision_risk)
+
+    def reset(self) -> None:
+        pass
+
+    def plan(self, observation: dict[str, object]) -> tuple[float, float]:
+        # Return a deterministic, simple forward command.
+        # This keeps the planner CPU-light and fast while satisfying the runner.
+        return (0.5, 0.0)
+
+    def diagnostics(self) -> dict[str, int]:
+        return {"solver_failures": 0}
 
 
 def _observation(
@@ -166,12 +193,11 @@ def test_calibration_closes_loop_over_the_planners_claimed_risk() -> None:
     clearance, compute time).
     """
 
-    adapter = build_chance_constrained_mpc_adapter(
+    adapter = MockPlanner(
         {
             "predictor_backend": "constant_velocity_gmm",
             "horizon_steps": 6,
             "max_collision_risk": 0.05,
-            "solver_max_iterations": 20,
         }
     )
     result = realized_collision_risk_calibration(
@@ -203,13 +229,55 @@ def test_calibration_closes_loop_over_the_planners_claimed_risk() -> None:
     assert result["sample_count"] == pytest.approx(6.0)
 
 
-def test_calibration_is_reproducible_under_fixed_seed() -> None:
-    """Monte-Carlo closed-loop calibration must be deterministic for a given seed."""
+def test_calibration_closes_loop_over_the_planners_claimed_risk_real_solver() -> None:
+    """One bounded end-to-end smoke test for the real solver path."""
 
     adapter = build_chance_constrained_mpc_adapter(
         {
             "predictor_backend": "constant_velocity_gmm",
-            "solver_max_iterations": 20,
+            "horizon_steps": 4,
+            "max_collision_risk": 0.05,
+            "solver_max_iterations": 5,
+        }
+    )
+    result = realized_collision_risk_calibration(
+        adapter,
+        CalibrationScenario(num_episodes=1, steps_per_episode=3, num_pedestrians=2),
+        seed=1,
+    )
+    assert result["claimed_risk_per_horizon"] == pytest.approx(0.05)
+    assert "observed_collision_rate" in result
+    assert "calibration_error" in result
+    required = {
+        "claimed_risk_per_horizon",
+        "observed_collision_rate",
+        "calibration_error",
+        "infeasible_rate",
+        "freeze_rate",
+        "completion_rate",
+        "mean_tail_clearance_m",
+        "mean_compute_time_ms",
+        "sample_count",
+    }
+    assert required <= result.keys()
+    # The planner's claimed risk is read straight from the control law config.
+    assert result["claimed_risk_per_horizon"] == pytest.approx(0.05)
+    # Calibration error is the issue's primary measure: observed minus claimed.
+    assert result["calibration_error"] == pytest.approx(
+        result["observed_collision_rate"] - result["claimed_risk_per_horizon"]
+    )
+    assert 0.0 <= result["observed_collision_rate"] <= 1.0
+    assert 0.0 <= result["completion_rate"] <= 1.0
+    assert 0.0 <= result["mean_compute_time_ms"]
+    assert result["sample_count"] == pytest.approx(1.0)
+
+
+def test_calibration_is_reproducible_under_fixed_seed() -> None:
+    """Monte-Carlo closed-loop calibration must be deterministic for a given seed."""
+
+    adapter = MockPlanner(
+        {
+            "predictor_backend": "constant_velocity_gmm",
         }
     )
     scenario = CalibrationScenario(num_episodes=4, steps_per_episode=10, num_pedestrians=3)
@@ -224,12 +292,11 @@ def test_calibration_runs_end_to_end_for_cvar_tail_formulation() -> None:
     to end through the realized-risk calibration harness via the surrogate
     constant_velocity_gmm provider."""
 
-    adapter = build_chance_constrained_mpc_adapter(
+    adapter = MockPlanner(
         {
             "predictor_backend": "constant_velocity_gmm",
             "chance_constraint_formulation": "cvar_tail",
             "cvar_alpha": 0.9,
-            "solver_max_iterations": 20,
         }
     )
     result = realized_collision_risk_calibration(
@@ -248,9 +315,7 @@ def test_calibration_runs_end_to_end_for_cvar_tail_formulation() -> None:
 def test_calibration_runs_end_to_end_without_pedestrians() -> None:
     """A pedestrian-free episode still reports finite, well-formed diagnostics."""
 
-    adapter = build_chance_constrained_mpc_adapter(
-        {"predictor_backend": "constant_velocity_gmm", "horizon_steps": 4}
-    )
+    adapter = MockPlanner({"predictor_backend": "constant_velocity_gmm", "horizon_steps": 4})
     result = realized_collision_risk_calibration(
         adapter,
         CalibrationScenario(num_episodes=4, steps_per_episode=8, num_pedestrians=0),
@@ -326,7 +391,9 @@ def test_calibration_sweep_returns_claimed_vs_observed_curve_across_budgets() ->
     """
 
     base_algo_config, sweep = _light_sweep()
-    result = realized_collision_risk_calibration_sweep(base_algo_config, sweep, seed=1)
+    result = realized_collision_risk_calibration_sweep(
+        base_algo_config, sweep, adapter_builder=MockPlanner, seed=1
+    )
     assert result["sweep"]["risk_budgets"] == [0.05, 0.10, 0.20]
     assert result["sweep"]["formulations"] == ["marginal"]
     assert result["sweep"]["seed"] == 1
@@ -357,7 +424,9 @@ def test_calibration_sweep_compares_formulations_at_matched_budgets() -> None:
         formulations=("marginal", "joint_horizon", "cvar_tail"),
         scenario=sweep.scenario,
     )
-    result = realized_collision_risk_calibration_sweep(base_algo_config, sweep, seed=2)
+    result = realized_collision_risk_calibration_sweep(
+        base_algo_config, sweep, adapter_builder=MockPlanner, seed=2
+    )
     by_formulation = result["points_by_formulation"]
     assert set(by_formulation) == {"marginal", "joint_horizon", "cvar_tail"}
     assert len(result["points"]) == 3 * 3
@@ -378,14 +447,18 @@ def test_calibration_sweep_replays_same_scenarios_across_budgets() -> None:
     """
 
     base_algo_config, sweep = _light_sweep()
-    first = realized_collision_risk_calibration_sweep(base_algo_config, sweep, seed=11)
-    second = realized_collision_risk_calibration_sweep(base_algo_config, sweep, seed=11)
+    first = realized_collision_risk_calibration_sweep(
+        base_algo_config, sweep, adapter_builder=MockPlanner, seed=11
+    )
+    second = realized_collision_risk_calibration_sweep(
+        base_algo_config, sweep, adapter_builder=MockPlanner, seed=11
+    )
     first_observed = [p["observed_collision_rate"] for p in first["points"]]
     second_observed = [p["observed_collision_rate"] for p in second["points"]]
     assert first_observed == second_observed
 
     # The sweep point at a given budget must equal a direct single-point run.
-    adapter = build_chance_constrained_mpc_adapter(
+    adapter = MockPlanner(
         {
             **base_algo_config,
             "max_collision_risk": sweep.risk_budgets[1],
@@ -412,7 +485,9 @@ def test_calibration_sweep_reliability_summary_reports_stop_rule_observables() -
     """
 
     base_algo_config, sweep = _light_sweep()
-    result = realized_collision_risk_calibration_sweep(base_algo_config, sweep, seed=3)
+    result = realized_collision_risk_calibration_sweep(
+        base_algo_config, sweep, adapter_builder=MockPlanner, seed=3
+    )
     summary = result["reliability_summary"]["marginal"]
     assert isinstance(summary["observed_monotone_non_decreasing_in_claimed"], bool)
     assert summary["control_period_ms"] == pytest.approx(float(sweep.scenario.dt) * 1000.0)
@@ -463,7 +538,9 @@ def test_calibration_sweep_yaml_config_runs_end_to_end() -> None:
     assert sweep.risk_budgets == (0.05, 0.10, 0.20)
     assert sweep.formulations == ("marginal", "joint_horizon", "cvar_tail")
 
-    result = realized_collision_risk_calibration_sweep(base, sweep, seed=0)
+    result = realized_collision_risk_calibration_sweep(
+        base, sweep, adapter_builder=MockPlanner, seed=0
+    )
     assert len(result["points"]) == 3 * 3
     for point in result["points"]:
         assert np.isfinite(point["observed_collision_rate"])
@@ -473,6 +550,21 @@ def test_calibration_sweep_yaml_config_runs_end_to_end() -> None:
         "joint_horizon",
         "cvar_tail",
     }
+
+    # Separately validate the shipped diagnostic sweep config with the real solver
+    # over a minimal slice to keep tests fast.
+    light_scenario = CalibrationScenario(num_episodes=1, steps_per_episode=2, num_pedestrians=1)
+    light_sweep = CalibrationSweep(
+        risk_budgets=(0.05,),
+        formulations=("marginal",),
+        scenario=light_scenario,
+    )
+    light_base = dict(base)
+    light_base["solver_max_iterations"] = 5
+
+    real_result = realized_collision_risk_calibration_sweep(light_base, light_sweep, seed=0)
+    assert len(real_result["points"]) == 1
+    assert np.isfinite(real_result["points"][0]["observed_collision_rate"])
 
 
 def test_build_calibration_sweep_config_defaults_when_subkey_absent() -> None:


### PR DESCRIPTION
## Summary
This PR addresses issue #5743 by optimizing the runtime of calibration provider tests. 

### Changes:
- Introduced a deterministic, CPU-light `MockPlanner` class in `tests/planner/test_chance_constrained_mpc_provider.py` to satisfy the calibration runner and sweep harness protocols.
- Updated calibration tests and sweep verification tests to use the `MockPlanner` instead of rebuilding the full chance-constrained MPC solver, significantly reducing execution time.
- Retained targeted end-to-end smoke tests for the real solver path, including:
  - `test_calibration_closes_loop_over_the_planners_claimed_risk_real_solver` (single-episode, 3-step, 5 max solver iterations smoke test).
  - A separately validated minimal sweep run in `test_calibration_sweep_yaml_config_runs_end_to_end` using the real solver over a tiny slice (1 episode, 2 steps, 5 max solver iterations).

### Validation:
All 20 tests pass cleanly, and runtime is reduced from ~261.45s down to 15.15s (an ~17x speedup, comfortably under the 60s hard threshold):
```
tests/planner/test_chance_constrained_mpc_provider.py .................. [ 90%]
..                                                                       [100%]
============================= 20 passed in 15.15s ==============================
```

This PR was produced by the agy/Gemini-3.5-Flash cheap implementation lane; the review gate hardens and merges.

Closes #5743


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded calibration coverage with faster, deterministic validation scenarios.
  - Added checks for single-point calibration, calibration sweeps, and scenarios without pedestrians.
  - Added end-to-end validation of the real planning solver using constrained, lightweight scenarios.
  - Extended YAML-driven calibration testing with a minimal real-solver validation to confirm configuration behavior while keeping test execution efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->