### PR TITLE
Issue #5810: complete robot-sf doctor readiness checks (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/doctor.py
+++ b/robot_sf/benchmark/doctor.py
@@ -316,6 +316,7 @@ def _resolve_quickstart_examples(
     manifest_path = workspace_root / "examples" / "examples_manifest.yaml"
     try:
         manifest = load_manifest(manifest_path=manifest_path, validate_paths=False)
+    # Any loader exception, including malformed YAML, must become a readiness failure.
     except Exception as exc:
         return (), f"{type(exc).__name__}: {exc}"
 

--- a/robot_sf/benchmark/doctor.py
+++ b/robot_sf/benchmark/doctor.py
@@ -8,6 +8,7 @@ import json
 import os
 import platform
 import shutil
+import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
@@ -15,6 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import robot_sf
+from robot_sf.examples.manifest_loader import load_manifest
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -29,20 +31,15 @@ DEFAULT_WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
 OPTIONAL_EXTRAS = ("training", "gpu", "orca", "socnav", "rllib", "analysis")
 # Map deps are pulled in by osmnx-based OSM map authoring examples.
 MAP_DEP_IMPORTS = ("osmnx", "shapely")
-# Bundled model artifacts the quickstart examples rely on.
+# Bundled model artifacts the quickstart examples rely on, including the PPO
+# checkpoint referenced by configs/baselines/ppo.yaml.
 MODEL_ARTIFACTS = (
+    Path("model/ppo_model_retrained_10m_2025-02-01.zip"),
     Path("model/pedestrian/ppo_ped_01.zip"),
     Path("model/pedestrian/ppo_ped_02.zip"),
     Path("model/pedestrian/ppo_corner.zip"),
     Path("model/pedestrian/ppo_headon.zip"),
     Path("model/pedestrian/ppo_intersection.zip"),
-)
-# Quickstart examples the doctor can sanity-check for presence/runnability.
-QUICKSTART_EXAMPLES = (
-    Path("examples/quickstart/01_basic_robot.py"),
-    Path("examples/quickstart/02_trained_model.py"),
-    Path("examples/quickstart/03_custom_map.py"),
-    Path("examples/quickstart/04_occupancy_grid.py"),
 )
 UV_BOOTSTRAP_HINT = (
     "Install uv (https://docs.astral.sh/uv/getting-started/) with one of:\n"
@@ -120,11 +117,14 @@ def _check_binary(name: str, *, required: bool) -> DoctorCheck:
         DoctorCheck: Binary availability check result.
     """
     path = shutil.which(name)
+    details: dict[str, Any] = {"path": path}
+    if path is None:
+        details["hint"] = f"Install {name} and ensure it is available on PATH."
     return DoctorCheck(
         name=f"binary:{name}",
         status="ok" if path else ("failed" if required else "missing_optional"),
         required=required,
-        details={"path": path},
+        details=details,
     )
 
 
@@ -135,11 +135,14 @@ def _check_optional_import(name: str) -> DoctorCheck:
         DoctorCheck: Optional import availability check result.
     """
     spec = importlib_util.find_spec(name)
+    details: dict[str, Any] = {"available": spec is not None}
+    if spec is None:
+        details["hint"] = f"Install the dependency providing {name} (try: uv sync --all-extras)."
     return DoctorCheck(
         name=f"import:{name}",
         status="ok" if spec else "missing_optional",
         required=False,
-        details={"available": spec is not None},
+        details=details,
     )
 
 
@@ -298,26 +301,169 @@ def _check_optional_extras() -> DoctorCheck:
     )
 
 
-def _check_quickstart(workspace_root: Path) -> DoctorCheck:
-    """Report whether the quickstart examples are present and importable.
+def _resolve_quickstart_examples(
+    workspace_root: Path,
+) -> tuple[tuple[Path, ...], str | None]:
+    """Resolve quickstart examples from the canonical examples manifest.
+
+    Args:
+        workspace_root: Repository workspace root containing ``examples/``.
+
+    Returns:
+        tuple[tuple[Path, ...], str | None]: Resolved absolute example paths and
+        an optional manifest error string. On error the path tuple is empty.
+    """
+    manifest_path = workspace_root / "examples" / "examples_manifest.yaml"
+    try:
+        manifest = load_manifest(manifest_path=manifest_path, validate_paths=False)
+    except Exception as exc:
+        return (), f"{type(exc).__name__}: {exc}"
+
+    examples = tuple(manifest.examples_for_category("quickstart"))
+    return tuple(manifest.resolve_example_path(example) for example in examples), None
+
+
+def _tail_output(value: str | bytes | None, *, limit: int = 20) -> str:
+    """Return a bounded text tail for a failed quickstart subprocess.
+
+    Args:
+        value: Raw subprocess output (stdout/stderr combined or None).
+        limit: Maximum number of trailing lines to keep.
+
+    Returns:
+        str: Bounded tail of the output, or an empty string.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="replace")
+    lines = value.splitlines()
+    return "\n".join(lines[-limit:])
+
+
+def _check_quickstart(
+    workspace_root: Path,
+    artifact_root: Path,
+    *,
+    run_smoke: bool,
+) -> DoctorCheck:
+    """Report whether manifest-declared quickstarts are present and runnable.
+
+    Resolves quickstart entries from ``examples/examples_manifest.yaml`` (the
+    single source of truth) instead of a hard-coded list, fails closed on a
+    missing/unreadable manifest or an empty quickstart category, and optionally
+    executes each quickstart headlessly and fails closed on non-zero exit.
+
+    Args:
+        workspace_root: Repository workspace root containing ``examples/``.
+        artifact_root: Artifact root for smoke outputs.
+        run_smoke: When ``True`` and all examples are present, execute each
+            quickstart headlessly and report the first non-zero exit as a failure.
 
     Returns:
         DoctorCheck: Quickstart readiness check result.
     """
