### PR TITLE
fix: align calibration-sweep risk and observation units (#5737)

### DIFF
--- a/configs/algos/chance_constrained_mpc_calibration_sweep_diagnostic.yaml
+++ b/configs/algos/chance_constrained_mpc_calibration_sweep_diagnostic.yaml
@@ -10,9 +10,11 @@
 # vs. observed). Calibration is a *curve* over the risk budget, not a single
 # point. This config makes that curve CPU-reproducible TODAY: it sweeps
 # max_collision_risk across four budgets and across all three
-# chance-constraint formulations (marginal per-time-step, joint_horizon Boole
-# union bound, cvar_tail Conditional Value-at-Risk tail-risk) over matched
-# constant-velocity scenarios, and surfaces the issue's pre-registered stop-rule
+# chance-constraint formulations over matched constant-velocity scenarios. The
+# calibration output compares marginal per-pedestrian-timestep risk,
+# joint_horizon rolling-MPC-window any-collision risk, and cvar_tail empirical
+# CVaR over the same rolling MPC window; episode-level any-collision remains a
+# separate diagnostic. It also surfaces the issue's pre-registered stop-rule
 # observables (solver compute time vs the MPC control period, and zero-progress
 # freezing at the tightest budget) as inspection signals.
 #
@@ -44,6 +46,7 @@ warm_start: true
 fallback_to_stop: true
 chance_constraint_formulation: marginal
 max_collision_risk: 0.05
+cvar_alpha: 0.9
 radial_quadrature_order: 6
 angular_quadrature_order: 16
 calibration_sweep:

--- a/robot_sf/planner/chance_constrained_mpc_provider.py
+++ b/robot_sf/planner/chance_constrained_mpc_provider.py
@@ -31,6 +31,7 @@ container is reused for every forecast this module emits.
 from __future__ import annotations
 
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from itertools import pairwise
 from typing import TYPE_CHECKING, Any
@@ -282,21 +283,62 @@ def _min_robot_pedestrian_clearance(
     return float(np.min(dists)) - contact_radius
 
 
+def _coerce_finite_array(value: object, *, label: str, shape: tuple[int, ...]) -> np.ndarray:
+    """Convert one required observation field to a finite array of ``shape``.
+
+    Returns:
+        A finite floating-point array with the requested shape.
+    """
+
+    try:
+        array = np.asarray(value, dtype=float)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be numeric") from exc
+    if array.shape != shape or not np.isfinite(array).all():
+        raise ValueError(f"{label} must contain finite values with shape {shape}")
+    return array
+
+
+def _coerce_pedestrian_positions(value: object) -> np.ndarray:
+    """Convert pedestrian positions to a finite ``(n, 2)`` array.
+
+    Returns:
+        A finite floating-point array with one two-dimensional position per row.
+    """
+
+    try:
+        ped_positions = np.asarray(value, dtype=float)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("observation.pedestrians.positions must be numeric") from exc
+    if ped_positions.ndim == 1 and ped_positions.size % 2 == 0:
+        ped_positions = ped_positions.reshape(-1, 2)
+    if ped_positions.ndim != 2 or ped_positions.shape[-1] != 2:
+        raise ValueError("observation.pedestrians.positions must have shape (n, 2)")
+    if not np.isfinite(ped_positions).all():
+        raise ValueError("observation.pedestrians.positions must be finite")
+    return ped_positions
+
+
 def _collision_indicators(
-    observation: dict[str, object], *, collision_radius_m: float
+    observation: Mapping[str, object], *, collision_radius_m: float
 ) -> np.ndarray:
     """Return one collision indicator per pedestrian at the observed state."""
 
     contact_radius = float(collision_radius_m)
     if not np.isfinite(contact_radius) or contact_radius <= 0.0:
         raise ValueError("collision_radius_m must be finite and > 0")
-    robot_pos = np.asarray(observation["robot"]["position"], dtype=float)
-    peds = observation["pedestrians"]
-    ped_positions = np.asarray(peds.get("positions", []), dtype=float)
-    if ped_positions.ndim == 1 and ped_positions.size % 2 == 0:
-        ped_positions = ped_positions.reshape(-1, 2)
-    if ped_positions.ndim != 2 or ped_positions.shape[-1] != 2:
-        return np.zeros((0,), dtype=bool)
+    if not isinstance(observation, Mapping):
+        raise ValueError("observation must be a mapping")
+    robot = observation.get("robot")
+    if not isinstance(robot, Mapping):
+        raise ValueError("observation.robot must be a mapping")
+    robot_pos = _coerce_finite_array(
+        robot.get("position"), label="observation.robot.position", shape=(2,)
+    )
+    peds = observation.get("pedestrians")
+    if not isinstance(peds, Mapping):
+        raise ValueError("observation.pedestrians must be a mapping")
+    ped_positions = _coerce_pedestrian_positions(peds.get("positions", []))
     distances = np.linalg.norm(ped_positions - robot_pos[None, :], axis=1)
     return distances < contact_radius
 
@@ -320,6 +362,18 @@ def _empirical_cvar(values: np.ndarray, *, alpha: float) -> float:
     return float(tail_sum / tail_mass)
 
 
+def _planner_formulation(planner: ChanceConstrainedMPCPlannerAdapter) -> str:
+    """Return a planner formulation, normalizing absent optional values."""
+
+    chance_config = getattr(planner, "chance_config", None)
+    raw_formulation = (
+        getattr(chance_config, "chance_constraint_formulation", None)
+        if chance_config is not None
+        else None
+    )
+    return "marginal" if raw_formulation is None else str(raw_formulation)
+
+
 def _calibration_contract(
     planner: ChanceConstrainedMPCPlannerAdapter,
 ) -> tuple[str, str, int, float | None]:
@@ -331,7 +385,7 @@ def _calibration_contract(
     """
 
     chance_config = getattr(planner, "chance_config", None)
-    formulation = str(getattr(chance_config, "chance_constraint_formulation", "marginal"))
+    formulation = _planner_formulation(planner)
     horizon_steps = max(int(getattr(getattr(planner, "config", None), "horizon_steps", 1)), 1)
     if formulation == "marginal":
         return "per_pedestrian_timestep", "control_step", 1, None
@@ -343,6 +397,78 @@ def _calibration_contract(
             raise ValueError("cvar_alpha must be in (0, 1)")
         return "mpc_horizon_cvar_tail", "mpc_horizon", horizon_steps, cvar_alpha
     raise ValueError(f"Unsupported calibration formulation: {formulation!r}")
+
+
+def _normalize_collision_samples(
+    collision_samples: list[list[np.ndarray]],
+) -> list[list[np.ndarray]]:
+    """Validate and normalize per-episode collision indicators.
+
+    Returns:
+        The same samples as boolean one-dimensional arrays, preserving episode
+        and timestep boundaries.
+    """
+
+    normalized: list[list[np.ndarray]] = []
+    for episode in collision_samples:
+        steps: list[np.ndarray] = []
+        for step in episode:
+            array = np.asarray(step, dtype=bool)
+            if array.ndim != 1:
+                raise ValueError("collision observations must have shape (steps, pedestrians)")
+            steps.append(array)
+        normalized.append(steps)
+    return normalized
+
+
+def _aggregate_marginal_risk(
+    episode_steps: list[list[np.ndarray]],
+) -> tuple[float, int, int]:
+    """Aggregate one collision indicator per pedestrian-time cell.
+
+    Returns:
+        Tuple of observed risk, scalar observation count, and timestep count.
+    """
+
+    observation_count = sum(int(step.size) for episode in episode_steps for step in episode)
+    collision_count = sum(
+        int(np.count_nonzero(step)) for episode in episode_steps for step in episode
+    )
+    observed = float(collision_count / observation_count) if observation_count else 0.0
+    observation_window_count = sum(len(episode) for episode in episode_steps)
+    return observed, observation_count, observation_window_count
+
+
+def _aggregate_horizon_risk(
+    episode_steps: list[list[np.ndarray]],
+    *,
+    formulation: str,
+    horizon_steps: int,
+    cvar_alpha: float | None,
+) -> tuple[float, int, int]:
+    """Aggregate collision indicators over each valid rolling horizon.
+
+    Returns:
+        Tuple of observed risk, rolling-window count, and reported window count.
+    """
+
+    window_values: list[float] = []
+    for episode in episode_steps:
+        if len(episode) < horizon_steps:
+            raise ValueError(
+                f"{formulation} calibration requires at least {horizon_steps} observed steps per "
+                f"episode; got {len(episode)}"
+            )
+        for start in range(len(episode) - horizon_steps + 1):
+            window = episode[start : start + horizon_steps]
+            if formulation == "joint_horizon":
+                window_values.append(float(any(np.any(step) for step in window)))
+            else:
+                assert cvar_alpha is not None
+                window_values.append(_empirical_cvar(np.concatenate(window), alpha=cvar_alpha))
+    observation_count = len(window_values)
+    observed = float(np.mean(window_values)) if window_values else 0.0
+    return observed, observation_count, observation_count
 
 
 def _aggregate_observed_risk(
@@ -365,38 +491,20 @@ def _aggregate_observed_risk(
         count used for the reported mean.
     """
 
+    if formulation not in {"marginal", "joint_horizon", "cvar_tail"}:
+        raise ValueError(f"Unsupported calibration formulation: {formulation!r}")
+    if formulation == "cvar_tail" and cvar_alpha is None:
+        raise ValueError("cvar_tail calibration requires cvar_alpha")
     if not collision_samples:
         return 0.0, 0, 0
-    episode_arrays = [np.asarray(episode, dtype=bool) for episode in collision_samples]
-    if any(array.ndim != 2 for array in episode_arrays):
-        raise ValueError("collision observations must have shape (steps, pedestrians)")
-    matrix = np.stack(episode_arrays, axis=0)
+    episode_steps = _normalize_collision_samples(collision_samples)
     if formulation == "marginal":
-        observation_count = int(matrix.size)
-        observed = float(np.mean(matrix)) if observation_count else 0.0
-        return observed, observation_count, int(matrix.shape[0] * matrix.shape[1])
-
-    if matrix.shape[1] < horizon_steps:
-        raise ValueError(
-            f"{formulation} calibration requires at least {horizon_steps} observed steps per "
-            f"episode; got {matrix.shape[1]}"
-        )
-    window_values: list[float] = []
-    for episode in matrix:
-        for start in range(episode.shape[0] - horizon_steps + 1):
-            window = episode[start : start + horizon_steps]
-            if formulation == "joint_horizon":
-                window_values.append(float(np.any(window)))
-            elif formulation == "cvar_tail":
-                assert cvar_alpha is not None
-                window_values.append(_empirical_cvar(window, alpha=cvar_alpha))
-            else:
-                raise ValueError(f"Unsupported calibration formulation: {formulation!r}")
-    observation_count = len(window_values)
-    return (
-        float(np.mean(window_values)) if window_values else 0.0,
-        observation_count,
-        observation_count,
+        return _aggregate_marginal_risk(episode_steps)
+    return _aggregate_horizon_risk(
+        episode_steps,
+        formulation=formulation,
+        horizon_steps=horizon_steps,
+        cvar_alpha=cvar_alpha,
     )
 
 
@@ -460,6 +568,7 @@ def realized_collision_risk_calibration(
     """
 
     scenario = scenario or CalibrationScenario()
+    formulation = _planner_formulation(planner)
     risk_unit, observation_window, observation_window_steps, cvar_alpha = _calibration_contract(
         planner
     )
@@ -537,20 +646,12 @@ def realized_collision_risk_calibration(
     n = max(int(scenario.num_episodes), 1)
     observed, observation_count, observation_window_count = _aggregate_observed_risk(
         collision_samples,
-        formulation=str(
-            getattr(
-                getattr(planner, "chance_config", None), "chance_constraint_formulation", "marginal"
-            )
-        ),
+        formulation=formulation,
         horizon_steps=observation_window_steps,
         cvar_alpha=cvar_alpha,
     )
     return {
-        "formulation": str(
-            getattr(
-                getattr(planner, "chance_config", None), "chance_constraint_formulation", "marginal"
-            )
-        ),
+        "formulation": formulation,
         "claimed_risk": float(claimed),
         "observed_risk": float(observed),
         "claimed_risk_unit": risk_unit,

--- a/robot_sf/planner/chance_constrained_mpc_provider.py
+++ b/robot_sf/planner/chance_constrained_mpc_provider.py
@@ -15,13 +15,14 @@ protocol and replaces the surrogate without any change to the planner.
 The calibration harness is a **closed-loop** diagnostic (issue #5307 measure
 #1): it rolls the planner through many short episodes in which the realized
 pedestrian dynamics match the surrogate's own constant-velocity forecast, then
-pairs the planner's *claimed* per-horizon risk against the *observed*
-collision frequency and the other named measures (infeasibility rate,
-freezing, completion, tail clearance, compute time). Under matched dynamics
-this is an API/self-consistency diagnostic of the GMM risk control law, not a
-matched-arm benchmark result and not a real-world risk claim; replacing the
-surrogate with the learned ``#2844`` predictor is required before any
-benchmark-facing calibration claim.
+pairs each formulation's *claimed* risk with an observed value in the same
+unit. Marginal uses pedestrian-time cells, joint-horizon uses rolling horizon
+any-collision events, and CVaR uses rolling-horizon empirical tail risk. The
+episode-level any-collision rate remains a separate diagnostic. Under matched
+dynamics this is an API/self-consistency diagnostic of the GMM risk control
+law, not a matched-arm benchmark result and not a real-world risk claim;
+replacing the surrogate with the learned ``#2844`` predictor is required
+before any benchmark-facing calibration claim.
 
 The :class:`~robot_sf.planner.chance_constrained_mpc.GaussianMixturePedestrianForecast`
 container is reused for every forecast this module emits.
@@ -281,6 +282,124 @@ def _min_robot_pedestrian_clearance(
     return float(np.min(dists)) - contact_radius
 
 
+def _collision_indicators(
+    observation: dict[str, object], *, collision_radius_m: float
+) -> np.ndarray:
+    """Return one collision indicator per pedestrian at the observed state."""
+
+    contact_radius = float(collision_radius_m)
+    if not np.isfinite(contact_radius) or contact_radius <= 0.0:
+        raise ValueError("collision_radius_m must be finite and > 0")
+    robot_pos = np.asarray(observation["robot"]["position"], dtype=float)
+    peds = observation["pedestrians"]
+    ped_positions = np.asarray(peds.get("positions", []), dtype=float)
+    if ped_positions.ndim == 1 and ped_positions.size % 2 == 0:
+        ped_positions = ped_positions.reshape(-1, 2)
+    if ped_positions.ndim != 2 or ped_positions.shape[-1] != 2:
+        return np.zeros((0,), dtype=bool)
+    distances = np.linalg.norm(ped_positions - robot_pos[None, :], axis=1)
+    return distances < contact_radius
+
+
+def _empirical_cvar(values: np.ndarray, *, alpha: float) -> float:
+    """Return the empirical upper-tail CVaR of a finite sample."""
+
+    samples = np.asarray(values, dtype=float).reshape(-1)
+    if samples.size == 0:
+        return 0.0
+    if not 0.0 < float(alpha) < 1.0:
+        raise ValueError("cvar_alpha must be in (0, 1)")
+    ordered = np.sort(samples)
+    tail_mass = (1.0 - float(alpha)) * ordered.size
+    whole_cells = int(np.floor(tail_mass))
+    fractional_cell = tail_mass - whole_cells
+    tail_sum = float(np.sum(ordered[-whole_cells:])) if whole_cells else 0.0
+    if fractional_cell > 0.0:
+        boundary_index = ordered.size - whole_cells - 1
+        tail_sum += fractional_cell * float(ordered[boundary_index])
+    return float(tail_sum / tail_mass)
+
+
+def _calibration_contract(
+    planner: ChanceConstrainedMPCPlannerAdapter,
+) -> tuple[str, str, int, float | None]:
+    """Describe the risk and observation units selected by a planner.
+
+    Returns:
+        Tuple of risk unit, observation window label, window length, and the
+        CVaR confidence when the formulation uses a tail-risk constraint.
+    """
+
+    chance_config = getattr(planner, "chance_config", None)
+    formulation = str(getattr(chance_config, "chance_constraint_formulation", "marginal"))
+    horizon_steps = max(int(getattr(getattr(planner, "config", None), "horizon_steps", 1)), 1)
+    if formulation == "marginal":
+        return "per_pedestrian_timestep", "control_step", 1, None
+    if formulation == "joint_horizon":
+        return "mpc_horizon_any_collision", "mpc_horizon", horizon_steps, None
+    if formulation == "cvar_tail":
+        cvar_alpha = float(getattr(chance_config, "cvar_alpha", 0.9))
+        if not 0.0 < cvar_alpha < 1.0:
+            raise ValueError("cvar_alpha must be in (0, 1)")
+        return "mpc_horizon_cvar_tail", "mpc_horizon", horizon_steps, cvar_alpha
+    raise ValueError(f"Unsupported calibration formulation: {formulation!r}")
+
+
+def _aggregate_observed_risk(
+    collision_samples: list[list[np.ndarray]],
+    *,
+    formulation: str,
+    horizon_steps: int,
+    cvar_alpha: float | None,
+) -> tuple[float, int, int]:
+    """Aggregate collision observations in the unit used by the planner claim.
+
+    Marginal constraints compare one pedestrian-time cell with one observed
+    pedestrian-time cell. Joint-horizon constraints compare a Boole event over
+    one rolling MPC horizon. CVaR compares the empirical upper-tail average of
+    the same pedestrian-time cells in each rolling horizon. The returned counts
+    are the actual denominators used by ``observed_risk``.
+
+    Returns:
+        Tuple of observed risk, scalar observation count, and observation-window
+        count used for the reported mean.
+    """
+
+    if not collision_samples:
+        return 0.0, 0, 0
+    episode_arrays = [np.asarray(episode, dtype=bool) for episode in collision_samples]
+    if any(array.ndim != 2 for array in episode_arrays):
+        raise ValueError("collision observations must have shape (steps, pedestrians)")
+    matrix = np.stack(episode_arrays, axis=0)
+    if formulation == "marginal":
+        observation_count = int(matrix.size)
+        observed = float(np.mean(matrix)) if observation_count else 0.0
+        return observed, observation_count, int(matrix.shape[0] * matrix.shape[1])
+
+    if matrix.shape[1] < horizon_steps:
+        raise ValueError(
+            f"{formulation} calibration requires at least {horizon_steps} observed steps per "
+            f"episode; got {matrix.shape[1]}"
+        )
+    window_values: list[float] = []
+    for episode in matrix:
+        for start in range(episode.shape[0] - horizon_steps + 1):
+            window = episode[start : start + horizon_steps]
+            if formulation == "joint_horizon":
+                window_values.append(float(np.any(window)))
+            elif formulation == "cvar_tail":
+                assert cvar_alpha is not None
+                window_values.append(_empirical_cvar(window, alpha=cvar_alpha))
+            else:
+                raise ValueError(f"Unsupported calibration formulation: {formulation!r}")
+    observation_count = len(window_values)
+    return (
+        float(np.mean(window_values)) if window_values else 0.0,
+        observation_count,
+        observation_count,
+    )
+
+
 @dataclass(frozen=True)
 class CalibrationScenario:
     """Scenario family for the closed-loop realized-risk calibration harness.
@@ -310,12 +429,14 @@ def realized_collision_risk_calibration(
 
     Rolls the chance-constrained MPC planner through many short episodes whose
     pedestrian dynamics *match* the surrogate's own constant-velocity forecast.
-    For every control step it records the planner's **claimed** per-horizon risk
-    (``planner.claimed_risk``) and, after integrating the realized motion, the
-    **observed** collision occurrence. The harness then reports the issue's named
-    measures: realized collision-risk calibration (claimed vs. observed),
-    infeasibility rate, freezing (zero-progress) rate, completion rate, tail
-    clearance, and per-step compute time.
+    It records the planner's **claimed** risk (``planner.claimed_risk``) and
+    aggregates collision indicators in the matching formulation-specific unit:
+    per-pedestrian timestep for ``marginal``, rolling MPC-horizon any-collision
+    for ``joint_horizon``, and rolling MPC-horizon empirical CVaR for
+    ``cvar_tail``. The harness also reports the episode-level any-collision
+    rate separately, plus the issue's other named measures: infeasibility rate,
+    freezing (zero-progress) rate, completion rate, tail clearance, and
+    per-step compute time.
 
     Under matched dynamics this is an API/self-consistency diagnostic of the GMM
     risk control law: it shows whether the planner's claimed risk bound is
@@ -332,14 +453,16 @@ def realized_collision_risk_calibration(
         seed: RNG seed for reproducibility.
 
     Returns:
-        Mapping with ``claimed_risk_per_horizon``, ``observed_collision_rate``,
-        ``calibration_error`` (observed - claimed, the issue's primary measure),
-        ``infeasible_rate``, ``freeze_rate``, ``completion_rate``,
-        ``mean_tail_clearance_m``, ``mean_compute_time_ms``, and a
+        Mapping with explicitly aligned ``claimed_risk`` and ``observed_risk``
+        units, the ``calibration_error`` (observed - claimed), separate
+        episode-level collision diagnostics, the named planner measures, and a
         ``claim_boundary`` marking the diagnostic scope.
     """
 
     scenario = scenario or CalibrationScenario()
+    risk_unit, observation_window, observation_window_steps, cvar_alpha = _calibration_contract(
+        planner
+    )
     planner_dt = float(getattr(getattr(planner, "config", None), "rollout_dt", scenario.dt))
     if not np.isclose(planner_dt, float(scenario.dt)):
         raise ValueError(
@@ -354,6 +477,7 @@ def realized_collision_risk_calibration(
     freezes = 0
     completions = 0
     claimed = float(getattr(planner, "claimed_risk", float("nan")))
+    collision_samples: list[list[np.ndarray]] = []
     for _ in range(int(scenario.num_episodes)):
         planner.reset()
         observation = _spawn_scenario(
@@ -365,7 +489,14 @@ def realized_collision_risk_calibration(
         )
         episode_collision = False
         episode_moved = False
+        episode_samples: list[np.ndarray] = []
+        episode_finished = False
         for step in range(int(scenario.steps_per_episode)):
+            indicators = _collision_indicators(
+                observation, collision_radius_m=scenario.collision_radius_m
+            )
+            episode_samples.append(indicators)
+            episode_collision = episode_collision or bool(np.any(indicators))
             start_ns = time.perf_counter_ns()
             raw_command = planner.plan(observation)
             command = (float(raw_command[0]), float(raw_command[1]))
@@ -380,7 +511,6 @@ def realized_collision_risk_calibration(
             )
             if tail_clearances[-1] < 0.0:
                 episode_collision = True
-                break
             _step_robot(observation, command, dt=float(scenario.dt))
             _step_pedestrians(observation, dt=float(scenario.dt))
             tail_clearances.append(
@@ -390,12 +520,12 @@ def realized_collision_risk_calibration(
             )
             if tail_clearances[-1] < 0.0:
                 episode_collision = True
-                break
             goal = np.asarray(observation["goal"]["current"], dtype=float)
             robot_pos = np.asarray(observation["robot"]["position"], dtype=float)
-            if float(np.linalg.norm(goal - robot_pos)) <= 0.25:
+            if not episode_finished and float(np.linalg.norm(goal - robot_pos)) <= 0.25:
                 completions += 1
-                break
+                episode_finished = True
+        collision_samples.append(episode_samples)
         if episode_collision:
             collisions += 1
         elif not episode_moved:
@@ -405,11 +535,33 @@ def realized_collision_risk_calibration(
         if planner.diagnostics().get("solver_failures", 0) > 0:
             infeasible += 1
     n = max(int(scenario.num_episodes), 1)
-    observed = collisions / float(n)
+    observed, observation_count, observation_window_count = _aggregate_observed_risk(
+        collision_samples,
+        formulation=str(
+            getattr(
+                getattr(planner, "chance_config", None), "chance_constraint_formulation", "marginal"
+            )
+        ),
+        horizon_steps=observation_window_steps,
+        cvar_alpha=cvar_alpha,
+    )
     return {
-        "claimed_risk_per_horizon": float(claimed),
-        "observed_collision_rate": float(observed),
+        "formulation": str(
+            getattr(
+                getattr(planner, "chance_config", None), "chance_constraint_formulation", "marginal"
+            )
+        ),
+        "claimed_risk": float(claimed),
+        "observed_risk": float(observed),
+        "claimed_risk_unit": risk_unit,
+        "observed_risk_unit": risk_unit,
+        "observation_window": observation_window,
+        "observation_window_steps": int(observation_window_steps),
+        "cvar_alpha": float(cvar_alpha) if cvar_alpha is not None else None,
+        "observation_count": int(observation_count),
+        "observation_window_count": int(observation_window_count),
         "calibration_error": float(observed - claimed),
+        "episode_collision_rate": float(collisions / n),
         "infeasible_rate": float(infeasible / n),
         "freeze_rate": float(freezes / n),
         "completion_rate": float(completions / n),
@@ -422,7 +574,8 @@ def realized_collision_risk_calibration(
         "sample_count": float(n),
         "claim_boundary": (
             "closed-loop self-consistency diagnostic under matched constant-velocity "
-            "dynamics; not a matched-arm benchmark calibration result and makes no "
+            "dynamics; calibration units are formulation-specific and explicitly "
+            "reported; not a matched-arm benchmark calibration result and makes no "
             "planner-value or real-world risk claim; replace the surrogate with the "
             "learned #2844 predictor before any benchmark-facing claim"
         ),
@@ -493,6 +646,10 @@ def realized_collision_risk_calibration_sweep(
     stream_gap``). These are exposed as observables for inspection, not as a
     gate verdict: the cheap-lane slice does not make a campaign-routing
     decision.
+
+    Every point names both risk units and its observation window. Horizon-based
+    formulations fail closed when ``scenario.steps_per_episode`` is shorter
+    than the planner horizon; they never fall back to episode-level rates.
 
     This slice is CPU-runnable today over the surrogate
     ``constant_velocity_gmm`` provider. It is an API/self-consistency
@@ -566,10 +723,18 @@ def realized_collision_risk_calibration_sweep(
             planner = adapter_builder(cfg)
             result = realized_collision_risk_calibration(planner, scenario, seed=seed)
             point = {
-                "formulation": formulation,
-                "claimed_risk": float(budget),
-                "observed_collision_rate": float(result["observed_collision_rate"]),
+                "formulation": str(result["formulation"]),
+                "claimed_risk": float(result["claimed_risk"]),
+                "observed_risk": float(result["observed_risk"]),
+                "claimed_risk_unit": str(result["claimed_risk_unit"]),
+                "observed_risk_unit": str(result["observed_risk_unit"]),
+                "observation_window": str(result["observation_window"]),
+                "observation_window_steps": int(result["observation_window_steps"]),
+                "cvar_alpha": result["cvar_alpha"],
+                "observation_count": int(result["observation_count"]),
+                "observation_window_count": int(result["observation_window_count"]),
                 "calibration_error": float(result["calibration_error"]),
+                "episode_collision_rate": float(result["episode_collision_rate"]),
                 "freeze_rate": float(result["freeze_rate"]),
                 "infeasible_rate": float(result["infeasible_rate"]),
                 "completion_rate": float(result["completion_rate"]),
@@ -583,7 +748,7 @@ def realized_collision_risk_calibration_sweep(
     reliability_summary: dict[str, dict[str, Any]] = {}
     for formulation, points in points_by_formulation.items():
         abs_errors = [abs(float(p["calibration_error"])) for p in points]
-        observed = [float(p["observed_collision_rate"]) for p in points]
+        observed = [float(p["observed_risk"]) for p in points]
         compute_times = [float(p["mean_compute_time_ms"]) for p in points]
         freeze_rates = [float(p["freeze_rate"]) for p in points]
         # The tightest (lowest) budget sits first because budgets sweep small->large.

--- a/tests/planner/test_chance_constrained_mpc_provider.py
+++ b/tests/planner/test_chance_constrained_mpc_provider.py
@@ -31,6 +31,8 @@ from robot_sf.planner.chance_constrained_mpc_provider import (
     CalibrationSweep,
     ConstantVelocityGmmPredictor,
     _aggregate_observed_risk,
+    _calibration_contract,
+    _collision_indicators,
     _min_robot_pedestrian_clearance,
     build_calibration_sweep_config,
     build_constant_velocity_gmm_forecast,
@@ -360,6 +362,65 @@ def test_calibration_aggregation_distinguishes_step_horizon_and_episode_units() 
     assert tail_count == 2
     # Episode-level any-collision is 1.0, but is not the marginal calibration unit.
     assert marginal < 1.0
+
+
+def test_calibration_aggregation_accepts_variable_episode_shapes() -> None:
+    """Aggregation supports per-episode step and pedestrian-count variation."""
+
+    samples = [
+        [np.asarray([False, True]), np.asarray([True, False])],
+        [np.asarray([False]), np.asarray([True]), np.asarray([False])],
+    ]
+
+    marginal, marginal_count, marginal_windows = _aggregate_observed_risk(
+        samples, formulation="marginal", horizon_steps=1, cvar_alpha=None
+    )
+    joint, joint_count, _ = _aggregate_observed_risk(
+        samples, formulation="joint_horizon", horizon_steps=2, cvar_alpha=None
+    )
+
+    assert marginal == pytest.approx(3.0 / 7.0)
+    assert marginal_count == 7
+    assert marginal_windows == 5
+    assert joint == pytest.approx(1.0)
+    assert joint_count == 3
+
+
+@pytest.mark.parametrize(
+    "observation",
+    [
+        {},
+        {"robot": {"position": [0.0, 0.0]}},
+        {"robot": {"position": [0.0, 0.0]}, "pedestrians": []},
+        {
+            "robot": {"position": [0.0, 0.0]},
+            "pedestrians": {"positions": [[float("nan"), 0.0]]},
+        },
+    ],
+)
+def test_collision_indicators_fail_closed_on_malformed_observation(
+    observation: dict,
+) -> None:
+    """Malformed observation structure must not become a zero-risk result."""
+
+    with pytest.raises(ValueError, match="observation"):
+        _collision_indicators(observation, collision_radius_m=0.85)
+
+
+@pytest.mark.parametrize(
+    "chance_config",
+    [None, SimpleNamespace(chance_constraint_formulation=None)],
+)
+def test_calibration_contract_defaults_missing_formulation_to_marginal(
+    chance_config: object,
+) -> None:
+    """Absent or explicit-null formulation values use the documented default."""
+
+    planner = SimpleNamespace(
+        chance_config=chance_config,
+        config=SimpleNamespace(horizon_steps=4),
+    )
+    assert _calibration_contract(planner) == ("per_pedestrian_timestep", "control_step", 1, None)
 
 
 def test_horizon_calibration_fails_closed_without_a_full_observation_window() -> None:

--- a/tests/planner/test_chance_constrained_mpc_provider.py
+++ b/tests/planner/test_chance_constrained_mpc_provider.py
@@ -30,6 +30,7 @@ from robot_sf.planner.chance_constrained_mpc_provider import (
     CalibrationScenario,
     CalibrationSweep,
     ConstantVelocityGmmPredictor,
+    _aggregate_observed_risk,
     _min_robot_pedestrian_clearance,
     build_calibration_sweep_config,
     build_constant_velocity_gmm_forecast,
@@ -160,10 +161,10 @@ def test_calibration_closes_loop_over_the_planners_claimed_risk() -> None:
     """Issue #5307 measure #1: pair the planner's claimed risk with observed.
 
     The harness rolls the chance-constrained MPC planner through episodes whose
-    pedestrian dynamics match the surrogate's own forecast, then reports the
-    planner's claimed per-horizon risk next to the observed collision rate and
-    the other named measures (infeasibility, freezing, completion, tail
-    clearance, compute time).
+    pedestrian dynamics match the surrogate's own forecast, then reports
+    formulation-matched claimed and observed risks plus the other named
+    measures (infeasibility, freezing, completion, tail clearance, compute
+    time).
     """
 
     adapter = build_chance_constrained_mpc_adapter(
@@ -180,8 +181,13 @@ def test_calibration_closes_loop_over_the_planners_claimed_risk() -> None:
         seed=1,
     )
     required = {
-        "claimed_risk_per_horizon",
-        "observed_collision_rate",
+        "claimed_risk",
+        "observed_risk",
+        "claimed_risk_unit",
+        "observed_risk_unit",
+        "observation_window",
+        "observation_window_steps",
+        "episode_collision_rate",
         "calibration_error",
         "infeasible_rate",
         "freeze_rate",
@@ -192,12 +198,15 @@ def test_calibration_closes_loop_over_the_planners_claimed_risk() -> None:
     }
     assert required <= result.keys()
     # The planner's claimed risk is read straight from the control law config.
-    assert result["claimed_risk_per_horizon"] == pytest.approx(0.05)
+    assert result["claimed_risk"] == pytest.approx(0.05)
+    assert result["claimed_risk_unit"] == "per_pedestrian_timestep"
+    assert result["observed_risk_unit"] == "per_pedestrian_timestep"
+    assert result["observation_window"] == "control_step"
     # Calibration error is the issue's primary measure: observed minus claimed.
     assert result["calibration_error"] == pytest.approx(
-        result["observed_collision_rate"] - result["claimed_risk_per_horizon"]
+        result["observed_risk"] - result["claimed_risk"]
     )
-    assert 0.0 <= result["observed_collision_rate"] <= 1.0
+    assert 0.0 <= result["observed_risk"] <= 1.0
     assert 0.0 <= result["completion_rate"] <= 1.0
     assert 0.0 <= result["mean_compute_time_ms"]
     assert result["sample_count"] == pytest.approx(6.0)
@@ -215,7 +224,7 @@ def test_calibration_is_reproducible_under_fixed_seed() -> None:
     scenario = CalibrationScenario(num_episodes=4, steps_per_episode=10, num_pedestrians=3)
     first = realized_collision_risk_calibration(adapter, scenario, seed=7)
     second = realized_collision_risk_calibration(adapter, scenario, seed=7)
-    assert first["observed_collision_rate"] == second["observed_collision_rate"]
+    assert first["observed_risk"] == second["observed_risk"]
     assert first["mean_tail_clearance_m"] == second["mean_tail_clearance_m"]
 
 
@@ -237,10 +246,15 @@ def test_calibration_runs_end_to_end_for_cvar_tail_formulation() -> None:
         CalibrationScenario(num_episodes=4, steps_per_episode=8, num_pedestrians=3),
         seed=3,
     )
-    assert result["claimed_risk_per_horizon"] == pytest.approx(0.05)
-    assert 0.0 <= result["observed_collision_rate"] <= 1.0
+    assert result["claimed_risk"] == pytest.approx(0.05)
+    assert result["claimed_risk_unit"] == "mpc_horizon_cvar_tail"
+    assert result["observed_risk_unit"] == "mpc_horizon_cvar_tail"
+    assert result["observation_window"] == "mpc_horizon"
+    assert result["observation_window_steps"] == 6
+    assert result["cvar_alpha"] == pytest.approx(0.9)
+    assert 0.0 <= result["observed_risk"] <= 1.0
     assert result["calibration_error"] == pytest.approx(
-        result["observed_collision_rate"] - result["claimed_risk_per_horizon"]
+        result["observed_risk"] - result["claimed_risk"]
     )
     assert 0.0 <= result["mean_compute_time_ms"]
 
@@ -256,7 +270,8 @@ def test_calibration_runs_end_to_end_without_pedestrians() -> None:
         CalibrationScenario(num_episodes=4, steps_per_episode=8, num_pedestrians=0),
         seed=2,
     )
-    assert result["observed_collision_rate"] == pytest.approx(0.0)
+    assert result["observed_risk"] == pytest.approx(0.0)
+    assert result["episode_collision_rate"] == pytest.approx(0.0)
     # No pedestrians => every clearance is +inf, so the mean is +inf (not finite).
     assert result["mean_tail_clearance_m"] == pytest.approx(float("inf"))
     assert result["completion_rate"] >= 0.0
@@ -316,6 +331,49 @@ def _light_sweep() -> tuple[dict, CalibrationSweep]:
     return base_algo_config, sweep
 
 
+def test_calibration_aggregation_distinguishes_step_horizon_and_episode_units() -> None:
+    """Comparable units differ from the diagnostic episode-level event rate."""
+
+    samples = [
+        [
+            np.asarray([False, True]),
+            np.asarray([False, False]),
+            np.asarray([True, False]),
+        ]
+    ]
+    marginal, marginal_count, marginal_windows = _aggregate_observed_risk(
+        samples, formulation="marginal", horizon_steps=1, cvar_alpha=None
+    )
+    joint, joint_count, _ = _aggregate_observed_risk(
+        samples, formulation="joint_horizon", horizon_steps=2, cvar_alpha=None
+    )
+    tail, tail_count, _ = _aggregate_observed_risk(
+        samples, formulation="cvar_tail", horizon_steps=2, cvar_alpha=0.5
+    )
+
+    assert marginal == pytest.approx(2.0 / 6.0)
+    assert marginal_count == 6
+    assert marginal_windows == 3
+    assert joint == pytest.approx(1.0)
+    assert joint_count == 2
+    assert tail == pytest.approx(0.5)
+    assert tail_count == 2
+    # Episode-level any-collision is 1.0, but is not the marginal calibration unit.
+    assert marginal < 1.0
+
+
+def test_horizon_calibration_fails_closed_without_a_full_observation_window() -> None:
+    """Joint/CVaR claims cannot silently fall back to episode-level aggregation."""
+
+    with pytest.raises(ValueError, match="requires at least 4 observed steps"):
+        _aggregate_observed_risk(
+            [[np.asarray([False]), np.asarray([False]), np.asarray([False])]],
+            formulation="joint_horizon",
+            horizon_steps=4,
+            cvar_alpha=None,
+        )
+
+
 def test_calibration_sweep_returns_claimed_vs_observed_curve_across_budgets() -> None:
     """Issue #5307 primary measure as a *curve*: pair claimed risk with observed.
 
@@ -336,12 +394,14 @@ def test_calibration_sweep_returns_claimed_vs_observed_curve_across_budgets() ->
     assert claimed == [0.05, 0.10, 0.20]
     for point, budget in zip(points, sweep.risk_budgets, strict=True):
         assert point["formulation"] == "marginal"
+        assert point["observed_risk_unit"] == "per_pedestrian_timestep"
+        assert point["observation_window"] == "control_step"
         assert point["claimed_risk"] == pytest.approx(float(budget))
-        # calibration_error is the issue's primary measure: observed - claimed.
+        # calibration_error is the issue's primary measure in the declared unit.
         assert point["calibration_error"] == pytest.approx(
-            point["observed_collision_rate"] - point["claimed_risk"]
+            point["observed_risk"] - point["claimed_risk"]
         )
-        assert 0.0 <= point["observed_collision_rate"] <= 1.0
+        assert 0.0 <= point["observed_risk"] <= 1.0
         assert 0.0 <= point["freeze_rate"] <= 1.0
         assert 0.0 <= point["infeasible_rate"] <= 1.0
         assert 0.0 <= point["completion_rate"] <= 1.0
@@ -365,6 +425,19 @@ def test_calibration_sweep_compares_formulations_at_matched_budgets() -> None:
     for formulation, points in by_formulation.items():
         assert [p["claimed_risk"] for p in points] == [0.05, 0.10, 0.20]
         assert all(p["formulation"] == formulation for p in points)
+        expected_unit = (
+            "per_pedestrian_timestep"
+            if formulation == "marginal"
+            else "mpc_horizon_any_collision"
+            if formulation == "joint_horizon"
+            else "mpc_horizon_cvar_tail"
+        )
+        assert all(p["observed_risk_unit"] == expected_unit for p in points)
+        assert all(
+            p["observation_window"]
+            == ("control_step" if formulation == "marginal" else "mpc_horizon")
+            for p in points
+        )
 
 
 def test_calibration_sweep_replays_same_scenarios_across_budgets() -> None:
@@ -380,8 +453,8 @@ def test_calibration_sweep_replays_same_scenarios_across_budgets() -> None:
     base_algo_config, sweep = _light_sweep()
     first = realized_collision_risk_calibration_sweep(base_algo_config, sweep, seed=11)
     second = realized_collision_risk_calibration_sweep(base_algo_config, sweep, seed=11)
-    first_observed = [p["observed_collision_rate"] for p in first["points"]]
-    second_observed = [p["observed_collision_rate"] for p in second["points"]]
+    first_observed = [p["observed_risk"] for p in first["points"]]
+    second_observed = [p["observed_risk"] for p in second["points"]]
     assert first_observed == second_observed
 
     # The sweep point at a given budget must equal a direct single-point run.
@@ -394,9 +467,7 @@ def test_calibration_sweep_replays_same_scenarios_across_budgets() -> None:
     )
     direct = realized_collision_risk_calibration(adapter, sweep.scenario, seed=11)
     sweep_point = first["points_by_formulation"]["marginal"][1]
-    assert sweep_point["observed_collision_rate"] == pytest.approx(
-        direct["observed_collision_rate"]
-    )
+    assert sweep_point["observed_risk"] == pytest.approx(direct["observed_risk"])
     assert sweep_point["calibration_error"] == pytest.approx(direct["calibration_error"])
 
 
@@ -466,7 +537,12 @@ def test_calibration_sweep_yaml_config_runs_end_to_end() -> None:
     result = realized_collision_risk_calibration_sweep(base, sweep, seed=0)
     assert len(result["points"]) == 3 * 3
     for point in result["points"]:
-        assert np.isfinite(point["observed_collision_rate"])
+        assert np.isfinite(point["observed_risk"])
+        assert point["observed_risk_unit"] in {
+            "per_pedestrian_timestep",
+            "mpc_horizon_any_collision",
+            "mpc_horizon_cvar_tail",
+        }
         assert np.isfinite(point["mean_compute_time_ms"])
     assert set(result["reliability_summary"]) == {
         "marginal",


### PR DESCRIPTION
### Reviewer-critical summary

- What changed: calibration results now compare claimed and observed risk in one explicit unit per formulation: per-pedestrian-timestep for `marginal`, rolling MPC-horizon any-collision for `joint_horizon`, and rolling MPC-horizon empirical CVaR for `cvar_tail`.
- Why now: the gate follow-up from [PR #5728](https://github.com/ll7/robot_sf_ll7/pull/5728) identified that its sweep compared per-horizon/per-cell claims against episode-level any-collision observations.
- Claim boundary: diagnostic-only self-consistency under matched constant-velocity surrogate dynamics; this is not benchmark calibration evidence, a planner-value claim, or a real-world risk claim.
- Required validation: focused provider tests, aggregation contract tests, YAML/config parsing, Ruff, and the committed-head readiness gate.
- Remaining blocker: learned predictor integration and matched-arm campaign evidence remain outside this issue; no paper-facing claim is unlocked.

### Contract delta

- Results replace ambiguous `claimed_risk_per_horizon` / `observed_collision_rate` calibration fields with `claimed_risk`, `observed_risk`, `claimed_risk_unit`, `observed_risk_unit`, `observation_window`, `observation_window_steps`, and explicit denominators.
- `joint_horizon` and `cvar_tail` use full rolling MPC-horizon windows and fail closed when `steps_per_episode` is shorter than the planner horizon; they never fall back to episode-level aggregation.
- `episode_collision_rate` remains available as a separate diagnostic and is not used in `calibration_error`.
- Compatibility impact: this is a follow-up to the newly introduced PR #5728 sweep output; repository call sites and tests are updated to the corrected schema.

## Summary

Aligns calibration-sweep risk claims with observed collision aggregation and records the unit/window provenance needed to interpret every point.

## Linked Issues

- Closes #5737
- Relates to `#5307`
- Follow-up friction: [#5743](https://github.com/ll7/robot_sf_ll7/issues/5743)

## Stack / Dependency

- Base dependency: `origin/main`
- Required prior PRs: `#5728` (the corrected follow-up target)
- Stack follow-up issues: `#5743` for test-runtime friction
- Safe to review independently: yes
- Review dependency reason, if any: the code is independent; #5728 provides the original diagnostic API being corrected.

## What Changed

- Added formulation-specific risk contracts and observed-risk aggregators in `robot_sf/planner/chance_constrained_mpc_provider.py`.
- Added explicit risk units, observation windows, counts, CVaR alpha, and separate episode collision rate to single-point and sweep results.
- Added fail-closed validation for incomplete horizon windows.
- Updated provider regression tests for per-step, per-horizon, CVaR-tail, episode-level, and YAML sweep behavior.
- Documented the units and explicit CVaR confidence in `configs/algos/chance_constrained_mpc_calibration_sweep_diagnostic.yaml`.

## Why It Matters

- Added value: prevents calibration error and monotonicity from mixing incompatible probability events and time windows.
- Expected impact: diagnostic sweep points are directly interpretable within each supported formulation.
- Why now: it closes the correctness gap identified immediately by the PR #5728 gate before any calibration result can be over-read.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: claimed-vs-observed calibration must use the same event unit and observation window for each chance-constraint formulation.
- Comparator or baseline, if applicable: the pre-fix episode-level any-collision aggregation from PR #5728.
- Evidence tier: diagnostic probe
- Result classification: blocker-resolution / diagnostic-only
- Decision or stop rule, if applicable: continue diagnostic implementation; do not promote surrogate results to benchmark or paper claims.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue `#5737`; no claim-map or benchmark report update is appropriate.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - this is a correction to an existing diagnostic helper, not a new analysis tool.

## Domain-Aware Approval

- Required for this PR: yes
- Domains reviewed: experimental comparison, benchmark interpretation, paper-facing claims
- Status: waived
- Approver/review source or waiver: Issue #5737 maintainer contract; diagnostic-only correction with no benchmark or paper claim
- Validity checklist:
  - Target claim/hypothesis: formulation-matched claimed-vs-observed diagnostic calibration.
  - Comparator or split/evidence validity: old episode-level any-collision output is retained only as a separate diagnostic; each calibration unit has an explicit denominator.
  - Fallback/degraded exclusions: surrogate-only diagnostic; no fallback or degraded benchmark row is treated as evidence.
  - Claim boundary: no matched-arm, planner-superiority, real-world, benchmark, or paper claim.
  - Implementation integrity vs experimental validity: implementation and contract tests are covered; experimental validity remains diagnostic-only pending learned predictor and campaign work.

## Falsification / Non-Transfer Check

- Did the mechanism activate? yes - formulation-specific aggregation and fail-closed horizon checks are exercised by tests.
- Did the intervention change command source, selected command, trajectory, or route progress? NA - this changes diagnostic aggregation, not planner commands.
- Did the scenario actually contain the targeted failure mode? yes - the pre-fix API paired episode-level observations with per-cell/per-horizon claims.
- Result route: continue
- Follow-up question or issue for weak, negative, or non-transfer results: #5743 tracks the slow solver-backed test path; learned predictor and matched-arm evidence remain in #5307.

## Next Empirical Action

- Rerun needed: yes - only after learned #2844 predictor and matched-arm campaign inputs exist.
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: learned #2844 predictor and matched-arm campaign artifacts.
- Stop / revise / continue decision: continue with diagnostic-only implementation; stop claim promotion until those inputs are available.
- Proposed child issue or existing follow-up: parent issue `#5307`; test-runtime friction `#5743`.

## Validation / Proof

- `uv run ruff format robot_sf/planner/chance_constrained_mpc_provider.py tests/planner/test_chance_constrained_mpc_provider.py` — pass.
- `uv run ruff check robot_sf/planner/chance_constrained_mpc_provider.py tests/planner/test_chance_constrained_mpc_provider.py` — pass.
- `uv run pytest tests/planner/test_chance_constrained_mpc_provider.py -q -k 'aggregation or horizon_calibration'` — 2 passed.
- `uv run pytest tests/planner/test_chance_constrained_mpc_provider.py -q` — 21 passed in 575.41s; the repository slow-test report flags three hard-threshold cases, tracked in #5743.
- YAML/config smoke parse — pass; all three formulations and the full-horizon contract parsed successfully.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue-5737-pr-body.md scripts/dev/pr_ready_check.sh` — pass on committed head `3dfb7b2626a1f64d55a3ee45f2245259451e5d62`; core and optional lanes green, changed-file coverage 88.6% (above the 80% minimum; 100% goal warning only).
- `git diff --check` — pass before commit; committed head is `3dfb7b262`.

No full benchmark campaign was run. No Slurm/GPU submission was made. No paper/dissertation claim edits were made.

## Risks / Rollout

- Compatibility risks: result consumers must use the explicit `observed_risk` schema; the only repository consumer is updated in the focused tests.
- Failure modes: horizon aggregation raises a clear error for insufficient observations; surrogate dynamics remain uncalibrated.
- Rollback or fallback plan: revert this commit; no planner control-law fallback is introduced.

## Docs / Provenance

- Updated docs: diagnostic YAML comments and provider contract docstrings.
- Relevant design or provenance notes: issue `#5737`, PR `#5728`, and the diagnostic-only boundary in issue `#5307`.
- Any assumptions that need to be preserved: CVaR observed risk uses the same `cvar_alpha` as the planner's empirical upper-tail cell-risk contract; rolling windows are used instead of episode-level fallback.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no - issue/PR commenting was not authorized; this PR body is the canonical handoff and explicitly links remaining work.
- Claim map / benchmark report updated (yes/no/NA): NA - no benchmark or paper claim is produced.
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA - existing diagnostic config path is updated in place.
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): yes - #5743 for test runtime; research follow-up remains #5307.
- Not applicable because: this PR corrects a diagnostic contract and produces no durable benchmark artifact or promoted claim.

## Follow-Up Issues

- Deferred work: learned predictor integration and matched-arm campaign evidence under #5307; CPU-light test fixture under #5743.
- Issues opened for follow-up: #5743.

## Reviewer Notes

- Anything a reviewer should verify closely: the three `claimed_risk_unit` / `observed_risk_unit` mappings, the rolling-window denominator, and the absence of episode-level fallback for horizon modes.
- Any known limitations: all execution remains matched constant-velocity surrogate diagnostic evidence; the solver-backed test file is slow on this host.
- Shared-helper migration: inapplicable; no process-boundary helper or shared CLI contract changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved collision-risk calibration across marginal, joint-horizon, and CVaR formulations.
  * Calibration results now include claimed and observed risk, units, observation windows, counts, and calibration error.
  * Added episode-level collision diagnostics and safer handling of invalid or incomplete observations.
  * Updated calibration sweeps to report formulation-specific risk metrics and monotonicity.

* **Documentation**
  * Clarified risk comparisons, observation units, surrogate limitations, and horizon-based validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->