### PR TITLE
fix(torch): align CUDA extra with Torch 2.13 safety contract (#5556)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 
 [project.optional-dependencies]
 gpu = [
-    "torch[cuda]>=2.5.1",
+    "torch[cuda]>=2.13.0,<2.14.0",
 ]
 training = [
     "stable-baselines3>=2.9.0",

--- a/tests/test_ci_driver_contract.py
+++ b/tests/test_ci_driver_contract.py
@@ -160,6 +160,38 @@ def _pyproject() -> dict[str, Any]:
     return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
 
 
+def test_torch_213_constraint_is_shared_by_training_and_gpu_extras() -> None:
+    """Keep both Torch installation paths on the tested 2.13 release line (issue #5556)."""
+    project = _pyproject()["project"]
+    optional_dependencies = project["optional-dependencies"]
+    training_requirement = next(
+        Requirement(value)
+        for value in optional_dependencies["training"]
+        if Requirement(value).name == "torch"
+    )
+    gpu_requirement = next(
+        Requirement(value)
+        for value in optional_dependencies["gpu"]
+        if Requirement(value).name == "torch"
+    )
+    expected = Requirement("torch>=2.13.0,<2.14.0").specifier
+
+    assert training_requirement.specifier == expected
+    assert gpu_requirement.specifier == expected
+    assert gpu_requirement.extras == {"cuda"}
+
+    lock_data = tomllib.loads((ROOT / "uv.lock").read_text(encoding="utf-8"))
+    locked_project = next(item for item in lock_data["package"] if item["name"] == "robot-sf")
+    locked_torch = {
+        (item["marker"], tuple(item.get("extras", []))): item
+        for item in locked_project["metadata"]["requires-dist"]
+        if item["name"] == "torch"
+    }
+
+    assert locked_torch[("extra == 'training'", ())]["specifier"] == ">=2.13.0,<2.14.0"
+    assert locked_torch[("extra == 'gpu'", ("cuda",))]["specifier"] == ">=2.13.0,<2.14.0"
+
+
 def test_extract_workflow_phases_handles_multiple_phase_args() -> None:
     """Capture all phase arguments from one workflow run stanza."""
 

--- a/tests/test_ci_driver_contract.py
+++ b/tests/test_ci_driver_contract.py
@@ -165,14 +165,14 @@ def test_torch_213_constraint_is_shared_by_training_and_gpu_extras() -> None:
     project = _pyproject()["project"]
     optional_dependencies = project["optional-dependencies"]
     training_requirement = next(
-        Requirement(value)
+        requirement
         for value in optional_dependencies["training"]
-        if Requirement(value).name == "torch"
+        if (requirement := Requirement(value)).name == "torch"
     )
     gpu_requirement = next(
-        Requirement(value)
+        requirement
         for value in optional_dependencies["gpu"]
-        if Requirement(value).name == "torch"
+        if (requirement := Requirement(value)).name == "torch"
     )
     expected = Requirement("torch>=2.13.0,<2.14.0").specifier
 
@@ -182,14 +182,22 @@ def test_torch_213_constraint_is_shared_by_training_and_gpu_extras() -> None:
 
     lock_data = tomllib.loads((ROOT / "uv.lock").read_text(encoding="utf-8"))
     locked_project = next(item for item in lock_data["package"] if item["name"] == "robot-sf")
+    locked_metadata = locked_project.get("metadata", {})
+    assert isinstance(locked_metadata, dict)
+    requires_dist = locked_metadata.get("requires-dist", [])
+    assert isinstance(requires_dist, list)
     locked_torch = {
-        (item["marker"], tuple(item.get("extras", []))): item
-        for item in locked_project["metadata"]["requires-dist"]
-        if item["name"] == "torch"
+        (item.get("marker"), tuple(item.get("extras", []))): item
+        for item in requires_dist
+        if isinstance(item, dict) and item.get("name") == "torch"
     }
 
-    assert locked_torch[("extra == 'training'", ())]["specifier"] == ">=2.13.0,<2.14.0"
-    assert locked_torch[("extra == 'gpu'", ("cuda",))]["specifier"] == ">=2.13.0,<2.14.0"
+    training_lock = locked_torch.get(("extra == 'training'", ()))
+    gpu_lock = locked_torch.get(("extra == 'gpu'", ("cuda",)))
+    assert training_lock is not None, "uv.lock is missing the training Torch entry"
+    assert gpu_lock is not None, "uv.lock is missing the gpu Torch entry"
+    assert training_lock.get("specifier") == ">=2.13.0,<2.14.0"
+    assert gpu_lock.get("specifier") == ">=2.13.0,<2.14.0"
 
 
 def test_extract_workflow_phases_handles_multiple_phase_args() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -5290,7 +5290,7 @@ requires-dist = [
     { name = "tensorboard", marker = "extra == 'training'", specifier = ">=2.21.0" },
     { name = "tensorflow", marker = "extra == 'sacadrl'", specifier = ">=2.15.0" },
     { name = "torch", marker = "extra == 'training'", specifier = ">=2.13.0,<2.14.0" },
-    { name = "torch", extras = ["cuda"], marker = "extra == 'gpu'", specifier = ">=2.5.1" },
+    { name = "torch", extras = ["cuda"], marker = "extra == 'gpu'", specifier = ">=2.13.0,<2.14.0" },
     { name = "tqdm", marker = "extra == 'progress'", specifier = ">=4.68.4" },
     { name = "wandb", marker = "extra == 'training'", specifier = ">=0.28.0" },
 ]


### PR DESCRIPTION
## Reviewer-critical summary

This PR adds the missing CUDA-extra integration contract for [issue #5556](https://github.com/ll7/robot_sf_ll7/issues/5556): both `training` and `gpu` now resolve Torch within the tested `>=2.13.0,<2.14.0` range, and the lockfile/test contract prevents the two paths from drifting again.

- Why now: the live issue review shows the Python 3.12/3.13 runtime fixes and CPU CI/smoke slices already merged in [#5577](https://github.com/ll7/robot_sf_ll7/pull/5577), [#5652](https://github.com/ll7/robot_sf_ll7/pull/5652), and [#5685](https://github.com/ll7/robot_sf_ll7/pull/5685). The remaining actionable code gap was the weaker `gpu` extra; this is a consolidation/integration slice, not another runtime micro-guard.
- Claim boundary: local metadata/lock proof and a bounded local CUDA smoke on `imech036` (Python 3.13.13, Torch 2.13.0+cu130, RTX 3080) are smoke evidence only. This PR does not claim supported hosted CUDA-runner evidence, full issue closure, benchmark evidence, or a dissertation result.
- Required validation: focused contract/compatibility tests, locked export, Ruff, local CUDA smoke, and final committed-HEAD `pr_ready_check`.
- Remaining blocker: supported CUDA-host validation for the issue’s full Definition of Done remains outside this PR’s no-submission scope.

## Contract delta

- New schema fields: none.
- New fail-closed dependency boundary: the `gpu` extra now rejects Torch versions outside `>=2.13.0,<2.14.0`, matching `training`; the lock metadata is checked for both markers.
- Compatibility impact: users selecting `gpu` no longer receive Torch 2.5–2.12; `torch[cuda]` remains the declared CUDA path and the runtime compatibility helpers are unchanged.

## Scope and decision

- Changed `pyproject.toml` and generated `uv.lock` to align the CUDA extra with the adopted Torch 2.13.0 release line.
- Added a CI metadata contract test that checks both optional-dependency specifiers, the CUDA extra marker, and the corresponding lock entries.
- Assumption: because the CPU/runtime slices are already merged and the fragmentation guard rules out another micro-guard, aligning the remaining dependency contract is the smallest reversible integration capability that improves readiness for the outstanding CUDA validation.

## Validation / proof

- `uv lock --check` -> pass.
- `uv run --no-sync pytest tests/test_ci_driver_contract.py tests/test_seed_utils.py tests/common -q -m 'not slow'` -> 50 passed, 21 deselected.
- `uv run --no-sync ruff check pyproject.toml tests/test_ci_driver_contract.py` -> pass.
- `uv run --no-sync ruff format --check tests/test_ci_driver_contract.py` -> pass.
- `uv export --frozen --extra gpu --no-dev --no-emit-project` -> pass; export contains `torch==2.13.0`, Triton, and CUDA/NVIDIA packages.
- Bounded local CUDA smoke -> pass; Torch 2.13.0+cu130 applied deterministic mode and completed a CUDA tensor operation on the RTX 3080 without a crash.
- `BASE_REF=origin/main PR_READY_MODE=final PR_READY_PR_BODY_FILE=.git/codex-agent-runs/active/issue-5556/PR_BODY.md PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> exit 0 after refreshing onto current `origin/main`; clean-tree stamp for head `ccf571e3ffcec8641057e7220b2038f873c22f97`, core readiness, fast-pysf preflight, TODO-docstring ratchet, and broad-exception ratchet all passed.

## Follow-up and claim boundary

`Refs #5556`

Remaining checklist:

- [x] Keep the `training` and `gpu` Torch dependency contracts on the same tested 2.13 release line.
- [x] Preserve a regression check for the project metadata and lock markers.
- [ ] Run the supported hosted CUDA-extra/unit/example-smoke path required by the parent issue and attach its evidence before closing #5556.

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

## Friction / follow-up issues

- Filed [#5764](https://github.com/ll7/robot_sf_ll7/issues/5764): `uv tree` 0.11.21 does not accept project-extra selectors; the working `uv export --extra gpu` workaround and exact error are recorded there.

<details>
<summary>Governance, provenance, and downstream propagation</summary>

- Fragmentation guard: three related #5556 slices merged in the previous 24 hours; this PR adds the nameable new capability of a shared CUDA dependency contract and integration proof rather than duplicating a guard.
- Evidence tier: smoke evidence for dependency resolution and one local CUDA process; no fallback/degraded benchmark row is treated as success evidence.
- Comparator: `origin/main` before this PR, where `training` was constrained to Torch 2.13 but `gpu` still declared `torch[cuda]>=2.5.1`.
- Decision/stop rule: merge this contract slice only with a fresh clean-HEAD readiness pass; keep #5556 open until supported CUDA-host evidence exists.
- Artifact handling: no benchmark artifacts or model outputs are promoted; generated `output/` content remains disposable worktree-local state.
- Parent issue propagation: no issue/PR comment was made because `comment_issue_or_pr: false`; no transient host, queue, or packet-routing state was added to tracked files. This PR body is the canonical handoff for this slice, and existing #5556/#5685 tracking carries the remaining GPU evidence action.
- Immediate pre-open live recheck: `gh issue view 5556 --repo ll7/robot_sf_ll7 --comments` still hit the already-tracked [#5729](https://github.com/ll7/robot_sf_ll7/issues/5729) Projects-classic GraphQL failure; REST read all 12 comments, found no comment newer than the 2026-07-15T10:32:00Z start, and confirmed the latest guidance remains the GPU/CUDA evidence blocker.
- No new schema, metric semantics, planner behavior, or paper-facing surface changed.

</details>
