### PR TITLE
fix(validation): repair main CI regressions (#5754)

### DIFF
--- a/scripts/validation/check_issue_5592_cross_matrix_preregistration.py
+++ b/scripts/validation/check_issue_5592_cross_matrix_preregistration.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -301,12 +302,48 @@ def _configure_machine_readable_logging() -> None:
     logger.add(sys.stderr, level="DEBUG")
 
 
+def _run_machine_readable_validation(packet: Path) -> int:
+    """Run JSON validation without mutating the caller's process-global Loguru sinks."""
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--packet",
+        str(packet),
+        "--json",
+        "--machine-readable-child",
+    ]
+    try:
+        completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    except OSError as exc:
+        print(f"isolated validation failed: {exc}", file=sys.stderr)
+        print(json.dumps({"status": "not_ready", "error": str(exc)}))
+        return 1
+
+    if completed.stderr:
+        sys.stderr.write(completed.stderr)
+    try:
+        json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        if completed.stdout:
+            sys.stderr.write(completed.stdout)
+        print(
+            json.dumps({"status": "not_ready", "error": "isolated validation emitted invalid JSON"})
+        )
+        return completed.returncode or 1
+
+    sys.stdout.write(completed.stdout)
+    return completed.returncode
+
+
 def main(argv: list[str] | None = None) -> int:
     """Validate the packet and emit a compact JSON or text result."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--packet", type=Path, default=DEFAULT_PACKET)
     parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument("--machine-readable-child", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args(argv)
+    if args.as_json and not args.machine_readable_child:
+        return _run_machine_readable_validation(args.packet)
     if args.as_json:
         _configure_machine_readable_logging()
     try:

--- a/scripts/validation/check_issue_5592_cross_matrix_preregistration.py
+++ b/scripts/validation/check_issue_5592_cross_matrix_preregistration.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path, PurePosixPath
 from typing import Any
 
 import yaml
+from loguru import logger
 
 from robot_sf.training.scenario_loader import load_scenarios
 
@@ -293,12 +295,20 @@ def validate_packet(packet: dict[str, Any], *, repo_root: Path | None = None) ->
     }
 
 
+def _configure_machine_readable_logging() -> None:
+    """Route validation diagnostics to stderr so JSON stdout stays parseable."""
+    logger.remove()
+    logger.add(sys.stderr, level="DEBUG")
+
+
 def main(argv: list[str] | None = None) -> int:
     """Validate the packet and emit a compact JSON or text result."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--packet", type=Path, default=DEFAULT_PACKET)
     parser.add_argument("--json", action="store_true", dest="as_json")
     args = parser.parse_args(argv)
+    if args.as_json:
+        _configure_machine_readable_logging()
     try:
         result = validate_packet(load_packet(args.packet))
     except (OSError, PacketError, ValueError, TypeError, KeyError, yaml.YAMLError) as exc:

