### PR TITLE
Issue #5782: readiness base-drift guard so stamps survive origin/main advance (cheap-lane worker)

### DIFF
--- a/scripts/dev/check_base_drift.py
+++ b/scripts/dev/check_base_drift.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Lightweight base-drift check for the PR-readiness gate (issue #5782).
+
+The costly readiness lanes (pytest, coverage) validate a branch against a
+specific base commit.  When ``origin/main`` advances during that long run, the
+base the run validated against is no longer current, so any readiness stamp
+recorded at the end is immediately stale relative to the moving base.
+
+This check supports the readiness gate's base-drift handling for issue #5782:
+the gate captures the concrete base SHA before the expensive lanes start and then
+invokes this check immediately before recording the readiness stamp, to fail
+closed when ``origin/main`` moved *during* those lanes.
+
+When the base *has* drifted but the drifted commits touch **none** of the
+files this PR changes, the drift is unrelated to the changed paths and a
+reviewable reuse path is recommended (exit 0, ``reuse_recommended``).  When the
+drift intersects the PR's changed files, the check fails closed (exit 1) and
+names the exact base SHA that must be revalidated.
+
+Exit codes:
+    0  No base drift, or drift unrelated to changed paths (reuse recommended).
+    1  Base drift affects the PR's changed paths; revalidation required.
+    2  Could not resolve the base ref or compute the drift (indeterminate).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _run_git(args: list[str]) -> tuple[int, str]:
+    """Return (returncode, stdout) for a git command; never raise on failure."""
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode, result.stdout.strip()
+
+
+def _resolve_base_sha(base_ref: str) -> tuple[str | None, str | None]:
+    """Resolve *base_ref* to a concrete commit SHA.
+
+    Returns:
+        (sha, None) on success, or (None, error_message) when the ref does not
+        resolve to a local commit.
+    """
+    rc, stdout = _run_git(["rev-parse", "--verify", "--quiet", f"{base_ref}^{{commit}}"])
+    if rc != 0:
+        return None, f"base ref {base_ref!r} does not resolve to a local commit"
+    sha = stdout.strip()
+    if not sha:
+        return None, f"base ref {base_ref!r} resolved to an empty SHA"
+    return sha, None
+
+
+def _merge_base(commit_a: str, commit_b: str) -> tuple[str | None, str | None]:
+    """Return the merge base of two commits, or (None, error) on failure."""
+    rc, stdout = _run_git(["merge-base", commit_a, commit_b])
+    if rc != 0:
+        return None, "could not compute merge-base"
+    sha = stdout.strip()
+    if not sha:
+        return None, "merge-base resolved to an empty SHA"
+    return sha, None
+
+
+def _diff_name_only(base: str, tip: str) -> tuple[list[str] | None, str | None]:
+    """Return the sorted, unique changed paths between *base* and *tip*.
+
+    Returns:
+        (paths, None) on success, or (None, error) when the diff cannot be read.
+    """
+    rc, stdout = _run_git(["diff", "--name-only", base, tip])
+    if rc != 0:
+        return None, f"could not diff {base}..{tip}"
+    paths = [line.strip() for line in stdout.splitlines() if line.strip()]
+    return sorted(set(paths)), None
+
+
+def _pr_changed_files(
+    validated_base_sha: str,
+    *,
+    changed_files_override: list[str] | None = None,
+) -> tuple[list[str] | None, str | None]:
+    """Return the files this PR changes relative to the validated base.
+
+    Uses the three-dot diff against HEAD (changes on the HEAD side since the
+    merge base with the validated base), matching the changed-file scope the
+    readiness gate already uses.  When *changed_files_override* is provided it
+    is used verbatim (tests and callers that precomputed the set).
+    """
+    if changed_files_override is not None:
+        return sorted(set(changed_files_override)), None
+    merge_base, err = _merge_base(validated_base_sha, "HEAD")
+    if err is not None:
+        return None, err
+    return _diff_name_only(merge_base, "HEAD")
+
+
+def check_base_drift(
+    *,
+    base_ref: str,
+    validated_base_sha: str | None,
+    changed_files: list[str] | None = None,
+) -> dict[str, Any]:
+    """Compare the validated base SHA against the current base and classify drift.
+
+    Returns:
+        A result dict with keys including ``status`` (one of ``current``,
+        ``reuse_recommended``, ``revalidate_required``) and ``exit_code``.
+    """
+    result: dict[str, Any] = {
+        "base_ref": base_ref,
+        "validated_base_sha": validated_base_sha,
+    }
+
+    current_base_sha, err = _resolve_base_sha(base_ref)
+    if current_base_sha is None:
+        result["status"] = "indeterminate"
+        result["error"] = err
+        result["exit_code"] = 2
+        return result
+    result["current_base_sha"] = current_base_sha
+
+    if validated_base_sha is None or validated_base_sha == current_base_sha:
+        result["status"] = "current"
+        result["exit_code"] = 0
+        return result
+
+    # Base has drifted between validation start and now.
+    drift_files, err = _diff_name_only(validated_base_sha, current_base_sha)
+    if drift_files is None:
+        result["status"] = "indeterminate"
+        result["error"] = err
+        result["exit_code"] = 2
+        return result
+    result["drift_file_count"] = len(drift_files)
+    result["drift_files"] = drift_files
+
+    pr_files, err = _pr_changed_files(validated_base_sha, changed_files_override=changed_files)
+    if pr_files is None:
+        result["status"] = "indeterminate"
+        result["error"] = err
+        result["exit_code"] = 2
+        return result
+    result["pr_changed_file_count"] = len(pr_files)
+    result["pr_changed_files"] = pr_files
+
+    affected = sorted(set(drift_files) & set(pr_files))
+    result["affected_file_count"] = len(affected)
+    result["affected_files"] = affected
+
+    if affected:
+        result["status"] = "revalidate_required"
+        result["exit_code"] = 1
+        result["message"] = (
+            f"Base drifted to {current_base_sha[:8]}; revalidate against "
+            f"{base_ref} (was {validated_base_sha[:8]}). Drift touches "
+            f"{len(affected)} PR-changed file(s): {', '.join(affected[:10])}"
+        )
+    else:
+        result["status"] = "reuse_recommended"
+        result["exit_code"] = 0
+        result["message"] = (
+            f"Base drifted to {current_base_sha[:8]} but drift is unrelated to the "
+            f"{len(pr_files)} PR-changed file(s); reuse the passing run after noting "
+            f"the base moved from {validated_base_sha[:8]}."
+        )
+    return result
+
+
+def _read_changed_files_file(path: str) -> list[str]:
+    """Read one changed file path per line from *path*."""
+    return [
+        line.strip() for line in Path(path).read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+
+
+def _emit(result: dict[str, Any], *, as_json: bool) -> None:
+    """Print the result and return via sys.exit with the result's exit code."""
+    if as_json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        status = result.get("status")
+        if status == "current":
+            print(f"Base {result['base_ref']} is current at {result['current_base_sha'][:8]}.")
+        elif status in ("reuse_recommended", "revalidate_required"):
+            print(result["message"])
+        else:
+            print(f"Error: {result.get('error', 'indeterminate')}", file=sys.stderr)
+    raise SystemExit(result["exit_code"])
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry point for the base-drift check."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-ref",
+        default="origin/main",
+        help="Base ref to compare against (default: origin/main).",
+    )
+    parser.add_argument(
+        "--validated-base-sha",
+        default=None,
+        help="Concrete base SHA the readiness run started validating against.",
+    )
+    parser.add_argument(
+        "--changed-files",
+        default=None,
+        help="Path to a file with one PR-changed file path per line (otherwise computed via git).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON output.")
+    args = parser.parse_args(argv)
+
+    changed_files = _read_changed_files_file(args.changed_files) if args.changed_files else None
+    result = check_base_drift(
+        base_ref=args.base_ref,
+        validated_base_sha=args.validated_base_sha,
+        changed_files=changed_files,
+    )
+    _emit(result, as_json=args.json)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -269,6 +269,16 @@ while IFS= read -r changed_file; do
   fi
 done < <(git diff --name-only --diff-filter=ACMRT "$BASE_REF...HEAD")
 
+# The existing readiness lanes intentionally exclude deleted paths from their
+# optional-test classification.  The base-drift guard has a stronger contract:
+# every path changed by the PR must participate in the intersection, including a
+# path deleted by the PR, because main can modify that path during the run.
+drift_changed_files=()
+while IFS= read -r changed_file; do
+  [[ -z "$changed_file" ]] && continue
+  drift_changed_files+=("$changed_file")
+done < <(git diff --name-only --diff-filter=ACDMRT "$BASE_REF...HEAD")
+
 if [[ ${#changed_files[@]} -gt 0 ]]; then
   if [[ "$pr_ready_final" == "1" ]]; then
     printf 'Changed files vs %s:\n' "$BASE_REF" >&2
@@ -386,8 +396,8 @@ fi
 # a later freshness status check still catches any residual drift.
 if [[ -n "$VALIDATED_BASE_SHA" ]]; then
   changed_files_tmp="$(mktemp)"
-  if [[ ${#changed_files[@]} -gt 0 ]]; then
-    printf '%s\n' "${changed_files[@]}" > "$changed_files_tmp"
+  if [[ ${#drift_changed_files[@]} -gt 0 ]]; then
+    printf '%s\n' "${drift_changed_files[@]}" > "$changed_files_tmp"
   fi
   # ``set -e`` would exit on the failing command substitution before ``drift_rc`` is
   # captured, so append ``|| drift_rc=$?`` to record the exit code without aborting.

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -286,6 +286,16 @@ if [[ ${#optional_changed_files[@]} -gt 0 ]]; then
   printf '%s\n' "${optional_changed_files[@]}" >&2
 fi
 
+# Issue #5782: capture the concrete base SHA this readiness run validates against
+# BEFORE the expensive lanes start, so a later base-drift recheck can compare the
+# moving base to the SHA we actually proved the PR against.  When BASE_REF does not
+# resolve locally (handled by resolve_base_ref's HEAD fallback), leave VALIDATED_BASE_SHA
+# empty so the drift check and freshness stamp fall back to the base_ref string.
+VALIDATED_BASE_SHA="$(git rev-parse --verify --quiet "${BASE_REF}^{commit}" 2>/dev/null || true)"
+if [[ -n "$VALIDATED_BASE_SHA" ]]; then
+  printf 'Validated base SHA for this run: %s\n' "${VALIDATED_BASE_SHA:0:8}" >&2
+fi
+
 followup_args=()
 if [[ "$pr_ready_final" == "1" ]]; then
   followup_args+=(--require-body)
@@ -356,6 +366,9 @@ check_no_orphaned_pytest_workers() {
 }
 
 freshness_args=(write --base-ref "$BASE_REF")
+if [[ -n "$VALIDATED_BASE_SHA" ]]; then
+  freshness_args+=(--base-sha "$VALIDATED_BASE_SHA")
+fi
 if [[ "$pr_ready_final" == "1" ]]; then
   freshness_args+=(--require-clean-tree)
 elif [[ "$(worktree_state)" != "clean" ]]; then
@@ -363,6 +376,55 @@ elif [[ "$(worktree_state)" != "clean" ]]; then
   printf 'Interim readiness is not changed-file proof for the dirty paths listed above.\n' >&2
   printf 'Use PR_READY_MODE=final BASE_REF=%q %q for final committed-HEAD PR proof.\n' "$BASE_REF" "$0" >&2
 fi
+
+# Issue #5782: final base-drift recheck immediately before recording the stamp.
+# The base may have advanced during the long lanes; if the drift intersects the
+# PR's changed files, fail closed and name the exact base SHA to revalidate.  If
+# drift is unrelated to the changed paths, the check recommends reuse (exit 0) so
+# a passing run is not needlessly re-run; the reuse message is surfaced so the
+# decision is reviewable.  Either way the resolved SHA is recorded in the stamp so
+# a later freshness status check still catches any residual drift.
+if [[ -n "$VALIDATED_BASE_SHA" ]]; then
+  changed_files_tmp="$(mktemp)"
+  if [[ ${#changed_files[@]} -gt 0 ]]; then
+    printf '%s\n' "${changed_files[@]}" > "$changed_files_tmp"
+  fi
+  # ``set -e`` would exit on the failing command substitution before ``drift_rc`` is
+  # captured, so append ``|| drift_rc=$?`` to record the exit code without aborting.
+  drift_rc=0
+  drift_msg="$(uv run python "$SCRIPT_DIR/check_base_drift.py" \
+    --base-ref "$BASE_REF" \
+    --validated-base-sha "$VALIDATED_BASE_SHA" \
+    --changed-files "$changed_files_tmp")" || drift_rc=$?
+  rm -f "$changed_files_tmp"
+  case "$drift_rc" in
+    0)
+      # rc 0 covers both "current" (no drift) and "reuse_recommended" (drift
+      # unrelated to the PR's changed paths).  Surface the reuse message so the
+      # reviewable reuse path is visible, then record the stamp as-is.
+      if [[ -n "$drift_msg" ]]; then
+        printf '%s\n' "$drift_msg" >&2
+      fi
+      ;;
+    1)
+      # Drift intersects the PR's changed files: the validated base no longer
+      # matches reality, so the stamp would be misleading.  Fail closed and name
+      # the exact base to revalidate.
+      printf '%s\n' "$drift_msg" >&2
+      printf 'Base drifted during readiness lanes and touches PR-changed files; ' >&2
+      printf 'revalidate against %s before recording the stamp (issue #5782).\n' "$BASE_REF" >&2
+      exit 1
+      ;;
+    *)
+      # Indeterminate (rc 2): the base ref could not be resolved/compared (e.g.
+      # offline checkout).  Do not block on a check that cannot run; record the
+      # stamp and report the indeterminate result so it is not silently ignored.
+      printf 'Final base-drift recheck returned rc=%d; recording stamp regardless (issue #5782).\n' \
+        "$drift_rc" >&2
+      ;;
+  esac
+fi
+
 uv run python "$SCRIPT_DIR/pr_ready_freshness.py" "${freshness_args[@]}"
 
 # Final orphan guard (issue #5594): after all lanes exit, assert no worktree-owned

--- a/scripts/dev/pr_ready_freshness.py
+++ b/scripts/dev/pr_ready_freshness.py
@@ -41,6 +41,26 @@ def _head_sha() -> str:
     return _run_git(["rev-parse", "HEAD"])
 
 
+def _resolve_base_sha(base_ref: str) -> str | None:
+    """Resolve *base_ref* to a concrete commit SHA.
+
+    Returns:
+        Full git SHA for *base_ref*, or ``None`` when the ref does not resolve to
+        a local commit (e.g. a fresh checkout where ``origin/main`` was never
+        fetched).  A ``None`` result is intentional: callers must skip the
+        resolved-SHA comparison rather than fail closed on a ref they cannot see.
+    """
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{base_ref}^{{commit}}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
 def _tree_state() -> str:
     """Return whether the current non-ignored worktree has uncommitted changes.
 
@@ -99,6 +119,7 @@ def _write_stamp(
     path: Path,
     branch: str,
     base_ref: str,
+    base_sha: str | None,
     head_sha: str,
     tree_state: str,
     status: str,
@@ -115,6 +136,7 @@ def _write_stamp(
             "reason": "dirty_worktree",
             "branch": branch,
             "base_ref": base_ref,
+            "base_sha": base_sha,
             "head_sha": head_sha,
             "tree_state": tree_state,
             "stamp_path": str(path),
@@ -123,6 +145,7 @@ def _write_stamp(
     payload = {
         "branch": branch,
         "base_ref": base_ref,
+        "base_sha": base_sha,
         "head_sha": head_sha,
         "recorded_at_utc": datetime.now(UTC).isoformat(),
         "status": status,
@@ -133,11 +156,66 @@ def _write_stamp(
     return payload
 
 
+def _base_sha_drift_advisory(
+    stamp: dict[str, Any],
+    base_ref: str,
+    current_base_sha: str | None,
+) -> dict[str, str] | None:
+    """Return an advisory describing base drift between the stamped and current base.
+
+    The stamp records the concrete base SHA that the readiness run actually validated
+    against (issue #5782).  When ``origin/main`` (or another moving base) advances
+    after the stamp was recorded, that SHA no longer matches the current base.  This
+    is reported as a reviewable advisory rather than a freshness failure: the
+    readiness gate already ran a base-drift recheck before recording the stamp and
+    records the stamp only when the drift is current or unrelated to the PR's changed
+    paths, so failing status here would recreate the re-run friction the gate-level
+    check exists to break.
+
+    Returns:
+        ``None`` when the base SHA is still current or cannot be compared; otherwise
+        an advisory dict with the stamped and current base SHAs.
+    """
+    stamped_base_sha = stamp.get("base_sha")
+    if not stamped_base_sha or current_base_sha is None:
+        # Either the stamp predates base-SHA capture or the ref cannot be resolved
+        # locally; nothing to compare, so there is no drift advisory.
+        return None
+    if stamped_base_sha == current_base_sha:
+        return None
+    return {
+        "base_ref": base_ref,
+        "stamped_base_sha": str(stamped_base_sha),
+        "current_base_sha": str(current_base_sha),
+    }
+
+
+def _equality_mismatch_reason(
+    stamp: dict[str, Any],
+    *,
+    branch: str,
+    base_ref: str,
+    head_sha: str,
+) -> str | None:
+    """Return the reason string for the first non-matching equality field, else None."""
+    checks = [
+        ("status", "passed", "status_not_passed"),
+        ("branch", branch, "branch_mismatch"),
+        ("base_ref", base_ref, "base_ref_mismatch"),
+        ("head_sha", head_sha, "head_sha_mismatch"),
+    ]
+    for key, expected, reason in checks:
+        if str(stamp.get(key)) != str(expected):
+            return reason
+    return None
+
+
 def _freshness_result(
     *,
     path: Path,
     branch: str,
     base_ref: str,
+    base_sha: str | None,
     head_sha: str,
     tree_state: str | None,
     require_clean_tree: bool,
@@ -153,6 +231,7 @@ def _freshness_result(
         "stamp_path": str(path),
         "branch": branch,
         "base_ref": base_ref,
+        "base_sha": base_sha,
         "head_sha": head_sha,
         "tree_state": tree_state,
         "require_clean_tree": require_clean_tree,
@@ -177,16 +256,25 @@ def _freshness_result(
         result["reason"] = "stamp_tree_state_not_clean"
         return False, result
 
-    checks = [
-        ("status", "passed", "status_not_passed"),
-        ("branch", branch, "branch_mismatch"),
-        ("base_ref", base_ref, "base_ref_mismatch"),
-        ("head_sha", head_sha, "head_sha_mismatch"),
-    ]
-    for key, expected, reason in checks:
-        if str(stamp.get(key)) != str(expected):
-            result["reason"] = reason
-            return False, result
+    equality_reason = _equality_mismatch_reason(
+        stamp, branch=branch, base_ref=base_ref, head_sha=head_sha
+    )
+    if equality_reason is not None:
+        result["reason"] = equality_reason
+        return False, result
+
+    # The validated base SHA is captured for provenance and reported as an advisory
+    # when origin/main (or another moving base) has advanced since the gate recorded
+    # the stamp. It is intentionally NOT a freshness failure here: the readiness gate
+    # already ran a base-drift recheck before recording the stamp (issue #5782) and
+    # records the stamp only when the drift is current or unrelated to the PR's
+    # changed paths. Failing status on any base movement would force the opener to
+    # re-run the gate every time main advances during an active merge window -- the
+    # exact friction the gate-level drift check exists to break. The advisory keeps
+    # the drift visible and reviewable without invalidating a gate-approved stamp.
+    drift_advisory = _base_sha_drift_advisory(stamp, base_ref, base_sha)
+    if drift_advisory is not None:
+        result["base_drift"] = drift_advisory
 
     try:
         recorded_at = datetime.fromisoformat(str(stamp.get("recorded_at_utc")))
@@ -224,6 +312,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Check whether a recent successful readiness run exists for this branch and HEAD.",
     )
     status_parser.add_argument("--base-ref", default="origin/main")
+    status_parser.add_argument("--base-sha")
     status_parser.add_argument("--branch")
     status_parser.add_argument("--head-sha")
     status_parser.add_argument("--stamp-path")
@@ -240,6 +329,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Record a successful readiness run for this branch and HEAD.",
     )
     write_parser.add_argument("--base-ref", default="origin/main")
+    write_parser.add_argument("--base-sha")
     write_parser.add_argument("--branch")
     write_parser.add_argument("--head-sha")
     write_parser.add_argument("--stamp-path")
@@ -263,12 +353,19 @@ def main() -> int:
     head_sha = args.head_sha or _head_sha()
     tree_state = args.tree_state or _tree_state()
     stamp_path = _resolve_stamp_path(args.stamp_path, branch)
+    # Resolve the concrete base SHA the run validates against.  When the caller
+    # passed an explicit SHA (e.g. a gate that just resolved it), honour it,
+    # otherwise resolve the base_ref to its current commit.  A None result means
+    # the ref is not visible locally; the drift check then falls back to the
+    # base_ref string comparison and stays fail-open on resolution failure.
+    base_sha = args.base_sha if args.base_sha else _resolve_base_sha(args.base_ref)
 
     if args.command == "write":
         payload = _write_stamp(
             path=stamp_path,
             branch=branch,
             base_ref=args.base_ref,
+            base_sha=base_sha,
             head_sha=head_sha,
             tree_state=tree_state,
             status=args.status,
@@ -290,6 +387,7 @@ def main() -> int:
         path=stamp_path,
         branch=branch,
         base_ref=args.base_ref,
+        base_sha=base_sha,
         head_sha=head_sha,
         tree_state=tree_state,
         require_clean_tree=args.require_clean_tree,

--- a/tests/dev/test_check_base_drift.py
+++ b/tests/dev/test_check_base_drift.py
@@ -99,7 +99,11 @@ def _build_drift_repo(tmp_path: Path, *, main_touches_pr_file: bool) -> tuple[Pa
     pr_commit = _git(repo, "rev-parse", "HEAD")
 
     # Advance origin/main one commit past the base.
-    subprocess.run(["git", "branch", "main", base_sha], cwd=repo, check=True)
+    # Git may initialize the repository with ``main`` already configured as the
+    # default branch.  Detach the PR commit first, then move that branch to the
+    # base commit instead of assuming the name is available for creation.
+    subprocess.run(["git", "checkout", "-q", "--detach"], cwd=repo, check=True)
+    subprocess.run(["git", "branch", "-f", "main", base_sha], cwd=repo, check=True)
     subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
     if main_touches_pr_file:
         (repo / "shared.py").write_text("print('unrelated main change')\n", encoding="utf-8")

--- a/tests/dev/test_check_base_drift.py
+++ b/tests/dev/test_check_base_drift.py
@@ -1,0 +1,199 @@
+"""Tests for the base-drift check (scripts/dev/check_base_drift.py, issue #5782)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "dev" / "check_base_drift.py"
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run a git command in *repo* and return stdout."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _run_in(repo: Path, *args: str, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    """Run the base-drift helper inside *repo* and return the completed process.
+
+    Always requests machine-readable JSON output so tests can assert on the
+    structured result regardless of the human-readable status message path.
+    """
+    cmd = [sys.executable, str(SCRIPT), "--json", *args]
+    return subprocess.run(
+        cmd,
+        cwd=str(repo),
+        check=False,
+        capture_output=True,
+        text=True,
+        input=stdin,
+    )
+
+
+def _init_repo(repo: Path) -> None:
+    """Create an empty committed git repo in *repo*."""
+    repo.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "-q",
+            "--allow-empty",
+            "-m",
+            "init",
+        ],
+        cwd=repo,
+        check=True,
+    )
+
+
+def _build_drift_repo(tmp_path: Path, *, main_touches_pr_file: bool) -> tuple[Path, str]:
+    """Build a repo with a PR branch and an advanced origin/main.
+
+    Returns (repo, validated_base_sha). The PR branch sits on top of
+    ``validated_base_sha``; ``origin/main`` is advanced one commit past it.
+    When *main_touches_pr_file* is True the advanced main commit edits the PR's
+    own changed file (shared.py); otherwise it edits an unrelated file so drift
+    does not intersect the PR's changed-file set.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "shared.py").write_text("print('base')\n", encoding="utf-8")
+    (repo / "unrelated.py").write_text("print('base')\n", encoding="utf-8")
+    _init_repo(repo)
+    (repo / "shared.py").write_text("print('base commit')\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A"], cwd=repo, check=True
+    )
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "base"],
+        cwd=repo,
+        check=True,
+    )
+    base_sha = _git(repo, "rev-parse", "HEAD")
+
+    # PR branch commit touches shared.py.
+    (repo / "shared.py").write_text("print('pr change')\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A"], cwd=repo, check=True
+    )
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "pr"],
+        cwd=repo,
+        check=True,
+    )
+    pr_commit = _git(repo, "rev-parse", "HEAD")
+
+    # Advance origin/main one commit past the base.
+    subprocess.run(["git", "branch", "main", base_sha], cwd=repo, check=True)
+    subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+    if main_touches_pr_file:
+        (repo / "shared.py").write_text("print('unrelated main change')\n", encoding="utf-8")
+    else:
+        (repo / "unrelated.py").write_text("print('unrelated main change')\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A"], cwd=repo, check=True
+    )
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "main advance"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(["git", "update-ref", "refs/remotes/origin/main", "HEAD"], cwd=repo, check=True)
+
+    # Return HEAD to the PR commit.
+    subprocess.run(["git", "checkout", "-q", pr_commit], cwd=repo, check=True)
+    return repo, base_sha
+
+
+def test_current_base_reports_no_drift(tmp_path: Path) -> None:
+    """When validated SHA matches the current base, status is current (exit 0)."""
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True, exist_ok=True)
+    _init_repo(repo)
+    base_sha = _git(repo, "rev-parse", "HEAD")
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/main", base_sha], cwd=repo, check=True
+    )
+    result = _run_in(repo, "--base-ref", "origin/main", "--validated-base-sha", base_sha)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "current"
+
+
+def test_unrelated_drift_recommends_reuse(tmp_path: Path) -> None:
+    """Drift that avoids PR-changed files yields reuse_recommended (exit 0)."""
+    repo, base_sha = _build_drift_repo(tmp_path, main_touches_pr_file=False)
+    result = _run_in(
+        repo,
+        "--base-ref",
+        "origin/main",
+        "--validated-base-sha",
+        base_sha,
+        "--changed-files",
+        "/dev/stdin",
+        stdin="shared.py\n",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "reuse_recommended"
+    assert payload["affected_file_count"] == 0
+    assert "reuse" in payload["message"].lower()
+
+
+def test_drift_touching_pr_files_fails_closed(tmp_path: Path) -> None:
+    """Drift intersecting PR-changed files fails closed (exit 1) and names files."""
+    repo, base_sha = _build_drift_repo(tmp_path, main_touches_pr_file=True)
+    result = _run_in(
+        repo,
+        "--base-ref",
+        "origin/main",
+        "--validated-base-sha",
+        base_sha,
+        "--changed-files",
+        "/dev/stdin",
+        stdin="shared.py\n",
+    )
+    assert result.returncode == 1, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "revalidate_required"
+    assert payload["affected_file_count"] >= 1
+    assert "shared.py" in payload["affected_files"]
+
+
+def test_unresolved_base_ref_is_indeterminate(tmp_path: Path) -> None:
+    """A base ref that does not resolve locally yields indeterminate (exit 2)."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    result = _run_in(repo, "--base-ref", "does/not/exist", "--validated-base-sha", "abc123")
+    assert result.returncode == 2, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "indeterminate"
+
+
+def test_identical_sha_is_current_without_drift_compute(tmp_path: Path) -> None:
+    """When validated SHA equals current base, status is current (exit 0)."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    base_sha = _git(repo, "rev-parse", "HEAD")
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/main", base_sha], cwd=repo, check=True
+    )
+    result = _run_in(repo, "--base-ref", "origin/main", "--validated-base-sha", base_sha)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "current"

--- a/tests/dev/test_pr_ready_preflight.py
+++ b/tests/dev/test_pr_ready_preflight.py
@@ -38,6 +38,11 @@ _POST_PREFLIGHT_SCRIPTS = [
     "check_docstring_todos_diff.sh",
     "check_docstring_todos_ratchet.sh",
     "check_optional_import_pr_freshness.py",
+    # check_base_drift.py is invoked by pr_ready_check.sh as a final base-drift
+    # recheck before recording the freshness stamp (issue #5782).  Stub it here so
+    # the fake repo exercises the wiring cleanly instead of emitting a missing-file
+    # error that the rc-2 fallback silently swallows.
+    "check_base_drift.py",
     "pr_ready_freshness.py",
 ]
 
@@ -125,6 +130,31 @@ def _make_fake_bin(repo: Path, *, fail: bool = True) -> None:
         '  exec "$@"\n'
         "fi\n"
         f'exec "{real_uv}" "$@"\n',
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+
+
+def _make_real_python_bin(repo: Path) -> None:
+    """Create a fake ``uv`` that execs the real Python interpreter.
+
+    The base-drift end-to-end tests need ``check_base_drift.py`` to run with a real
+    interpreter (so its git logic executes), while still avoiding ``uv sync`` and
+    stubbing the expensive readiness lanes. Unlike ``_make_fake_bin``, this does NOT
+    replace ``python``: ``uv run python <script>`` execs ``python <script>`` which PATH
+    resolves to the real interpreter, so the real ``check_base_drift.py`` logic runs in
+    interim mode (where the final-mode analytics preflight is skipped).
+    """
+    bin_dir = repo / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    fake_uv = bin_dir / "uv"
+    fake_uv.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [[ "$1" == "run" ]]; then\n'
+        "  shift\n"
+        '  exec "$@"\n'
+        "fi\n"
+        f'exec "{shutil.which("uv") or "uv"}" "$@"\n',
         encoding="utf-8",
     )
     fake_uv.chmod(0o755)
@@ -575,3 +605,148 @@ def test_preflight_skip_env_var_bypasses_check(preflight_repo: Path) -> None:
     )
     assert result.returncode == 0, f"Script failed: {result.stderr}"
     assert "Final PR readiness requires analytics dependencies" not in result.stderr
+
+
+# Issue #5782: end-to-end wiring of the base-drift recheck in pr_ready_check.sh.
+# These build a fake repo whose post-preflight lanes are stubbed (so the expensive
+# pytest/coverage gates are skipped) but whose check_base_drift.py is the REAL
+# script. The ``run_tests_parallel.sh`` stub advances origin/main mid-run to
+# deterministically model main advancing during the long lanes, then the gate
+# fails closed on related drift and surfaces the reuse path on unrelated drift.
+
+
+def _wire_real_base_drift(repo: Path) -> None:
+    """Replace the stubbed check_base_drift.py with the real script from this checkout."""
+    shutil.copy2(
+        SCRIPTS_DEV / "check_base_drift.py",
+        repo / "scripts" / "dev" / "check_base_drift.py",
+    )
+
+
+def _commit(repo: Path, message: str) -> None:
+    """Stage and commit all changes in *repo* with a test identity."""
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+
+
+def _build_drift_pr_repo(tmp_path: Path, *, main_touches_pr_file: bool) -> tuple[Path, str, str]:
+    """Build a fake repo with a PR branch on a base commit and an advanced main commit.
+
+    Returns (repo, base_sha, moved_sha). The PR branch sits on top of ``base_sha``
+    and changes ``shared.py``; a separate ``main`` branch advances one commit past
+    ``base_sha``. When *main_touches_pr_file* is True that advance edits
+    ``shared.py`` (related drift); otherwise it edits ``unrelated.py`` (unrelated
+    drift). ``origin/main`` starts at ``base_sha`` so a run captures the validated
+    base SHA; the lane stub advances it to ``moved_sha`` mid-run.
+    """
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts" / "dev"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy2(SCRIPTS_DEV / "common_setup.sh", scripts_dir / "common_setup.sh")
+    shutil.copy2(SCRIPTS_DEV / "pr_ready_check.sh", scripts_dir / "pr_ready_check.sh")
+    _make_fake_scripts(repo)
+    _wire_real_base_drift(repo)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    (repo / ".git" / "info" / "exclude").write_text("bin/\n.home/\nlane.log\n", encoding="utf-8")
+
+    (repo / "shared.py").write_text("print('base')\n", encoding="utf-8")
+    (repo / "unrelated.py").write_text("print('base')\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "--allow-empty", "-m", "init")
+    (repo / "shared.py").write_text("print('base commit')\n", encoding="utf-8")
+    _commit(repo, "base")
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    # PR commit on top of base changes shared.py.
+    (repo / "shared.py").write_text("print('pr change')\n", encoding="utf-8")
+    _commit(repo, "pr")
+    pr_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    # Advance a main branch one commit past the base (simulating main moving).
+    subprocess.run(["git", "branch", "main", base_sha], cwd=repo, check=True)
+    subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+    if main_touches_pr_file:
+        (repo / "shared.py").write_text("print('main moved shared')\n", encoding="utf-8")
+    else:
+        (repo / "unrelated.py").write_text("print('main moved unrelated')\n", encoding="utf-8")
+    _commit(repo, "main advance")
+    moved_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    # origin/main starts AT THE BASE so the run captures the validated base SHA; the
+    # lane stub advances it to moved_sha mid-run (see _wire_lane_stub_advancing_base).
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/main", base_sha], cwd=repo, check=True
+    )
+    # Return HEAD to the PR commit.
+    subprocess.run(["git", "checkout", "-q", pr_commit], cwd=repo, check=True)
+    return repo, base_sha, moved_sha
+
+
+def _wire_lane_stub_advancing_base(repo: Path, moved_sha: str) -> None:
+    """Make the stubbed ``run_tests_parallel.sh`` advance origin/main mid-run.
+
+    pr_ready_check.sh captures the validated base SHA BEFORE the expensive lanes and
+    rechecks it AFTER. In production, origin/main advances during those long lanes.
+    The stubbed lanes complete instantly, so this stub advances origin/main to
+    *moved_sha* while the lane runs, deterministically modelling that passage of
+    time so the final drift recheck observes the moved base.
+    """
+    stub = repo / "scripts" / "dev" / "run_tests_parallel.sh"
+    stub.write_text(
+        f"#!/usr/bin/env bash\ngit update-ref refs/remotes/origin/main {moved_sha}\nexit 0\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+
+
+def test_pr_ready_check_fails_closed_on_related_base_drift(tmp_path: Path) -> None:
+    """Issue #5782: drift touching a PR-changed file must fail the gate before stamping.
+
+    The expensive pytest/coverage lanes are stubbed. The ``run_tests_parallel.sh``
+    stub models the passage of time during the long lanes by advancing origin/main
+    (as an unrelated PR merging would). pr_ready_check.sh captures the base SHA at
+    the start, so when the final drift recheck sees the advanced base editing the
+    PR's own file, it must exit nonzero and name the base to revalidate instead of
+    recording a misleading stamp.
+    """
+    repo, _base_sha, moved = _build_drift_pr_repo(tmp_path, main_touches_pr_file=True)
+    _make_real_python_bin(repo)
+    _wire_lane_stub_advancing_base(repo, moved)
+
+    result = _run_pr_ready(
+        repo,
+        help_flag=False,
+        env_overrides={"BASE_REF": "origin/main", "PR_READY_MODE": "interim"},
+    )
+    assert result.returncode != 0, (
+        f"expected base-drift failure, got rc={result.returncode}: {result.stderr}"
+    )
+    assert "revalidate against origin/main" in result.stderr
+    assert "shared.py" in result.stderr
+    assert "Validated base SHA for this run" in result.stderr
+
+
+def test_pr_ready_check_surfaces_reuse_path_on_unrelated_base_drift(tmp_path: Path) -> None:
+    """Issue #5782: drift unrelated to the PR's changed files recommends reuse.
+
+    origin/main advances during the (stubbed) lanes but only edits a file the PR
+    does not touch. The gate must still succeed and surface the reviewable reuse
+    message rather than needlessly failing or silently ignoring the drift.
+    """
+    repo, _base_sha, moved = _build_drift_pr_repo(tmp_path, main_touches_pr_file=False)
+    _make_real_python_bin(repo)
+    _wire_lane_stub_advancing_base(repo, moved)
+
+    result = _run_pr_ready(
+        repo,
+        help_flag=False,
+        env_overrides={"BASE_REF": "origin/main", "PR_READY_MODE": "interim"},
+    )
+    assert result.returncode == 0, f"expected reuse success, got: {result.stderr}"
+    # The reuse decision must be visible (reviewable), not silently swallowed.
+    assert "reuse" in result.stderr.lower()

--- a/tests/dev/test_pr_ready_preflight.py
+++ b/tests/dev/test_pr_ready_preflight.py
@@ -667,7 +667,11 @@ def _build_drift_pr_repo(tmp_path: Path, *, main_touches_pr_file: bool) -> tuple
     ).stdout.strip()
 
     # Advance a main branch one commit past the base (simulating main moving).
-    subprocess.run(["git", "branch", "main", base_sha], cwd=repo, check=True)
+    # Git may initialize the repository with ``main`` already configured as the
+    # default branch.  Detach the PR commit first, then move that branch to the
+    # base commit instead of assuming the name is available for creation.
+    subprocess.run(["git", "checkout", "-q", "--detach"], cwd=repo, check=True)
+    subprocess.run(["git", "branch", "-f", "main", base_sha], cwd=repo, check=True)
     subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
     if main_touches_pr_file:
         (repo / "shared.py").write_text("print('main moved shared')\n", encoding="utf-8")

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -503,6 +503,7 @@ def test_pr_ready_check_records_freshness_after_successful_gates() -> None:
     )
     assert "Optional-extra changed files requiring the predictive lane" in script_text
     assert "No changed files require the optional-extra lane." in script_text
+    assert 'git diff --name-only --diff-filter=ACDMRT "$BASE_REF...HEAD"' in script_text
 
     freshness_call = 'uv run python "$SCRIPT_DIR/pr_ready_freshness.py" "${freshness_args[@]}"'
     assert 'freshness_args=(write --base-ref "$BASE_REF")' in script_text

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -517,6 +517,38 @@ def test_pr_ready_check_records_freshness_after_successful_gates() -> None:
     )
 
 
+def test_pr_ready_check_captures_validated_base_sha_for_drift_guard(tmp_path: Path) -> None:
+    """Issue #5782: the readiness gate must capture the concrete base SHA it validates
+    against and run a final base-drift recheck before recording the freshness stamp.
+
+    The drift guard compares the captured base SHA against the (moving) base ref
+    again before the stamp is written, so a readiness stamp cannot stay green
+    through a silent origin/main advance during the long lanes.
+    """
+    script_text = PR_READY_CHECK.read_text(encoding="utf-8")
+
+    # The gate resolves the concrete base commit before the expensive lanes.
+    assert (
+        'VALIDATED_BASE_SHA="$(git rev-parse --verify --quiet "${BASE_REF}^{commit}"' in script_text
+    )
+    assert "Validated base SHA for this run" in script_text
+
+    # The freshness stamp now records the resolved base SHA.
+    assert 'freshness_args+=(--base-sha "$VALIDATED_BASE_SHA")' in script_text
+
+    # A final lightweight drift recheck runs before the stamp is written.
+    assert 'uv run python "$SCRIPT_DIR/check_base_drift.py"' in script_text
+    assert "--validated-base-sha" in script_text
+    assert "--changed-files" in script_text
+    assert "revalidate against" in script_text
+    # The drift recheck must sit before the freshness stamp write.
+    drift_index = script_text.find('uv run python "$SCRIPT_DIR/check_base_drift.py"')
+    freshness_write_index = script_text.find('uv run python "$SCRIPT_DIR/pr_ready_freshness.py"')
+    assert 0 < drift_index < freshness_write_index, (
+        "base-drift recheck must precede the stamp write"
+    )
+
+
 def test_pr_ready_check_exposes_final_committed_head_mode() -> None:
     """Final PR proof should fail closed on dirty trees and mark clean-tree stamps."""
     script_text = PR_READY_CHECK.read_text(encoding="utf-8")

--- a/tests/tools/test_pr_open_readiness.py
+++ b/tests/tools/test_pr_open_readiness.py
@@ -220,3 +220,101 @@ def test_pr_ready_freshness_rejects_stale_stamp(tmp_path: Path) -> None:
     payload = json.loads(result.stdout)
     assert payload["fresh"] is False
     assert payload["reason"] == "expired"
+
+
+def test_pr_ready_freshness_write_records_base_sha(tmp_path: Path) -> None:
+    """The readiness stamp should capture the validated base SHA (issue #5782)."""
+    stamp_path = tmp_path / "ready.json"
+    result = _run(
+        "write",
+        "--branch",
+        "codex/712-pr-open-skill",
+        "--head-sha",
+        "abc123",
+        "--base-ref",
+        "origin/main",
+        "--base-sha",
+        "deadbeefcafe",
+        "--stamp-path",
+        str(stamp_path),
+    )
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["stamp"]["base_sha"] == "deadbeefcafe"
+
+
+def test_pr_ready_freshness_status_reports_base_drift_as_advisory(tmp_path: Path) -> None:
+    """Base drift is reported as a reviewable advisory, not a freshness failure.
+
+    Issue #5782: a readiness stamp recorded against one origin/main commit remains
+    fresh after origin/main advances, because the readiness gate already ran a
+    base-drift recheck before recording the stamp and records it only when the drift
+    is current or unrelated to the PR's changed paths. Failing status on any base
+    movement would recreate the re-run friction the gate-level check exists to break,
+    so status reports the drift as a visible advisory instead.
+    """
+    stamp_path = tmp_path / "ready.json"
+    payload = {
+        "branch": "codex/712-pr-open-skill",
+        "base_ref": "origin/main",
+        "base_sha": "oldsha0000000000000000000000000000000000",
+        "head_sha": "abc123",
+        "recorded_at_utc": datetime.now(UTC).isoformat(),
+        "status": "passed",
+    }
+    stamp_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = _run(
+        "status",
+        "--branch",
+        "codex/712-pr-open-skill",
+        "--head-sha",
+        "abc123",
+        "--base-ref",
+        "origin/main",
+        "--base-sha",
+        "newsha1111111111111111111111111111111111",
+        "--stamp-path",
+        str(stamp_path),
+    )
+
+    assert result.returncode == 0
+    result_payload = json.loads(result.stdout)
+    assert result_payload["fresh"] is True
+    assert result_payload["reason"] == "fresh"
+    # The drift must be surfaced for review even though the stamp stays fresh.
+    drift = result_payload["base_drift"]
+    assert drift["stamped_base_sha"].startswith("oldsha")
+    assert drift["current_base_sha"].startswith("newsha")
+    assert drift["base_ref"] == "origin/main"
+
+
+def test_pr_ready_freshness_status_ignores_drift_when_sha_unknown(tmp_path: Path) -> None:
+    """When neither the stamp nor the caller can resolve a base SHA, fall back to
+    the base_ref string comparison (issue #5782 graceful degradation)."""
+    stamp_path = tmp_path / "ready.json"
+    payload = {
+        "branch": "codex/712-pr-open-skill",
+        "base_ref": "origin/main",
+        "head_sha": "abc123",
+        "recorded_at_utc": datetime.now(UTC).isoformat(),
+        "status": "passed",
+    }
+    stamp_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    # Caller passes no --base-sha (ref unresolvable locally); stamp has none either.
+    result = _run(
+        "status",
+        "--branch",
+        "codex/712-pr-open-skill",
+        "--head-sha",
+        "abc123",
+        "--base-ref",
+        "origin/main",
+        "--stamp-path",
+        str(stamp_path),
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["fresh"] is True


### PR DESCRIPTION
## What

Closes #5782 — the readiness gate now captures the concrete base SHA it validates against and runs a lightweight base-drift recheck before recording the freshness stamp, so a passing gate is no longer made stale the instant `origin/main` advances during the long optional lane.

## Why

Issue #5782 (friction): during a 15–20 min readiness run, `origin/main` advances repeatedly. After the gate passed and a fresh fetch reported the branch behind, the readiness stamp — which only recorded the moving ref *name* `origin/main` — was stale immediately after a successful gate, forcing repeated full-gate reruns until the handoff head held a clean stamp while the remote kept advancing.

The suggested change was to capture the validated base SHA and perform a final lightweight base-drift check before recording the stamp: reuse the passing run when drift is unrelated to changed paths; otherwise fail closed with the exact base SHA that needs revalidation.

## How

- **`scripts/dev/check_base_drift.py`** (new): classifies base drift as `current` / `reuse_recommended` / `revalidate_required` / `indeterminate` (exit 0 / 0 / 1 / 2). Compares the validated base SHA against the current base ref; if they differ it intersects the drifted files with the PR's changed files — empty intersection ⇒ reuse, non-empty ⇒ revalidate.
- **`scripts/dev/pr_ready_check.sh`**: captures `VALIDATED_BASE_SHA` *before* the expensive lanes, passes `--base-sha` to the stamp write, and runs the drift recheck immediately before recording the stamp. On `revalidate_required` it fails closed and names the base to revalidate; on `reuse_recommended` it surfaces the reuse decision for review; on `indeterminate` it records the stamp and reports the indeterminate result. (Handles `set -e` via `… || drift_rc=$?` so the failing command substitution is captured instead of aborting the script.)
- **`scripts/dev/pr_ready_freshness.py`**: the stamp now records `base_sha` (the validated base SHA, as provenance). The `status` check reports base drift as a **reviewable advisory** (`base_drift`) rather than a freshness failure — the gate already ran the drift recheck before recording the stamp, so failing `status` on any base movement would recreate the very re-run friction this fix exists to break.

## Validation (CPU-level only)

```
$ uv run pytest tests/dev/test_check_base_drift.py tests/dev/test_pr_ready_preflight.py \
                 tests/tools/test_pr_open_readiness.py tests/test_ci_script_contract.py -q
113 passed in 23.71s
```

- `tests/dev/test_check_base_drift.py` (5): current / unrelated-reuse / related-fail-closed / unresolved-indeterminate / identical-current.
- `tests/dev/test_pr_ready_preflight.py`: end-to-end wiring through the real `pr_ready_check.sh` — the `run_tests_parallel.sh` stub deterministically advances `origin/main` mid-run to model main moving during the long lanes. `related` drift ⇒ gate fails closed and names `shared.py` + `revalidate against origin/main`; `unrelated` drift ⇒ gate succeeds and surfaces the `reuse` message. (Added `check_base_drift.py` to the fake-repo stub list so the wiring is exercised cleanly.)
- `tests/tools/test_pr_open_readiness.py`: stamp records `base_sha`; `status` reports drift as an advisory (stays fresh); graceful degradation when no base SHA is known.
- `tests/test_ci_script_contract.py`: contract test asserting the gate captures `VALIDATED_BASE_SHA`, passes `--base-sha`, runs `check_base_drift.py`, and orders the drift recheck before the stamp write.

```
$ ruff check <changed .py files>          # All checks passed!
$ ruff format --check <changed .py files> # already formatted
$ bash -n scripts/dev/pr_ready_check.sh   # OK
```

No campaigns, Slurm, training, or benchmark claims — this is a readiness-gate tooling change.

## Downstream propagation

NA — tooling/docs-adjacent dev-script change with no benchmark, metric, schema, model-provenance, or paper-facing claim. Artifact handling: no `output/` artifacts produced (readiness stamps remain worktree-local under the ignored `output/validation/pr_ready`).

## Successor / scope note

This PR fully resolves issue #5782's suggested change (capture validated base SHA + final lightweight base-drift check with unrelated-reuse / related-fail-closed). No prior PR sliced this issue (no PRs reference #5782); this is not a successor slice and duplicates nothing.

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.

Closes #5782


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added base-drift detection to PR readiness checks.
  * Detects whether changes to the base branch affect files in the pull request.
  * Recommends reuse when drift is unrelated and requires revalidation when affected files overlap.
  * Records the validated base revision and surfaces later drift as an advisory.

* **Bug Fixes**
  * Ensures deleted and modified pull-request paths are included in drift comparisons.
  * Fails readiness checks safely when relevant base drift is detected.

* **Tests**
  * Added coverage for current, unrelated, overlapping, and unresolved base-drift scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->