### PR TITLE
P0: unbreak main — native PPO must run (exact-repeat disposition regression) + safety-wrapper manifest provenance

### DIFF
--- a/robot_sf/benchmark/exact_repeat_campaign.py
+++ b/robot_sf/benchmark/exact_repeat_campaign.py
@@ -74,10 +74,10 @@ def _record_is_degraded(record: Any) -> bool:
     """Return True when an episode record is a degraded fallback rather than native output.
 
     A target is degraded when the planner step fell back to a zero-velocity action
-    inside the isolation worker. Two signals are checked: the planner
-    ``algorithm_metadata.status`` prefix and the outcome ``timeout_event`` that the
-    runner sets when every step fell back. Either one is sufficient evidence that the
-    repeats do not represent native planner behavior.
+    inside the isolation worker. The runner reports that through the planner status
+    and the explicit ``policy_step_timeout.fallback_actions`` counter. Episode-level
+    ``outcome.timeout_event`` is deliberately not used: it also represents a native
+    episode reaching its configured horizon and is not planner-degradation evidence.
     """
     if not isinstance(record, Mapping):
         return False
@@ -86,9 +86,15 @@ def _record_is_degraded(record: Any) -> bool:
         status = metadata.get("status")
         if isinstance(status, str) and status.startswith(_DEGRADED_STATUS_PREFIXES):
             return True
-    outcome = record.get("outcome")
-    if isinstance(outcome, Mapping) and outcome.get("timeout_event") is True:
-        return True
+        timeout_metadata = metadata.get("policy_step_timeout")
+        if isinstance(timeout_metadata, Mapping):
+            fallback_actions = timeout_metadata.get("fallback_actions")
+            if not isinstance(fallback_actions, bool):
+                try:
+                    if float(fallback_actions) > 0:
+                        return True
+                except (TypeError, ValueError):
+                    pass
     return False
 
 

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -283,6 +283,10 @@ def _build_observation(
 
 # Safety/robustness defaults for any baseline policy
 POLICY_STEP_TIMEOUT_SECS: float = 0.2  # step(obs) time budget; fallback to zero action on timeout
+# Model loading happens during the worker handshake, but PyTorch still performs
+# one-time kernel/runtime initialization on the first real PPO inference. Keep
+# that cold-start cost outside the strict steady-state planner-step budget.
+PPO_FIRST_STEP_TIMEOUT_SECS: float = 30.0
 # Native ORCA may transiently lose its forked worker; keep one retry before degrading.
 ORCA_TRANSIENT_STEP_RETRIES: int = 1
 FINAL_SPEED_CLAMP: float = 2.0  # m/s cap to prevent unrealistic velocities
@@ -331,13 +335,21 @@ def _planner_step_worker(conn: Any, planner: Any) -> None:
 class _PlannerStepProcess:
     """Persistent process boundary for planner.step with hard timeout cleanup."""
 
-    def __init__(self, planner: Any, *, timeout_s: float) -> None:
+    def __init__(
+        self,
+        planner: Any,
+        *,
+        timeout_s: float,
+        first_step_timeout_s: float | None = None,
+    ) -> None:
         if "fork" not in mp.get_all_start_methods():
             raise RuntimeError(
                 "planner step timeout isolation requires multiprocessing fork support"
             )
         self._planner = planner
         self._timeout_s = timeout_s
+        self._first_step_timeout_s = first_step_timeout_s
+        self._worker_needs_warmup = True
         self._ctx = mp.get_context("fork")
         self._process: mp.Process | None = None
         self._conn: Any | None = None
@@ -357,7 +369,12 @@ class _PlannerStepProcess:
             self.close()
             raise RuntimeError("planner step worker was unavailable") from exc
 
-        deadline = time.monotonic() + self._timeout_s
+        step_timeout_s = (
+            self._first_step_timeout_s
+            if self._worker_needs_warmup and self._first_step_timeout_s is not None
+            else self._timeout_s
+        )
+        deadline = time.monotonic() + step_timeout_s
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -372,6 +389,7 @@ class _PlannerStepProcess:
                         "planner step worker exited before returning an action"
                     ) from exc
                 if status == "ok":
+                    self._worker_needs_warmup = False
                     return payload
                 error_type, message = payload
                 raise RuntimeError(f"Planner step failed in worker ({error_type}: {message})")
