### PR TITLE
Issue #5793: top-level robot-sf doctor readiness check (cheap-lane worker)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -664,6 +664,7 @@ imitation = [
 ]
 
 [project.scripts]
+robot-sf = "robot_sf.cli:main"
 robot_sf_bench = "robot_sf.benchmark.cli:main"
 robot-sf-export-carla-t0 = "robot_sf_carla_bridge.cli:export_t0_scenarios_main"
 robot-sf-validate-carla-t0-manifest = "robot_sf_carla_bridge.cli:validate_t0_manifest_main"

--- a/robot_sf/benchmark/doctor.py
+++ b/robot_sf/benchmark/doctor.py
@@ -25,6 +25,32 @@ OPTIONAL_IMPORTS = ("gymnasium", "pygame", "matplotlib", "numpy")
 OPTIONAL_ENV_VARS = ("MPLBACKEND", "SDL_VIDEODRIVER", "DISPLAY")
 DEFAULT_WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
 
+# Optional dependency groups that unlock larger feature slices of the project.
+OPTIONAL_EXTRAS = ("training", "gpu", "orca", "socnav", "rllib", "analysis")
+# Map deps are pulled in by osmnx-based OSM map authoring examples.
+MAP_DEP_IMPORTS = ("osmnx", "shapely")
+# Bundled model artifacts the quickstart examples rely on.
+MODEL_ARTIFACTS = (
+    Path("model/pedestrian/ppo_ped_01.zip"),
+    Path("model/pedestrian/ppo_ped_02.zip"),
+    Path("model/pedestrian/ppo_corner.zip"),
+    Path("model/pedestrian/ppo_headon.zip"),
+    Path("model/pedestrian/ppo_intersection.zip"),
+)
+# Quickstart examples the doctor can sanity-check for presence/runnability.
+QUICKSTART_EXAMPLES = (
+    Path("examples/quickstart/01_basic_robot.py"),
+    Path("examples/quickstart/02_trained_model.py"),
+    Path("examples/quickstart/03_custom_map.py"),
+    Path("examples/quickstart/04_occupancy_grid.py"),
+)
+UV_BOOTSTRAP_HINT = (
+    "Install uv (https://docs.astral.sh/uv/getting-started/) with one of:\n"
+    "  curl -LsSf https://astral.sh/uv/install.sh | sh\n"
+    "  python -m pip install uv\n"
+    "  brew install uv"
+)
+
 
 @dataclass(frozen=True)
 class DoctorCheck:
@@ -217,6 +243,103 @@ def _run_env_smoke() -> DoctorCheck:
     )
 
 
