### PR TITLE
P0: unbreak main round 2 — preserve preloaded PPO models during lazy init (obs-key regression)

### DIFF
--- a/robot_sf/baselines/ppo.py
+++ b/robot_sf/baselines/ppo.py
@@ -269,7 +269,8 @@ class PPOPlanner:
         """Lazily load model and init predictive foresight if not done yet."""
         if getattr(self, "_initialized", False):
             return
-        self._load_model()
+        if self._model is None:
+            self._load_model()
         self._init_predictive_foresight()
         if self._model is not None and self._runtime_observation_space is not None:
             self._validate_runtime_observation_space()


### PR DESCRIPTION
Unblock-main fix; merge ahead of the frozen queue.

## Root cause
main CI red on exactly one test: `tests/test_baseline_ppo_observation_keys.py::test_ppo_dict_obs_maps_flat_runner_keys_to_nested_model_space` (action {vx:0.0,vy:0.5} instead of {vx:0.4,vy:-0.2}). `_ensure_ready()` unconditionally called `_load_model()`, clobbering a preloaded/injected PPO model during lazy init, so the policy fell back to a different model than the test injected.

## Fix
Guard lazy init: only load when `self._model is None` (preserves preloaded models; unchanged behavior for the normal load path).

## Validation
- Target test passes at this commit (run locally on the hub).
- Safety-wrapper manifest tests pass at this commit (earlier reports of their failure were misread pytest duration listings — the only FAILED line on main CI run 29426940606 is the obs-key test).
- Full CI on this PR is the authoritative gate.

Note: commit authored by the unbreak2 codex worker; PR opened by the orchestrator to cut latency — the worker's remaining full-suite validation is superseded by CI here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model initialization so an already loaded model is reused instead of being loaded again.
  * Reduced unnecessary model-loading operations during repeated initialization checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->