### PR TITLE
Issue #5795: robot-sf recipe curated catalog (list/run/explain) (cheap-lane worker)

### DIFF
--- a/configs/recipes/benchmark-mini-run.yaml
+++ b/configs/recipes/benchmark-mini-run.yaml
@@ -1,0 +1,19 @@
+id: benchmark-mini-run
+title: Mini benchmark batch run
+purpose: >
+  Run a small headless batch of episodes through the benchmark CLI
+  (robot_sf_bench run) on the planner-sanity scenario matrix and write the
+  episode JSONL plus aggregate metrics. A minimal end-to-end benchmark run with
+  no training and no model checkpoint.
+runtime: "< 2 min CPU"
+category: benchmark
+command: >
+  uv run robot_sf_bench run
+  --matrix configs/scenarios/single/planner_sanity_simple.yaml
+  --out output/recipes/benchmark-mini-run/episodes.jsonl
+  --algo simple_policy --horizon 120 --no-video
+configs:
+  - configs/scenarios/single/planner_sanity_simple.yaml
+outputs:
+  - output/recipes/benchmark-mini-run/episodes.jsonl
+docs: docs/recipes/README.md

--- a/configs/recipes/custom-svg-map.yaml
+++ b/configs/recipes/custom-svg-map.yaml
@@ -1,0 +1,16 @@
+id: custom-svg-map
+title: Simulate on a bundled custom SVG map
+purpose: >
+  Load an SVG map into Robot SF and run a short random-policy rollout on it.
+  This is the starting point for bringing your own map into the simulator
+  before authoring scenarios on top of it.
+runtime: "< 30s CPU"
+category: maps
+command: >
+  uv run python examples/quickstart/03_custom_map.py
+configs:
+  - examples/quickstart/03_custom_map.py
+  - maps/svg_maps/debug_06.svg
+outputs:
+  - "(stdout only: map-conversion logs and rollout progress)"
+docs: docs/recipes/README.md

--- a/configs/recipes/first-demo.yaml
+++ b/configs/recipes/first-demo.yaml
@@ -1,0 +1,15 @@
+id: first-demo
+title: First Robot SF rollout (random policy)
+purpose: >
+  The shortest path to seeing Robot SF run: a headless random-policy rollout on
+  the default map. Use this as your very first command to confirm the install
+  works before trying recipes that need a trained model or a custom map.
+runtime: "< 30s CPU"
+category: getting-started
+command: >
+  uv run python examples/quickstart/01_basic_robot.py
+configs:
+  - examples/quickstart/01_basic_robot.py
+outputs:
+  - "(stdout only: per-step reward and termination status)"
+docs: docs/recipes/README.md

--- a/configs/recipes/map-validation.yaml
+++ b/configs/recipes/map-validation.yaml
@@ -1,0 +1,15 @@
+id: map-validation
+title: Validate repository SVG maps
+purpose: >
+  Run the SVG map verifier over the CI-enabled map set to catch structural,
+  metadata, and runtime-compatibility problems. Use this when you add or edit a
+  map and want to confirm it is well-formed before depending on it.
+runtime: "< 1 min CPU"
+category: maps
+command: >
+  uv run python scripts/validation/verify_maps.py --scope ci --mode local
+configs:
+  - scripts/validation/verify_maps.py
+outputs:
+  - (stdout summary of per-map validation status)
+docs: docs/recipes/README.md

--- a/configs/recipes/orca-smoke.yaml
+++ b/configs/recipes/orca-smoke.yaml
@@ -1,0 +1,19 @@
+id: orca-smoke
+title: ORCA / social-force planner smoke benchmark
+purpose: >
+  Run a tiny headless benchmark sweep of the social-force (ORCA-style) planner
+  on the planner-sanity scenario to confirm the benchmark runner, episode
+  recording, and aggregation pipeline are wired up. No trained model required.
+runtime: "< 1 min CPU"
+category: planners
+command: >
+  uv run python scripts/demo/run_robot_sf_smoke.py
+  --planners social_force --horizon 120
+configs:
+  - configs/scenarios/single/planner_sanity_simple.yaml
+  - scripts/demo/run_robot_sf_smoke.py
+outputs:
+  - output/demo/smoke_benchmark/summary.json
+  - output/demo/smoke_benchmark/report.md
+  - output/demo/smoke_benchmark/episodes/social_force.jsonl
+docs: docs/recipes/README.md

--- a/configs/recipes/planner-comparison.yaml
+++ b/configs/recipes/planner-comparison.yaml
@@ -1,0 +1,20 @@
+id: planner-comparison
+title: Compare planners on a sanity scenario
+purpose: >
+  Run the one-command smoke benchmark that exercises both the simple-policy and
+  social-force planners on the planner-sanity scenario and writes a Markdown
+  comparison table plus aggregate metrics. The cheapest way to see planner-vs-
+  planner behaviour side by side.
+runtime: "< 2 min CPU"
+category: planners
+command: >
+  uv run python scripts/demo/run_robot_sf_smoke.py
+configs:
+  - configs/scenarios/single/planner_sanity_simple.yaml
+  - scripts/demo/run_robot_sf_smoke.py
+outputs:
+  - output/demo/smoke_benchmark/summary.json
+  - output/demo/smoke_benchmark/report.md
+  - output/demo/smoke_benchmark/episodes/simple_policy.jsonl
+  - output/demo/smoke_benchmark/episodes/social_force.jsonl
+docs: docs/recipes/README.md

--- a/configs/recipes/ppo-smoke.yaml
+++ b/configs/recipes/ppo-smoke.yaml
@@ -1,0 +1,21 @@
+id: ppo-smoke
+title: PPO baseline smoke test (dry-run)
+purpose: >
+  Exercise the PPO training entry point on CPU with a tiny smoke config in
+  --dry-run mode. This confirms the training stack, config loading, and the
+  manifest/artifact pipeline are wired up WITHOUT performing real PPO
+  optimisation. Remove --dry-run to run actual (longer) training. Requires the
+  'training' extra (uv sync --extra training) for Stable-Baselines3.
+runtime: "< 2 min CPU"
+category: training
+command: >
+  uv run python scripts/training/train_ppo.py
+  --config configs/training/ppo/issue_4017_unconstrained_smoke.yaml
+  --dry-run
+configs:
+  - configs/training/ppo/issue_4017_unconstrained_smoke.yaml
+  - configs/scenarios/sets/classic_cross_trap_subset.yaml
+  - scripts/training/train_ppo.py
+outputs:
+  - (dry-run manifest and placeholder checkpoint under the imitation report dir)
+docs: docs/recipes/README.md

--- a/configs/recipes/ppo-smoke.yaml
+++ b/configs/recipes/ppo-smoke.yaml
@@ -1,7 +1,8 @@
 id: ppo-smoke
 title: PPO baseline smoke test (dry-run)
 purpose: >