-    missing = [str(rel) for rel in QUICKSTART_EXAMPLES if not (workspace_root / rel).is_file()]
-    status = "ok" if not missing else "failed"
+    manifest_path = workspace_root / "examples" / "examples_manifest.yaml"
+    examples, manifest_error = _resolve_quickstart_examples(workspace_root)
+    if manifest_error is not None:
+        return DoctorCheck(
+            name="quickstart",
+            status="failed",
+            required=True,
+            details={
+                "manifest": str(manifest_path),
+                "error": manifest_error,
+                "hint": "Restore a valid examples/examples_manifest.yaml before running quickstarts.",
+            },
+        )
+    if not examples:
+        return DoctorCheck(
+            name="quickstart",
+            status="failed",
+            required=True,
+            details={
+                "manifest": str(manifest_path),
+                "present": [],
+                "missing": [],
+                "smoke": "skipped",
+                "failures": [],
+                "hint": "Add at least one manifest-declared quickstart example.",
+            },
+        )
+
+    missing = [str(path.relative_to(workspace_root)) for path in examples if not path.is_file()]
+    failures: list[dict[str, Any]] = []
+    smoke_status = "skipped"
+    if not missing and run_smoke:
+        smoke_status = "passed"
+        smoke_env = os.environ.copy()
+        smoke_env.update(
+            {
+                "DISPLAY": "",
+                "MPLBACKEND": "Agg",
+                "SDL_VIDEODRIVER": "dummy",
+                "ROBOT_SF_FAST_DEMO": "1",
+                "ROBOT_SF_EXAMPLES_MAX_STEPS": "12",
+                "ROBOT_SF_ARTIFACT_ROOT": str((artifact_root / "quickstart_smoke").resolve()),
+            }
+        )
+        pythonpath = [str(workspace_root)]
+        if smoke_env.get("PYTHONPATH"):
+            pythonpath.append(smoke_env["PYTHONPATH"])
+        smoke_env["PYTHONPATH"] = os.pathsep.join(pythonpath)
+        for path in examples:
+            try:
+                completed = subprocess.run(
+                    [sys.executable, str(path)],
+                    cwd=workspace_root,
+                    env=smoke_env,
+                    capture_output=True,
+                    text=True,
+                    timeout=30.0,
+                    check=False,
+                )
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                failures.append(
+                    {
+                        "path": str(path.relative_to(workspace_root)),
+                        "error": f"{type(exc).__name__}: {exc}",
+                    }
+                )
+                smoke_status = "failed"
+                break
+            if completed.returncode != 0:
+                failures.append(
+                    {
+                        "path": str(path.relative_to(workspace_root)),
+                        "returncode": completed.returncode,
+                        "output_tail": _tail_output(
+                            "\n".join(part for part in (completed.stdout, completed.stderr) if part)
+                        ),
+                    }
+                )
+                smoke_status = "failed"
+                break
+
+    status = "ok" if not missing and not failures else "failed"
     return DoctorCheck(
         name="quickstart",
         status=status,
         required=True,
         details={
+            "manifest": str(manifest_path),
             "present": [
-                str(rel) for rel in QUICKSTART_EXAMPLES if (workspace_root / rel).is_file()
+                str(path.relative_to(workspace_root)) for path in examples if path.is_file()
             ],
             "missing": missing,
-            "hint": "Quickstart examples are missing from the checkout."
-            if missing
-            else "Quickstart examples present; run with: uv run python examples/quickstart/01_basic_robot.py",
+            "smoke": smoke_status,
+            "failures": failures,
+            "hint": (
+                "Restore the missing quickstart files from the checkout."
+                if missing
+                else "Fix the failed quickstart smoke before relying on this environment."
+                if failures
+                else "Quickstart examples passed the headless smoke."
+            ),
         },
     )
 
