### PR TITLE
Issue #5792: add `robot-sf demo` one-command visual demo (cheap-lane worker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,19 @@ cd robot_sf_ll7
 scripts/dev/check_runtime_requirements.sh
 uv sync --all-extras
 
+# One-command visual demo: run a tiny deterministic episode and open a viewer.
+uv run robot-sf demo
+
 uv run python examples/quickstart/01_basic_robot.py
 uv run python examples/quickstart/02_trained_model.py
 uv run python examples/quickstart/03_custom_map.py
 ```
+
+`uv run robot-sf demo` runs a short deterministic scenario, writes a recorded episode
+(`episode.jsonl`), a static browser viewer (`viewer/index.html`), a map thumbnail
+(`thumbnail.png`), and a plain-English summary under `output/demo/latest/`. It is the
+fastest install → run → *see something* path and is CPU-only. Open
+`output/demo/latest/viewer/index.html` in a browser to replay the episode.
 
 ### Packaging smoke (wheel install smoke)
 

--- a/configs/scenarios/single/quickstart_demo.yaml
+++ b/configs/scenarios/single/quickstart_demo.yaml
@@ -1,0 +1,22 @@
+scenarios:
+- name: quickstart_demo_crossing_basic
+  map_file: ../../../maps/svg_maps/francis2023/francis2023_circular_crossing.svg
+  simulation_config:
+    max_episode_steps: 120
+    ped_density: 0.04
+  robot_config: {}
+  metadata:
+    figure: quickstart
+    archetype: circular_crossing
+    flow: circular
+    behavior: traffic
+    plausibility:
+      status: unverified
+      verified_on: null
+      verified_by: null
+      method: null
+      notes: null
+      metrics: {}
+      metrics_updated_on: null
+  seeds:
+  - 270

--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -1,5 +1,8 @@
 # Context Retrieval Index
 
+Issue #5792 one-command demo reproducibility and CPU UX smoke record:
+[issue_5792_demo_validation_2026-07-15.md](evidence/issue_5792_demo_validation_2026-07-15.md).
+
 Issue #5579 MPC tuning-budget archaeology and bounded sensitivity packet (two prediction-MPC arms,
 20-point shared grid, fixed paired slice, and fail-closed diagnostic read):
 [issue_5579_mpc_tuning_budget_sensitivity.md](issue_5579_mpc_tuning_budget_sensitivity.md).

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -24,6 +24,10 @@ entries:
   status: evidence
   freshness: dated
   area: reproducibility
+- path: docs/context/evidence/issue_5792_demo_validation_2026-07-15.md.review.json
+  status: evidence
+  freshness: dated
+  area: reproducibility
 - path: docs/context/evidence/issue_5446_release_0_0_3_candidates/README.md
   status: evidence
   freshness: evidence

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -20,6 +20,10 @@ freshness_values:
   policy: Durable policy boundary; update only when the policy changes.
   evidence: Evidence pointer or manifest; preserve provenance and checksums when applicable.
 entries:
+- path: docs/context/evidence/issue_5792_demo_validation_2026-07-15.md
+  status: evidence
+  freshness: dated
+  area: reproducibility
 - path: docs/context/evidence/issue_5446_release_0_0_3_candidates/README.md
   status: evidence
   freshness: evidence

--- a/docs/context/evidence/issue_5792_demo_validation_2026-07-15.md
+++ b/docs/context/evidence/issue_5792_demo_validation_2026-07-15.md
@@ -1,0 +1,45 @@
+# Issue #5792 demo validation record
+
+Status: `diagnostic-only` UX/reproducibility evidence; not benchmark, safety, or paper evidence.
+
+This compact record is the durable artifact pointer for PR #5807. The generated JSONL, viewer, and
+PNG remain worktree-local under `output/` and are intentionally not copied into git. They can be
+recovered from the tracked scenario, code, seed, and command below.
+
+## Reproduction
+
+- Source repair commit: `240963388` (`fix(ux): make demo artifacts deterministic`)
+- Scenario: `configs/scenarios/single/quickstart_demo.yaml`
+- Scenario name: `quickstart_demo_crossing_basic`
+- Planner: built-in `random`
+- Seed: `270`
+- Command: `uv run robot-sf demo --output-root output/demo/latest --seed 270`
+- Artifact root: `output/demo/latest/`
+- Artifact set: `episode.jsonl`, `summary.json`, `metrics.json`, `viewer/index.html`,
+  `viewer/scene.json`, and `thumbnail.png`
+
+## Observed CPU smoke
+
+Two fresh process invocations on 2026-07-15 completed in `21.04–21.07 s` wall time on this
+validation host, each producing 122 JSONL records for a 120-step episode. The two
+`episode.jsonl` files and the two `viewer/scene.json` files were byte-for-byte equal.
+
+This timing is a local UX smoke range, not a performance benchmark or cross-host guarantee.
+
+## Validation commands
+
+```bash
+uv run ruff check robot_sf/cli.py scripts/demo/quickstart_demo.py tests/test_quickstart_demo.py
+uv run ruff format --check robot_sf/cli.py scripts/demo/quickstart_demo.py tests/test_quickstart_demo.py
+scripts/dev/run_focused_tests.sh tests/test_quickstart_demo.py -q
+```
+
+The focused suite passed 5 tests, including full JSONL/viewer determinism, repository-root-
+independent CLI dispatch, an empty scenario manifest, and a failed required-runtime check.
+
+## Claim boundary
+
+The record supports only that the demo path ran on this host for the named scenario and seed and
+that its generated recording/viewer inputs were stable across this two-run smoke. It does not
+support planner ranking, collision safety, benchmark performance, deployment readiness, or
+generalized timing claims.

--- a/docs/context/evidence/issue_5792_demo_validation_2026-07-15.md
+++ b/docs/context/evidence/issue_5792_demo_validation_2026-07-15.md
@@ -1,3 +1,5 @@
+<!-- AI-GENERATED (robot_sf#5792, 2026-07-15) - NEEDS-REVIEW -->
+
 # Issue #5792 demo validation record
 
 Status: `diagnostic-only` UX/reproducibility evidence; not benchmark, safety, or paper evidence.

--- a/docs/context/evidence/issue_5792_demo_validation_2026-07-15.md
+++ b/docs/context/evidence/issue_5792_demo_validation_2026-07-15.md
@@ -3,7 +3,8 @@
 Status: `diagnostic-only` UX/reproducibility evidence; not benchmark, safety, or paper evidence.
 
 This compact record is the durable artifact pointer for PR #5807. The generated JSONL, viewer, and
-PNG remain worktree-local under `output/` and are intentionally not copied into git. They can be
+PNG remain worktree-local under the configured demo artifact root and are intentionally not copied
+into git. They can be
 recovered from the tracked scenario, code, seed, and command below.
 
 ## Reproduction
@@ -13,8 +14,8 @@ recovered from the tracked scenario, code, seed, and command below.
 - Scenario name: `quickstart_demo_crossing_basic`
 - Planner: built-in `random`
 - Seed: `270`
-- Command: `uv run robot-sf demo --output-root output/demo/latest --seed 270`
-- Artifact root: `output/demo/latest/`
+- Command: `uv run robot-sf demo --output-root <demo-artifact-root> --seed 270`
+- Artifact root: `<demo-artifact-root>/`
 - Artifact set: `episode.jsonl`, `summary.json`, `metrics.json`, `viewer/index.html`,
   `viewer/scene.json`, and `thumbnail.png`
 

--- a/docs/context/evidence/issue_5792_demo_validation_2026-07-15.md
+++ b/docs/context/evidence/issue_5792_demo_validation_2026-07-15.md
@@ -9,7 +9,7 @@ recovered from the tracked scenario, code, seed, and command below.
 
 ## Reproduction
 
-- Source repair commit: `240963388` (`fix(ux): make demo artifacts deterministic`)
+- Source repair commit: `b93983c2e` (`fix(ux): make demo artifacts deterministic`)
 - Scenario: `configs/scenarios/single/quickstart_demo.yaml`
 - Scenario name: `quickstart_demo_crossing_basic`
 - Planner: built-in `random`

--- a/docs/context/evidence/issue_5792_demo_validation_2026-07-15.md.review.json
+++ b/docs/context/evidence/issue_5792_demo_validation_2026-07-15.md.review.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "evidence-review-marker.v1",
+  "artifact_path": "docs/context/evidence/issue_5792_demo_validation_2026-07-15.md",
+  "artifact_sha256": "d40e3afd3dfecfa090c4298677209772dca4bde35dc6400cb7f89a7983ae6ce7",
+  "review_marker": "AI-GENERATED NEEDS-REVIEW",
+  "preserved_exact_bytes": true
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -387,6 +387,7 @@ max-statements = 60
 "scripts/classic_benchmark_full.py" = ["BLE001"]
 "scripts/coverage/open_coverage_report.py" = ["BLE001"]
 "scripts/demo/run_robot_sf_smoke.py" = ["BLE001"]
+"scripts/demo/quickstart_demo.py" = ["BLE001"]
 "scripts/demo_jsonl_recording.py" = ["BLE001"]
 "scripts/dev/compact_ci_snapshot.py" = ["BLE001"]
 "scripts/dev/compact_worktree_snapshot.py" = ["BLE001"]
@@ -666,6 +667,7 @@ imitation = [
 [project.scripts]
 robot-sf = "robot_sf.cli:main"
 robot_sf_bench = "robot_sf.benchmark.cli:main"
+robot-sf = "robot_sf.cli:main"
 robot-sf-export-carla-t0 = "robot_sf_carla_bridge.cli:export_t0_scenarios_main"
 robot-sf-validate-carla-t0-manifest = "robot_sf_carla_bridge.cli:validate_t0_manifest_main"
 robot-sf-validate-carla-t0-batch = "robot_sf_carla_bridge.cli:validate_t0_export_batch_main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -667,7 +667,6 @@ imitation = [
 [project.scripts]
 robot-sf = "robot_sf.cli:main"
 robot_sf_bench = "robot_sf.benchmark.cli:main"
-robot-sf = "robot_sf.cli:main"
 robot-sf-export-carla-t0 = "robot_sf_carla_bridge.cli:export_t0_scenarios_main"
 robot-sf-validate-carla-t0-manifest = "robot_sf_carla_bridge.cli:validate_t0_manifest_main"
 robot-sf-validate-carla-t0-batch = "robot_sf_carla_bridge.cli:validate_t0_export_batch_main"

--- a/robot_sf/cli.py
+++ b/robot_sf/cli.py
@@ -65,7 +65,11 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _handle_doctor(args: argparse.Namespace) -> int:
-    """Run the doctor check and print the report."""
+    """Run the doctor check and print the report.
+
+    Returns:
+        int: Process-style doctor exit code.
+    """
     report = collect_doctor_report(
         artifact_root=args.artifact_root,
         run_env_smoke=not args.skip_env_smoke,

--- a/robot_sf/cli.py
+++ b/robot_sf/cli.py
@@ -1,9 +1,8 @@
 """Top-level ``robot-sf`` command line interface.
 
-Thin, user-facing entry point for everyday Robot SF workflows. The
-``doctor`` subcommand wraps the existing runtime diagnostics in
-:mod:`robot_sf.benchmark.doctor` behind one obvious command, adding
-friendly, remedy-bearing output for beginners.
+The command exposes the existing runtime doctor and the one-command visual
+demo from the adoption/UX epic. More everyday workflows can be added here
+without creating another top-level entry point.
 """
 
 from __future__ import annotations
@@ -15,52 +14,58 @@ from typing import TYPE_CHECKING
 
 from robot_sf.benchmark.doctor import collect_doctor_report, doctor_exit_code
 
-if TYPE_CHECKING:  # pragma: no cover - static typing only
+if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    """Build the top-level parser with its subcommands.
+    """Construct the top-level ``robot-sf`` argument parser.
 
     Returns:
-        argparse.ArgumentParser: Configured argument parser.
+        argparse.ArgumentParser: Parser with the registered subcommands.
     """
     parser = argparse.ArgumentParser(
         prog="robot-sf",
         description="Robot SF top-level command line interface.",
     )
-    sub = parser.add_subparsers(dest="cmd")
-    doc = sub.add_parser(
+    subparsers = parser.add_subparsers(dest="command")
+
+    doctor = subparsers.add_parser(
         "doctor",
-        help="Environment/readiness check with friendly remedies (uv run robot-sf doctor)",
+        help="Environment/readiness check with friendly remedies.",
     )
-    doc.add_argument(
+    doctor.add_argument(
         "--format",
         choices=("friendly", "json"),
         default="friendly",
         help="Output format (default: friendly).",
     )
-    doc.add_argument(
+    doctor.add_argument(
         "--artifact-root",
         type=Path,
         default=Path("output"),
-        help="Artifact root to probe for temporary write access (default: output)",
+        help="Artifact root to probe for temporary write access (default: output).",
     )
-    doc.add_argument(
+    doctor.add_argument(
         "--skip-env-smoke",
         action="store_true",
-        default=False,
-        help="Skip the minimal reset/step environment smoke check",
+        help="Skip the minimal reset/step environment smoke check.",
     )
+
+    demo = subparsers.add_parser(
+        "demo",
+        help="Run the one-command visual demo (tiny deterministic episode + viewer).",
+    )
+    demo.add_argument("--output-root", type=Path, default=None)
+    demo.add_argument("--scenario", type=Path, default=None)
+    demo.add_argument("--seed", type=int, default=None)
+    demo.add_argument("--verbose", action="store_true")
+
     return parser
 
 
 def _handle_doctor(args: argparse.Namespace) -> int:
-    """Run the doctor check and print the report.
-
-    Returns:
-        int: Doctor command exit code.
-    """
+    """Run the doctor check and print the report."""
     report = collect_doctor_report(
         artifact_root=args.artifact_root,
         run_env_smoke=not args.skip_env_smoke,
@@ -76,28 +81,35 @@ def _handle_doctor(args: argparse.Namespace) -> int:
     return doctor_exit_code(report)
 
 
-_HANDLERS = {
-    "doctor": _handle_doctor,
-}
-
-
 def main(argv: Sequence[str] | None = None) -> int:
-    """Top-level ``robot-sf`` entry point.
+    """Dispatch to the requested ``robot-sf`` subcommand.
 
     Returns:
-        int: Process-style exit code.
+        int: Process exit status code.
     """
     parser = _build_parser()
     args = parser.parse_args(argv)
-    if args.cmd is None:
-        parser.print_help()
-        return 1
-    handler = _HANDLERS.get(args.cmd)
-    if handler is None:  # pragma: no cover - defensive
-        parser.error(f"unknown command: {args.cmd}")
-        return 2
-    return handler(args)
+
+    if args.command == "doctor":
+        return _handle_doctor(args)
+
+    if args.command == "demo":
+        from scripts.demo.quickstart_demo import main as demo_main  # noqa: PLC0415
+
+        demo_argv = []
+        if args.output_root is not None:
+            demo_argv += ["--output-root", str(args.output_root)]
+        if args.scenario is not None:
+            demo_argv += ["--scenario", str(args.scenario)]
+        if args.seed is not None:
+            demo_argv += ["--seed", str(args.seed)]
+        if args.verbose:
+            demo_argv.append("--verbose")
+        return demo_main(demo_argv)
+
+    parser.print_help()
+    return 1
 
 
-if __name__ == "__main__":  # pragma: no cover - entrypoint
-    raise SystemExit(main())
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/scripts/demo/quickstart_demo.py
+++ b/scripts/demo/quickstart_demo.py
@@ -49,6 +49,7 @@ from robot_sf.gym_env.environment_factory import make_robot_env  # noqa: E402
 from robot_sf.gym_env.robot_env import RobotEnv  # noqa: E402
 from robot_sf.render.jsonl_playback import JSONLPlaybackLoader  # noqa: E402
 from robot_sf.render.threejs_viewer import export_threejs_viewer  # noqa: E402
+from robot_sf.sensor.range_sensor import LidarScannerSettings  # noqa: E402
 from robot_sf.training.scenario_loader import (  # noqa: E402
     build_robot_config_from_scenario,
     load_scenarios,
@@ -80,6 +81,18 @@ class DemoResult:
     viewer_html: Path
     thumbnail_png: Path
 
+    def _artifact_paths(self) -> dict[str, str]:
+        """Return stable output-root-relative artifact paths for user-facing payloads."""
+        output_root = self.summary_json.parent
+        paths = {
+            "episode_jsonl": self.episode_jsonl,
+            "summary_json": self.summary_json,
+            "metrics_json": self.metrics_json,
+            "viewer_html": self.viewer_html,
+            "thumbnail_png": self.thumbnail_png,
+        }
+        return {name: path.relative_to(output_root).as_posix() for name, path in paths.items()}
+
     def to_summary_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable plain-English summary payload."""
         return {
@@ -92,13 +105,7 @@ class DemoResult:
             "min_ped_distance_m": self.min_ped_distance_m,
             "route_complete": self.route_complete,
             "claim_boundary": CLAIM_BOUNDARY,
-            "artifacts": {
-                "episode_jsonl": str(self.episode_jsonl),
-                "summary_json": str(self.summary_json),
-                "metrics_json": str(self.metrics_json),
-                "viewer_html": str(self.viewer_html),
-                "thumbnail_png": str(self.thumbnail_png),
-            },
+            "artifacts": self._artifact_paths(),
         }
 
 
@@ -113,6 +120,23 @@ def _build_scenario_config(scenario_path: Path) -> dict[str, Any]:
             f"available: {available}",
         )
     return matches[0]
+
+
+def _deterministic_lidar_settings(settings: LidarScannerSettings) -> LidarScannerSettings:
+    """Return equivalent LiDAR settings without stochastic scan corruption.
+
+    The default scanner intentionally injects small global-NumPy noise for
+    simulation realism. The quickstart demo promises a reproducible recording,
+    including the rays consumed by its viewer, so this UX-only run uses the
+    same geometry with both noise probabilities disabled.
+    """
+    return LidarScannerSettings(
+        max_scan_dist=settings.max_scan_dist,
+        visual_angle_portion=settings.visual_angle_portion,
+        num_rays=settings.num_rays,
+        scan_noise=[0.0, 0.0],
+        detect_other_robots=settings.detect_other_robots,
+    )
 
 
 def _select_action(planner: Any) -> np.ndarray:
@@ -166,6 +190,7 @@ def _run_deterministic_episode(
         scenario_config,
         scenario_path=scenario_path,
     )
+    config.lidar_config = _deterministic_lidar_settings(config.lidar_config)
     planner = RandomPlanner({"mode": "velocity", "v_max": 1.5}, seed=seed)
 
     env: RobotEnv = make_robot_env(  # type: ignore[assignment]
@@ -244,6 +269,11 @@ def _export_viewer(episode_jsonl: Path, output_root: Path) -> Path:
     """Export the recorded episode into a static browser viewer."""
     viewer_dir = output_root / "viewer"
     result = export_threejs_viewer(episode_jsonl, viewer_dir)
+    scene = json.loads(result.scene_path.read_text(encoding="utf-8"))
+    scene["source"] = "episode.jsonl"
+    result.scene_path.write_text(
+        json.dumps(scene, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     return result.html_path
 
 
@@ -278,16 +308,16 @@ def _check_runtime_requirements(*, strict: bool = False) -> bool:
     """
     script = ROOT / "scripts" / "dev" / "check_runtime_requirements.sh"
     if not script.exists():
-        print("Skipping runtime check (scripts/dev/check_runtime_requirements.sh not found).")
-        return True
+        print("Runtime check: failed (scripts/dev/check_runtime_requirements.sh not found).")
+        return False
     cmd = ["bash", str(script)]
     if strict:
         cmd.append("--strict")
     try:
         completed = subprocess.run(cmd, check=False, capture_output=True, text=True)
     except FileNotFoundError:
-        print("Runtime check: skipped (bash not available).")
-        return True
+        print("Runtime check: failed (bash not available).")
+        return False
     ok = completed.returncode == 0
     print(f"Runtime check: {'ok' if ok else 'missing required tool(s)'}")
     # Surface the full doctor report only when something is wrong, so the
@@ -313,7 +343,8 @@ def run_demo(
     recording_dir = output_root / "recordings"
 
     if check_deps:
-        _check_runtime_requirements()
+        if not _check_runtime_requirements():
+            raise RuntimeError("Required runtime checks failed; see the doctor report above.")
 
     scenario_config = _build_scenario_config(scenario_path)
     result = _run_deterministic_episode(
@@ -347,9 +378,9 @@ def run_demo(
             "collisions": result.collisions,
             "min_ped_distance_m": result.min_ped_distance_m,
             "route_complete": result.route_complete,
-            "episode_jsonl": str(result.episode_jsonl),
-            "viewer_html": str(viewer_html),
-            "thumbnail_png": str(thumbnail_png),
+            "episode_jsonl": result._artifact_paths()["episode_jsonl"],
+            "viewer_html": result._artifact_paths()["viewer_html"],
+            "thumbnail_png": result._artifact_paths()["thumbnail_png"],
             "claim_boundary": CLAIM_BOUNDARY,
         },
     )
@@ -375,8 +406,19 @@ def _print_summary(result: DemoResult) -> None:
         f"Scenario: {result.scenario_name}   Planner: {result.planner}   Steps: {result.steps}",
     )
     print(f"Collisions: {result.collisions}   Min pedestrian distance: {min_dist}")
-    print(f"Viewer: {result.viewer_html}   Metrics: {result.metrics_json}")
+    print(
+        "Viewer: "
+        f"{_display_path(result.viewer_html)}   Metrics: {_display_path(result.metrics_json)}",
+    )
     print(CLAIM_BOUNDARY)
+
+
+def _display_path(path: Path) -> str:
+    """Prefer repository-relative paths in the default newcomer-facing summary."""
+    try:
+        return path.relative_to(ROOT).as_posix()
+    except ValueError:
+        return str(path)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/demo/quickstart_demo.py
+++ b/scripts/demo/quickstart_demo.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""One-command Robot SF visual demo: install -> run -> see something.
+
+This is the artifact-producing entry point behind ``robot-sf demo``. It runs a
+single tiny deterministic episode (``quickstart_demo_crossing_basic`` + the
+built-in ``random`` planner), records it as JSONL, exports a static Three.js
+viewer, renders a map thumbnail, and writes a plain-English summary.
+
+The experience is intentionally stable and reviewable: a fixed seed drives both
+the environment and the planner, so re-running the demo reproduces the same
+artifacts byte-for-byte on a clean CPU checkout.
+
+Artifacts land under ``output/demo/latest/``:
+
+    episode.jsonl        - per-step recorded simulation states
+    summary.json         - plain-English run summary + outcome metadata
+    metrics.json         - machine-readable outcome metrics
+    viewer/index.html    - static browser viewer built from the recording
+    thumbnail.png        - top-down map/route thumbnail
+
+Usage:
+    uv run robot-sf demo
+    uv run python scripts/demo/quickstart_demo.py --output-root output/demo/latest --seed 270
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+import numpy as np
+from loguru import logger
+
+# Keep the one-command demo readable.
+logger.remove()
+logger.add(sys.stderr, level="ERROR")
+
+from robot_sf.gym_env.environment_factory import make_robot_env  # noqa: E402
+from robot_sf.gym_env.robot_env import RobotEnv  # noqa: E402
+from robot_sf.render.jsonl_playback import JSONLPlaybackLoader  # noqa: E402
+from robot_sf.render.threejs_viewer import export_threejs_viewer  # noqa: E402
+from robot_sf.training.scenario_loader import (  # noqa: E402
+    build_robot_config_from_scenario,
+    load_scenarios,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCENARIO = ROOT / "configs/scenarios/single/quickstart_demo.yaml"
+DEFAULT_OUTPUT_ROOT = ROOT / "output/demo/latest"
+DEFAULT_SEED = 270
+DEMO_SCENARIO_NAME = "quickstart_demo_crossing_basic"
+DEMO_PLANNER = "random"
+CLAIM_BOUNDARY = "Local demo output is reproducibility/UX evidence only; not a benchmark result."
+
+
+@dataclass
+class DemoResult:
+    """Outcomes and artifact paths produced by the one-command demo."""
+
+    scenario_name: str
+    planner: str
+    seed: int
+    steps: int
+    collisions: int
+    min_ped_distance_m: float | None
+    route_complete: bool
+    episode_jsonl: Path
+    summary_json: Path
+    metrics_json: Path
+    viewer_html: Path
+    thumbnail_png: Path
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable plain-English summary payload."""
+        return {
+            "schema_version": "robot_sf_quickstart_demo.v1",
+            "scenario": self.scenario_name,
+            "planner": self.planner,
+            "seed": self.seed,
+            "steps": self.steps,
+            "collisions": self.collisions,
+            "min_ped_distance_m": self.min_ped_distance_m,
+            "route_complete": self.route_complete,
+            "claim_boundary": CLAIM_BOUNDARY,
+            "artifacts": {
+                "episode_jsonl": str(self.episode_jsonl),
+                "summary_json": str(self.summary_json),
+                "metrics_json": str(self.metrics_json),
+                "viewer_html": str(self.viewer_html),
+                "thumbnail_png": str(self.thumbnail_png),
+            },
+        }
+
+
+def _build_scenario_config(scenario_path: Path) -> dict[str, Any]:
+    """Load the demo scenario definition from the YAML matrix."""
+    scenarios = load_scenarios(scenario_path)
+    matches = [sc for sc in scenarios if sc.get("name") == DEMO_SCENARIO_NAME]
+    if not matches:
+        available = [sc.get("name") for sc in scenarios]
+        raise ValueError(
+            f"Demo scenario '{DEMO_SCENARIO_NAME}' not found in {scenario_path}; "
+            f"available: {available}",
+        )
+    return matches[0]
+
+
+def _select_action(planner: Any) -> np.ndarray:
+    """Convert a planner decision into the env-action array.
+
+    The built-in random planner ignores observation contents (it samples
+    actions), so we pass a minimal planner-facing mapping rather than the
+    full environment observation dict. The robot lidar env expects a
+    ``(vx, vy)`` action vector.
+    """
+    decision = planner.step({"dt": 0.1, "robot": {}, "agents": []})
+    return np.array([float(decision["vx"]), float(decision["vy"])], dtype=np.float32)
+
+
+def _step_min_ped_distance(env: RobotEnv) -> float | None:
+    """Return the closest pedestrian distance to the robot at the current step.
+
+    ``RobotEnv.step`` does not surface ``min_ped_distance`` in its ``info``
+    payload by default (it only appears in the optional telemetry stream), so
+    the demo computes the headline summary metric directly from the simulator
+    state. Returns ``None`` when there are no pedestrians.
+    """
+    simulator = getattr(env, "simulator", None)
+    if simulator is None:
+        return None
+    ped_positions = np.asarray(getattr(simulator, "ped_pos", np.zeros((0, 2))), dtype=float)
+    robot_poses = getattr(simulator, "robot_poses", None)
+    if ped_positions.size == 0 or not robot_poses:
+        return None
+    try:
+        robot_pos = np.asarray(robot_poses[0][0], dtype=float)
+    except (IndexError, TypeError, ValueError):  # Defensive: malformed pose
+        return None
+    deltas = ped_positions - robot_pos
+    if deltas.shape[1] < 2:
+        return None
+    return float(np.min(np.linalg.norm(deltas[:, :2], axis=1)))
+
+
+def _run_deterministic_episode(
+    *,
+    scenario_config: dict[str, Any],
+    scenario_path: Path,
+    seed: int,
+    recording_dir: Path,
+) -> DemoResult:
+    """Run one deterministic recorded episode and capture outcome metrics."""
+    from robot_sf.baselines.random_policy import RandomPlanner
+
+    config = build_robot_config_from_scenario(
+        scenario_config,
+        scenario_path=scenario_path,
+    )
+    planner = RandomPlanner({"mode": "velocity", "v_max": 1.5}, seed=seed)
+
+    env: RobotEnv = make_robot_env(  # type: ignore[assignment]
+        config=config,
+        seed=seed,
+        debug=False,
+        recording_enabled=True,
+        use_jsonl_recording=True,
+        recording_dir=str(recording_dir),
+        suite_name="demo",
+        scenario_name=DEMO_SCENARIO_NAME,
+        algorithm_name=DEMO_PLANNER,
+        recording_seed=seed,
+    )
+    env.applied_seed = seed
+
+    try:
+        env.reset(seed=seed)
+        planner.reset(seed=seed)
+
+        steps = 0
+        collisions = 0
+        min_ped_distance: float | None = None
+        route_complete = False
+
+        truncated = False
+        while not truncated:
+            action = _select_action(planner)
+            _obs, _reward, terminated, truncated, info = env.step(action)
+            steps += 1
+            if bool(info.get("collision")):
+                collisions += 1
+            step_min = _step_min_ped_distance(env)
+            if step_min is not None:
+                min_ped_distance = (
+                    step_min if min_ped_distance is None else min(min_ped_distance, step_min)
+                )
+            if bool(info.get("success")):
+                route_complete = True
+            if terminated:
+                break
+
+        env.end_episode_recording()
+    finally:
+        env.close_recorder()
+        env.exit()
+
+    # The JSONLRecorder names files as ``{suite}_{scenario}_{algorithm}_{seed}_ep{id}.jsonl``;
+    # prefer that, falling back to the most recent recording in the directory.
+    episode_jsonl = recording_dir / f"demo_{DEMO_SCENARIO_NAME}_{DEMO_PLANNER}_{seed}_ep0000.jsonl"
+    if not episode_jsonl.exists():
+        candidates = sorted(recording_dir.glob("*.jsonl"))
+        if not candidates:
+            raise FileNotFoundError(
+                f"No recorded episode JSONL found under {recording_dir}",
+            )
+        episode_jsonl = candidates[-1]
+
+    return DemoResult(
+        scenario_name=DEMO_SCENARIO_NAME,
+        planner=DEMO_PLANNER,
+        seed=seed,
+        steps=steps,
+        collisions=collisions,
+        min_ped_distance_m=min_ped_distance,
+        route_complete=route_complete,
+        episode_jsonl=episode_jsonl,
+        summary_json=recording_dir.parent / "summary.json",
+        metrics_json=recording_dir.parent / "metrics.json",
+        viewer_html=recording_dir.parent / "viewer" / "index.html",
+        thumbnail_png=recording_dir.parent / "thumbnail.png",
+    )
+
+
+def _export_viewer(episode_jsonl: Path, output_root: Path) -> Path:
+    """Export the recorded episode into a static browser viewer."""
+    viewer_dir = output_root / "viewer"
+    result = export_threejs_viewer(episode_jsonl, viewer_dir)
+    return result.html_path
+
+
+def _render_thumbnail(episode_jsonl: Path, output_root: Path) -> Path:
+    """Render a top-down map thumbnail from the recorded episode metadata."""
+    from robot_sf.maps.map_visualizer import visualize_map_definition
+
+    _episode, map_def = JSONLPlaybackLoader().load_single_episode(episode_jsonl)
+    thumbnail_path = output_root / "thumbnail.png"
+    visualize_map_definition(
+        map_def,
+        output_path=thumbnail_path,
+        title=f"{DEMO_SCENARIO_NAME} ({DEMO_PLANNER})",
+    )
+    return thumbnail_path
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write stable, sorted JSON with a trailing newline."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _check_runtime_requirements(*, strict: bool = False) -> bool:
+    """Run the shared runtime-requirements doctor check (advisory by default).
+
+    Reuses ``scripts/dev/check_runtime_requirements.sh`` so the demo reports the
+    same core-tool status as the rest of the project. In advisory mode the check
+    only fails on missing *required* core tools; optional capabilities (docker,
+    SLURM, GPU) are reported but never fail the demo. Returns ``True`` when the
+    required core tools are present.
+    """
+    script = ROOT / "scripts" / "dev" / "check_runtime_requirements.sh"
+    if not script.exists():
+        print("Skipping runtime check (scripts/dev/check_runtime_requirements.sh not found).")
+        return True
+    cmd = ["bash", str(script)]
+    if strict:
+        cmd.append("--strict")
+    try:
+        completed = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    except FileNotFoundError:
+        print("Runtime check: skipped (bash not available).")
+        return True
+    ok = completed.returncode == 0
+    print(f"Runtime check: {'ok' if ok else 'missing required tool(s)'}")
+    # Surface the full doctor report only when something is wrong, so the
+    # default newcomer flow stays readable (a clean check prints one line).
+    if not ok:
+        if completed.stdout:
+            sys.stdout.write(completed.stdout)
+        if completed.stderr:
+            sys.stderr.write(completed.stderr)
+    return ok
+
+
+def run_demo(
+    *,
+    output_root: Path = DEFAULT_OUTPUT_ROOT,
+    scenario_path: Path = DEFAULT_SCENARIO,
+    seed: int = DEFAULT_SEED,
+    check_deps: bool = True,
+) -> DemoResult:
+    """Run the one-command demo and write all artifacts under ``output_root``."""
+    output_root = Path(output_root)
+    scenario_path = Path(scenario_path)
+    recording_dir = output_root / "recordings"
+
+    if check_deps:
+        _check_runtime_requirements()
+
+    scenario_config = _build_scenario_config(scenario_path)
+    result = _run_deterministic_episode(
+        scenario_config=scenario_config,
+        scenario_path=scenario_path,
+        seed=seed,
+        recording_dir=recording_dir,
+    )
+
+    _copy_episode_result(result, recording_dir, output_root)
+    viewer_html = _export_viewer(result.episode_jsonl, output_root)
+    thumbnail_png = _render_thumbnail(result.episode_jsonl, output_root)
+
+    result.viewer_html = viewer_html
+    result.thumbnail_png = thumbnail_png
+
+    summary_path = output_root / "summary.json"
+    metrics_path = output_root / "metrics.json"
+    result.summary_json = summary_path
+    result.metrics_json = metrics_path
+
+    _write_json(summary_path, result.to_summary_dict())
+    _write_json(
+        metrics_path,
+        {
+            "schema_version": "robot_sf_quickstart_demo.metrics.v1",
+            "scenario": result.scenario_name,
+            "planner": result.planner,
+            "seed": result.seed,
+            "steps": result.steps,
+            "collisions": result.collisions,
+            "min_ped_distance_m": result.min_ped_distance_m,
+            "route_complete": result.route_complete,
+            "episode_jsonl": str(result.episode_jsonl),
+            "viewer_html": str(viewer_html),
+            "thumbnail_png": str(thumbnail_png),
+            "claim_boundary": CLAIM_BOUNDARY,
+        },
+    )
+    return result
+
+
+def _copy_episode_result(result: DemoResult, recording_dir: Path, output_root: Path) -> None:
+    """Promote the recorded episode JSONL to ``output_root/episode.jsonl`` for stability."""
+    if result.episode_jsonl.exists():
+        target = output_root / "episode.jsonl"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(result.episode_jsonl, target)
+        result.episode_jsonl = target
+
+
+def _print_summary(result: DemoResult) -> None:
+    """Print a plain-English summary of what the demo did."""
+    min_dist = (
+        f"{result.min_ped_distance_m:.2f} m" if result.min_ped_distance_m is not None else "n/a"
+    )
+    print("Robot SF demo complete.")
+    print(
+        f"Scenario: {result.scenario_name}   Planner: {result.planner}   Steps: {result.steps}",
+    )
+    print(f"Collisions: {result.collisions}   Min pedestrian distance: {min_dist}")
+    print(f"Viewer: {result.viewer_html}   Metrics: {result.metrics_json}")
+    print(CLAIM_BOUNDARY)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the demo command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--scenario", type=Path, default=DEFAULT_SCENARIO)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument(
+        "--no-check-deps",
+        action="store_true",
+        help="Skip the shared runtime-requirements doctor check.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show detailed simulator logs.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the one-command demo CLI."""
+    args = build_parser().parse_args(argv)
+    if args.verbose:
+        logger.remove()
+        logger.add(sys.stderr, level="DEBUG")
+    result = run_demo(
+        output_root=args.output_root,
+        scenario_path=args.scenario,
+        seed=args.seed,
+        check_deps=not args.no_check_deps,
+    )
+    _print_summary(result)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/test_quickstart_demo.py
+++ b/tests/test_quickstart_demo.py
@@ -1,0 +1,65 @@
+"""Smoke tests for the one-command ``robot-sf demo`` visual demo (issue #5792)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from robot_sf.cli import main as cli_main
+from scripts.demo.quickstart_demo import run_demo
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _read_jsonl_lines(path: Path) -> list[dict[str, object]]:
+    """Return the parsed JSONL records from ``path``."""
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def test_demo_produces_expected_artifacts(tmp_path: Path) -> None:
+    """Running the demo writes episode.jsonl, summary.json, metrics.json, the viewer, and a thumbnail."""
+    output_root = tmp_path / "demo" / "latest"
+    result = run_demo(output_root=output_root, seed=270)
+
+    assert result.episode_jsonl.exists()
+    assert result.summary_json.exists()
+    assert result.metrics_json.exists()
+    assert result.viewer_html.exists()
+    assert result.thumbnail_png.exists()
+    assert result.viewer_html.parent.joinpath("scene.json").exists()
+
+    summary = json.loads(result.summary_json.read_text(encoding="utf-8"))
+    assert summary["scenario"] == "quickstart_demo_crossing_basic"
+    assert summary["planner"] == "random"
+    assert summary["steps"] > 0
+
+    metrics = json.loads(result.metrics_json.read_text(encoding="utf-8"))
+    assert metrics["seed"] == 270
+    assert metrics["steps"] == summary["steps"]
+
+
+def test_demo_episode_is_deterministic_and_records_steps(tmp_path: Path) -> None:
+    """The same seed reproduces an identical recorded episode (stable, reviewable demo output)."""
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    run_a = run_demo(output_root=root_a, seed=270)
+    run_b = run_demo(output_root=root_b, seed=270)
+
+    lines_a = _read_jsonl_lines(run_a.episode_jsonl)
+    lines_b = _read_jsonl_lines(run_b.episode_jsonl)
+
+    assert len(lines_a) == len(lines_b) > 0
+    # The recorded robot trajectory is reproduced across runs.
+    traj_a = [line.get("state", {}).get("robot_pose") for line in lines_a]
+    traj_b = [line.get("state", {}).get("robot_pose") for line in lines_b]
+    assert traj_a == traj_b
+
+
+def test_demo_cli_dispatches(tmp_path: Path, capsys) -> None:
+    """The umbrella ``robot-sf demo`` subcommand runs and prints the plain-English summary."""
+    rc = cli_main(["demo", "--output-root", str(tmp_path / "cli"), "--seed", "270"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Robot SF demo complete." in out
+    assert (tmp_path / "cli" / "episode.jsonl").exists()

--- a/tests/test_quickstart_demo.py
+++ b/tests/test_quickstart_demo.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+import pytest
+
 from robot_sf.cli import main as cli_main
-from scripts.demo.quickstart_demo import run_demo
+from scripts.demo import quickstart_demo as demo
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -20,7 +22,7 @@ def _read_jsonl_lines(path: Path) -> list[dict[str, object]]:
 def test_demo_produces_expected_artifacts(tmp_path: Path) -> None:
     """Running the demo writes episode.jsonl, summary.json, metrics.json, the viewer, and a thumbnail."""
     output_root = tmp_path / "demo" / "latest"
-    result = run_demo(output_root=output_root, seed=270)
+    result = demo.run_demo(output_root=output_root, seed=270)
 
     assert result.episode_jsonl.exists()
     assert result.summary_json.exists()
@@ -37,29 +39,53 @@ def test_demo_produces_expected_artifacts(tmp_path: Path) -> None:
     metrics = json.loads(result.metrics_json.read_text(encoding="utf-8"))
     assert metrics["seed"] == 270
     assert metrics["steps"] == summary["steps"]
+    assert summary["artifacts"]["viewer_html"] == "viewer/index.html"
+    assert metrics["episode_jsonl"] == "episode.jsonl"
 
 
 def test_demo_episode_is_deterministic_and_records_steps(tmp_path: Path) -> None:
     """The same seed reproduces an identical recorded episode (stable, reviewable demo output)."""
     root_a = tmp_path / "a"
     root_b = tmp_path / "b"
-    run_a = run_demo(output_root=root_a, seed=270)
-    run_b = run_demo(output_root=root_b, seed=270)
+    run_a = demo.run_demo(output_root=root_a, seed=270)
+    run_b = demo.run_demo(output_root=root_b, seed=270)
 
     lines_a = _read_jsonl_lines(run_a.episode_jsonl)
     lines_b = _read_jsonl_lines(run_b.episode_jsonl)
 
     assert len(lines_a) == len(lines_b) > 0
-    # The recorded robot trajectory is reproduced across runs.
-    traj_a = [line.get("state", {}).get("robot_pose") for line in lines_a]
-    traj_b = [line.get("state", {}).get("robot_pose") for line in lines_b]
-    assert traj_a == traj_b
+    assert lines_a == lines_b
+    assert (run_a.viewer_html.parent / "scene.json").read_bytes() == (
+        run_b.viewer_html.parent / "scene.json"
+    ).read_bytes()
 
 
-def test_demo_cli_dispatches(tmp_path: Path, capsys) -> None:
+def test_demo_cli_dispatches(tmp_path: Path, capsys, monkeypatch) -> None:
     """The umbrella ``robot-sf demo`` subcommand runs and prints the plain-English summary."""
+    monkeypatch.chdir(tmp_path)
     rc = cli_main(["demo", "--output-root", str(tmp_path / "cli"), "--seed", "270"])
     assert rc == 0
     out = capsys.readouterr().out
     assert "Robot SF demo complete." in out
     assert (tmp_path / "cli" / "episode.jsonl").exists()
+
+
+def test_demo_rejects_empty_scenario_manifest(tmp_path: Path) -> None:
+    """A missing demo scenario fails closed instead of running a different default."""
+    scenario_path = tmp_path / "empty.yaml"
+    scenario_path.write_text("scenarios: []\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing scenarios"):
+        demo.run_demo(
+            output_root=tmp_path / "output",
+            scenario_path=scenario_path,
+            check_deps=False,
+        )
+
+
+def test_demo_fails_when_runtime_check_fails(tmp_path: Path, monkeypatch) -> None:
+    """A failed required-runtime check stops the demo before simulation output is written."""
+    monkeypatch.setattr(demo, "_check_runtime_requirements", lambda: False)
+
+    with pytest.raises(RuntimeError, match="Required runtime checks failed"):
+        demo.run_demo(output_root=tmp_path / "output")


### PR DESCRIPTION
## What

Adds a one-command visual demo so a newcomer goes **install → run → *see something*** in a single CPU-only step (Issue #5792, part of adoption/UX epic #5791).

```bash
uv run robot-sf demo
```

This adds a top-level `robot-sf` umbrella CLI (`robot_sf/cli.py`) with a `demo` subcommand, backed by `scripts/demo/quickstart_demo.py`.

## What the demo does

1. **Dependency check** — runs `scripts/dev/check_runtime_requirements.sh`; missing required checks fail closed, while optional host capabilities remain advisory.
2. **Deterministic episode** — runs one tiny episode (`quickstart_demo_crossing_basic` + the built-in `random` baseline planner) at fixed seed `270`. The demo disables stochastic LiDAR corruption for this UX-only run, so the recorded episode and viewer scene are reproducible byte-for-byte.
3. **Artifacts under `output/demo/latest/`:**
   - `episode.jsonl` — per-step recorded simulation states
   - `summary.json` / `metrics.json` — plain-English + machine-readable outcomes
   - `viewer/index.html` (+ `scene.json`, `viewer.js`) — static Three.js browser viewer
   - `thumbnail.png` — top-down map thumbnail
4. **Viewer** — exported through the existing `robot_sf.render.threejs_viewer.export_threejs_viewer` path.
5. **Plain-English summary:**
   ```
   Robot SF demo complete.
   Scenario: quickstart_demo_crossing_basic   Planner: random   Steps: 120
   Collisions: 0   Min pedestrian distance: 1.90 m
   Viewer: output/demo/latest/viewer/index.html   Metrics: output/demo/latest/metrics.json
   ```

## Why

The single highest-leverage first experience is letting someone see the simulator work immediately. The orchestrator reuses existing primitives — **no new simulation logic**:

- `make_robot_env` with JSONL recording
- `RandomPlanner` baseline
- `export_threejs_viewer` + `JSONLPlaybackLoader`
- `visualize_map_definition`
- `build_robot_config_from_scenario` / `load_scenarios`

The headline minimum pedestrian distance is computed from `env.simulator` state because `RobotEnv.step` does not expose that optional telemetry field by default.

## Validation (CPU, headless only — no campaigns/Slurm/training)

```bash
uv run ruff check robot_sf/cli.py scripts/demo/quickstart_demo.py tests/test_quickstart_demo.py
uv run ruff format --check robot_sf/cli.py scripts/demo/quickstart_demo.py tests/test_quickstart_demo.py
scripts/dev/run_focused_tests.sh tests/test_quickstart_demo.py -q
```

The focused suite passed **5 tests**, covering the full artifact set, full JSONL/viewer determinism, repository-root-independent CLI dispatch, an empty scenario manifest, and failed required-runtime handling. Two fresh seed-270 CPU process runs produced 122 JSONL records each in **21.04–21.07 seconds** and equal `episode.jsonl`/`viewer/scene.json` bytes.

## Durable validation artifact

The compact, tracked validation record is [`docs/context/evidence/issue_5792_demo_validation_2026-07-15.md`](docs/context/evidence/issue_5792_demo_validation_2026-07-15.md). It records the reproduction command, scenario, seed `270`, artifact paths, observed `21.04–21.07 s` local CPU smoke range, and the diagnostic-only claim boundary. Generated `output/` files remain reproducible local staging, not benchmark evidence.

## Research Result Guidance

- Result type: `diagnostic-only` UX/reproducibility smoke; no planner-ranking, safety, benchmark, or paper claim.
- Hypothesis: a new user can install and run one small deterministic visual episode with one command.
- Evidence: the focused five-test contract plus the two-run record linked above.
- Comparator: the pre-PR repository had no top-level `robot-sf` umbrella demo command.
- Limits: one scenario, one planner, one seed, one CPU host; the runtime range is not a performance benchmark.

## Domain-Aware Approval

Not required for evidence-validity or benchmark-sensitive claims: this PR explicitly remains diagnostic-only UX tooling and adds no benchmark metric, planner ranking, or model-provenance claim.

## Follow-Up Issues

- [Issue #5791](https://github.com/ll7/robot_sf_ll7/issues/5791) tracks the broader adoption/UX epic; the concrete #5792 one-command demo acceptance criteria are complete here.

## Downstream propagation / closure

Issue #5792 acceptance is complete: the CLI, deterministic episode, artifact set, summary, and smoke tests are included here. The broader adoption/UX epic Issue #5791 remains open for future onboarding work.

Closes #5792

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardened and validated it.
