### PR TITLE
docs: document uv extra inspection for #5764

### DIFF
--- a/docs/dev_runtime_requirements.md
+++ b/docs/dev_runtime_requirements.md
@@ -56,6 +56,16 @@ source .venv/bin/activate
 `--extra` is repeatable when a workflow needs more than one named optional dependency. Supplying it
 selects those named extras instead of the bootstrap helper's default `--all-extras` route.
 
+To inspect the locked dependencies selected by one project extra with uv 0.11.21, use `uv export`:
+
+```bash
+uv export --frozen --extra gpu --no-dev --no-emit-project
+```
+
+Replace `gpu` with the extra to inspect. In uv 0.11.21, `uv tree` does not accept project-extra
+selectors such as `--extra` or `--all-extras`; the frozen export is the supported read-only
+inspection path.
+
 CARLA is deliberately excluded from `--all-extras`. Use `uv sync --all-extras --group carla` only
 on machines or worktrees that need the host-side CARLA Python client.
 


### PR DESCRIPTION
## Reviewer-critical summary

- What changed: documented the uv 0.11.21 command for inspecting one locked project extra in `docs/dev_runtime_requirements.md`.
- Why now: `uv tree` rejects project-extra selectors in the installed uv version, so contributors need the supported read-only inspection path.
- Claim boundary: documentation-only workflow guidance; the command was exercised against this checkout's locked `gpu` extra and emitted the expected Torch/NVIDIA resolution.
- Required validation: `uv tree --frozen --extra gpu --no-dev` reproduces the documented rejection; `uv export --frozen --extra gpu --no-dev --no-emit-project` succeeds; docs consistency and active-document checks pass.
- Remaining blocker: none for this documentation contract.

## Contract delta

- New contract: use `uv export --frozen --extra <name> --no-dev --no-emit-project` to inspect a locked project extra with uv 0.11.21.
- New fail-closed blockers: none.
- Compatibility impact: documentation only; no dependency, lockfile, runtime, or benchmark behavior changes.

## Linked Issues

- Closes #5764

## Scope and validation

This PR contains the complete reversible documentation slice requested by #5764. The issue had no
comments at the final pre-open read. The required `gh issue view 5764 --comments` CLI path is
currently blocked by its deprecated Projects Classic GraphQL field, so the complete issue and
comment history was confirmed through the GitHub REST fallback (zero comments).

Validation results:

- `uv --version` -> `uv 0.11.21`.
- `uv tree --frozen --extra gpu --no-dev` -> exit 2 with `unexpected argument '--extra'` (expected reproduction).
- `uv export --frozen --extra gpu --no-dev --no-emit-project` -> exit 0; locked `torch==2.13.0` and NVIDIA packages were present.
- `uv run --active python scripts/validation/check_docs_proof_consistency.py --base origin/main --path docs/dev_runtime_requirements.md` -> passed.
- `uv run --active python scripts/validation/check_active_doc_examples.py --fail-on-diagnostic docs/dev_runtime_requirements.md` -> passed.
- `git diff --check` -> passed.
- `PR_READY_MODE=final PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> rerun with this body file; result recorded in the handoff.

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Governance appendix</summary>

### Research and evidence status

- Evidence tier: docs-only.
- Result classification: blocker-resolution.
- Target claim / comparator: NA; this PR documents a dependency-inspection command and makes no research or benchmark claim.
- Domain-aware approval: not required because this is support documentation with no evidence-semantic change.

## Follow-Up Issues

- Deferred work: none; the requested documentation contract is self-contained.
- Issues opened for follow-up: none; maintainer waiver for residual scope: the explicitly out-of-scope campaign, Slurm/GPU, and paper/dissertation actions are unrelated to this docs-only issue.

### Risks and downstream propagation

- Compatibility risk: future uv releases may add project-extra support to `uv tree`; the version qualifier keeps this guidance scoped to uv 0.11.21.
- Rollback: remove the ten-line documentation addition.
- Parent issue updated: no; the PR is the canonical propagation surface and issue comments are disabled by authorization.
- Claim map, benchmark report, leaderboard, registry, config index, context index, and memory note: not applicable because no research artifact or contract schema changed.
- Follow-up issues: none.

### Out-of-scope confirmation

No benchmark campaign, Slurm/GPU job, release action, merge, or paper/dissertation edit was performed.

</details>