--- a/tests/validation/test_check_issue_5248_salvaged_trace_rerun.py
+++ b/tests/validation/test_check_issue_5248_salvaged_trace_rerun.py
@@ -39,9 +39,8 @@ def test_real_harvest_blocks_on_trace_label_floor_not_missing_inputs() -> None:
     """
 
     if not HARVEST_CAMPAIGN_ROOT.is_dir():
-        raise pytest.skip.Exception(
-            "verified job-13334 harvest absent on this host",
-            reason="harvest_not_available",
+        pytest.skip(
+            "harvest_not_available: verified job-13334 harvest absent on this host",
         )
 
     receipt = build_registration_receipt(

--- a/tests/validation/test_check_issue_5592_cross_matrix_preregistration.py
+++ b/tests/validation/test_check_issue_5592_cross_matrix_preregistration.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
+from loguru import logger
 
 from scripts.validation import check_issue_5592_cross_matrix_preregistration as checker
 
@@ -68,3 +70,23 @@ def test_cli_emits_machine_readable_ready_status(capsys) -> None:
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload["status"] == "ready"
     assert payload["campaign_execution_allowed"] is False
+
+
+def test_json_cli_preserves_caller_loguru_sink(capsys) -> None:
+    """JSON validation must not remove process-global sinks installed by callers."""
+    sink_id = logger.add(sys.stdout, format="{message}")
+    try:
+        exit_code = checker.main(["--json"])
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+        assert json.loads(captured.out)["status"] == "ready"
+        assert captured.err
+
+        logger.info("caller sink remains active")
+        assert capsys.readouterr().out.strip() == "caller sink remains active"
+    finally:
+        try:
+            logger.remove(sink_id)
+        except ValueError:
+            pass


### PR DESCRIPTION
## Summary

Repair the two fast-feedback validation regressions reported by main CI run `29405496799`.
The change is limited to the two directly owned validation surfaces and preserves their
fail-closed contracts.

## Linked Issues

- Relates to `#5754`

## Stack / Dependency

- Base dependency: `origin/main` at `e5490302f0076d05eab3b3691742f9c6782197e6`
- Required prior PRs: none
- Safe to review independently: yes

## What Changed

- Route Loguru diagnostics to stderr for the #5592 `--json` CLI path, so a warning emitted while
  loading the scenario matrix cannot contaminate the single machine-readable JSON document on
  stdout. Validation results and failure exit behavior are unchanged.
- Use pytest's supported skip API for the host-local #5248 harvest guard, retaining an explicit
  `harvest_not_available` reason instead of constructing `Skipped` with an unsupported keyword.
- The introducing commits were `f53d1a0e22` (#5592 checker/CLI) and `3244bfd93c` (#5248 host-local
  regression guard).

## Why It Matters

- Restores deterministic machine-readable checker output under test-order logging contamination.
- Converts an unavailable host-local harvest into the intended skip rather than a collection-time
  TypeError; no harvest or benchmark data is acquired.

## Research Result Guidance

- Target claim / hypothesis / blocker: `NA` — support-only validation repair; no research claim.
- Comparator or baseline: `NA`
- Evidence tier: `NA`
- Result classification: `NA`
- Decision or stop rule: `NA`
- Parent issue, claim map, registry, context note, or synthesis surface to update: `#5754` only.
- New research/benchmark/metric/paper-facing analysis tool: `NA - support helper`; this repair does
  not interpret evidence.

## Domain-Aware Approval

- Required for this PR: no - support-only validation behavior with no benchmark or paper claim.
- Domains reviewed: NA
- Status: not required

## Validation / Proof

- Before editing, CI run `29405496799` was inspected at head
  `250c661ad51820b64b714fe08897a0df679638b8`; it reported the two named failures.
- Before editing, the required combined local command reproduced the #5248 TypeError; the #5592
  failure reproduced exactly when a prior Loguru sink printed warnings through stdout, matching the
  CI `JSONDecodeError: Extra data` stream contamination.
- At validated head `404e4ec8d61d6db98443965325a76a52abc0c6ea`:
  `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest -q
  tests/validation/test_check_issue_5592_cross_matrix_preregistration.py
  tests/validation/test_check_issue_5248_salvaged_trace_rerun.py` → **13 passed, 1 skipped**.
- The same contamination probe for `test_cli_emits_machine_readable_ready_status` → **1 passed**.
- Ruff check → **passed**; `ruff format --check` → **2 files already formatted**;
  `git diff --check` → **passed**.
- The #5248 real-harvest test skips locally because the issue-declared host-local harvest is absent;
  no campaign rerun or data acquisition was performed.
- Full `pr_ready_check.sh` was not run because its repo-wide fix/format step exceeds the explicit
  four-file allowlist. Hosted CI remains the source of merge readiness; this PR does not claim it.

## Risks / Rollout

- Compatibility risks: none expected; only validation output routing and an unavailable-fixture skip
  path changed.
- Failure modes: malformed #5592 packets still return `not_ready`; incomplete #5248 registrations
  still return blocked status; missing host-local harvests now skip as intended.
- Rollback or fallback plan: revert commit `404e4ec8d`.

## Docs / Provenance

- Updated docs: none.
- Relevant provenance: CI run `29405496799`; introducing commits listed above.
- Generated artifacts: no new durable artifacts. Pre-existing ignored `output/repos/` and
  `output/compute_feasibility_matrix_v1/` were inspected, left untouched, and are not part of this
  PR.

## Downstream Propagation

- Parent issue updated: no
- Claim map / benchmark report updated: NA
- Leaderboard / artifact catalog updated: NA
- Registry or config index updated: NA
- Context index / memory note updated: NA
- Follow-up issue opened: no
- Not applicable because: this is a bounded main-CI validation repair with no evidence or artifact
  promotion.

## Follow-Up Issues

- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes

- Verify that JSON mode sends all diagnostics to stderr while stdout remains exactly one JSON object.
- Verify that the host-local harvest guard skips only when its declared input root is absent and that
  the existing trace-label floor remains fail-closed when the harvest is present.
- Validated head SHA: `404e4ec8d61d6db98443965325a76a52abc0c6ea`.