@@ -344,9 +490,17 @@ def collect_doctor_report(
     *,
     artifact_root: Path = Path("output"),
     run_env_smoke: bool = True,
+    run_quickstart_smoke: bool = False,
     workspace_root: Path | None = None,
 ) -> dict[str, Any]:
     """Collect local runtime diagnostics for issue reports and setup triage.
+
+    Args:
+        artifact_root: Artifact root to probe for temporary write access.
+        run_env_smoke: When ``True``, run the minimal reset/step env smoke.
+        run_quickstart_smoke: When ``True``, execute manifest-declared quickstart
+            examples headlessly and fail closed on non-zero exits.
+        workspace_root: Repository workspace root. Defaults to the package root.
 
     Returns:
         dict[str, Any]: JSON-serializable doctor report.
@@ -367,7 +521,11 @@ def collect_doctor_report(
         _check_artifact_root(resolved_artifact_root),
         _check_model_artifacts(resolved_workspace_root),
         _check_optional_extras(),
-        _check_quickstart(resolved_workspace_root),
+        _check_quickstart(
+            resolved_workspace_root,
+            resolved_artifact_root,
+            run_smoke=run_quickstart_smoke,
+        ),
     ]
     if run_env_smoke:
         checks.append(_run_env_smoke())
@@ -408,7 +566,6 @@ def _format_human(report: dict[str, Any]) -> str:
         str: Human-readable doctor report.
     """
     lines: list[str] = ["Robot SF environment check", ""]
-    failures: list[str] = []
     for check in report["checks"]:
         symbol = _STATUS_SYMBOL.get(check["status"], check["status"].upper())
         lines.append(f"[{symbol}] {check['name']}")
@@ -417,8 +574,6 @@ def _format_human(report: dict[str, Any]) -> str:
         if hint and check["status"] in {"failed", "missing_optional"}:
             for hint_line in str(hint).splitlines():
                 lines.append(f"      -> {hint_line}")
-        if check["status"] == "failed":
-            failures.append(check["name"])
     lines.append("")
     overall = report["status"]
     if overall == "ok":

--- a/robot_sf/cli.py
+++ b/robot_sf/cli.py
@@ -60,6 +60,12 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Skip the minimal reset/step environment smoke check.",
     )