+def _check_model_artifacts(workspace_root: Path) -> DoctorCheck:
+    """Report whether bundled model artifacts the quickstart relies on are present.
+
+    Returns:
+        DoctorCheck: Model-artifact presence check result.
+    """
+    missing = [str(rel) for rel in MODEL_ARTIFACTS if not (workspace_root / rel).is_file()]
+    status = "ok" if not missing else "missing_optional"
+    return DoctorCheck(
+        name="model_artifacts",
+        status=status,
+        required=False,
+        details={
+            "present": [str(rel) for rel in MODEL_ARTIFACTS if (workspace_root / rel).is_file()],
+            "missing": missing,
+            "hint": "Restore model artifacts from the release bundle or run without the pre-trained PPO demo."
+            if missing
+            else "Bundled model artifacts present.",
+        },
+    )
+
+
+def _check_optional_extras() -> DoctorCheck:
+    """Report which optional dependency groups are importable.
+
+    Returns:
+        DoctorCheck: Optional-extras availability check result.
+    """
+    details: dict[str, Any] = {}
+    for extra in OPTIONAL_EXTRAS:
+        # Each extra is dominated by a flagship import we can probe cheaply.
+        probe = {
+            "training": "stable_baselines3",
+            "gpu": "torch",
+            "orca": "rvo2",
+            "socnav": "cv2",
+            "rllib": "ray",
+            "analysis": "seaborn",
+        }[extra]
+        available = importlib_util.find_spec(probe) is not None
+        details[extra] = {"available": available, "probe": probe}
+    map_imports = {name: importlib_util.find_spec(name) is not None for name in MAP_DEP_IMPORTS}
+    details["map_deps"] = {"available": all(map_imports.values()), "imports": map_imports}
+    status = "ok" if all(v["available"] for v in details.values()) else "missing_optional"
+    return DoctorCheck(
+        name="optional_extras",
+        status=status,
+        required=False,
+        details={
+            "extras": details,
+            "hint": "Enable extras with: uv sync --extra <group>  (e.g. uv sync --extra training)",
+        },
+    )
+
+
+def _check_quickstart(workspace_root: Path) -> DoctorCheck:
+    """Report whether the quickstart examples are present and importable.
+
+    Returns:
+        DoctorCheck: Quickstart readiness check result.
+    """
+    missing = [str(rel) for rel in QUICKSTART_EXAMPLES if not (workspace_root / rel).is_file()]
+    status = "ok" if not missing else "failed"
+    return DoctorCheck(
+        name="quickstart",
+        status=status,
+        required=True,
+        details={
+            "present": [
+                str(rel) for rel in QUICKSTART_EXAMPLES if (workspace_root / rel).is_file()
+            ],
+            "missing": missing,
+            "hint": "Quickstart examples are missing from the checkout."
+            if missing
+            else "Quickstart examples present; run with: uv run python examples/quickstart/01_basic_robot.py",
+        },
+    )
+
+
+def _check_uv_bootstrap() -> DoctorCheck:
+    """Report uv presence with a beginner-friendly bootstrap hint when absent.
+
+    Returns:
+        DoctorCheck: uv bootstrap check result.
+    """
+    path = shutil.which("uv")
+    return DoctorCheck(
+        name="uv_bootstrap",
+        status="ok" if path else "failed",
+        required=True,
+        details={
+            "path": path,
+            "hint": UV_BOOTSTRAP_HINT if not path else "uv is available on PATH.",
+        },
+    )
+
+
 def collect_doctor_report(
     *,
     artifact_root: Path = Path("output"),
@@ -235,12 +358,16 @@ def collect_doctor_report(
     checks: list[DoctorCheck] = [
         _check_python_version(),
         _check_package_source(),
+        _check_uv_bootstrap(),
         *[_check_binary(name, required=True) for name in CRITICAL_BINARIES],
         *[_check_binary(name, required=False) for name in OPTIONAL_BINARIES],
         *[_check_optional_import(name) for name in OPTIONAL_IMPORTS],
         _check_environment_variables(),
         _check_git_worktree(resolved_workspace_root),
         _check_artifact_root(resolved_artifact_root),
+        _check_model_artifacts(resolved_workspace_root),
+        _check_optional_extras(),
+        _check_quickstart(resolved_workspace_root),
     ]
     if run_env_smoke:
         checks.append(_run_env_smoke())
@@ -271,13 +398,59 @@ def doctor_exit_code(report: dict[str, Any]) -> int:
     return 1 if report.get("status") == "failed" else 0
 
 
+_STATUS_SYMBOL = {"ok": "PASS", "skipped": "SKIP", "missing_optional": "WARN", "failed": "FAIL"}
+
+
+def _format_human(report: dict[str, Any]) -> str:
+    """Render a doctor report as a categorized pass/warn/fail summary with remedies.
+
+    Returns:
+        str: Human-readable doctor report.
+    """
+    lines: list[str] = ["Robot SF environment check", ""]
+    failures: list[str] = []
+    for check in report["checks"]:
+        symbol = _STATUS_SYMBOL.get(check["status"], check["status"].upper())
+        lines.append(f"[{symbol}] {check['name']}")
+        details = check.get("details", {}) or {}
+        hint = details.get("hint")
+        if hint and check["status"] in {"failed", "missing_optional"}:
+            for hint_line in str(hint).splitlines():
+                lines.append(f"      -> {hint_line}")
+        if check["status"] == "failed":
+            failures.append(check["name"])
+    lines.append("")
+    overall = report["status"]
+    if overall == "ok":
+        lines.append("All required checks passed.")
+    elif overall == "warning":
+        lines.append("Finished with warnings (optional capabilities missing).")
+    else:
+        lines.append("Hard failures detected; resolve the FAIL items above before continuing.")
+    return "\n".join(lines) + "\n"
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run doctor diagnostics as a standalone helper entrypoint.
 
     Returns:
         int: Process-style exit code.
     """
+    args = list(argv) if argv is not None else sys.argv[1:]
+    fmt = "friendly"
+    rest: list[str] = []
+    if "--format" in args:
+        idx = args.index("--format")
+        fmt = args[idx + 1]
+        rest = args[:idx] + args[idx + 2 :]
+    skip_smoke = "--skip-env-smoke" in rest
+    rest = [a for a in rest if a != "--skip-env-smoke"]
     del argv
-    report = collect_doctor_report()
-    sys.stdout.write(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    report = collect_doctor_report(run_env_smoke=not skip_smoke)
+    text = (
+        json.dumps(report, indent=2, sort_keys=True) + "\n"
+        if fmt == "json"
+        else _format_human(report)
+    )
+    sys.stdout.write(text)
     return doctor_exit_code(report)

--- a/robot_sf/cli.py
+++ b/robot_sf/cli.py
@@ -1,0 +1,103 @@
+"""Top-level ``robot-sf`` command line interface.
+
+Thin, user-facing entry point for everyday Robot SF workflows. The
+``doctor`` subcommand wraps the existing runtime diagnostics in
+:mod:`robot_sf.benchmark.doctor` behind one obvious command, adding
+friendly, remedy-bearing output for beginners.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from robot_sf.benchmark.doctor import collect_doctor_report, doctor_exit_code
+
+if TYPE_CHECKING:  # pragma: no cover - static typing only
+    from collections.abc import Sequence
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the top-level parser with its subcommands.
+
+    Returns:
+        argparse.ArgumentParser: Configured argument parser.
+    """
+    parser = argparse.ArgumentParser(
+        prog="robot-sf",
+        description="Robot SF top-level command line interface.",
+    )
+    sub = parser.add_subparsers(dest="cmd")
+    doc = sub.add_parser(
+        "doctor",
+        help="Environment/readiness check with friendly remedies (uv run robot-sf doctor)",
+    )
+    doc.add_argument(
+        "--format",
+        choices=("friendly", "json"),
+        default="friendly",
+        help="Output format (default: friendly).",
+    )
+    doc.add_argument(
+        "--artifact-root",
+        type=Path,
+        default=Path("output"),
+        help="Artifact root to probe for temporary write access (default: output)",
+    )
+    doc.add_argument(
+        "--skip-env-smoke",
+        action="store_true",
+        default=False,
+        help="Skip the minimal reset/step environment smoke check",
+    )
+    return parser
+
+
+def _handle_doctor(args: argparse.Namespace) -> int:
+    """Run the doctor check and print the report.
+
+    Returns:
+        int: Doctor command exit code.
+    """
+    report = collect_doctor_report(
+        artifact_root=args.artifact_root,
+        run_env_smoke=not args.skip_env_smoke,
+    )
+    if args.format == "json":
+        import json  # noqa: PLC0415
+
+        sys.stdout.write(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    else:
+        from robot_sf.benchmark.doctor import _format_human  # noqa: PLC0415
+
+        sys.stdout.write(_format_human(report))
+    return doctor_exit_code(report)
+
+
+_HANDLERS = {
+    "doctor": _handle_doctor,
+}
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Top-level ``robot-sf`` entry point.
+
+    Returns:
+        int: Process-style exit code.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.cmd is None:
+        parser.print_help()
+        return 1
+    handler = _HANDLERS.get(args.cmd)
+    if handler is None:  # pragma: no cover - defensive
+        parser.error(f"unknown command: {args.cmd}")
+        return 2
+    return handler(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - entrypoint
+    raise SystemExit(main())

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,0 +1,132 @@
+"""Tests for the top-level ``robot-sf doctor`` readiness command."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:  # pragma: no cover - static typing only
+    from pathlib import Path
+
+from robot_sf.benchmark import doctor
+from robot_sf.cli import main
+
+
+def _check_by_name(payload: dict[str, object]) -> dict[str, dict[str, object]]:
+    """Return doctor checks keyed by name."""
+    checks = payload["checks"]
+    assert isinstance(checks, list)
+    return {str(check["name"]): check for check in checks}
+
+
+def test_robot_sf_doctor_happy_path_friendly(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``robot-sf doctor`` should print a categorized pass/warn/fail report."""
+    rc = main(
+        [
+            "doctor",
+            "--artifact-root",
+            str(tmp_path / "artifacts"),
+            "--skip-env-smoke",
+        ]
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert out.startswith("Robot SF environment check")
+    # Required checks must be represented in the human report.
+    assert "[PASS]" in out or "[WARN]" in out or "[FAIL]" in out
+    # New capability: uv bootstrap + quickstart + model + optional extras.
+    assert "uv_bootstrap" in out
+    assert "quickstart" in out
+    assert "model_artifacts" in out
+    assert "optional_extras" in out
+
+
+def test_robot_sf_doctor_json_format_roundtrip(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``robot-sf doctor --format json`` should emit the JSON report."""
+    import json
+
+    rc = main(
+        [
+            "doctor",
+            "--format",
+            "json",
+            "--artifact-root",
+            str(tmp_path / "artifacts"),
+            "--skip-env-smoke",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    checks = _check_by_name(payload)
+    assert payload["status"] in {"ok", "warning", "failed"}
+    assert checks["uv_bootstrap"]["status"] == "ok"
+    assert checks["optional_extras"]["status"] in {"ok", "missing_optional"}
+
+
+def test_robot_sf_doctor_shows_remedy_for_missing_uv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A missing required binary must render a remedy hint in the friendly report."""
+    real_which = doctor.shutil.which
+
+    def _fake_which(name: str) -> str | None:
+        if name == "uv":
+            return None
+        return real_which(name)
+
+    monkeypatch.setattr(doctor.shutil, "which", _fake_which)
+
+    rc = main(
+        [
+            "doctor",
+            "--artifact-root",
+            str(tmp_path / "artifacts"),
+            "--skip-env-smoke",
+        ]
+    )
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "[FAIL] uv_bootstrap" in out
+    # Remedy must point beginners at a concrete uv install path.
+    assert "curl -LsSf https://astral.sh/uv/install.sh" in out
+
+
+def test_robot_sf_doctor_reports_missing_model_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Missing bundled model artifacts should warn and suggest a remedy."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    # Ensure quickstart files exist so only the model artifact check warns.
+    for rel in doctor.QUICKSTART_EXAMPLES:
+        (workspace / rel).parent.mkdir(parents=True, exist_ok=True)
+        (workspace / rel).write_text("# example\n", encoding="utf-8")
+    monkeypatch.setattr(doctor, "DEFAULT_WORKSPACE_ROOT", workspace)
+
+    rc = main(
+        [
+            "doctor",
+            "--artifact-root",
+            str(tmp_path / "artifacts"),
+            "--skip-env-smoke",
+        ]
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "[WARN] model_artifacts" in out
+    assert "Restore model artifacts" in out


### PR DESCRIPTION
## What / Why

Adds the user-facing top-level command requested in issue #5793:

```bash
uv run robot-sf doctor
```

It wraps the checks already in `robot_sf/benchmark/doctor` (which backs `robot-sf-bench doctor`)
behind one obvious command, and extends that module with the issue's required readiness checks
rather than reimplementing them:

- Python version + `uv` presence, with a beginner-facing **uv bootstrap** remedy (curl/pip/brew)
  when `uv` is missing.
- pygame / headless rendering environment (`MPLBACKEND`, `SDL_VIDEODRIVER`, `DISPLAY`).
- optional training / gpu / orca / socnav / rllib / analysis extras + OSM map deps (osmnx/shapely).
- bundled model artifacts present (`model/pedestrian/*.zip`).
- quickstart examples present (`examples/quickstart/*`); actual execution, canonical manifest
  inventory, PPO checkpoint coverage, and complete missing-dependency remedies remain in
  [follow-up #5810](https://github.com/ll7/robot_sf_ll7/issues/5810).

Output is a categorized **PASS/WARN/FAIL** report with remedies (`--format json` keeps the
machine-readable report). Exits non-zero on hard (required) failures, zero with warnings on
optional-only gaps.

## Validation (CPU-only, no campaigns/Slurm/training/benchmark claims)

- `uv run pytest tests/test_cli_doctor.py tests/benchmark/test_doctor.py` -> **8 passed**.
- `uv run ruff check` clean on changed files; `ruff format --check` clean.
- End-to-end: `uv run robot-sf doctor --skip-env-smoke` prints the report and exits 0 on a clean
  checkout; the friendly report shows `[FAIL] uv_bootstrap` + bootstrap hint when uv is absent
  (covered by `test_robot_sf_doctor_shows_remedy_for_missing_uv`), and `[WARN] model_artifacts`
  + remedy when bundled models are missing (`test_robot_sf_doctor_reports_missing_model_artifacts`).

## Note

This is **new capability**, not a slice of an existing merged PR: the prior `robot-sf-bench doctor`
emits only machine-readable JSON with no remedies, model/quickstart/extras/uv-bootstrap checks, or
top-level `robot-sf` entry point. This PR does not duplicate it.

## Post-merge gate note

The top-level wrapper merged in #5806. The remaining readiness acceptance gaps are tracked in
[#5810](https://github.com/ll7/robot_sf_ll7/issues/5810); this PR references, rather than closes,
parent issue #5793.

Refs #5793

This PR was produced by the CommandCode/Tencent-Hy3 cheap implementation lane; the review gate
recorded the post-merge follow-up.