@@ -427,6 +445,7 @@ class _PlannerStepProcess:
                 raise RuntimeError("planner step worker initialization timed out")
             error_type, msg = payload
             raise RuntimeError(f"planner step worker failed to initialize ({error_type}: {msg})")
+        self._worker_needs_warmup = True
 
     def _terminate_worker(self) -> None:
         """Terminate the current worker after a timeout."""
@@ -764,6 +783,9 @@ def _create_robot_policy(  # noqa: C901, PLR0915
     timeout_metadata: dict[str, Any] = {
         "isolation": "process",
         "step_timeout_s": POLICY_STEP_TIMEOUT_SECS,
+        "first_step_timeout_s": (
+            PPO_FIRST_STEP_TIMEOUT_SECS if algo == "ppo" else POLICY_STEP_TIMEOUT_SECS
+        ),
         "step_timeouts": 0,
         "worker_errors": 0,
         "step_retries": 0,
@@ -772,7 +794,14 @@ def _create_robot_policy(  # noqa: C901, PLR0915
     retry_budget = ORCA_TRANSIENT_STEP_RETRIES if algo == "orca" else 0
     step_runner: _PlannerStepProcess | None
     try:
-        step_runner = _PlannerStepProcess(planner, timeout_s=POLICY_STEP_TIMEOUT_SECS)
+        if algo == "ppo":
+            step_runner = _PlannerStepProcess(
+                planner,
+                timeout_s=POLICY_STEP_TIMEOUT_SECS,
+                first_step_timeout_s=PPO_FIRST_STEP_TIMEOUT_SECS,
+            )
+        else:
+            step_runner = _PlannerStepProcess(planner, timeout_s=POLICY_STEP_TIMEOUT_SECS)
     except RuntimeError as exc:
         step_runner = None
         timeout_metadata["isolation"] = "unavailable"

--- a/tests/benchmark/test_exact_repeat_executor.py
+++ b/tests/benchmark/test_exact_repeat_executor.py
@@ -548,13 +548,51 @@ def test_record_is_degraded_detects_fallback_status():
     )
 
 
-def test_record_is_degraded_detects_timeout_event():
-    """An outcome timeout_event marks a record as degraded even when status is ok."""
+def test_record_is_degraded_accepts_native_episode_horizon_timeout():
+    """A normal episode horizon timeout does not imply planner-step degradation.
+
+    ``run_episode`` sets ``outcome.timeout_event`` whenever an otherwise-native
+    episode reaches its configured horizon.  Planner fallback is reported
+    separately through ``algorithm_metadata`` and must not be inferred from the
+    episode outcome.
+    """
     assert (
         _record_is_degraded(
             {"algorithm_metadata": {"status": "ok"}, "outcome": {"timeout_event": True}}
         )
+        is False
+    )
+
+
+def test_record_is_degraded_detects_fallback_counter_when_status_is_stale():
+    """Explicit planner-step fallback counts remain fail-closed evidence."""
+    assert (
+        _record_is_degraded(
+            {
+                "algorithm_metadata": {
+                    "status": "ok",
+                    "policy_step_timeout": {"fallback_actions": 1},
+                },
+                "outcome": {"timeout_event": False},
+            }
+        )
         is True
+    )
+
+
+def test_record_is_degraded_ignores_malformed_fallback_counter():
+    """Malformed fallback metadata neither raises nor fabricates degradation."""
+    assert (
+        _record_is_degraded(
+            {
+                "algorithm_metadata": {
+                    "status": "ok",
+                    "policy_step_timeout": {"fallback_actions": "not-a-number"},
+                },
+                "outcome": {"timeout_event": False},
+            }
+        )
+        is False
     )
 
 

--- a/tests/test_runner_policy_timeout.py
+++ b/tests/test_runner_policy_timeout.py
@@ -29,6 +29,19 @@ class _SlowPlanner:
         return {"algorithm": "random", "status": "ok", "seed": self.seed}
 
 
+class _SlowFirstStepPlanner:
+    """Planner whose one-time inference warm-up exceeds the steady-state budget."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def step(self, _obs: Any) -> dict[str, float]:
+        self.calls += 1
+        if self.calls == 1:
+            time.sleep(0.1)
+        return {"vx": 1.0, "vy": 0.0}
+
+
 class _FailingPlanner:
     """Planner stub whose worker step raises a diagnostic error."""
 
@@ -158,6 +171,21 @@ def test_planner_step_timeout_fails_fast_and_reports_metadata(
     assert timeout_metadata["step_timeout_s"] == 0.05
     assert timeout_metadata["step_timeouts"] == 1
     assert timeout_metadata["fallback_actions"] == 1
+
+
+@pytest.mark.skipif("fork" not in mp.get_all_start_methods(), reason="requires fork isolation")
+def test_planner_step_process_allows_one_time_inference_warmup() -> None:
+    """The first inference gets a startup budget; later steps use the strict budget."""
+    step_process = runner._PlannerStepProcess(
+        _SlowFirstStepPlanner(),
+        timeout_s=0.02,
+        first_step_timeout_s=0.5,
+    )
+    try:
+        assert step_process.step({"obs": "cold"}) == {"vx": 1.0, "vy": 0.0}
+        assert step_process.step({"obs": "warm"}) == {"vx": 1.0, "vy": 0.0}
+    finally:
+        step_process.close()
 
 
 @pytest.mark.skipif("fork" not in mp.get_all_start_methods(), reason="requires fork isolation")


### PR DESCRIPTION
## Summary

Unblock main by keeping cold-start native Proximal Policy Optimization (PPO) inference outside the strict steady-state planner-step timeout and by classifying degradation only from explicit planner fallback metadata. The safety-wrapper manifest provenance tests are also verified on the pinned main head; they already pass there and require no unrelated production change.

This is the unblock-main fix and should merge ahead of the frozen green-PR queue. Do not hold it behind normal backpressure.

## Linked Issues

- Relates to `#5538` only as a possible downstream symptom; this PR does not expand into the S30 ablation investigation.

## Stack / Dependency

- Base dependency: `origin/main` at `5b1bf8ba907c118d608eb302dd19f27422e0cc0d`
- Required prior PRs: none
- Stack follow-up issues: none for this P0
- Safe to review independently: yes
- Review dependency reason, if any: none

## What Changed

- Give only the first PPO inference in each fresh planner worker a 30-second cold-start budget; subsequent steps retain the existing 0.2-second limit.
- Record both first-step and steady-state timeout budgets in planner metadata.
- Detect degraded exact-repeat rows from the planner fallback status or `policy_step_timeout.fallback_actions`, not from an episode-level horizon timeout.
- Add regressions for slow first inference, explicit fallback counters, and native horizon exhaustion.

## Root Cause / Offending Commits

- `583425e1f3055b7af5e036fb4dc642ee72f9bf4c` (#5499) introduced degraded-row classification but incorrectly treated `outcome.timeout_event` as proof of planner-step fallback. `run_episode` also sets that field when a native episode simply reaches its horizon.
- `c0031a2ba853a6f53b559849fa0ea43b1424ff58` (#5740) moved model loading into the worker handshake but did not warm or separately budget the first real PyTorch inference. A cold probe at the failing main head observed `status=policy_step_timeout_fallback`, `step_timeouts=1`, and `fallback_actions=1` on the first PPO step.
- `bade1ffaf66efcd7e5a1dbc02e7008cbd5c69cfc` (#5766) added the real native-PPO regression test that exposed the latent cold-start defect; it did not itself change runner behavior.

## Why It Matters

- Added value: native PPO exact-repeat targets are no longer converted into unrunnable rows by cold-start overhead or by normal episode horizon exhaustion.
- Expected impact: restore main CI and release the merge queue while preserving fail-closed treatment of actual fallback actions.
- Why this is worth merging now: main is red and an unblocker watch is holding multiple otherwise-green PRs.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: main-CI blocker only; no planner-quality claim.
- Comparator or baseline, if applicable: failing cold-cache `origin/main` execution versus this branch.
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: merge only if cold-cache native PPO has zero degraded disposition and all repository readiness gates pass.
- Parent issue, claim map, registry, context note, or synthesis surface to update: none for this CI repair; existing issue `#5538` remains the owner of any S30 investigation.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - runtime correctness repair; no analysis tool or research claim.

## Domain-Aware Approval

- Required for this PR: yes - exact-repeat fallback classification is benchmark-sensitive.
- Domains reviewed: evidence classification and benchmark interpretation
- Status: approved
- Approver/review source or waiver: current maintainer direction in this P0 task requires native PPO to run and forbids treating it as unrunnable; runner metadata and red/green regression evidence confirm the boundary.
- Validity checklist:
  - Target claim/hypothesis: actual planner fallback remains excluded; native execution remains eligible for exact-repeat verification.
  - Comparator or split/evidence validity: same scenario `classic_cross_trap_high`, planner `ppo`, seed `111`, horizon `498`, and real `run_episode` path.
  - Fallback/degraded exclusions: explicit fallback status or positive fallback counter still dispositions the target.
  - Claim boundary: targeted blocker-resolution only; not benchmark or paper-facing performance evidence.
  - Implementation integrity vs experimental validity: implementation is exercised on the real production path; no experimental performance conclusion is made.

## Falsification / Non-Transfer Check

- Did the mechanism activate? yes - a cold probe reproduced one first-step timeout/fallback before the fix.
- Did the intervention change command source, selected command, trajectory, or route progress? It prevents the erroneous zero-action fallback; it does not change native PPO action semantics.
- Did the scenario actually contain the targeted failure mode? yes - the exact CI target reproduced it from a cold model cache.
- Result route: narrow
- Follow-up question or issue for weak, negative, or non-transfer results: any S30/issue `#5538` rerun remains separately scoped.

## Next Empirical Action

- Rerun needed: no for this P0 after readiness; S30 reruns remain under `#5538`.
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none for the CI blocker
- Stop / revise / continue decision: stop after main is green; do not broaden this PR.
- Proposed child issue or existing follow-up: existing `#5538` if the S30 symptom persists.

## Validation / Proof

- Commands run:
  - `uv run python -m pytest tests/benchmark/test_exact_repeat_executor.py::test_native_ppo_target_runs_deterministically_with_real_runner tests/benchmark/test_safety_wrapper_ablation_manifest.py -x -q`
  - `uv run python -m pytest tests/benchmark/test_exact_repeat_executor.py tests/benchmark/test_safety_wrapper_ablation_manifest.py tests/test_runner_policy_timeout.py tests/unit/test_runner_helper_coverage.py -q`
  - `uv run ruff check robot_sf/benchmark/runner.py robot_sf/benchmark/exact_repeat_campaign.py tests/benchmark/test_exact_repeat_executor.py tests/test_runner_policy_timeout.py`
  - `uv run ruff format --check robot_sf/benchmark/runner.py robot_sf/benchmark/exact_repeat_campaign.py tests/benchmark/test_exact_repeat_executor.py tests/test_runner_policy_timeout.py`
  - `git diff --check`
  - `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/unbreakmain-pr-body.md scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: cold-cache requested command passed `26 passed, 3 warnings in 19.44s`; focused runner/executor suite passed `87 passed, 9 warnings in 28.17s`; final core and optional pytest lanes passed, changed-line coverage was `100.0%` for both changed production files, and readiness stamped clean head `ba73f071c054d97a84a742c8ba5654539c989920` as passed.
- Benchmarks or smoke tests, if applicable: real native PPO exact-repeat test; no fallback/degraded row and three deterministic repeats.

## Risks / Rollout

- Compatibility risks: the longer first-step budget applies only to PPO and only once per fresh worker; all steady-state planners retain the 0.2-second budget.
- Failure modes: a genuinely hung PPO first inference can now take up to 30 seconds before failing closed; later hung steps still fail after 0.2 seconds.
- Rollback or fallback plan: revert this commit; do not weaken the native-PPO regression or promote fallback rows.

## Docs / Provenance

- Updated docs: none; behavior is covered by code comments and regression tests.
- Relevant design or provenance notes: offending commits and the exact cold-probe metadata are recorded above.
- Any assumptions that need to be preserved: episode horizon timeout and planner-step timeout are distinct contracts.

## Downstream Propagation

- Parent issue updated (yes/no/NA): NA
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): no; `#5538` already owns the related investigation.
- Not applicable because: this is a bounded main-CI runtime repair with no evidence promotion or durable benchmark artifact.

## Follow-Up Issues

- Deferred work: none for the P0. If the same exact-repeat classification caused the S30 failure, diagnose/rerun it under existing issue `#5538` after main is green.
- Issues opened for follow-up: none; `#5538` already exists.

## Reviewer Notes

- Verify that the first-step budget is scoped to PPO and resets only for a fresh worker.
- Verify that normal horizon exhaustion remains native while explicit fallback status/counters remain degraded.
- Any known limitations: this PR does not rerun or reinterpret S30 ablation evidence.
- Shared-helper migration: inapplicable; no helper migration. The process-boundary change has both a focused worker test and the real native-PPO exact-repeat production-path test.
