### PR TITLE
fix(ped-npc): force_population_size instantiates exactly N (off-by-one broke S30 rerun, #5666 assertion)

### DIFF
--- a/robot_sf/ped_npc/ped_population.py
+++ b/robot_sf/ped_npc/ped_population.py
@@ -133,6 +133,8 @@ class PedSpawnConfig:
             "spread" spaces groups along the route length.
         route_spawn_jitter_frac: Fraction of spacing used as random jitter when spreading.
         route_spawn_seed: Optional RNG seed for deterministic spawn placement/jitter.
+        force_population_size: Optional exact total pedestrian count across route,
+            crowded-zone, and explicitly defined single-pedestrian spawns.
     """
 
     peds_per_area_m2: float
@@ -703,6 +705,84 @@ def populate_single_pedestrians(
     return ped_states, metadata
 
 
+def _spawn_configs_for_forced_population(
+    spawn_config: PedSpawnConfig,
+    ped_routes: list[GlobalRoute],
+    ped_crowded_zones: list[Zone],
+    single_pedestrians: list | None,
+) -> tuple[PedSpawnConfig, PedSpawnConfig, bool]:
+    """Budget a forced total across explicit, crowded-zone, and route pedestrians.
+
+    Returns:
+        Crowd and route spawn configs plus whether archetype factors must be applied
+        after the population is merged.
+    """
+    forced_population_size = spawn_config.force_population_size
+    if forced_population_size is None:
+        return spawn_config, spawn_config, False
+
+    single_pedestrian_count = len(single_pedestrians or [])
+    if single_pedestrian_count > forced_population_size:
+        raise ValueError(
+            "force_population_size cannot be smaller than the number of explicitly defined "
+            f"single pedestrians ({forced_population_size} < {single_pedestrian_count})"
+        )
+    background_population_size = forced_population_size - single_pedestrian_count
+    if background_population_size > 0 and not (ped_crowded_zones or ped_routes):
+        raise ValueError(
+            "force_population_size requires a pedestrian route or crowded zone for the "
+            f"remaining {background_population_size} background pedestrians"
+        )
+
+    apply_archetypes_to_forced_population = spawn_config.archetype_composition is not None
+    # Direct callers of ``populate_ped_routes`` retain their existing archetype behavior.
+    # Here the final merged population owns the composition, so defer factor assignment
+    # until explicit pedestrians have been appended and every simulator index is known.
+    background_spawn_config = (
+        replace(spawn_config, archetype_composition=None)
+        if apply_archetypes_to_forced_population
+        else spawn_config
+    )
+    if ped_crowded_zones and ped_routes:
+        zone_share = background_population_size // 2
+        route_share = background_population_size - zone_share
+    elif ped_crowded_zones:
+        zone_share = background_population_size
+        route_share = 0
+    else:
+        zone_share = 0
+        route_share = background_population_size
+
+    return (
+        replace(background_spawn_config, force_population_size=zone_share),
+        replace(background_spawn_config, force_population_size=route_share),
+        apply_archetypes_to_forced_population,
+    )
+
+
+def _apply_forced_population_contract(
+    ped_states: np.ndarray,
+    spawn_config: PedSpawnConfig,
+    apply_archetypes: bool,
+) -> None:
+    """Verify the forced count and apply one composition across the merged population."""
+    forced_population_size = spawn_config.force_population_size
+    if forced_population_size is not None and ped_states.shape[0] != forced_population_size:
+        raise RuntimeError(
+            "forced pedestrian population accounting failed: "
+            f"instantiated {ped_states.shape[0]}, expected {forced_population_size}"
+        )
+    if not apply_archetypes or ped_states.shape[0] == 0:
+        return
+    speed_factors = assign_archetype_speed_factors(
+        ped_states.shape[0],
+        spawn_config.archetype_composition,
+        spawn_config.archetype_speed_factors,
+        seed=spawn_config.archetype_seed,
+    )
+    ped_states[:, 2:4] *= speed_factors[:, np.newaxis]
+
+
 def populate_simulation(  # noqa: PLR0913
     tau: float,
     spawn_config: PedSpawnConfig,
@@ -756,18 +836,18 @@ def populate_simulation(  # noqa: PLR0913
     """
     prepared_obstacles = prepare_obstacle_polygons(obstacle_polygons or [])
 
-    # ``force_population_size`` sets the EXACT total pedestrian count. Both the crowded-zone
-    # and route spawners honor the field independently, so when a scenario declares both
-    # routes and crowded zones a naive pass would spawn ``2 * force_population_size`` peds
-    # (issue #4618 R4). Split the forced total between the two active spawners so the merged
-    # population matches the requested size; any odd remainder is assigned to routes.
-    crowd_spawn_config = spawn_config
-    route_spawn_config = spawn_config
-    if spawn_config.force_population_size is not None and ped_crowded_zones and ped_routes:
-        zone_share = spawn_config.force_population_size // 2
-        route_share = spawn_config.force_population_size - zone_share
-        crowd_spawn_config = replace(spawn_config, force_population_size=zone_share)
-        route_spawn_config = replace(spawn_config, force_population_size=route_share)
+    # ``force_population_size`` sets the exact total across every spawn channel. Reserve
+    # map-defined single pedestrians first, then split the remaining background budget
+    # between crowded zones and routes. Without the reservation, a map with one explicit
+    # pedestrian and a forced route population of 12 instantiated 13 pedestrians.
+    crowd_spawn_config, route_spawn_config, apply_archetypes_to_forced_population = (
+        _spawn_configs_for_forced_population(
+            spawn_config,
+            ped_routes,
+            ped_crowded_zones,
+            single_pedestrians,
+        )
+    )
 
     crowd_ped_states_np, crowd_groups, zone_assignments = populate_crowded_zones(
         crowd_spawn_config,
@@ -792,6 +872,11 @@ def populate_simulation(  # noqa: PLR0913
     # Combine all pedestrian states: crowd + route + single
     combined_ped_states_np = np.concatenate(
         (crowd_ped_states_np, route_ped_states_np, single_ped_states_np[:, :6]),
+    )
+    _apply_forced_population_contract(
+        combined_ped_states_np,
+        spawn_config,
+        apply_archetypes_to_forced_population,
     )
     taus = np.full((combined_ped_states_np.shape[0]), tau)
     ped_states = np.concatenate((combined_ped_states_np, np.expand_dims(taus, -1)), axis=-1)

--- a/tests/ped_npc/test_force_population_size_split.py
+++ b/tests/ped_npc/test_force_population_size_split.py
@@ -8,11 +8,26 @@ forced size must instead be the exact TOTAL, split across the active spawners.
 
 from __future__ import annotations
 
+from collections import Counter
+from pathlib import Path
+
 import numpy as np
 import pytest
 
+from robot_sf.nav.navigation import get_prepared_obstacles
+from robot_sf.nav.svg_map_parser import SvgMapConverter
 from robot_sf.ped_npc import ped_population
+from robot_sf.ped_npc.ped_archetypes import assign_archetype_labels
 from robot_sf.ped_npc.ped_population import PedSpawnConfig, populate_simulation
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CLASSIC_BOTTLENECK_MEDIUM_SVG = _REPO_ROOT / "maps" / "svg_maps" / "classic_bottleneck_medium.svg"
+
+
+@pytest.fixture(scope="module")
+def _route_map_with_explicit_pedestrian():
+    """Load a real map containing both a route and one explicit pedestrian."""
+    return SvgMapConverter(str(_CLASSIC_BOTTLENECK_MEDIUM_SVG)).get_map_definition()
 
 
 @pytest.fixture
@@ -27,15 +42,17 @@ def _captured_spawner_sizes(monkeypatch):
 
     def _fake_crowded(config, crowded_zones, *, obstacle_polygons=None):
         captured["crowd"] = config.force_population_size
-        return np.zeros((0, 6)), [], {}
+        count = int(config.force_population_size or 0) if crowded_zones else 0
+        return np.zeros((count, 6)), [], {}
 
     def _fake_routes(config, routes, *, obstacle_polygons=None):
         captured["route"] = config.force_population_size
-        return np.zeros((0, 6)), [], {}, {}
+        count = int(config.force_population_size or 0) if routes else 0
+        return np.zeros((count, 6)), [], {}, {}
 
     monkeypatch.setattr(ped_population, "populate_crowded_zones", _fake_crowded)
     monkeypatch.setattr(ped_population, "populate_ped_routes", _fake_routes)
-    # Replace behavior constructors with no-ops; the spawners return empty populations.
+    # Replace behavior constructors with no-ops; the spawners return count-only states.
     monkeypatch.setattr(ped_population, "CrowdedZoneBehavior", lambda *a, **k: object())
     monkeypatch.setattr(ped_population, "FollowRouteBehavior", lambda *a, **k: object())
     return captured
@@ -97,3 +114,69 @@ def test_force_population_size_not_split_when_only_routes(_captured_spawner_size
     )
 
     assert _captured_spawner_sizes["route"] == 10
+
+
+@pytest.mark.parametrize("population_size", [1, 3, 6, 12, 24])
+def test_force_population_size_includes_explicit_pedestrians(
+    _route_map_with_explicit_pedestrian,
+    population_size: int,
+) -> None:
+    """The forced total includes map-defined pedestrians as well as route spawns."""
+    map_def = _route_map_with_explicit_pedestrian
+    spawn_config = PedSpawnConfig(
+        peds_per_area_m2=0.02,
+        max_group_members=3,
+        force_population_size=population_size,
+        route_spawn_distribution="spread",
+        route_spawn_seed=3574,
+    )
+
+    ped_states, _groups, _behaviors = populate_simulation(
+        tau=0.5,
+        spawn_config=spawn_config,
+        ped_routes=map_def.ped_routes,
+        ped_crowded_zones=map_def.ped_crowded_zones,
+        obstacle_polygons=get_prepared_obstacles(map_def),
+        single_pedestrians=map_def.single_pedestrians,
+    )
+
+    assert ped_states.num_peds == population_size
+
+
+def test_force_population_size_preserves_full_population_archetype_mix(
+    _route_map_with_explicit_pedestrian,
+) -> None:
+    """The forced 12-person population realizes the declared 3/6/3 speed split."""
+    map_def = _route_map_with_explicit_pedestrian
+    spawn_config = PedSpawnConfig(
+        peds_per_area_m2=0.02,
+        max_group_members=3,
+        initial_speed=0.5,
+        force_population_size=12,
+        route_spawn_distribution="spread",
+        route_spawn_seed=3574,
+        archetype_composition={"cautious": 0.25, "standard": 0.5, "hurried": 0.25},
+        archetype_speed_factors={"cautious": 0.7, "standard": 1.0, "hurried": 1.4},
+        archetype_seed=3574,
+    )
+
+    ped_states, _groups, _behaviors = populate_simulation(
+        tau=0.5,
+        spawn_config=spawn_config,
+        ped_routes=map_def.ped_routes,
+        ped_crowded_zones=map_def.ped_crowded_zones,
+        obstacle_polygons=get_prepared_obstacles(map_def),
+        single_pedestrians=map_def.single_pedestrians,
+    )
+
+    speeds = np.linalg.norm(ped_states.ped_velocities, axis=1)
+    labels = assign_archetype_labels(
+        12,
+        spawn_config.archetype_composition,
+        seed=spawn_config.archetype_seed,
+    )
+    expected_speeds = np.asarray(
+        [0.5 * spawn_config.archetype_speed_factors[label] for label in labels],
+    )
+    assert np.allclose(speeds, expected_speeds)
+    assert Counter(np.round(speeds, 6).tolist()) == {0.35: 3, 0.5: 6, 0.7: 3}


### PR DESCRIPTION
## Summary

Make `force_population_size` an exact total across route, crowded-zone, and explicit single-pedestrian spawn channels. This fixes the 12-to-13 off-by-one that blocked the S30 heterogeneity rerun while preserving the declared 3/6/3 archetype composition.

## Linked Issues

- Relates to `#5666`

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: none

## What Changed

- Reserve map-defined single pedestrians from the forced total before allocating background pedestrians.
- Split only the remaining background budget between crowded zones and routes; odd remainders still go to routes.
- Apply archetype speed factors once across the final merged forced population so simulator indices and declared composition remain aligned.
- Fail closed when a forced total is smaller than the number of explicit pedestrians or when no spawn source can realize the remaining budget.
- Add real-map regression coverage for `N in {1, 3, 6, 12, 24}` and the 12-person cautious/standard/hurried `3/6/3` split.

## Why It Matters

- Added value: the simulator now realizes the exact population declared by the harness.
- Expected impact: the unchanged `#5666` assertion passes on maps that combine route spawns with explicit pedestrians.
- Why this is worth merging now: it unblocks the S30 full rerun.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: blocker only — forced population accounting must realize exactly the declared count.
- Comparator or baseline, if applicable: prior behavior spawned 12 route pedestrians and then appended one explicit pedestrian, producing 13.
- Evidence tier: NA — implementation validation only; no research result is claimed
- Result classification: NA — runtime bug fix
- Decision or stop rule, if applicable: merge when exact-count unit coverage, the production run-step smoke, and repository readiness are green.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `#5666`; no research result surface changes.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA — no analysis tool added.

## Domain-Aware Approval

- Required for this PR: no — this fixes implementation integrity without changing evidence classification, comparison methodology, figure eligibility, benchmark interpretation, or claim boundaries.
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: repository domain-approval contract
- Validity checklist:
  - Target claim/hypothesis: exact population accounting only
  - Comparator or split/evidence validity: unchanged
  - Fallback/degraded exclusions: native `fast-pysf` execution used; no fallback/degraded evidence counted
  - Claim boundary: unit and targeted run-step smoke proof only
  - Implementation integrity vs experimental validity: implementation integrity proven; no experimental-validity claim

## Falsification / Non-Transfer Check

- Did the mechanism activate? yes — the real regression map changed from `N + 1` to exactly `N`.
- Did the intervention change command source, selected command, trajectory, or route progress? no; population construction only.
- Did the scenario actually contain the targeted failure mode? yes — `classic_bottleneck_medium.svg` contains one explicit pedestrian plus a pedestrian route.
- Result route: continue
- Follow-up question or issue for weak, negative, or non-transfer results: none.

## Next Empirical Action

- Rerun needed: yes — run the S30 full rerun after merge.
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none for this implementation fix
- Stop / revise / continue decision: continue to the full rerun after the gate merges this PR
- Proposed child issue or existing follow-up: existing S30 rerun workflow

## Validation / Proof

- Commands run:
  - `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run python -m pytest tests/ped_npc/test_force_population_size_split.py tests/ped_npc/test_ped_archetypes.py tests/test_single_pedestrian.py tests/benchmark/test_heterogeneous_population_ablation.py::test_matrix_harness_aligns_trace_labels_to_each_density_population tests/benchmark/test_heterogeneous_population_ablation.py::test_small_map_low_density_forces_declared_population_and_realizes_mix -q`
  - `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run python -m pytest tests/ -q -m "not slow" -n 16`
  - `scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574.py` and `scripts/benchmark/run_heterogeneous_population_ablation_issue_3574.py` against a two-row local manifest on `classic_bottleneck_medium.svg`
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (passed on clean committed head; changed-line coverage 83.9%, above the required 80% with a goal-only warning)
  - `git diff --check`
- Evidence that the change works here: 60 focused tests passed; 859 fast tests passed. The exact-count regression passes for 1, 3, 6, 12, and 24, and the 12-person test verifies per-index archetype speed assignment plus a 3/6/3 count.
- Benchmarks or smoke tests, if applicable: the production ablation run-step wrote two `episode_records` rows with declared=12, instantiated=12, trace_count=12, no disposition, and heterogeneous archetype counts 3/6/3. This is smoke evidence, not a benchmark-result claim.

## Risks / Rollout

- Compatibility risks: forced populations now include explicit map pedestrians, matching the declared-total contract. Non-forced population behavior is unchanged.
- Failure modes: impossible forced totals fail closed instead of silently dropping explicit pedestrians or inventing background agents.
- Rollback or fallback plan: revert this PR; no fallback mode is introduced.

## Docs / Provenance

- Updated docs: the `PedSpawnConfig.force_population_size` public docstring now states that the count spans all spawn channels.
- Relevant design or provenance notes: the existing `#5666` assertion remains unchanged.
- Any assumptions that need to be preserved: explicit pedestrians are part of the forced total; the ego state is separate from the robot-only benchmark population.

## Downstream Propagation

- Parent issue updated (yes/no/NA): NA
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): no
- Not applicable because: this PR repairs runtime population accounting and makes no research or benchmark-result claim. Local smoke outputs were inspected and discarded; no durable evidence artifact is introduced.

## Follow-Up Issues

- Deferred work: none
- Issues opened for follow-up: none.

## Reviewer Notes

- Anything a reviewer should verify closely: the explicit-pedestrian reservation and the one-time merged-population archetype assignment.
- Any known limitations: a forced total smaller than the explicit-pedestrian count, or larger than that count on a map with no background spawn source, now raises a clear error.
- Shared-helper migration: inapplicable; no shared-helper migration or process-boundary change.