+    doctor.add_argument(
+        "--skip-quickstart-smoke",
+        action="store_true",
+        default=False,
+        help="Skip executing the manifest-declared quickstart examples",
+    )
     _add_models_subparser(subparsers)
     _add_datasets_subparser(subparsers)
     # The ``examples`` subcommand owns its own sub-subcommand parser
@@ -91,6 +97,7 @@ def _handle_doctor(args: argparse.Namespace) -> int:
     report = collect_doctor_report(
         artifact_root=args.artifact_root,
         run_env_smoke=not args.skip_env_smoke,
+        run_quickstart_smoke=not args.skip_quickstart_smoke,
     )
     if args.format == "json":
         import json  # noqa: PLC0415

--- a/scripts/validation/broad_exception_baseline.json
+++ b/scripts/validation/broad_exception_baseline.json
@@ -4,7 +4,7 @@
       "robot_sf/benchmark/camera_ready/campaign.py": 1,
       "robot_sf/benchmark/camera_ready/resource_lifecycle.py": 2,
       "robot_sf/benchmark/candidate_trace_resolution.py": 1,
-      "robot_sf/benchmark/doctor.py": 1,
+      "robot_sf/benchmark/doctor.py": 2,
       "robot_sf/benchmark/forecast_lane_inventory.py": 1,
       "robot_sf/benchmark/helper_catalog.py": 2,
       "robot_sf/benchmark/learned_predictor_capability_inventory.py": 1,
@@ -104,7 +104,7 @@
       "scripts/validation/verify_maps.py": 1,
       "scripts/validation/verify_sf_implementation.py": 4
     },
-    "total": 175
+    "total": 176
   },
   "description": "Broad exception handler baseline for benchmark/script surfaces. Run scripts/validation/check_broad_exceptions.py --write-baseline to refresh after intentionally removing or approving entries.",
   "entries": [
@@ -150,6 +150,15 @@
       "fingerprint": "c68a0e0b1fcaafb1",
       "handler": "Exception",
       "lineno": 207,
+      "path": "robot_sf/benchmark/doctor.py",
+      "source": "except Exception as exc:"
+    },
+    {
+      "col_offset": 4,
+      "context": "_resolve_quickstart_examples",
+      "fingerprint": "fcee4a1031e8281c",
+      "handler": "Exception",
+      "lineno": 320,
       "path": "robot_sf/benchmark/doctor.py",
       "source": "except Exception as exc:"
     },

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import pytest
@@ -20,6 +21,42 @@ def _check_by_name(payload: dict[str, object]) -> dict[str, dict[str, object]]:
     return {str(check["name"]): check for check in checks}
 
 
+def _write_quickstart_workspace(workspace: Path, relative_paths: tuple[str, ...]) -> None:
+    """Create a minimal manifest-backed workspace for doctor tests.
+
+    Writes ``examples/examples_manifest.yaml`` with a ``quickstart`` category and
+    one example script per provided relative path (under ``examples/``), so the
+    doctor's manifest-driven quickstart check has realistic inputs.
+    """
+    examples_root = workspace / "examples"
+    examples_root.mkdir(parents=True)
+    manifest_lines = [
+        "version: 0.1.0",
+        "categories:",
+        "  - slug: quickstart",
+        "    title: Quickstart",
+        "    description: Test quickstarts",
+        "    order: 1",
+        "examples: []" if not relative_paths else "examples:",
+    ]
+    for index, relative_path in enumerate(relative_paths):
+        manifest_lines.extend(
+            [
+                f"  - path: {relative_path}",
+                f'    name: "Test Quickstart {index}"',
+                "    summary: Test quickstart",
+                "    category_slug: quickstart",
+            ]
+        )
+        example_path = examples_root / relative_path
+        example_path.parent.mkdir(parents=True, exist_ok=True)
+        example_path.write_text("print('ok')\n", encoding="utf-8")
+    (examples_root / "examples_manifest.yaml").write_text(
+        "\n".join(manifest_lines) + "\n",
+        encoding="utf-8",
+    )
+
+
 def test_robot_sf_doctor_happy_path_friendly(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -31,6 +68,7 @@ def test_robot_sf_doctor_happy_path_friendly(
             "--artifact-root",
             str(tmp_path / "artifacts"),
             "--skip-env-smoke",
+            "--skip-quickstart-smoke",
         ]
     )
 