-  Exercise the PPO training entry point on CPU with a tiny smoke config in
+  Exercise the PPO training entry point with the current tiny fixed-density
+  CPU smoke config in
   --dry-run mode. This confirms the training stack, config loading, and the
   manifest/artifact pipeline are wired up WITHOUT performing real PPO
   optimisation. Remove --dry-run to run actual (longer) training. Requires the
@@ -10,11 +11,11 @@ runtime: "< 2 min CPU"
 category: training
 command: >
   uv run python scripts/training/train_ppo.py
-  --config configs/training/ppo/issue_4017_unconstrained_smoke.yaml
+  --config configs/training/ppo/ablations/issue_4018_fixed_density_smoke.yaml
   --dry-run
 configs:
-  - configs/training/ppo/issue_4017_unconstrained_smoke.yaml
-  - configs/scenarios/sets/classic_cross_trap_subset.yaml
+  - configs/training/ppo/ablations/issue_4018_fixed_density_smoke.yaml
+  - configs/scenarios/sets/ppo_all_available_training_v1_h500_schedule.yaml
   - scripts/training/train_ppo.py
 outputs:
   - (dry-run manifest and placeholder checkpoint under the imitation report dir)

--- a/configs/recipes/scenario-thumbnail-generation.yaml
+++ b/configs/recipes/scenario-thumbnail-generation.yaml
@@ -1,0 +1,22 @@
+id: scenario-thumbnail-generation
+title: Generate scenario thumbnail figures
+purpose: >
+  Produce scenario thumbnail figures from a bundled golden episodes fixture using
+  the figure-generation script. This is the cheapest way to exercise the
+  thumbnail / figure pipeline without running a fresh campaign. Pareto plotting is
+  skipped because the fixture holds a single algorithm family.
+runtime: "< 1 min CPU"
+category: visualization
+command: >
+  uv run python scripts/generate_figures.py
+  --episodes tests/fixtures/benchmark/golden/aggregate_episodes.jsonl
+  --out-dir output/recipes/scenario-thumbnail-generation
+  --no-pareto
+  --thumbs-matrix configs/baselines/example_matrix.yaml
+configs:
+  - tests/fixtures/benchmark/golden/aggregate_episodes.jsonl
+  - configs/baselines/example_matrix.yaml
+  - scripts/generate_figures.py
+outputs:
+  - output/recipes/scenario-thumbnail-generation/
+docs: docs/recipes/README.md

--- a/configs/recipes/telemetry-headless-demo.yaml
+++ b/configs/recipes/telemetry-headless-demo.yaml
@@ -1,0 +1,15 @@
+id: telemetry-headless-demo
+title: Headless telemetry / occupancy-grid demo
+purpose: >
+  Run the occupancy-grid quickstart, which exercises the observation, sensor,
+  and telemetry surfaces headless on CPU. Use this to confirm the perception
+  and telemetry pipeline produces observations without a display.
+runtime: "< 30s CPU"
+category: telemetry
+command: >
+  uv run python examples/quickstart/04_occupancy_grid.py
+configs:
+  - examples/quickstart/04_occupancy_grid.py
+outputs:
+  - "(stdout only: observation/occupancy-grid shape and reward logs)"
+docs: docs/recipes/README.md

