### PR TITLE
fix(readiness): include tests/ped_npc in core lane (#5753)

### DIFF
--- a/scripts/dev/run_tests_parallel.sh
+++ b/scripts/dev/run_tests_parallel.sh
@@ -70,6 +70,7 @@ core_test_paths=(
   tests/contract
   tests/factories
   tests/guard
+  tests/ped_npc
   tests/prediction
   tests/scenario_certification
   tests/sensor

--- a/tests/dev/test_pr_ready_preflight.py
+++ b/tests/dev/test_pr_ready_preflight.py
@@ -439,6 +439,20 @@ def test_optional_lane_collection_hook_skips_core_paths(monkeypatch: pytest.Monk
     )
 
 
+def test_ped_npc_collection_stays_in_core_lane(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pedestrian population tests are core-only, not optional-extra tests (#5753)."""
+    import tests.conftest as test_conftest
+
+    ped_npc_test = Path("tests/ped_npc/test_force_population_size_split.py")
+    assert test_conftest._is_optional_readiness_test_path(ped_npc_test.as_posix()) is False
+
+    monkeypatch.setenv("ROBOT_SF_TEST_LANE", "core")
+    assert test_conftest.pytest_ignore_collect(ped_npc_test, None) is False
+
+    monkeypatch.setenv("ROBOT_SF_TEST_LANE", "optional")
+    assert test_conftest.pytest_ignore_collect(ped_npc_test, None) is True
+
+
 def test_focused_snqi_selector_collects_without_unrelated_optional_stacks(tmp_path: Path) -> None:
     """Explicit SNQI targets must collect when unrelated optional imports are unavailable."""
     sitecustomize = tmp_path / "sitecustomize.py"

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -38,6 +38,7 @@ CI_DRIVER = ROOT / "scripts" / "dev" / "ci_driver.sh"
 GH_COMMENT = ROOT / "scripts" / "dev" / "gh_comment.sh"
 PYPROJECT = ROOT / "pyproject.toml"
 RUN_TESTS_PARALLEL = ROOT / "scripts" / "dev" / "run_tests_parallel.sh"
+OPTIONAL_ALLOWLIST = ROOT / "tests" / "support" / "optional_test_allowlist.txt"
 RUN_XDIST_RACE_VALIDATION = ROOT / "scripts" / "dev" / "run_xdist_race_validation.sh"
 RUN_CI_LOCAL = ROOT / "scripts" / "dev" / "run_ci_local.sh"
 LOCAL_SIGNOFF = ROOT / "scripts" / "dev" / "local_signoff.sh"
@@ -93,6 +94,7 @@ def test_run_tests_parallel_exposes_xdist_distribution_mode() -> None:
     assert "core_test_paths=(" in script_text
     assert "tests/adversarial" in script_text
     assert "tests/analysis_workbench" in script_text
+    assert "tests/ped_npc" in script_text
     assert "tests/scenario_certification" in script_text
     assert "explicit_test_targets=(" in script_text
     assert 'cmd+=("--ignore=$optional_test_path")' in script_text
@@ -228,6 +230,9 @@ def test_run_tests_parallel_core_lane_includes_changed_top_level_core_tests(tmp_
     (repo / "tests" / "test_optional_top_level.py").write_text(
         "def test_optional(): pass\n", encoding="utf-8"
     )
+    ped_npc_test = repo / "tests" / "ped_npc" / "test_population.py"
+    ped_npc_test.parent.mkdir(parents=True)
+    ped_npc_test.write_text("def test_population(): pass\n", encoding="utf-8")
     subprocess.run(["git", "add", "tests"], cwd=repo, check=True, capture_output=True, text=True)
     subprocess.run(
         ["git", "commit", "-m", "add top-level tests"],
@@ -258,6 +263,16 @@ def test_run_tests_parallel_core_lane_includes_changed_top_level_core_tests(tmp_
     pytest_args = captured_args.read_text(encoding="utf-8")
     assert "tests/test_new_top_level.py" in pytest_args
     assert "tests/test_optional_top_level.py" not in pytest_args
+    assert "tests/ped_npc" in pytest_args
+
+
+def test_run_tests_parallel_keeps_ped_npc_in_core_lane() -> None:
+    """The core lane must collect pedestrian-constructor tests (issue #5753)."""
+    script_text = RUN_TESTS_PARALLEL.read_text(encoding="utf-8")
+    core_paths = script_text.split("core_test_paths=(", maxsplit=1)[1].split(")", maxsplit=1)[0]
+
+    assert "\n  tests/ped_npc\n" in core_paths
+    assert "tests/ped_npc" not in OPTIONAL_ALLOWLIST.read_text(encoding="utf-8")
 
 
 def test_run_tests_parallel_serial_fallback_is_single_worker_and_fail_closed(


### PR DESCRIPTION
## Reviewer-critical summary

- What changed: added `tests/ped_npc` to the explicit `core_test_paths` collection in
  `scripts/dev/run_tests_parallel.sh` and added lane-contract coverage for its collection.
- Why now: issue #5753 identified that population-constructor tests were classified as core but
  omitted from both readiness lanes.
- Claim boundary: this proves readiness collection and core/optional separation only; it makes no
  population-behavior, benchmark, or paper-facing claim.
- Required validation: focused lane-contract/preflight tests, direct core-lane wrapper execution,
  shell syntax, Ruff, and final `pr_ready_check.sh`.
- Remaining blocker: none for the scoped implementation; merge and downstream PR-gate review remain.

Closes #5753

## Contract delta

- New schema fields: none.
- New fail-closed blockers: none.
- Collection contract: `tests/ped_npc` is a core lane directory and remains excluded from the
  optional-extra lane by the existing allowlist-driven classifier.
- Compatibility impact: no runtime or population behavior changes; existing core/optional target
  semantics remain unchanged.

<details>
<summary>Repository handoff details</summary>

## Summary

Include the pedestrian population-constructor tests in the core readiness lane.

## Linked Issues

- Issue: https://github.com/ll7/robot_sf_ll7/issues/5753
- Closes #5753

## Stack / Dependency

- Base dependency: `origin/main`
- Required prior PRs: none
- Safe to review independently: yes

## What Changed

- Added `tests/ped_npc` to `core_test_paths`.
- Extended `tests/test_ci_script_contract.py` to exercise and assert core-lane collection.
- Extended `tests/dev/test_pr_ready_preflight.py` to prove core collection and optional-lane
  exclusion for a pedestrian population test.

## Why It Matters

Population-constructor changes now receive the core readiness coverage intended by their existing
classification instead of being silently omitted.

## Research Result Guidance

- Target claim / hypothesis / blocker: readiness collection blocker in issue #5753.
- Comparator or baseline: `origin/main` lane target list.
- Evidence tier: NA - support/tooling contract change; no research result claimed.
- Result classification: NA
- Decision or stop rule: stop after focused contract proof and final readiness pass.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #5753 and
  this PR body.
- New research/benchmark/metric/paper-facing analysis tool: NA - support helper.

## Domain-Aware Approval

- Required for this PR: no - support/tooling change makes no research or paper-facing claim.
- Domains reviewed: NA
- Status: not required.
- Approver/review source or waiver: support/tooling scope; no domain review needed.
- Validity checklist:
  - Target claim/hypothesis: NA - no research claim.
  - Comparator or split/evidence validity: NA - no evidence comparison.
  - Fallback/degraded exclusions: NA - no benchmark execution.
  - Claim boundary: readiness collection only; no research or paper-facing claim.
  - Implementation integrity vs experimental validity: implementation integrity covered by the
    focused contract tests and final readiness gate; experimental validity is not applicable.

## Falsification / Non-Transfer Check

- Did the mechanism activate? NA - no research mechanism.
- Result route: NA.

## Next Empirical Action

- Rerun needed: NA - no campaign or empirical claim.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: stop for this scoped readiness fix.

## Validation / Proof

- `uv run pytest tests/test_ci_script_contract.py tests/dev/test_pr_ready_preflight.py -q` — 95
  passed.
- `uv run ruff check tests/test_ci_script_contract.py tests/dev/test_pr_ready_preflight.py` — passed.
- `uv run ruff format --check tests/test_ci_script_contract.py tests/dev/test_pr_ready_preflight.py`
  — passed; files already formatted.
- `bash -n scripts/dev/run_tests_parallel.sh` — passed.
- `PYTEST_NUM_WORKERS=1 PYTEST_FAST_FAIL=0 scripts/dev/run_tests_parallel.sh --lane core
  tests/ped_npc` — passed.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed; final clean-tree
  readiness recorded in the agent-run log.

## Risks / Rollout

- Compatibility risks: none identified; the target list only broadens core collection by one
  already-classified directory.
- Failure modes: a future reclassification must update the shared optional allowlist and its lane
  contract tests together.
- Rollback or fallback plan: revert the single core target entry and its regression tests.

## Docs / Provenance

- Updated docs: none required for this script/test contract change.
- Relevant design or provenance notes: issue #5753 body and existing optional allowlist.
- Assumptions: the existing explicit core directory list is the readiness owner; `tests/ped_npc`
  is intentionally core because it is absent from `tests/support/optional_test_allowlist.txt`.

## Downstream Propagation

- Parent issue updated: no separate issue comment; comment authorization was not granted, and this
  PR body is the durable handoff surface.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened for deferred propagation: no.
- Not applicable because: this is a support/tooling readiness contract with no durable research
  artifact or benchmark result.

## Follow-Up Issues

- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes

- Verify that the new directory is present in core wrapper arguments and absent from optional
  collection.
- No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.
- The live issue thread was re-read immediately before PR creation; it had no comments or later
  maintainer guidance.

</details>