@@ -61,6 +99,7 @@ def test_robot_sf_doctor_json_format_roundtrip(
             "--artifact-root",
             str(tmp_path / "artifacts"),
             "--skip-env-smoke",
+            "--skip-quickstart-smoke",
         ]
     )
 
@@ -93,6 +132,7 @@ def test_robot_sf_doctor_shows_remedy_for_missing_uv(
             "--artifact-root",
             str(tmp_path / "artifacts"),
             "--skip-env-smoke",
+            "--skip-quickstart-smoke",
         ]
     )
 
@@ -110,11 +150,7 @@ def test_robot_sf_doctor_reports_missing_model_artifacts(
 ) -> None:
     """Missing bundled model artifacts should warn and suggest a remedy."""
     workspace = tmp_path / "workspace"
-    workspace.mkdir()
-    # Ensure quickstart files exist so only the model artifact check warns.
-    for rel in doctor.QUICKSTART_EXAMPLES:
-        (workspace / rel).parent.mkdir(parents=True, exist_ok=True)
-        (workspace / rel).write_text("# example\n", encoding="utf-8")
+    _write_quickstart_workspace(workspace, ("quickstart/custom.py",))
     monkeypatch.setattr(doctor, "DEFAULT_WORKSPACE_ROOT", workspace)
 
     rc = main(
@@ -123,6 +159,7 @@ def test_robot_sf_doctor_reports_missing_model_artifacts(
             "--artifact-root",
             str(tmp_path / "artifacts"),
             "--skip-env-smoke",
+            "--skip-quickstart-smoke",
         ]
     )
 
