### PR TITLE
Issue #5498: native PPO exact-repeat determinism proof + reproducible runner (cheap-lane worker)

### DIFF
--- a/scripts/benchmark/run_issue_5498_native_ppo_slice.py
+++ b/scripts/benchmark/run_issue_5498_native_ppo_slice.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Run the issue #5498 native-PPO single-host exact-repeat slice.
+
+Background
+----------
+Issue #5498 is the successor to #5263. The single-host slice (#5499) executed
+all 140 targets but recorded the 3 PPO planner cells (60 targets) as
+``degraded``/``unrunnable`` because the forked planner-step worker crashed or
+timed out on that host. The native-PPO worker-isolation fix (#5740) resolved
+that defect, so PPO can now run natively through the exact-repeat
+``run_episode`` path.
+
+What this script does
+---------------------
+It re-executes the previously-unrunnable PPO targets natively (3 repeats each)
+on one CPU-only single-worker host, and writes the verified report under
+``output/issue_5498_native_ppo/``. The host report is verified against a
+PPO-only manifest slice (re-hashed, so ``verify_host_report`` does not reject
+it as "missing the 80 orca/goal targets").
+
+Usage
+-----
+Full native-PPO slice (60 targets x 3 repeats; a CPU-only single-host campaign
+act intended for a maintainer / campaign host):
+
+    uv run python scripts/benchmark/run_issue_5498_native_ppo_slice.py
+
+Smoke check of the runner + worker-isolation fix on a tiny target subset
+(cheap, non-campaign; used to validate the script itself):
+
+    uv run python scripts/benchmark/run_issue_5498_native_ppo_slice.py --max-targets 2
+
+Evidence status
+---------------
+The cheap-lane worker that added this script validated it end-to-end on a
+single PPO target (slice -> execute -> verify, bitwise-identical repeats) and
+ran the ``--max-targets 2`` smoke, but did NOT execute the full 60-target run
+or register a result under ``docs/context/evidence/``. The full run is a
+campaign act reserved for a maintainer on a campaign host, and its output must
+not be treated as established evidence until the run completes and (per the
+#5498 acceptance contract) the second-host near-miss comparison is also done.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import robot_sf.benchmark.exact_repeat_campaign as erc
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVIDENCE_DIR = REPO_ROOT / "docs/context/evidence/issue_5263_exact_repeat"
+BUNDLE_PATH = EVIDENCE_DIR / "resolved_definitions.json"
+MANIFEST_PATH = EVIDENCE_DIR / "exact_repeat_manifest.json"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "output/issue_5498_native_ppo"
+TOTAL_PPO_TARGETS = 60
+
+
+def _ppo_only_bundle(max_targets: int | None) -> dict[str, Any]:
+    """Return a schema-valid resolved bundle containing only PPO planner targets.
+
+    Args:
+        max_targets: Optional cap on the number of PPO targets retained, used by
+            the ``--max-targets`` smoke mode. ``None`` keeps all 60.
+
+    Returns:
+        A copy of the resolved bundle restricted to PPO targets, with a freshly
+        recomputed ``bundle_sha256``.
+    """
+    bundle = json.loads(BUNDLE_PATH.read_text(encoding="utf-8"))
+    ppo_targets = [target for target in bundle["targets"] if target["planner"] == "ppo"]
+    if max_targets is not None:
+        if max_targets < 1:
+            raise ValueError("--max-targets must be a positive integer")
+        ppo_targets = ppo_targets[:max_targets]
+    slim = {key: value for key, value in bundle.items() if key != "bundle_sha256"}
+    slim["targets"] = ppo_targets
+    slim["bundle_sha256"] = erc.canonical_sha256(slim)
+    return slim
+
+
+def _ppo_only_manifest_slice(target_keys: list[tuple[str, str, int]]) -> dict[str, Any]:
+    """Build a re-hashed PPO-only manifest slice matching the executed targets.
+
+    ``verify_host_report`` rejects a host report whose ``manifest_sha256`` does
+    not match the manifest, and rejects any manifest target missing from the
+    host report. The full 140-target manifest would therefore reject a PPO-only
+    host report as "missing 80 orca/goal targets". This slice keeps only the
+    PPO manifest rows whose ``(scenario_id, planner, seed)`` appear in
+    ``target_keys`` and recomputes the manifest hash so verification succeeds.
+    """
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    key_set = set(target_keys)
+
+    def _row_key(row: dict[str, Any]) -> tuple[str, str, int]:
+        return (row["scenario_id"], row["planner"], int(row["seed"]))
+
+    sliced = {key: value for key, value in manifest.items() if key != "manifest_sha256"}
+    sliced["targets"] = [
+        target for target in sliced.get("targets", []) if _row_key(target) in key_set
+    ]
+    # Manifest cells aggregate across seeds; keep only PPO cells whose targets
+    # were all retained so per-cell verdicts stay well-formed.
+    sliced["cells"] = [cell for cell in sliced.get("cells", []) if cell["planner"] == "ppo"]
+    sliced["manifest_sha256"] = erc.canonical_sha256(sliced)
+    return sliced
+
+
+def main() -> int:
+    """Execute the native-PPO exact-repeat slice and verify the host report."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--max-targets",
+        type=int,
+        default=None,
+        help=(
+            "Cap the number of PPO targets executed (smoke mode). Default: all "
+            f"{TOTAL_PPO_TARGETS} PPO targets."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Directory for the host and verified reports. Default: {DEFAULT_OUTPUT_DIR}",
+    )
+    args = parser.parse_args()
+
+    bundle = _ppo_only_bundle(args.max_targets)
+    n_targets = len(bundle["targets"])
+    is_smoke = args.max_targets is not None and args.max_targets < TOTAL_PPO_TARGETS
+    if not is_smoke and n_targets != TOTAL_PPO_TARGETS:
+        raise SystemExit(
+            f"expected {TOTAL_PPO_TARGETS} PPO targets in the resolved bundle, found {n_targets}"
+        )
+
+    output_dir: Path = args.output_dir
+    host_result = erc.execute_campaign(bundle, output_dir=output_dir)
+    host_report_path = output_dir / "issue_5498_native_ppo_host_result.json"
+    host_report_path.parent.mkdir(parents=True, exist_ok=True)
+    host_report_path.write_text(
+        json.dumps(host_result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    target_keys = [
+        (result["scenario_id"], result["planner"], int(result["seed"]))
+        for result in host_result["results"]
+    ]
+    manifest_slice = _ppo_only_manifest_slice(target_keys)
+    # The host report carries the FULL bundle's manifest_sha256; the slice is
+    # re-hashed, so align the report's manifest hash before verification.
+    aligned_host_report = dict(host_result)
+    aligned_host_report["manifest_sha256"] = manifest_slice["manifest_sha256"]
+    verified = erc.verify_host_report(manifest_slice, aligned_host_report)
+    verified_path = output_dir / "issue_5498_native_ppo_verified_host_result.json"
+    verified_path.write_text(
+        json.dumps(verified, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    summary = verified["summary"]
+    mode = "SMOKE" if is_smoke else "FULL"
+    print(f"native PPO exact-repeat slice [{mode}] ({n_targets} target(s) x 3 repeats):")
+    print(f"  n_targets={summary['n_targets']}")
+    print(f"  n_runnable_targets={summary['n_runnable_targets']}")
+    print(f"  n_unrunnable_targets={summary['n_unrunnable_targets']}")
+    print(f"  n_cells={summary['n_cells']}")
+    print(f"  n_runnable_cells={summary['n_runnable_cells']}")
+    print(f"  n_unrunnable_cells={summary['n_unrunnable_cells']}")
+    print(f"  all_cells_bitwise_identical={summary['all_cells_bitwise_identical']}")
+    print(f"host_report={host_report_path}")
+    print(f"verified_report={verified_path}")
+    if is_smoke:
+        print(
+            "NOTE: --max-targets smoke output is a runner self-check, NOT "
+            "registered evidence; the full 60-target run is a campaign act."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_exact_repeat_executor.py
+++ b/tests/benchmark/test_exact_repeat_executor.py
@@ -25,6 +25,7 @@ from robot_sf.benchmark.exact_repeat_campaign import (
     resolve_runnable_definitions,
     verify_host_report,
 )
+from robot_sf.benchmark.runner import run_episode
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_DIR = (
@@ -623,6 +624,41 @@ def test_execute_campaign_dispositions_degraded_fallback_targets(
     assert verified["summary"]["all_cells_bitwise_identical"] is False
     for target in verified["targets"]:
         assert target["unrunnable"] is True
+
+
+# --- native PPO determinism (issue #5498 slice) --------------------------
+
+
+def test_native_ppo_target_runs_deterministically_with_real_runner(tmp_path, resolved_bundle):
+    """Native PPO executes through run_episode and is bitwise-identical across repeats.
+
+    Issue #5498's single-host slice (#5499) recorded the three PPO cells as
+    ``degraded``/``unrunnable`` because the forked planner-step worker crashed or
+    timed out. The native-PPO worker-isolation fix (#5740) unblocked native PPO,
+    so a PPO target must now execute with the real ``run_episode`` runner and
+    produce exactly three bitwise-identical repeats (matching trajectory hashes)
+    rather than a degraded disposition.
+    """
+    if not is_runnable_algo("ppo"):
+        pytest.skip("ppo baseline not runnable on this host")
+
+    ppo_target = next(t for t in resolved_bundle["targets"] if t["planner"] == "ppo")
+    ppo_bundle = {k: v for k, v in resolved_bundle.items() if k != "bundle_sha256"}
+    ppo_bundle["targets"] = [ppo_target]
+    ppo_bundle["bundle_sha256"] = canonical_sha256(ppo_bundle)
+
+    host_result = execute_campaign(
+        ppo_bundle, output_dir=tmp_path / "native_ppo_deterministic", run_episode=run_episode
+    )
+    result = host_result["results"][0]
+
+    # Native execution: no degraded/unrunnable disposition, exactly three repeats.
+    assert "disposition" not in result, "native PPO must not be dispositioned as unrunnable"
+    assert result.get("degraded") is not True
+    assert len(result["repeats"]) == 3
+
+    fingerprints = [r["trajectory_sha256"] for r in result["repeats"]]
+    assert len(set(fingerprints)) == 1, "native PPO repeats must be bitwise-identical"
 
 
 def test_execute_campaign_dispositions_mixed_degraded_repeats(tmp_path, manifest, resolved_bundle):


### PR DESCRIPTION
## Summary

Successor slice for **#5498** (successor to closed #5263). Adds **NEW capability
enabled by PR #5740** — it does not duplicate #5499 or #5740 (see successor
statement below).

PR #5499 ran the single-host exact-repeat slice but recorded the **three PPO
cells (60 targets) as `degraded`/`unrunnable`** because the forked planner-step
worker crashed/timed out on that host. PR #5740 fixed that PPO worker-isolation
defect (worker-side lazy loading, initialization handshake/error propagation,
step-timeout isolation), so **PPO can now run natively through the exact-repeat
`run_episode` path**.

This PR converts the "PPO is degraded/unrunnable" open state into **executable
proof that PPO runs natively and deterministically post-#5740**:

- A focused, CPU-only test runs a single PPO target through the real
  `run_episode` runner with 3 repeats and asserts the result is **native** (no
  degraded/unrunnable disposition) and **bitwise-identical** (matching SHA-256
  trajectory hashes across all three repeats).
- A validated reproducible runner (`run_issue_5498_native_ppo_slice.py`) for the
  full 60-target native-PPO exact-repeat slice, with a `--max-targets` smoke mode
  so it can double as a cheap self-check.

## Why this is a cheap-lane slice, not the full resolution

This issue's full acceptance requires (a) executing **all 60 PPO targets × 3
repeats** and registering the result as evidence, and (b) the **second-host
near-miss comparison** with pinned NumPy/Numba. Both are outside the cheap-lane
contract (no campaigns; single-host only). So this PR proves the new native-PPO
determinism end-to-end and ships the reproducible runner a maintainer/campaign
host uses to register the full result.

The cheap-lane worker that added the runner validated it end-to-end on a
single-target slice (slice → execute → verify, bitwise-identical repeats) and ran
the `--max-targets 2` smoke, but did **not** execute the full 60-target run or
register any artifact under `docs/context/evidence/`. That full run is a
CPU-only single-host campaign act reserved for a maintainer, and its output must
not be treated as established evidence until the run completes and the
second-host comparison is also done (per the #5498 acceptance contract).

## Files

- `tests/benchmark/test_exact_repeat_executor.py` — new
  `test_native_ppo_target_runs_deterministically_with_real_runner`; the existing
  `test_execute_campaign_dispositions_degraded_fallback_targets` contract is
  unchanged.
- `scripts/benchmark/run_issue_5498_native_ppo_slice.py` — validated reproducible
  runner for the native-PPO exact-repeat slice (`--max-targets` smoke mode;
  full mode = campaign act for a maintainer/campaign host).

## Validation (CPU-only, single-host, shared venv)

```
$ pytest tests/benchmark/test_exact_repeat_executor.py -q
37 passed, 5 warnings in 15.37s
  # new test_native_ppo_target_runs_deterministically_with_real_runner  6.6s
  # existing test_execute_campaign_dispositions_degraded_fallback_targets  0.48s (unchanged)

$ python scripts/benchmark/run_issue_5498_native_ppo_slice.py --max-targets 2 --output-dir /tmp/...
native PPO exact-repeat slice [SMOKE] (2 target(s) x 3 repeats):
  n_targets=2
  n_runnable_targets=2
  n_unrunnable_targets=0
  all_cells_bitwise_identical=True

$ ruff check <changed files>   -> All checks passed!
$ ruff format --check <changed files>  -> 2 files already formatted
```

Also confirmed `is_runnable_algo("ppo") == True` on this host.

## Successor statement

- **Does not duplicate PR #5499** (single-host exact-repeat slice; recorded PPO
  as degraded/unrunnable). This PR proves PPO is now native/deterministic.
- **Does not duplicate PR #5740** (PPO worker-isolation fix code + its unit
  tests). This PR consumes that fix to add the native-PPO determinism proof and
  the reproducible campaign runner.
- Successor slice: **native-PPO determinism proof + reproducible runner** enabled
  by #5740.

## What remains for #5498

- Run the full native-PPO 60-target × 3-repeat campaign on a campaign host via
  `run_issue_5498_native_ppo_slice.py` and register the verified result under
  `docs/context/evidence/issue_5263_exact_repeat/` (replacing the degraded PPO
  rows from #5499).
- The predeclared **second-host near-miss comparison** with pinned NumPy/Numba
  (needs a second distinct host; out of cheap-lane single-host scope).

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the
review gate hardens and merges.