--- a/configs/recipes/trace-viewer-demo.yaml
+++ b/configs/recipes/trace-viewer-demo.yaml
@@ -1,0 +1,16 @@
+id: trace-viewer-demo
+title: JSONL episode recording + playback demo
+purpose: >
+  Demonstrate the per-episode JSONL recording and playback system end to end:
+  record short episodes to a temp directory and replay their trajectories. This
+  is the entry point for inspecting recorded trajectories before using the
+  full figure-generation pipeline.
+runtime: "< 1 min CPU"
+category: visualization
+command: >
+  uv run python scripts/demo_jsonl_recording.py
+configs:
+  - scripts/demo_jsonl_recording.py
+outputs:
+  - (temp JSONL recording files + stdout playback summary)
+docs: docs/recipes/README.md

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -1,0 +1,101 @@
+# Robot SF Recipe Catalog
+
+A **recipe** is a thin, blessed workflow that points at existing configs and
+scripts and hides path complexity for new users. Recipes never add new
+simulation or training logic; they only orchestrate commands that already live
+in the repository.
+
+Issue #5795 introduced the recipe layer as part of the adoption/UX epic.
+
+## Commands
+
+```bash
+uv run robot-sf recipe list            # browse every recipe grouped by category
+uv run robot-sf recipe explain <id>    # show purpose, mapped config, runtime, outputs
+uv run robot-sf recipe run <id>        # execute the recipe's declared command
+```
+
+Add `--dry-run` to `recipe run` to print the command without executing it.
+
+## Recipes
+
+| Category | Recipe | Runtime | One-line purpose |
+| --- | --- | --- | --- |
+| getting-started | [`first-demo`](#first-demo) | < 30s CPU | First headless random-policy rollout |
+| maps | [`custom-svg-map`](#custom-svg-map) | < 30s CPU | Simulate on a bundled custom SVG map |
+| maps | [`map-validation`](#map-validation) | < 1 min CPU | Validate repository SVG maps |
+| planners | [`orca-smoke`](#orca-smoke) | < 1 min CPU | ORCA / social-force planner smoke benchmark |
+| planners | [`planner-comparison`](#planner-comparison) | < 2 min CPU | Compare planners on a sanity scenario |
+| training | [`ppo-smoke`](#ppo-smoke) | < 2 min CPU | PPO training entry point, dry-run |
+| benchmark | [`benchmark-mini-run`](#benchmark-mini-run) | < 2 min CPU | Mini benchmark batch run via `robot_sf_bench` |
+| telemetry | [`telemetry-headless-demo`](#telemetry-headless-demo) | < 30s CPU | Headless occupancy-grid / telemetry demo |
+| visualization | [`trace-viewer-demo`](#trace-viewer-demo) | < 1 min CPU | JSONL episode recording + playback demo |
+| visualization | [`scenario-thumbnail-generation`](#scenario-thumbnail-generation) | < 1 min CPU | Generate scenario thumbnail figures |
+
+For the full, always-current detail of any recipe, run:
+
+```bash
+uv run robot-sf recipe explain <id>
+```
+
+### first-demo
+
+The shortest path to seeing Robot SF run: a headless random-policy rollout on
+the default map. Run this first to confirm the install works.
+
+### custom-svg-map
+
+Load an SVG map into Robot SF and run a short random-policy rollout on it — the
+starting point for bringing your own map into the simulator.
+
+### map-validation
+
+Run the SVG map verifier over the CI-enabled map set to catch structural,
+metadata, and runtime-compatibility problems.
+
+### orca-smoke
+
+A tiny headless benchmark sweep of the social-force (ORCA-style) planner on the
+planner-sanity scenario. Confirms the benchmark runner and aggregation pipeline.
+
+### planner-comparison
+
+Run the one-command smoke benchmark that exercises both simple-policy and
+social-force planners and writes a Markdown comparison table.
+
+### ppo-smoke
+
+Exercise the PPO training entry point on CPU with a tiny smoke config in
+`--dry-run` mode. Confirms the training stack and config loading **without**
+real PPO optimisation. Remove `--dry-run` for actual (longer) training.
+
+> **Dependency:** this recipe requires the `training` extra
+> (`uv sync --extra training`) because `scripts/training/train_ppo.py` imports
+> Stable-Baselines3, which is an optional dependency.
+
+### benchmark-mini-run
+
+Run a small headless batch of episodes through the benchmark CLI
+(`robot_sf_bench run`) on the planner-sanity scenario matrix. No training, no
+checkpoint.
+
+### telemetry-headless-demo
+
+Run the occupancy-grid quickstart, which exercises the observation, sensor, and
+telemetry surfaces headless on CPU.
+
+### trace-viewer-demo
+
+Demonstrate the per-episode JSONL recording and playback system end to end —
+the entry point for inspecting recorded trajectories.
+
+### scenario-thumbnail-generation
+
+Produce thumbnail figures from a bundled golden episodes fixture — the cheapest
+way to exercise the thumbnail / figure pipeline without a fresh campaign.
+
+## Claim boundary
+
+Recipe outputs are local, worktree-local convenience artifacts. They are **not**
+durable benchmark evidence unless promoted separately through the normal
+benchmark provenance path.

--- a/robot_sf/cli.py
+++ b/robot_sf/cli.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 from robot_sf import cli_datasets, cli_envs, cli_models
 from robot_sf.benchmark.doctor import collect_doctor_report, doctor_exit_code
 from robot_sf.examples_cli import examples_cli_main
+from robot_sf.recipes import cli as recipes_cli
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -149,6 +150,9 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Optional page title (defaults to a name derived from the matrix)",
     )
     g_build.set_defaults(gallery_cmd="build")
+
+    # Curated recipe catalog (issue #5795): list / run / explain blessed workflows.
+    recipes_cli.build_subparser(subparsers)
     return parser
 
 
@@ -604,6 +608,7 @@ _HANDLERS = {
     "datasets": _handle_datasets,
     "envs": _handle_envs,
     "gallery": _handle_gallery,
+    "recipe": recipes_cli.handle,
 }
 
 

--- a/robot_sf/recipes/__init__.py
+++ b/robot_sf/recipes/__init__.py
@@ -1,0 +1,31 @@
+"""Curated recipe catalog for the ``robot-sf recipe`` UX layer.
+
+A *recipe* is a thin, blessed workflow that points at EXISTING configs and
+scripts and hides path complexity for new users. Recipes never add new
+simulation or training logic; they only orchestrate commands that already live
+in the repository.
+
+Public surface:
+
+- :class:`Recipe` -- parsed and validated recipe manifest.
+- :func:`load_recipe` -- load one recipe by id.
+- :func:`discover_recipes` -- enumerate the catalog under ``configs/recipes``.
+- :func:`resolve_recipe_config_paths` -- expand every referenced config file.
+
+See :mod:`robot_sf.recipes.catalog` for discovery and
+:mod:`robot_sf.recipes.recipe` for the data model.
+"""
+
+from __future__ import annotations
+
+from robot_sf.recipes.catalog import discover_recipes, load_recipe, recipes_dir
+from robot_sf.recipes.recipe import Recipe, RecipeError, load_recipe_file
+
+__all__ = [
+    "Recipe",
+    "RecipeError",
+    "discover_recipes",
+    "load_recipe",
+    "load_recipe_file",
+    "recipes_dir",
+]

--- a/robot_sf/recipes/catalog.py
+++ b/robot_sf/recipes/catalog.py
@@ -1,0 +1,79 @@
+"""Recipe catalog discovery.
+
+Recipes live as individual YAML manifests under ``configs/recipes/``. This
+module discovers them, deduplicates by id, and provides lookup helpers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from robot_sf.common.artifact_paths import get_repository_root
+from robot_sf.recipes.recipe import Recipe, RecipeError, load_recipe_file
+
+#: Directory holding the recipe manifests, relative to the repository root.
+RECIPES_SUBDIR = Path("configs/recipes")
+
+
+def recipes_dir() -> Path:
+    """Return the absolute path to the recipe catalog directory."""
+    return get_repository_root() / RECIPES_SUBDIR
+
+
+def discover_recipes() -> list[Recipe]:
+    """Discover and validate every recipe manifest in the catalog.
+
+    Returns:
+        list[Recipe]: Recipes sorted by category order then id. The list is
+        never empty for a healthy catalog; an empty catalog raises
+        :class:`RecipeError` because it signals a broken install.
+
+    Raises:
+        RecipeError: If the catalog directory is missing, a manifest is
+            invalid, or two recipes share an id.
+    """
+    catalog = recipes_dir()
+    if not catalog.is_dir():
+        raise RecipeError(f"recipe catalog directory not found: {catalog}")
+    manifests = sorted(catalog.glob("*.yaml"))
+    if not manifests:
+        raise RecipeError(f"recipe catalog is empty: {catalog}")
+
+    by_id: dict[str, Recipe] = {}
+    for manifest in manifests:
+        recipe = load_recipe_file(manifest)
+        if recipe.id in by_id:
+            raise RecipeError(
+                f"duplicate recipe id {recipe.id!r}: {manifest} and "
+                f"{by_id[recipe.id].id}",  # pragma: no cover - defensive msg
+            )
+        by_id[recipe.id] = recipe
+
+    from robot_sf.recipes.recipe import CATEGORIES  # noqa: PLC0415 - avoid cycle at import
+
+    category_index = {name: i for i, name in enumerate(CATEGORIES)}
+
+    def _sort_key(recipe: Recipe) -> tuple[int, str]:
+        return (category_index.get(recipe.category, len(CATEGORIES)), recipe.id)
+
+    return sorted(by_id.values(), key=_sort_key)
+
+
+def load_recipe(recipe_id: str) -> Recipe:
+    """Load a single recipe by id.
+
+    Args:
+        recipe_id: The recipe id (must match a ``configs/recipes/<id>.yaml``).
+
+    Returns:
+        Recipe: The validated recipe.
+
+    Raises:
+        RecipeError: If the recipe id is unknown.
+    """
+    matches = [recipe for recipe in discover_recipes() if recipe.id == recipe_id]
+    if not matches:
+        raise RecipeError(
+            f"unknown recipe id {recipe_id!r}; run `robot-sf recipe list` to see options",
+        )
+    return matches[0]

--- a/robot_sf/recipes/cli.py
+++ b/robot_sf/recipes/cli.py
@@ -13,10 +13,12 @@ no simulation itself: every recipe delegates to an EXISTING config/script.
 
 from __future__ import annotations
 
+import shlex
 import subprocess
 import sys
 from typing import TYPE_CHECKING
 
+from robot_sf.common.artifact_paths import get_repository_root
 from robot_sf.recipes.catalog import discover_recipes, load_recipe
 from robot_sf.recipes.recipe import CATEGORIES, Recipe, RecipeError
 
@@ -112,10 +114,13 @@ def _run_recipe(recipe_id: str, *, dry_run: bool, cwd: Path | None = None) -> in
 
     sys.stdout.write("-" * 60 + "\n")
     sys.stdout.flush()
+    argv = shlex.split(command)
+    if not argv:
+        sys.stderr.write(f"error: recipe {recipe.id!r} has an empty command\n")
+        return 1
     completed = subprocess.run(
-        command,
-        shell=True,
-        cwd=str(cwd) if cwd else None,
+        argv,
+        cwd=str(cwd or get_repository_root()),
         check=False,
     )
     return completed.returncode

--- a/robot_sf/recipes/cli.py
+++ b/robot_sf/recipes/cli.py
@@ -1,0 +1,202 @@
+"""``robot-sf recipe`` subcommand: list / run / explain.
+
+This is the user-facing UX layer described in issue #5795. It discovers the
+recipe catalog under ``configs/recipes/`` and dispatches the three verbs:
+
+- ``recipe list`` -- table of every blessed workflow, grouped by category.
+- ``recipe explain <id>`` -- purpose, mapped config, runtime, and outputs.
+- ``recipe run <id>`` -- execute the recipe's declared command.
+
+The ``run`` verb shells out to the command stored in the manifest. It performs
+no simulation itself: every recipe delegates to an EXISTING config/script.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+from robot_sf.recipes.catalog import discover_recipes, load_recipe
+from robot_sf.recipes.recipe import CATEGORIES, Recipe, RecipeError
+
+if TYPE_CHECKING:  # pragma: no cover - static typing only
+    from collections.abc import Sequence
+    from pathlib import Path
+
+
+def _list_recipes() -> int:
+    """Print every recipe grouped by category.
+
+    Returns:
+        int: Process-style exit code (0 on success, 1 on catalog error).
+    """
+    try:
+        recipes = discover_recipes()
+    except RecipeError as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+
+    category_index = {name: i for i, name in enumerate(CATEGORIES)}
+    grouped: dict[str, list[Recipe]] = {name: [] for name in CATEGORIES}
+    for recipe in recipes:
+        grouped.setdefault(recipe.category, []).append(recipe)
+
+    sys.stdout.write("Robot SF recipe catalog\n\n")
+    sys.stdout.write(
+        "Run a recipe with: uv run robot-sf recipe run <id>\n"
+        "Explain a recipe with: uv run robot-sf recipe explain <id>\n\n",
+    )
+
+    header = f"{'ID':<22} {'TITLE':<40} {'RUNTIME':<16}"
+    for category in CATEGORIES:
+        rows = grouped.get(category, [])
+        if not rows:
+            continue
+        sys.stdout.write(f"## {category}\n\n")
+        sys.stdout.write(header + "\n")
+        sys.stdout.write("-" * len(header) + "\n")
+        for recipe in rows:
+            title = recipe.title if len(recipe.title) <= 40 else recipe.title[:37] + "..."
+            sys.stdout.write(f"{recipe.id:<22} {title:<40} {recipe.runtime:<16}\n")
+        sys.stdout.write("\n")
+
+    # Defensive: surface any recipe whose category slipped past validation.
+    unknown = [r for r in recipes if r.category not in category_index]
+    if unknown:  # pragma: no cover - load_recipe_file rejects these already
+        sys.stdout.write("## other\n\n")
+        for recipe in unknown:
+            sys.stdout.write(f"{recipe.id:<22} {recipe.title}\n")
+    return 0
+
+
+def _explain_recipe(recipe_id: str) -> int:
+    """Print the detailed explanation for one recipe.
+
+    Returns:
+        int: Process-style exit code (0 on success, 1 if the id is unknown).
+    """
+    try:
+        recipe = load_recipe(recipe_id)
+    except RecipeError as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+    sys.stdout.write(recipe.explain_text())
+    return 0
+
+
+def _run_recipe(recipe_id: str, *, dry_run: bool, cwd: Path | None = None) -> int:
+    """Execute the recipe's command via the shell.
+
+    Args:
+        recipe_id: Recipe to run.
+        dry_run: If True, print the command without executing it.
+        cwd: Working directory for execution (defaults to repo root).
+
+    Returns:
+        int: The executed command's exit code, or 1 if the id is unknown / dry-run.
+    """
+    try:
+        recipe = load_recipe(recipe_id)
+    except RecipeError as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+
+    command = recipe.command.strip()
+    sys.stdout.write(f"recipe: {recipe.id} -- {recipe.title}\n")
+    sys.stdout.write(f"runtime: {recipe.runtime}\n")
+    sys.stdout.write(f"command: {command}\n")
+    if dry_run:
+        sys.stdout.write("(dry-run: command not executed)\n")
+        return 0
+
+    sys.stdout.write("-" * 60 + "\n")
+    sys.stdout.flush()
+    completed = subprocess.run(
+        command,
+        shell=True,
+        cwd=str(cwd) if cwd else None,
+        check=False,
+    )
+    return completed.returncode
+
+
+def _add_recipe_verbs(subparsers) -> None:  # type: ignore[no-untyped-def]
+    """Register the list/explain/run verbs on a subparsers object.
+
+    Shared by :func:`build_subparser` (nested under ``robot-sf recipe``) and the
+    standalone :func:`main` so the verb surface stays identical.
+    """
+
+    subparsers.add_parser("list", help="List every recipe grouped by category.")
+
+    explain = subparsers.add_parser("explain", help="Show purpose, config, runtime, outputs.")
+    explain.add_argument("id", help="Recipe id (see `robot-sf recipe list`).")
+
+    run = subparsers.add_parser("run", help="Run a recipe's declared command.")
+    run.add_argument("id", help="Recipe id (see `robot-sf recipe list`).")
+    run.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the command that would run without executing it.",
+    )
+
+
+def build_subparser(subparsers):  # type: ignore[no-untyped-def]
+    """Register the ``recipe`` subcommand on an argparse subparsers object.
+
+    Returns:
+        argparse.ArgumentParser: The created ``recipe`` subparser.
+    """
+    import argparse  # noqa: PLC0415 - stdlib, avoids import-time cost
+
+    recipe_parser = subparsers.add_parser(
+        "recipe",
+        help="Curated recipe catalog (uv run robot-sf recipe list|run|explain)",
+        description=(
+            "Browse and run blessed Robot SF workflows. Recipes point at existing "
+            "configs and hide path complexity. No new simulation logic."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    recipe_sub = recipe_parser.add_subparsers(dest="recipe_cmd", required=True)
+    _add_recipe_verbs(recipe_sub)
+    return recipe_parser
+
+
+def handle(args) -> int:  # type: ignore[no-untyped-def]
+    """Dispatch a parsed ``recipe`` namespace to list/run/explain.
+
+    Returns:
+        int: Process-style exit code from the selected verb.
+    """
+    if args.recipe_cmd == "list":
+        return _list_recipes()
+    if args.recipe_cmd == "explain":
+        return _explain_recipe(args.id)
+    if args.recipe_cmd == "run":
+        return _run_recipe(args.id, dry_run=bool(args.dry_run))
+    sys.stderr.write(f"error: unknown recipe subcommand: {args.recipe_cmd}\n")
+    return 2
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Standalone entry point for direct invocation (``python -m`` style).
+
+    The primary path is the top-level ``robot-sf recipe`` subcommand wired in
+    :mod:`robot_sf.cli`; this entry point mirrors that dispatch so the recipe
+    module is also usable on its own, e.g. ``python -m robot_sf.recipes.cli list``.
+
+    Returns:
+        int: Process-style exit code from the selected verb.
+    """
+    import argparse  # noqa: PLC0415 - stdlib
+
+    parser = argparse.ArgumentParser(
+        prog="robot-sf recipe",
+        description="Curated Robot SF recipe catalog.",
+    )
+    sub = parser.add_subparsers(dest="recipe_cmd", required=True)
+    _add_recipe_verbs(sub)
+    args = parser.parse_args(argv)
+    return handle(args)

--- a/robot_sf/recipes/recipe.py
+++ b/robot_sf/recipes/recipe.py
@@ -147,12 +147,24 @@ def _resolve_repo_relative(ref: str, recipe_id: str, field_name: str) -> Path:
     Returns:
         Path: Absolute resolved path.
     """
-    cleaned = ref.strip().lstrip("./").lstrip("/")
+    cleaned = ref.strip()
+    while cleaned.startswith("./"):
+        cleaned = cleaned[2:]
     if not cleaned:
         raise RecipeError(
             f"recipe {recipe_id!r}: field {field_name!r} contains an empty path",
         )
-    return (get_repository_root() / cleaned).resolve()
+    if Path(cleaned).is_absolute():
+        raise RecipeError(f"recipe {recipe_id!r}: field {field_name!r} must be repository-relative")
+    root = get_repository_root().resolve()
+    resolved = (root / cleaned).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise RecipeError(
+            f"recipe {recipe_id!r}: field {field_name!r} escapes repository root: {ref!r}"
+        ) from exc
+    return resolved
 
 
 def _require_string_list(
@@ -268,7 +280,7 @@ def load_recipe_file(path: Path) -> Recipe:
         docs_ref = _require_str(docs_ref_raw, "docs", recipe_id)
         docs_path = _resolve_repo_relative(docs_ref, recipe_id, "docs")
 
-    return Recipe(
+    recipe = Recipe(
         id=recipe_id,
         title=title,
         purpose=purpose,
@@ -281,6 +293,12 @@ def load_recipe_file(path: Path) -> Recipe:
         config_refs=tuple(config_refs),
         docs_ref=docs_ref,
     )
+    config_errors = validate_configs_loadable(recipe.config_paths)
+    if config_errors:
+        raise RecipeError(f"recipe {recipe_id!r}: " + "; ".join(config_errors))
+    if recipe.docs_path is not None and not recipe.docs_path.is_file():
+        raise RecipeError(f"recipe {recipe_id!r}: missing docs: {recipe.docs_path}")
+    return recipe
 
 
 def validate_configs_loadable(config_paths: Sequence[Path]) -> list[str]:

--- a/robot_sf/recipes/recipe.py
+++ b/robot_sf/recipes/recipe.py
@@ -1,0 +1,311 @@
+"""Recipe data model, loader, and validation.
+
+A recipe manifest is a small YAML file living under ``configs/recipes/``. It
+describes a blessed, user-facing workflow that delegates to EXISTING configs
+and scripts. The recipe layer intentionally adds no simulation or training
+logic: it only resolves paths, validates that the referenced inputs exist and
+are loadable, and dispatches ``run`` to the declared command.
+
+Manifest schema (all fields required unless noted):
+
+```yaml
+id: ppo-smoke                  # unique, kebab-case, matches filename
+title: PPO baseline smoke test  # one-line human label
+purpose: >                      # 1-3 sentence plain-language summary
+  Exercise the PPO training pipeline on CPU with a tiny smoke config so a
+  new contributor can confirm the training stack is wired up correctly.
+runtime: "< 2 min CPU"          # honest wall-clock estimate
+category: training              # grouping for `recipe list` (see CATEGORIES)
+command: >                      # shell command executed by `recipe run`.
+  uv run python scripts/training/train_ppo.py
+  --config configs/training/ppo/issue_4017_unconstrained_smoke.yaml --dry-run
+configs:                        # repo-relative files the recipe depends on
+  - configs/training/ppo/issue_4017_unconstrained_smoke.yaml
+outputs:                        # artifacts produced (informational; may not exist)
+  - output/recipes/ppo-smoke/
+docs: docs/recipes/README.md    # optional, repo-relative doc anchor
+```
+
+The ``configs`` list is the loadability contract: :func:`load_recipe` resolves
+each entry against the repository root and :func:`Recipe.config_paths` returns
+the absolute paths. The catalog test asserts every referenced config exists and
+parses as YAML.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+from robot_sf.common.artifact_paths import get_repository_root
+
+if TYPE_CHECKING:  # pragma: no cover - static typing only
+    from collections.abc import Sequence
+
+#: Recipe categories used to group ``recipe list`` output. Order is presentation order.
+CATEGORIES: tuple[str, ...] = (
+    "getting-started",
+    "maps",
+    "planners",
+    "training",
+    "benchmark",
+    "telemetry",
+    "visualization",
+)
+
+
+class RecipeError(ValueError):
+    """Raised when a recipe manifest is missing fields or fails validation."""
+
+
+def _require_str(value: object, field_name: str, recipe_id: str) -> str:
+    """Return a non-empty stripped string field or raise a RecipeError."""
+    if not isinstance(value, str):
+        raise RecipeError(
+            f"recipe {recipe_id!r}: field {field_name!r} must be a non-empty string",
+        )
+    text = value.strip()
+    if not text:
+        raise RecipeError(
+            f"recipe {recipe_id!r}: field {field_name!r} must be a non-empty string",
+        )
+    return text
+
+
+@dataclass(frozen=True)
+class Recipe:
+    """A validated recipe manifest.
+
+    Attributes mirror the YAML schema documented at the top of this module.
+    ``config_paths`` and ``docs_path`` are resolved absolute paths (or ``None``
+    for an unset ``docs`` field).
+    """
+
+    id: str
+    title: str
+    purpose: str
+    runtime: str
+    category: str
+    command: str
+    config_paths: tuple[Path, ...]
+    outputs: tuple[str, ...] = ()
+    docs_path: Path | None = None
+    #: Repo-relative config strings exactly as written in the manifest.
+    config_refs: tuple[str, ...] = field(default=(), repr=False)
+    #: Repo-relative docs string exactly as written in the manifest.
+    docs_ref: str | None = None
+
+    def explain_text(self) -> str:
+        """Return the multi-line ``recipe explain`` text for this recipe."""
+        lines = [
+            f"# {self.id}",
+            f"title:    {self.title}",
+            f"category: {self.category}",
+            f"runtime:  {self.runtime}",
+            "",
+            "purpose:",
+            _indent(self.purpose),
+            "",
+            "command:",
+            _indent(self.command),
+            "",
+            "configs (loadability contract):",
+        ]
+        if self.config_refs:
+            lines.extend(f"  - {ref}" for ref in self.config_refs)
+        else:
+            lines.append("  (none -- this recipe uses bundled defaults)")
+        if self.outputs:
+            lines.append("")
+            lines.append("outputs:")
+            lines.extend(f"  - {item}" for item in self.outputs)
+        if self.docs_ref:
+            lines.append("")
+            lines.append(f"docs: {self.docs_ref}")
+        return "\n".join(lines) + "\n"
+
+
+def _indent(text: str, prefix: str = "  ") -> str:
+    """Indent every line of ``text`` with ``prefix``.
+
+    Returns:
+        str: The indented text (empty lines left blank).
+    """
+    return "\n".join(f"{prefix}{line}" if line else line for line in text.splitlines())
+
+
+def _resolve_repo_relative(ref: str, recipe_id: str, field_name: str) -> Path:
+    """Resolve a repo-relative path reference against the repository root.
+
+    Leading ``./`` is tolerated. The path is returned absolute but its
+    existence is NOT checked here; callers (validators/tests) decide whether
+    existence is required.
+
+    Returns:
+        Path: Absolute resolved path.
+    """
+    cleaned = ref.strip().lstrip("./").lstrip("/")
+    if not cleaned:
+        raise RecipeError(
+            f"recipe {recipe_id!r}: field {field_name!r} contains an empty path",
+        )
+    return (get_repository_root() / cleaned).resolve()
+
+
+def _require_string_list(
+    data: dict[str, object],
+    field_name: str,
+    recipe_id: str,
+) -> list[str]:
+    """Validate and return a list field of non-empty strings.
+
+    Args:
+        data: The parsed manifest mapping.
+        field_name: The manifest key holding the list.
+        recipe_id: Recipe id, used in error messages.
+
+    Returns:
+        list[str]: Stripped, non-empty string entries.
+
+    Raises:
+        RecipeError: If the field is missing, not a list, or contains bad entries.
+    """
+    raw = data.get(field_name, [])
+    if not isinstance(raw, list):
+        raise RecipeError(f"recipe {recipe_id!r}: field {field_name!r} must be a list")
+    out: list[str] = []
+    for entry in raw:
+        if not isinstance(entry, str) or not entry.strip():
+            raise RecipeError(
+                f"recipe {recipe_id!r}: every {field_name!r} entry must be a non-empty string",
+            )
+        out.append(entry.strip())
+    return out
+
+
+def _validate_id(recipe_id: str, path: Path) -> None:
+    """Ensure the recipe id matches its filename and is kebab-case.
+
+    Args:
+        recipe_id: The id parsed from the manifest.
+        path: The manifest file path (``path.stem`` is the expected id).
+
+    Raises:
+        RecipeError: If the id is malformed or mismatches the filename.
+    """
+    if recipe_id != path.stem:
+        raise RecipeError(
+            f"recipe file {path.name}: id {recipe_id!r} must match filename {path.stem!r}",
+        )
+    if not all(ch.isalnum() or ch in "-_" for ch in recipe_id):
+        raise RecipeError(
+            f"recipe {recipe_id!r}: id must be kebab-case (alnum, '-', '_')",
+        )
+
+
+def _parse_yaml_manifest(path: Path) -> dict[str, object]:
+    """Read and parse a recipe manifest, returning the top-level mapping.
+
+    Args:
+        path: Absolute path to a recipe YAML file.
+
+    Returns:
+        dict[str, object]: The parsed manifest.
+
+    Raises:
+        RecipeError: If the file is missing, invalid YAML, or not a mapping.
+    """
+    raw_text = path.read_text(encoding="utf-8")
+    try:
+        data = yaml.safe_load(raw_text)
+    except yaml.YAMLError as exc:
+        raise RecipeError(f"recipe file {path}: invalid YAML: {exc}") from exc
+    if not isinstance(data, dict):
+        raise RecipeError(f"recipe file {path}: top level must be a mapping")
+    return data
+
+
+def load_recipe_file(path: Path) -> Recipe:
+    """Load and validate a single recipe manifest from ``path``.
+
+    Args:
+        path: Absolute path to a recipe YAML file.
+
+    Returns:
+        Recipe: The validated recipe.
+
+    Raises:
+        RecipeError: If the manifest is malformed or fails schema validation.
+    """
+    path = Path(path).resolve()
+    data = _parse_yaml_manifest(path)
+
+    recipe_id = _require_str(data.get("id"), "id", path.stem)
+    _validate_id(recipe_id, path)
+
+    title = _require_str(data.get("title"), "title", recipe_id)
+    purpose = _require_str(data.get("purpose"), "purpose", recipe_id)
+    runtime = _require_str(data.get("runtime"), "runtime", recipe_id)
+    category = _require_str(data.get("category"), "category", recipe_id)
+    if category not in CATEGORIES:
+        raise RecipeError(
+            f"recipe {recipe_id!r}: category {category!r} not in {CATEGORIES}",
+        )
+    command = _require_str(data.get("command"), "command", recipe_id)
+
+    config_refs = _require_string_list(data, "configs", recipe_id)
+    config_paths = tuple(_resolve_repo_relative(ref, recipe_id, "configs") for ref in config_refs)
+
+    outputs = _require_string_list(data, "outputs", recipe_id)
+
+    docs_ref_raw = data.get("docs")
+    docs_ref: str | None = None
+    docs_path: Path | None = None
+    if docs_ref_raw is not None:
+        docs_ref = _require_str(docs_ref_raw, "docs", recipe_id)
+        docs_path = _resolve_repo_relative(docs_ref, recipe_id, "docs")
+
+    return Recipe(
+        id=recipe_id,
+        title=title,
+        purpose=purpose,
+        runtime=runtime,
+        category=category,
+        command=command,
+        config_paths=config_paths,
+        outputs=tuple(outputs),
+        docs_path=docs_path,
+        config_refs=tuple(config_refs),
+        docs_ref=docs_ref,
+    )
+
+
+def validate_configs_loadable(config_paths: Sequence[Path]) -> list[str]:
+    """Return a list of human-readable errors for configs that fail to load.
+
+    A "config" is considered loadable if it exists and parses as YAML. Binary
+    or non-YAML referenced files (e.g. SVG maps) are checked for existence only;
+    YAML files (``.yaml``/``.yml``) are parsed to catch corrupt configs early.
+
+    Args:
+        config_paths: Absolute paths to referenced recipe inputs.
+
+    Returns:
+        list[str]: Empty if all loadable; otherwise one message per failure.
+    """
+    errors: list[str] = []
+    for path in config_paths:
+        path = Path(path)
+        if not path.exists():
+            errors.append(f"missing: {path}")
+            continue
+        if path.suffix.lower() in {".yaml", ".yml"}:
+            try:
+                with path.open(encoding="utf-8") as handle:
+                    yaml.safe_load(handle)
+            except yaml.YAMLError as exc:
+                errors.append(f"unloadable YAML {path}: {exc}")
+    return errors

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,0 +1,184 @@
+"""Tests for the curated recipe catalog (``robot-sf recipe``; issue #5795).
+
+These tests enforce the issue's acceptance criteria:
+
+- ``recipe list`` / ``recipe run`` / ``recipe explain`` all work.
+- Every shipped recipe id resolves to a real, loadable config.
+- The 10 named blessed workflows from issue #5795 are present.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.cli import main
+from robot_sf.recipes import discover_recipes, load_recipe
+from robot_sf.recipes.catalog import recipes_dir
+from robot_sf.recipes.cli import build_subparser, handle
+from robot_sf.recipes.cli import main as recipes_main
+from robot_sf.recipes.recipe import CATEGORIES, RecipeError, validate_configs_loadable
+
+# The ten blessed workflows named in issue #5795.
+EXPECTED_RECIPE_IDS: frozenset[str] = frozenset(
+    {
+        "first-demo",
+        "custom-svg-map",
+        "orca-smoke",
+        "ppo-smoke",
+        "planner-comparison",
+        "benchmark-mini-run",
+        "telemetry-headless-demo",
+        "trace-viewer-demo",
+        "map-validation",
+        "scenario-thumbnail-generation",
+    }
+)
+
+
+def test_catalog_directory_exists() -> None:
+    """The recipe catalog lives under configs/recipes/."""
+    catalog = recipes_dir()
+    assert catalog.is_dir(), f"recipe catalog missing: {catalog}"
+    assert catalog.name == "recipes"
+
+
+def test_every_named_recipe_is_present() -> None:
+    """All ten workflows named in issue #5795 ship in the catalog."""
+    recipes = discover_recipes()
+    ids = {recipe.id for recipe in recipes}
+    assert EXPECTED_RECIPE_IDS <= ids, f"missing recipes: {EXPECTED_RECIPE_IDS - ids}"
+
+
+def test_recipe_ids_match_filenames() -> None:
+    """Each recipe id equals its filename stem so `run <id>` is unambiguous."""
+    for manifest in sorted(recipes_dir().glob("*.yaml")):
+        recipe = load_recipe(manifest.stem)
+        assert recipe.id == manifest.stem
+
+
+def test_every_recipe_resolves_to_real_loadable_config() -> None:
+    """Acceptance criterion: every recipe id resolves to a real, loadable config.
+
+    For recipes with no YAML config (e.g. quickstart examples) the referenced
+    script/asset file must at least exist.
+    """
+    for recipe in discover_recipes():
+        errors = validate_configs_loadable(recipe.config_paths)
+        assert not errors, f"recipe {recipe.id!r} has unloadable configs: {errors}"
+        assert recipe.command.strip(), f"recipe {recipe.id!r} has an empty command"
+
+
+def test_every_recipe_category_is_known() -> None:
+    """Every recipe must use a category from the canonical CATEGORIES tuple."""
+    for recipe in discover_recipes():
+        assert recipe.category in CATEGORIES, (
+            f"recipe {recipe.id!r} has unknown category {recipe.category!r}"
+        )
+
+
+def test_recipe_list_outputs_all_ids(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`robot-sf recipe list` prints every recipe id and a runtime estimate."""
+    rc = main(["recipe", "list"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Robot SF recipe catalog" in out
+    for recipe_id in EXPECTED_RECIPE_IDS:
+        assert recipe_id in out, f"`recipe list` missing id {recipe_id!r}"
+    assert "RUNTIME" in out
+
+
+def test_recipe_explain_prints_purpose_config_runtime_outputs(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`recipe explain <id>` shows purpose, config, runtime, and outputs."""
+    rc = main(["recipe", "explain", "ppo-smoke"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "# ppo-smoke" in out
+    assert "purpose:" in out
+    assert "runtime:" in out
+    assert "command:" in out
+    assert "configs (loadability contract):" in out
+    # The config this recipe maps to must be named in the explanation.
+    assert "issue_4017_unconstrained_smoke.yaml" in out
+
+
+def test_recipe_explain_unknown_id_errors(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unknown recipe id exits non-zero with a helpful message."""
+    rc = main(["recipe", "explain", "does-not-exist"])
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "does-not-exist" in err
+
+
+def test_recipe_run_dry_run_prints_command_without_executing(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`recipe run <id> --dry-run` prints the command but does not execute it."""
+    rc = main(["recipe", "run", "first-demo", "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "first-demo" in out
+    assert "examples/quickstart/01_basic_robot.py" in out
+    assert "dry-run: command not executed" in out
+
+
+def test_standalone_recipes_cli_list(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The recipe module is also usable on its own via its own entry point."""
+    rc = recipes_main(["list"])
+    assert rc == 0
+    assert "Robot SF recipe catalog" in capsys.readouterr().out
+
+
+def test_load_recipe_unknown_raises() -> None:
+    """Loading an unknown id raises a clear RecipeError."""
+    with pytest.raises(RecipeError, match="unknown recipe id"):
+        load_recipe("not-a-recipe")
+
+
+def test_build_subparser_registers_list_run_explain() -> None:
+    """The recipe subparser exposes the three required verbs."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd")
+    build_subparser(sub)
+    # Parsing each verb must succeed and record the recipe_cmd.
+    for verb, extra in [("list", []), ("explain", ["ppo-smoke"]), ("run", ["ppo-smoke"])]:
+        ns = parser.parse_args(["recipe", verb, *extra])
+        assert ns.cmd == "recipe"
+        assert ns.recipe_cmd == verb
+
+
+def test_handle_dispatches_subcommands() -> None:
+    """The handle() dispatcher routes to list/explain/run correctly."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd")
+    build_subparser(sub)
+    ns = parser.parse_args(["recipe", "run", "ppo-smoke", "--dry-run"])
+    # Dry-run must return 0 and not touch the filesystem.
+    assert handle(ns) == 0
+
+
+def test_recipe_with_no_configs_uses_bundled_defaults(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A recipe may declare no config refs (bundled-default workflow)."""
+    # first-demo references only the example script; explain still works.
+    rc = main(["recipe", "explain", "first-demo"])
+    assert rc == 0
+    assert "01_basic_robot.py" in capsys.readouterr().out
+
+
+def test_recipes_count_is_at_least_ten() -> None:
+    """Issue #5795 asks for 8-12 blessed workflows; we ship at least 10."""
+    recipes = discover_recipes()
+    assert len(recipes) >= 10

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -9,6 +9,9 @@ These tests enforce the issue's acceptance criteria:
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
 import pytest
 
 from robot_sf.cli import main
@@ -16,7 +19,15 @@ from robot_sf.recipes import discover_recipes, load_recipe
 from robot_sf.recipes.catalog import recipes_dir
 from robot_sf.recipes.cli import build_subparser, handle
 from robot_sf.recipes.cli import main as recipes_main
-from robot_sf.recipes.recipe import CATEGORIES, RecipeError, validate_configs_loadable
+from robot_sf.recipes.recipe import (
+    CATEGORIES,
+    RecipeError,
+    load_recipe_file,
+    validate_configs_loadable,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # The ten blessed workflows named in issue #5795.
 EXPECTED_RECIPE_IDS: frozenset[str] = frozenset(
@@ -102,7 +113,7 @@ def test_recipe_explain_prints_purpose_config_runtime_outputs(
     assert "command:" in out
     assert "configs (loadability contract):" in out
     # The config this recipe maps to must be named in the explanation.
-    assert "issue_4017_unconstrained_smoke.yaml" in out
+    assert "issue_4018_fixed_density_smoke.yaml" in out
 
 
 def test_recipe_explain_unknown_id_errors(
@@ -125,6 +136,79 @@ def test_recipe_run_dry_run_prints_command_without_executing(
     assert "first-demo" in out
     assert "examples/quickstart/01_basic_robot.py" in out
     assert "dry-run: command not executed" in out
+
+
+def test_recipe_run_is_shell_free_and_defaults_to_repository_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Installed CLI invocations work outside the checkout without a shell."""
+    captured: dict[str, object] = {}
+
+    def fake_run(argv, *, cwd, check):
+        captured.update(argv=argv, cwd=cwd, check=check)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("robot_sf.recipes.cli.subprocess.run", fake_run)
+
+    assert main(["recipe", "run", "first-demo"]) == 0
+    assert captured["argv"] == [
+        "uv",
+        "run",
+        "python",
+        "examples/quickstart/01_basic_robot.py",
+    ]
+    assert captured["cwd"] == str(recipes_dir().parents[1])
+    assert captured["check"] is False
+
+
+def test_recipe_manifest_rejects_repository_escape(tmp_path: Path) -> None:
+    """Manifest references may not traverse outside the repository."""
+    manifest = tmp_path / "escape.yaml"
+    manifest.write_text(
+        "\n".join(
+            [
+                "id: escape",
+                "title: Escape",
+                "purpose: Reject traversal.",
+                'runtime: "< 1s CPU"',
+                "category: getting-started",
+                "command: uv run python example.py",
+                "configs:",
+                "  - ../outside.yaml",
+                "outputs: []",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RecipeError, match="escapes repository root"):
+        load_recipe_file(manifest)
+
+
+def test_recipe_manifest_rejects_missing_docs(tmp_path: Path) -> None:
+    """Catalog discovery fails closed when its user-facing docs target is missing."""
+    manifest = tmp_path / "missing-docs.yaml"
+    manifest.write_text(
+        "\n".join(
+            [
+                "id: missing-docs",
+                "title: Missing docs",
+                "purpose: Reject missing docs.",
+                'runtime: "< 1s CPU"',
+                "category: getting-started",
+                "command: uv run python example.py",
+                "configs: []",
+                "outputs: []",
+                "docs: docs/definitely-missing-recipe-doc.md",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RecipeError, match="missing docs"):
+        load_recipe_file(manifest)
 
 
 def test_standalone_recipes_cli_list(


### PR DESCRIPTION
## What

Implements a thin recipe-catalog user experience for issue #5795:
`robot-sf recipe list|run|explain` points at existing configurations and scripts
so new users do not need to discover repository paths first.

No new simulation or training algorithm is added. Each recipe delegates to an
existing entry point.

```bash
uv run robot-sf recipe list
uv run robot-sf recipe explain ppo-smoke
uv run robot-sf recipe run ppo-smoke
uv run robot-sf recipe run ppo-smoke --dry-run
```

## Included workflows

| Recipe | Existing entry point |
| --- | --- |
| `first-demo` | `examples/quickstart/01_basic_robot.py` |
| `custom-svg-map` | `examples/quickstart/03_custom_map.py` |
| `map-validation` | `scripts/validation/verify_maps.py --scope ci` |
| `orca-smoke` | `scripts/demo/run_robot_sf_smoke.py` |
| `planner-comparison` | `scripts/demo/run_robot_sf_smoke.py` |
| `ppo-smoke` | `scripts/training/train_ppo.py --config configs/training/ppo/ablations/issue_4018_fixed_density_smoke.yaml --dry-run` |
| `telemetry-headless-demo` | existing telemetry demo |
| `trace-viewer-demo` | existing trace playback demo |
| `scenario-thumbnail-generation` | existing thumbnail generator |
| `benchmark-mini-run` | existing benchmark runner |

## Acceptance evidence

All 10 named recipes have now been run end-to-end in headless CPU mode within
their stated budgets. The first nine were recorded in the original validation;
the batch gate additionally ran:

```bash
DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy \
  uv run robot-sf recipe run ppo-smoke
```

Result: exit 0 in 7.26 seconds, with
`Dry-run completed for policy_id=issue_4018_fixed_density_smoke`.

Focused validation after gate hardening:

```bash
uv run ruff check robot_sf/recipes/cli.py robot_sf/recipes/recipe.py tests/test_recipes.py
DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy \
  uv run pytest tests/test_recipes.py tests/test_cli_doctor.py -q
```

Result: Ruff passed; 26 tests passed.

## Gate hardening

- Rebased onto current `main` while preserving both the existing top-level CLI
  commands and the new recipe command.
- Recipe execution defaults to the repository root and passes a tokenized
  argument vector to `subprocess`, without a shell.
- Recipe manifests reject absolute or repository-escaping references.
- Catalog loading fails closed for missing or unloadable configuration and
  documentation references.
- `ppo-smoke` now uses an existing current-schema smoke configuration; the
  stale #4017 configuration failed current config loading and is no longer
  presented as an executable recipe.
- Regression tests cover execution location, shell-free invocation, path
  traversal, missing documentation, and the current PPO recipe mapping.

This is workflow/tooling work, not benchmark or paper evidence. It creates no
new evidence claim and introduces no unused provenance field.

Closes #5795