@@ -130,3 +167,78 @@ def test_robot_sf_doctor_reports_missing_model_artifacts(
     out = capsys.readouterr().out
     assert "[WARN] model_artifacts" in out
     assert "Restore model artifacts" in out
+
+
+def test_quickstart_smoke_uses_manifest_and_reports_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Manifest-declared quickstarts must fail closed when execution fails."""
+    workspace = tmp_path / "workspace"
+    _write_quickstart_workspace(workspace, ("quickstart/custom.py",))
+
+    def _fake_run(*args: object, **kwargs: object) -> SimpleNamespace:
+        del args, kwargs
+        return SimpleNamespace(returncode=1, stdout="", stderr="smoke failed")
+
+    monkeypatch.setattr(doctor.subprocess, "run", _fake_run)
+
+    check = doctor._check_quickstart(workspace, tmp_path / "artifacts", run_smoke=True)
+
+    assert check.status == "failed"
+    assert check.details["present"] == ["examples/quickstart/custom.py"]
+    assert check.details["smoke"] == "failed"
+    assert check.details["failures"][0]["path"] == "examples/quickstart/custom.py"
+
+
+def test_quickstart_check_fails_without_manifest_entries(tmp_path: Path) -> None:
+    """An empty quickstart category must not be reported as runnable."""
+    workspace = tmp_path / "workspace"
+    _write_quickstart_workspace(workspace, ())
+
+    check = doctor._check_quickstart(workspace, tmp_path / "artifacts", run_smoke=False)
+
+    assert check.status == "failed"
+    assert check.details["hint"] == "Add at least one manifest-declared quickstart example."
+
+
+def test_optional_import_check_renders_remedy_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing optional import must carry an actionable install hint."""
+    real_find_spec = doctor.importlib_util.find_spec
+
+    def _fake_find_spec(name: str, *args: object, **kwargs: object) -> object:
+        if name == "numpy":
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(doctor.importlib_util, "find_spec", _fake_find_spec)
+
+    check = doctor._check_optional_import("numpy")
+
+    assert check.status == "missing_optional"
+    assert check.details["available"] is False
+    assert "hint" in check.details
+    assert "uv sync --all-extras" in check.details["hint"]
+
+
+def test_optional_binary_check_renders_remedy_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing optional binary must carry an actionable install hint."""
+    real_which = doctor.shutil.which
+
+    def _fake_which(name: str) -> str | None:
+        if name == "ffmpeg":
+            return None
+        return real_which(name)
+
+    monkeypatch.setattr(doctor.shutil, "which", _fake_which)
+
+    check = doctor._check_binary("ffmpeg", required=False)
+
+    assert check.status == "missing_optional"
+    assert check.details["path"] is None
+    assert "hint" in check.details
+    assert "Install ffmpeg" in check.details["hint"]


### PR DESCRIPTION
## What / Why

Completes the `robot-sf doctor` readiness checks left open after **PR #5806** merged at `5797d9cd` before the gate-repair commit `7631748c` reached the PR head. This PR lands the equivalent local repair through a normal follow-up change and implements the four acceptance items of #5810:

1. **Manifest-driven quickstarts + fail-closed smoke.** `_check_quickstart` resolves quickstart entries from `examples/examples_manifest.yaml` (the single source of truth) instead of a duplicated hard-coded list. It fails closed on a missing/unreadable manifest, an empty `quickstart` category, missing example files, or non-zero headless execution, with bounded output and an actionable hint. The `run_quickstart_smoke` report flag and `--skip-quickstart-smoke` CLI flag drive a real headless subprocess smoke with a 30-second timeout per script.
2. **PPO checkpoint from `configs/baselines/ppo.yaml`.** Added `model/ppo_model_retrained_10m_2025-02-01.zip` to the doctor’s model-artifact check.
3. **Single source of truth.** Removed the duplicated `QUICKSTART_EXAMPLES` constant; the manifest is now the quickstart inventory.
4. **Actionable remedy hints.** Missing required/optional binaries and imports now emit concrete installation hints.

No benchmark result or paper-facing claim is part of this change.

### Successor statement

Successor slice of #5806: it lands the gate-repair work that did not reach PR #5806's head. It does not duplicate PR #5806; it adds manifest resolution, headless smoke execution, the PPO checkpoint check, and dependency remedy hints on top of the merged base.

## Evidence (CPU-only; no campaigns/Slurm/training/benchmark claims)

**Targeted tests**:

```
DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests/test_cli_doctor.py tests/benchmark/test_doctor.py -v
12 passed in 7.90s
```

The adversarial cases cover failed smoke, an empty manifest inventory, missing model artifacts, and missing binary/import remedies.

**Default manifest smoke:**

```
DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run robot-sf doctor --format json --skip-env-smoke
status: failed
quickstart: failed; examples/quickstart/01_basic_robot.py returned -11
```

The doctor correctly fails closed after resolving all four manifest quickstarts. The underlying Torch 2.13/examples-smoke segmentation-fault compatibility problem is outside this PR’s doctor scope and is tracked in [#5556](https://github.com/ll7/robot_sf_ll7/issues/5556); this PR does not claim the default smoke is healthy until that issue is resolved. The `--skip-quickstart-smoke` path remains available for diagnostics.

**Lint/format and ratchet:** `uv run ruff check` clean; `ruff format --check` clean; the intentional fail-closed manifest catch is documented and approved in `scripts/validation/broad_exception_baseline.json`.

## Validation commands

```
uv run ruff check robot_sf/benchmark/doctor.py robot_sf/cli.py tests/test_cli_doctor.py
uv run ruff format --check robot_sf/benchmark/doctor.py robot_sf/cli.py tests/test_cli_doctor.py
uv run python scripts/validation/check_broad_exceptions.py
DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests/test_cli_doctor.py tests/benchmark/test_doctor.py -v
```

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.

Closes #5810
