### PR TITLE
Issue #5797: robot-sf models/datasets list · verify · download/prepare (cheap-lane worker)

### DIFF
--- a/robot_sf/cli.py
+++ b/robot_sf/cli.py
@@ -3,16 +3,21 @@
 Thin, user-facing entry point for everyday Robot SF workflows. The
 ``doctor`` subcommand wraps the existing runtime diagnostics in
 :mod:`robot_sf.benchmark.doctor` behind one obvious command, adding
-friendly, remedy-bearing output for beginners.
+friendly, remedy-bearing output for beginners. The ``models`` and
+``datasets`` subcommands wrap the existing model registry and external-data
+provenance/checksum machinery (issue #5797) behind list/verify/download and
+list/verify/prepare commands.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from robot_sf import cli_datasets, cli_models
 from robot_sf.benchmark.doctor import collect_doctor_report, doctor_exit_code
 
 if TYPE_CHECKING:  # pragma: no cover - static typing only
@@ -52,6 +57,8 @@ def _build_parser() -> argparse.ArgumentParser:
         default=False,
         help="Skip the minimal reset/step environment smoke check",
     )
+    _add_models_subparser(sub)
+    _add_datasets_subparser(sub)
     return parser
 
 
@@ -76,8 +83,327 @@ def _handle_doctor(args: argparse.Namespace) -> int:
     return doctor_exit_code(report)
 
 
+def _add_models_subparser(sub: argparse._SubParsersAction) -> None:
+    """Register the ``robot-sf models`` subcommand tree."""
+    models = sub.add_parser(
+        "models",
+        help="List, download, and verify registered model artifacts (uv run robot-sf models ...)",
+    )
+    models_sub = models.add_subparsers(dest="models_cmd", required=True)
+
+    verify = models_sub.add_parser("verify", help="Verify each model artifact's pinned checksum.")
+    verify.add_argument(
+        "model_id",
+        nargs="*",
+        help="Optional model ids to verify (default: all registered models).",
+    )
+    verify.add_argument(
+        "--format",
+        choices=("friendly", "json"),
+        default="friendly",
+        help="Output format (default: friendly).",
+    )
+    verify.add_argument(
+        "--registry",
+        type=Path,
+        default=None,
+        help="Path to model/registry.yaml (default: the bundled registry).",
+    )
+
+    lst = models_sub.add_parser(
+        "list",
+        help="List registered models and local artifact status.",
+    )
+    lst.add_argument(
+        "--format",
+        choices=("friendly", "json"),
+        default="friendly",
+        help="Output format (default: friendly).",
+    )
+    lst.add_argument(
+        "--registry",
+        type=Path,
+        default=None,
+        help="Path to model/registry.yaml (default: the bundled registry).",
+    )
+
+    download = models_sub.add_parser(
+        "download",
+        help="Download a model artifact through the registry download path.",
+    )
+    download.add_argument("model_id", help="Registry model id to download.")
+    download.add_argument(
+        "--registry",
+        type=Path,
+        default=None,
+        help="Path to model/registry.yaml (default: the bundled registry).",
+    )
+    download.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=None,
+        help="Cache directory for downloaded artifacts (default: output/model_cache).",
+    )
+    download.add_argument(
+        "--format",
+        choices=("friendly", "json"),
+        default="friendly",
+        help="Output format (default: friendly).",
+    )
+
+
+def _add_datasets_subparser(sub: argparse._SubParsersAction) -> None:
+    """Register the ``robot-sf datasets`` subcommand tree."""
+    datasets = sub.add_parser(
+        "datasets",
+        help="List, prepare, and verify external datasets (uv run robot-sf datasets ...)",
+    )
+    datasets_sub = datasets.add_subparsers(dest="datasets_cmd", required=True)
+
+    dlist = datasets_sub.add_parser("list", help="List registered datasets and local status.")
+    dlist.add_argument(
+        "--format",
+        choices=("friendly", "json"),
+        default="friendly",
+        help="Output format (default: friendly).",
+    )
+
+    dverify = datasets_sub.add_parser(
+        "verify", help="Verify each dataset's local layout and pinned checksum."
+    )
+    dverify.add_argument(
+        "asset_id",
+        nargs="*",
+        help="Optional dataset asset ids to verify (default: all registered datasets).",
+    )
+    dverify.add_argument(
+        "--format",
+        choices=("friendly", "json"),
+        default="friendly",
+        help="Output format (default: friendly).",
+    )
+
+    dprepare = datasets_sub.add_parser(
+        "prepare",
+        help="Print acquisition instructions and verify local layout WITHOUT downloading.",
+    )
+    dprepare.add_argument("asset_id", help="Dataset asset id to prepare.")
+    dprepare.add_argument(
+        "--source",
+        type=Path,
+        default=None,
+        help="Override the local source path to verify (default: the resolved asset path).",
+    )
+    dprepare.add_argument(
+        "--format",
+        choices=("friendly", "json"),
+        default="friendly",
+        help="Output format (default: friendly).",
+    )
+
+
+def _handle_models(args: argparse.Namespace) -> int:
+    """Dispatch the ``robot-sf models`` subcommand.
+
+    Returns:
+        int: Process-style exit code (0 success, 2 verify failure, 1 download error).
+    """
+    cmd = args.models_cmd
+    if cmd == "list":
+        rows = cli_models.list_models(registry_path=args.registry)
+        if args.format == "json":
+            sys.stdout.write(json.dumps(rows, indent=2) + "\n")
+        else:
+            _format_models_list(rows)
+        return 0
+    if cmd == "verify":
+        report = cli_models.verify_models(
+            registry_path=args.registry, model_ids=args.model_id or None
+        )
+        if args.format == "json":
+            sys.stdout.write(json.dumps(report, indent=2) + "\n")
+        else:
+            _format_models_verify(report)
+        # Non-zero when at least one pinned checksum failed to pass.
+        return 0 if report["ok"] else 2
+    if cmd == "download":
+        try:
+            report = cli_models.download_model(
+                args.model_id,
+                registry_path=args.registry,
+                cache_dir=args.cache_dir,
+            )
+        except Exception as exc:  # noqa: BLE001 - surface as a clean CLI error
+            sys.stderr.write(f"error: could not download model '{args.model_id}': {exc}\n")
+            return 1
+        if args.format == "json":
+            sys.stdout.write(json.dumps(report, indent=2) + "\n")
+        else:
+            sys.stdout.write(f"Resolved model '{report['model_id']}' to: {report['path']}\n")
+        return 0
+    parser = _build_parser()  # pragma: no cover - defensive
+    parser.error(f"unknown models command: {cmd}")
+    return 2
+
+
+def _format_models_list(rows: list[dict]) -> None:
+    """Print a friendly table for ``models list``."""
+    if not rows:
+        sys.stdout.write("No models registered.\n")
+        return
+    sys.stdout.write(f"{len(rows)} model(s) registered:\n\n")
+    for row in rows:
+        present = "present" if row["present_locally"] else "absent"
+        tags = ", ".join(row["tags"]) if row["tags"] else "-"
+        boundary = row["claim_boundary"] or "-"
+        sys.stdout.write(f"- {row['model_id']}  [{present}]\n")
+        sys.stdout.write(f"    name: {row['display_name']}\n")
+        sys.stdout.write(f"    tags: {tags}\n")
+        sys.stdout.write(f"    claim boundary: {boundary}\n")
+        if row["local_path"]:
+            sys.stdout.write(f"    local path: {row['local_path']}\n")
+        if row["local_only"]:
+            sys.stdout.write("    local-only: unavailable unless staged on this machine\n")
+        sys.stdout.write("\n")
+
+
+def _format_models_verify(report: dict) -> None:
+    """Print a friendly per-artifact checksum report for ``models verify``."""
+    sys.stdout.write(
+        f"Model artifact verification: {report['passed']}/{report['pinned_checksums']} "
+        f"pinned checksums passed ({report['checked']} checked).\n\n"
+    )
+    for result in report["results"]:
+        sys.stdout.write(f"- {result['model_id']}: {result['status']}\n")
+        if result.get("display_name"):
+            sys.stdout.write(f"    name: {result['display_name']}\n")
+        if result["pinned"]:
+            sys.stdout.write(f"    expected sha256: {result['expected_sha256']}\n")
+            if result.get("observed_sha256"):
+                sys.stdout.write(f"    observed sha256: {result['observed_sha256']}\n")
+        sys.stdout.write("\n")
+    if report["ok"]:
+        sys.stdout.write("All pinned checksums verified.\n")
+    else:
+        sys.stdout.write(
+            "One or more pinned checksums failed or are missing. Run "
+            "`uv run robot-sf models download <id>` to restore the artifact.\n"
+        )
+
+
+def _handle_datasets(args: argparse.Namespace) -> int:
+    """Dispatch the ``robot-sf datasets`` subcommand.
+
+    Returns:
+        int: Process-style exit code (0 success, 2 verify/layout failure).
+    """
+    cmd = args.datasets_cmd
+    if cmd == "list":
+        rows = cli_datasets.list_datasets()
+        if args.format == "json":
+            sys.stdout.write(json.dumps(rows, indent=2) + "\n")
+        else:
+            _format_datasets_list(rows)
+        return 0
+    if cmd == "verify":
+        report = cli_datasets.verify_datasets(asset_ids=args.asset_id or None)
+        if args.format == "json":
+            sys.stdout.write(json.dumps(report, indent=2) + "\n")
+        else:
+            _format_datasets_verify(report)
+        return 0 if report["ok"] else 2
+    if cmd == "prepare":
+        payload = cli_datasets.prepare_dataset(args.asset_id, source_path=args.source)
+        if args.format == "json":
+            sys.stdout.write(json.dumps(payload, indent=2) + "\n")
+        else:
+            _format_datasets_prepare(payload)
+        return 0 if payload["local_layout"]["ok"] else 2
+    parser = _build_parser()  # pragma: no cover - defensive
+    parser.error(f"unknown datasets command: {cmd}")
+    return 2
+
+
+def _format_datasets_list(rows: list[dict]) -> None:
+    """Print a friendly table for ``datasets list``."""
+    if not rows:
+        sys.stdout.write("No datasets registered.\n")
+        return
+    sys.stdout.write(f"{len(rows)} dataset(s) registered:\n\n")
+    for row in rows:
+        download = "auto-download" if row["auto_download_allowed"] else "manual/license-gated"
+        sys.stdout.write(f"- {row['asset_id']}  [{row['status']}]\n")
+        sys.stdout.write(f"    title: {row['title']}\n")
+        sys.stdout.write(f"    source: {row['source_url']}\n")
+        sys.stdout.write(f"    license: {row['license_note']}\n")
+        sys.stdout.write(f"    acquisition: {download}\n")
+        sys.stdout.write("\n")
+
+
+def _format_datasets_verify(report: dict) -> None:
+    """Print a friendly per-artifact layout+checksum report for ``datasets verify``."""
+    sys.stdout.write(
+        f"Dataset verification: {report['passed']}/{report['pinned_checksums']} "
+        f"pinned checksums passed ({report['checked']} checked).\n\n"
+    )
+    for result in report["results"]:
+        layout_ok = "yes" if result["layout_ok"] else "no"
+        sys.stdout.write(
+            f"- {result['asset_id']}: layout={result['layout_status']} ({layout_ok}); "
+            f"checksum={result['checksum_status']}\n"
+        )
+        if result["pinned_checksum"]:
+            sys.stdout.write(f"    expected tree sha256: {result['expected_tree_sha256']}\n")
+            if result.get("observed_tree_sha256"):
+                sys.stdout.write(f"    observed tree sha256: {result['observed_tree_sha256']}\n")
+        if result.get("missing_required_paths"):
+            sys.stdout.write(
+                f"    missing required paths: {', '.join(result['missing_required_paths'])}\n"
+            )
+        sys.stdout.write("\n")
+    if report["ok"]:
+        sys.stdout.write("All pinned dataset checksums verified.\n")
+    else:
+        sys.stdout.write(
+            "One or more datasets are missing, incomplete, or failed checksum. "
+            "Run `uv run robot-sf datasets prepare <id>` for acquisition instructions.\n"
+        )
+
+
+def _format_datasets_prepare(payload: dict) -> None:
+    """Print acquisition instructions and a local-layout verdict for ``datasets prepare``."""
+    layout = payload["local_layout"]
+    sys.stdout.write(f"Dataset: {payload['asset_id']} — {payload['title']}\n\n")
+    download = "auto-download" if payload["auto_download_allowed"] else "manual/license-gated"
+    sys.stdout.write("Acquisition\n")
+    sys.stdout.write(f"  source: {payload['source_url']}\n")
+    if payload.get("license_url"):
+        sys.stdout.write(f"  license url: {payload['license_url']}\n")
+    sys.stdout.write(f"  license: {payload['license_note']}\n")
+    sys.stdout.write(f"  acquisition: {download}\n")
+    sys.stdout.write(f"  instructions: {payload['access_note']}\n")
+    if payload.get("acquisition_doc"):
+        sys.stdout.write(f"  full guide: {payload['acquisition_doc']}\n")
+    sys.stdout.write("\nRequired local layout\n")
+    for required in payload["required_paths"]:
+        sys.stdout.write(
+            f"  - {required['pattern']} ({required['kind']}): {required['description']}\n"
+        )
+    sys.stdout.write("\nLocal verification (no download)\n")
+    sys.stdout.write(f"  status: {layout['status']} (ok={layout['ok']})\n")
+    sys.stdout.write(f"  checked path: {layout['source_path']}\n")
+    if layout.get("matched_required_paths"):
+        sys.stdout.write(f"  matched: {', '.join(layout['matched_required_paths'])}\n")
+    if layout.get("missing_required_paths"):
+        sys.stdout.write(f"  missing: {', '.join(layout['missing_required_paths'])}\n")
+    if layout.get("action"):
+        sys.stdout.write(f"  action: {layout['action']}\n")
+
+
 _HANDLERS = {
     "doctor": _handle_doctor,
+    "models": _handle_models,
+    "datasets": _handle_datasets,
 }
 
 

--- a/robot_sf/cli.py
+++ b/robot_sf/cli.py
@@ -417,6 +417,7 @@ _HANDLERS = {
     "datasets": _handle_datasets,
 }
 
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Dispatch to the requested ``robot-sf`` subcommand.
 

--- a/robot_sf/cli_datasets.py
+++ b/robot_sf/cli_datasets.py
@@ -1,0 +1,251 @@
+"""User-facing ``robot-sf datasets`` UX glue.
+
+Thin, beginner-facing surface over the existing external-data registry and
+provenance/checksum machinery in :mod:`scripts.tools.manage_external_data`.
+The functions here produce structured payloads so the CLI dispatcher
+(:mod:`robot_sf.cli`) and tests can share one implementation.
+
+Plain-language summary: ``datasets list`` shows registered datasets and whether
+the local layout is staged; ``datasets verify`` checks each staged asset's
+required-path layout and, when a provenance manifest pins a checksum, recomputes
+the aggregate tree checksum and reports pass/fail; ``datasets prepare <id>``
+prints exact acquisition instructions for license-restricted data and then
+verifies the local layout WITHOUT downloading.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.data.external.provenance import DEFAULT_MANIFEST_DIR
+from scripts.tools.manage_external_data import (
+    ASSETS,
+    AssetSpec,
+    _get_asset,
+    _matched_paths_for_report,
+    _tree_checksum,
+    check_asset,
+    list_assets,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - static typing only
+    from collections.abc import Sequence
+
+__all__ = [
+    "list_datasets",
+    "prepare_dataset",
+    "verify_datasets",
+]
+
+# Per-artifact verify statuses.
+STATUS_AVAILABLE = "available"
+STATUS_INCOMPLETE = "incomplete"
+STATUS_MISSING = "missing"
+STATUS_CHECKSUM_OK = "checksum_ok"
+STATUS_CHECKSUM_MISMATCH = "checksum_mismatch"
+STATUS_NO_PINNED_CHECKSUM = "no_pinned_checksum"
+
+
+def _manifest_path_for(asset: AssetSpec) -> Path:
+    """Return the default provenance-manifest path for an asset."""
+    return DEFAULT_MANIFEST_DIR / f"{asset.asset_id}.provenance.json"
+
+
+def _asset_list_summary(asset: AssetSpec, report: dict[str, Any]) -> dict[str, Any]:
+    """Build one ``list_datasets`` row from an asset spec plus a check report.
+
+    Returns:
+        dict[str, Any]: Per-dataset summary row.
+    """
+    return {
+        "asset_id": asset.asset_id,
+        "title": asset.title,
+        "source_url": asset.source_url,
+        "license_note": asset.license_note,
+        "license_url": asset.license_url,
+        "auto_download_allowed": asset.auto_download_allowed,
+        "status": report["status"],
+        "ok": report["ok"],
+        "expected_local_path": report["expected_local_path"],
+    }
+
+
+def list_datasets() -> list[dict[str, Any]]:
+    """Return one summary row per registered dataset, with local staging status.
+
+    Returns:
+        list[dict[str, Any]]: Per-dataset summary rows in registry order.
+    """
+    rows: list[dict[str, Any]] = []
+    for asset in list_assets():
+        report = check_asset(asset.asset_id)
+        rows.append(_asset_list_summary(asset, report))
+    return rows
+
+
+def _required_paths_view(asset: AssetSpec) -> list[dict[str, Any]]:
+    """Return the required-path descriptors for an asset, for instruction output."""
+    return [
+        {
+            "pattern": required.pattern,
+            "kind": required.kind,
+            "description": required.description,
+            "group": required.group,
+        }
+        for required in asset.required_paths
+    ]
+
+
+def prepare_dataset(asset_id: str, *, source_path: str | Path | None = None) -> dict[str, Any]:
+    """Print acquisition instructions and verify local layout WITHOUT downloading.
+
+    For license-restricted datasets, this is the safe path: it never attempts to
+    fetch restricted data. It surfaces the official source URL, license note, and
+    access instructions, then runs the layout check over the local path so a
+    user can confirm they staged the right files.
+
+    Returns:
+        dict[str, Any]: Acquisition instructions plus the local layout verdict.
+    """
+    asset = _get_asset(asset_id)
+    report = check_asset(asset_id, source_path=Path(source_path) if source_path else None)
+    return {
+        "schema": "robot_sf_datasets_prepare.v1",
+        "asset_id": asset.asset_id,
+        "title": asset.title,
+        "source_url": asset.source_url,
+        "license_note": asset.license_note,
+        "license_url": asset.license_url,
+        "access_note": asset.access_note,
+        "auto_download_allowed": asset.auto_download_allowed,
+        "required_paths": _required_paths_view(asset),
+        "acquisition_doc": _asset_acquisition_doc(asset),
+        "local_layout": {
+            "ok": report["ok"],
+            "status": report["status"],
+            "source_path": report["source_path"],
+            "expected_local_path": report["expected_local_path"],
+            "missing_required_paths": report["missing_required_paths"],
+            "matched_required_paths": report["matched_required_paths"],
+            "action": report.get("action"),
+        },
+    }
+
+
+def _asset_acquisition_doc(asset: AssetSpec) -> str | None:
+    """Return the dataset's docs/datasets acquisition path if declared, else None."""
+    candidate = Path("docs/datasets") / f"{asset.asset_id}.md"
+    if candidate.exists():
+        return str(candidate)
+    return None
+
+
+def verify_datasets(
+    *,
+    asset_ids: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Verify each dataset's layout and pinned checksum, returning pass/fail.
+
+    For every registered asset this runs the required-path layout check
+    (:func:`scripts.tools.manage_external_data.check_asset`). When the staged
+    layout is available AND a provenance manifest pins a ``tree_sha256``, the
+    aggregate tree checksum is recomputed over the matched files and compared
+    against the pin, yielding a ``checksum_ok`` / ``checksum_mismatch`` verdict.
+    Available layouts without a pinned checksum report ``no_pinned_checksum``.
+
+    Returns:
+        dict[str, Any]: Report with ``ok`` (all pinned checksums passed),
+        per-artifact ``results``, and aggregate counts.
+    """
+    if asset_ids is not None:
+        # Validate ids via _get_asset (raises on unknown).
+        requested = [_get_asset(asset_id).asset_id for asset_id in asset_ids]
+        targets = [asset for asset in ASSETS if asset.asset_id in requested]
+    else:
+        targets = list(ASSETS)
+
+    results: list[dict[str, Any]] = []
+    pinned_total = 0
+    pass_count = 0
+    for asset in targets:
+        result = _verify_one_dataset(asset)
+        results.append(result)
+        if result["pinned_checksum"]:
+            pinned_total += 1
+            if result["checksum_status"] == STATUS_CHECKSUM_OK:
+                pass_count += 1
+
+    return {
+        "schema": "robot_sf_datasets_verify.v1",
+        "ok": pinned_total > 0 and pass_count == pinned_total,
+        "checked": len(results),
+        "pinned_checksums": pinned_total,
+        "passed": pass_count,
+        "results": results,
+    }
+
+
+def _verify_one_dataset(asset: AssetSpec) -> dict[str, Any]:
+    """Build the layout + checksum verdict for a single dataset.
+
+    Returns:
+        dict[str, Any]: Per-dataset verify result with layout and checksum status.
+    """
+    report = check_asset(asset.asset_id)
+    result: dict[str, Any] = {
+        "asset_id": asset.asset_id,
+        "title": asset.title,
+        "layout_status": report["status"],
+        "layout_ok": report["ok"],
+        "source_path": report["source_path"],
+        "expected_tree_sha256": None,
+        "observed_tree_sha256": None,
+        "pinned_checksum": False,
+        "checksum_status": STATUS_NO_PINNED_CHECKSUM,
+        "missing_required_paths": report["missing_required_paths"],
+    }
+    if not report["ok"]:
+        # Layout incomplete: no checksum to verify.
+        return result
+
+    source_root = Path(report["source_path"])
+    manifest_path = _manifest_path_for(asset)
+    pinned = _load_pinned_tree_sha256(manifest_path)
+    if pinned is None:
+        # Available layout, but no manifest/pinned checksum to compare.
+        return result
+
+    result["pinned_checksum"] = True
+    result["expected_tree_sha256"] = pinned
+    matched_paths = _matched_paths_for_report(source_root, report)
+    try:
+        recomputed = _tree_checksum(source_root, matched_paths)
+    except OSError as exc:
+        result["checksum_status"] = "error"
+        result["error"] = str(exc)
+        return result
+    observed = recomputed["tree_sha256"]
+    result["observed_tree_sha256"] = observed
+    result["checksum_status"] = (
+        STATUS_CHECKSUM_OK if observed == pinned else STATUS_CHECKSUM_MISMATCH
+    )
+    return result
+
+
+def _load_pinned_tree_sha256(manifest_path: Path) -> str | None:
+    """Return the pinned ``tree_sha256`` from a provenance manifest, if present."""
+    import json  # noqa: PLC0415
+
+    if not manifest_path.is_file():
+        return None
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(manifest, dict):
+        return None
+    value = manifest.get("tree_sha256")
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip().lower()

--- a/robot_sf/cli_models.py
+++ b/robot_sf/cli_models.py
@@ -1,0 +1,224 @@
+"""User-facing ``robot-sf models`` UX glue.
+
+Thin, beginner-facing surface over the existing model registry and checksum
+machinery in :mod:`robot_sf.models.registry`. The functions here produce
+structured payloads so the CLI dispatcher (:mod:`robot_sf.cli`) and tests can
+share one implementation.
+
+Plain-language summary: ``models list`` shows what is registered and whether the
+local artifact is present; ``models verify`` checks the pinned SHA256 of each
+artifact (pass/fail/missing per model); ``models download <id>`` resolves and
+downloads a model artifact through the existing registry download path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.models.registry import (
+    DEFAULT_REGISTRY_PATH,
+    load_registry,
+    resolve_model_path,
+    sha256_of_file,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - static typing only
+    from collections.abc import Sequence
+
+__all__ = [
+    "download_model",
+    "list_models",
+    "verify_models",
+]
+
+# Status values reported by ``verify_models`` per artifact.
+STATUS_OK = "ok"
+STATUS_MISSING = "missing"
+STATUS_MISMATCH = "mismatch"
+STATUS_NO_CHECKSUM = "no_pinned_checksum"
+STATUS_ERROR = "error"
+
+
+def _claim_boundary(entry: Mapping[str, Any]) -> str | None:
+    """Return the registry entry's benchmark-promotion claim boundary, if any."""
+    promotion = entry.get("benchmark_promotion")
+    if isinstance(promotion, Mapping):
+        value = promotion.get("claim_boundary")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _entry_local_path(entry: Mapping[str, Any]) -> Path | None:
+    """Return the resolved local artifact path for a registry entry, or None."""
+    raw = entry.get("local_path")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    resolved = Path(raw)
+    if not resolved.is_absolute():
+        resolved = Path.cwd() / resolved
+    return resolved
+
+
+def _entry_release_sha256(entry: Mapping[str, Any]) -> str | None:
+    """Return the pinned GitHub-release SHA256 for an entry, normalized, if any."""
+    release = entry.get("github_release")
+    if not isinstance(release, Mapping):
+        return None
+    value = release.get("sha256")
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip().lower()
+
+
+def _entry_summary(entry: Mapping[str, Any], *, present: bool) -> dict[str, Any]:
+    """Build one ``list_models`` entry from a registry row plus a presence flag.
+
+    Returns:
+        dict[str, Any]: Per-model summary row.
+    """
+    return {
+        "model_id": entry.get("model_id"),
+        "display_name": entry.get("display_name"),
+        "tags": list(entry.get("tags") or []),
+        "claim_boundary": _claim_boundary(entry),
+        "local_path": str(_entry_local_path(entry)) if _entry_local_path(entry) else None,
+        "present_locally": present,
+        "downloadable": bool(entry.get("github_release")) or bool(entry.get("wandb_run_path")),
+        "local_only": bool(entry.get("local_only")),
+    }
+
+
+def list_models(
+    *,
+    registry_path: str | Path | None = None,
+) -> list[dict[str, Any]]:
+    """Return one summary row per registry entry, with local presence status.
+
+    Returns:
+        list[dict[str, Any]]: Per-model summary rows in registry order.
+    """
+    registry = load_registry(registry_path)
+    rows: list[dict[str, Any]] = []
+    for entry in registry.values():
+        local = _entry_local_path(entry)
+        present = bool(local and local.exists())
+        rows.append(_entry_summary(entry, present=present))
+    return rows
+
+
+def verify_models(
+    *,
+    registry_path: str | Path | None = None,
+    model_ids: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Verify each artifact's checksum and return a pass/fail report.
+
+    For entries with a pinned ``github_release.sha256``, the local file's SHA256
+    is compared against the pin and reported as ``ok`` / ``mismatch`` / ``missing``.
+    Entries without a pinned checksum are reported as ``no_pinned_checksum`` once
+    their local file presence is confirmed (or ``missing`` if absent). Local-only
+    entries without a pin therefore report presence rather than a checksum verdict.
+
+    Returns:
+        dict[str, Any]: Report with ``ok`` (all pinned checksums passed),
+        per-artifact ``results``, and aggregate counts.
+    """
+    registry = load_registry(registry_path)
+    if model_ids is not None:
+        requested = list(model_ids)
+        missing_ids = [mid for mid in requested if mid not in registry]
+        if missing_ids:
+            raise KeyError(f"Unknown model_id(s) in registry: {', '.join(missing_ids)}")
+        targets = {mid: registry[mid] for mid in requested}
+    else:
+        targets = registry
+
+    results: list[dict[str, Any]] = []
+    pass_count = 0
+    pinned_total = 0
+    for model_id, entry in targets.items():
+        result = _verify_one(model_id, entry)
+        results.append(result)
+        if result["pinned"]:
+            pinned_total += 1
+            if result["status"] == STATUS_OK:
+                pass_count += 1
+
+    return {
+        "schema": "robot_sf_models_verify.v1",
+        "ok": pinned_total > 0 and pass_count == pinned_total,
+        "checked": len(results),
+        "pinned_checksums": pinned_total,
+        "passed": pass_count,
+        "results": results,
+    }
+
+
+def _verify_one(model_id: str, entry: Mapping[str, Any]) -> dict[str, Any]:
+    """Build the verify verdict for a single model artifact.
+
+    Returns:
+        dict[str, Any]: Per-model verify result with checksum status.
+    """
+    local = _entry_local_path(entry)
+    expected = _entry_release_sha256(entry)
+    result: dict[str, Any] = {
+        "model_id": model_id,
+        "display_name": entry.get("display_name"),
+        "local_path": str(local) if local else None,
+        "expected_sha256": expected,
+        "observed_sha256": None,
+        "pinned": bool(expected),
+        "status": STATUS_MISSING,
+    }
+    if local is None or not local.exists():
+        result["status"] = STATUS_MISSING
+        return result
+    if not expected:
+        # No pinned checksum to compare against; report presence only.
+        result["status"] = STATUS_NO_CHECKSUM
+        return result
+    try:
+        observed = sha256_of_file(local)
+    except OSError as exc:
+        result["status"] = STATUS_ERROR
+        result["error"] = str(exc)
+        return result
+    result["observed_sha256"] = observed
+    result["status"] = STATUS_OK if observed == expected else STATUS_MISMATCH
+    return result
+
+
+def download_model(
+    model_id: str,
+    *,
+    registry_path: str | Path | None = None,
+    cache_dir: str | Path | None = None,
+) -> dict[str, Any]:
+    """Resolve (and download if needed) a model artifact and return a report.
+
+    Delegates to :func:`robot_sf.models.registry.resolve_model_path` so the
+    existing download/cache/checksum-validation path is reused unchanged.
+
+    Returns:
+        dict[str, Any]: Report with ``model_id``, resolved ``path``, and ``ok``.
+    """
+    path = resolve_model_path(
+        model_id,
+        registry_path=registry_path,
+        allow_download=True,
+        cache_dir=cache_dir,
+    )
+    return {
+        "model_id": model_id,
+        "path": str(path),
+        "ok": True,
+    }
+
+
+def _default_registry_path_or_none() -> Path | None:
+    """Return the default registry path (used by the CLI help text)."""
+    return DEFAULT_REGISTRY_PATH

--- a/robot_sf/models/__init__.py
+++ b/robot_sf/models/__init__.py
@@ -8,6 +8,7 @@ from robot_sf.models.registry import (
     load_registry,
     resolve_latest_wandb_model,
     resolve_model_path,
+    sha256_of_file,
     upsert_registry_entry,
     validate_registry_entry_benchmark_promotion,
 )
@@ -25,6 +26,7 @@ __all__ = [
     "load_registry",
     "resolve_latest_wandb_model",
     "resolve_model_path",
+    "sha256_of_file",
     "upsert_registry_entry",
     "validate_registry_entry_benchmark_promotion",
 ]

--- a/robot_sf/models/registry.py
+++ b/robot_sf/models/registry.py
@@ -279,6 +279,18 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def sha256_of_file(path: str | Path) -> str:
+    """Return the lowercase-hex SHA256 digest of a local file.
+
+    Public wrapper over the registry's checksum helper, used by the
+    ``robot-sf models verify`` UX so callers do not depend on a private name.
+
+    Returns:
+        str: Lowercase-hex SHA256 digest of the file at ``path``.
+    """
+    return _sha256(Path(path))
+
+
 def _download_from_github_release(entry: dict[str, Any], *, cache_dir: str | Path | None) -> Path:
     """Download a model artifact from a GitHub release asset.
 

--- a/tests/test_cli_datasets.py
+++ b/tests/test_cli_datasets.py
@@ -1,0 +1,139 @@
+"""Tests for the ``robot-sf datasets`` list/verify/prepare UX (issue #5797)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf import cli_datasets
+from robot_sf.cli import main
+from scripts.tools.manage_external_data import _tree_checksum
+
+if TYPE_CHECKING:  # pragma: no cover - static typing only
+    from pathlib import Path
+
+
+def _stage_sdd_layout(root: Path) -> tuple[Path, Path]:
+    """Stage a minimal SDD layout under a temp shared data root.
+
+    Returns the staged annotations file and the asset root used.
+    """
+    asset_root = root / "sdd"
+    asset_root.mkdir(parents=True)
+    annotations = asset_root / "annotations.txt"
+    annotations.write_text("frame rows\n", encoding="utf-8")
+    return annotations, asset_root
+
+
+def _write_provenance_manifest(manifest_dir: Path, asset_id: str, tree_sha256: str) -> Path:
+    """Write a minimal provenance manifest pinning a tree checksum."""
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = manifest_dir / f"{asset_id}.provenance.json"
+    manifest_path.write_text(
+        json.dumps({"asset_id": asset_id, "tree_sha256": tree_sha256}), encoding="utf-8"
+    )
+    return manifest_path
+
+
+def test_datasets_list_includes_real_registry_assets(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``datasets list`` should surface the real external-data registry assets."""
+    rc = main(["datasets", "list"])
+
+    assert rc == 0
+    rows = cli_datasets.list_datasets()
+    asset_ids = {row["asset_id"] for row in rows}
+    # The canonical restricted datasets must be represented.
+    assert {"sdd", "eth-ucy"}.issubset(asset_ids)
+    out = capsys.readouterr().out
+    assert "eth-ucy" in out
+
+
+def test_datasets_verify_passing_checksum(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``verify`` should PASS when a staged layout matches a pinned tree checksum."""
+    shared_root = tmp_path / "shared"
+    _stage_sdd_layout(shared_root)
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(shared_root))
+
+    manifest_dir = tmp_path / "manifests"
+    # Compute the canonical tree checksum for the staged files.
+    report = cli_datasets.verify_datasets(asset_ids=["sdd"])
+    # No manifest yet: available layout, no pinned checksum.
+    assert report["results"][0]["layout_ok"] is True
+    assert report["results"][0]["checksum_status"] == "no_pinned_checksum"
+
+    staged_path = tmp_path / "shared" / "sdd"
+    matched = sorted(staged_path.rglob("*"))
+    matched = [p for p in matched if p.is_file()]
+    checksum = _tree_checksum(staged_path, matched)
+    _write_provenance_manifest(manifest_dir, "sdd", checksum["tree_sha256"])
+    monkeypatch.setattr(cli_datasets, "DEFAULT_MANIFEST_DIR", manifest_dir)
+
+    report = cli_datasets.verify_datasets(asset_ids=["sdd"])
+
+    result = report["results"][0]
+    assert result["layout_ok"] is True
+    assert result["pinned_checksum"] is True
+    assert result["checksum_status"] == "checksum_ok"
+    assert report["ok"] is True
+
+
+def test_datasets_verify_corrupted_checksum_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``verify`` should FAIL when a staged layout's recomputed checksum differs."""
+    shared_root = tmp_path / "shared"
+    _stage_sdd_layout(shared_root)
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(shared_root))
+
+    manifest_dir = tmp_path / "manifests"
+    # Pin a deliberately-wrong checksum.
+    _write_provenance_manifest(manifest_dir, "sdd", "0" * 64)
+    monkeypatch.setattr(cli_datasets, "DEFAULT_MANIFEST_DIR", manifest_dir)
+
+    report = cli_datasets.verify_datasets(asset_ids=["sdd"])
+
+    result = report["results"][0]
+    assert result["layout_ok"] is True
+    assert result["pinned_checksum"] is True
+    assert result["checksum_status"] == "checksum_mismatch"
+    assert result["expected_tree_sha256"] == "0" * 64
+    assert result["observed_tree_sha256"] != "0" * 64
+    assert report["ok"] is False
+
+
+def test_datasets_prepare_restricted_prints_instructions_and_verifies_layout(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A restricted dataset must print acquisition instructions and verify layout WITHOUT download."""
+    # Stage a valid layout for a license-restricted dataset under a temp root.
+    shared_root = tmp_path / "shared"
+    _stage_sdd_layout(shared_root)
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(shared_root))
+
+    rc = main(["datasets", "prepare", "sdd"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Exact acquisition instructions for the license-restricted asset.
+    assert "https://cvgl.stanford.edu/projects/uav_data/" in out
+    assert "annotations.txt" in out
+    assert "manual/license-gated" in out
+    # Local layout verified without downloading.
+    assert "available" in out
+    assert "Local verification (no download)" in out
+
+
+def test_datasets_prepare_unknown_asset_errors(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unknown asset id should raise a user-facing error, not a traceback."""
+    from scripts.tools.manage_external_data import ExternalDataError
+
+    with pytest.raises(ExternalDataError):
+        cli_datasets.prepare_dataset("does-not-exist")

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -1,0 +1,185 @@
+"""Tests for the ``robot-sf models`` list/verify/download UX (issue #5797)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf import cli_models
+from robot_sf.cli import main
+
+if TYPE_CHECKING:  # pragma: no cover - static typing only
+    from pathlib import Path
+
+
+def _write_registry(tmp_path: Path, models: list[dict]) -> Path:
+    """Write a minimal model registry.yaml and return its path."""
+    import yaml
+
+    registry_path = tmp_path / "registry.yaml"
+    registry_path.write_text(yaml.safe_dump({"version": 1, "models": models}), encoding="utf-8")
+    return registry_path
+
+
+def test_models_list_reports_registered_ids_and_presence(tmp_path: Path) -> None:
+    """``models list`` should summarize every registry row with local presence."""
+    artifact = tmp_path / "good_model.zip"
+    artifact.write_bytes(b"good-bytes")
+    registry_path = _write_registry(
+        tmp_path,
+        [
+            {
+                "model_id": "good_model",
+                "display_name": "A good model",
+                "tags": ["ppo", "promoted"],
+                "local_path": str(artifact),
+                "benchmark_promotion": {"claim_boundary": "benchmark_promoted"},
+            },
+            {
+                "model_id": "absent_model",
+                "display_name": "An absent model",
+                "tags": [],
+                "local_path": str(tmp_path / "missing.zip"),
+            },
+        ],
+    )
+
+    rows = cli_models.list_models(registry_path=registry_path)
+
+    assert [row["model_id"] for row in rows] == ["good_model", "absent_model"]
+    good, absent = rows
+    assert good["present_locally"] is True
+    assert good["claim_boundary"] == "benchmark_promoted"
+    assert good["tags"] == ["ppo", "promoted"]
+    assert absent["present_locally"] is False
+    assert absent["claim_boundary"] is None
+
+
+def test_models_verify_reports_passing_checksum(tmp_path: Path) -> None:
+    """``models verify`` should PASS for a local file matching a pinned SHA256."""
+    import hashlib
+
+    content = b"verified-model-bytes"
+    digest = hashlib.sha256(content).hexdigest()
+    artifact = tmp_path / "model.zip"
+    artifact.write_bytes(content)
+    registry_path = _write_registry(
+        tmp_path,
+        [
+            {
+                "model_id": "pinned_model",
+                "display_name": "Pinned model",
+                "local_path": str(artifact),
+                "github_release": {"sha256": digest, "asset_name": "model.zip"},
+            }
+        ],
+    )
+
+    report = cli_models.verify_models(registry_path=registry_path)
+
+    assert report["ok"] is True
+    assert report["pinned_checksums"] == 1
+    assert report["passed"] == 1
+    result = report["results"][0]
+    assert result["status"] == "ok"
+    assert result["pinned"] is True
+    assert result["observed_sha256"] == digest
+
+
+def test_models_verify_reports_corrupted_checksum_failure(tmp_path: Path) -> None:
+    """``models verify`` should FAIL when the local SHA256 does not match the pin."""
+    artifact = tmp_path / "model.zip"
+    artifact.write_bytes(b"corrupted-bytes")
+    registry_path = _write_registry(
+        tmp_path,
+        [
+            {
+                "model_id": "corrupt_model",
+                "display_name": "Corrupt model",
+                "local_path": str(artifact),
+                "github_release": {
+                    "sha256": "0" * 64,
+                    "asset_name": "model.zip",
+                },
+            }
+        ],
+    )
+
+    report = cli_models.verify_models(registry_path=registry_path)
+
+    assert report["ok"] is False
+    result = report["results"][0]
+    assert result["status"] == "mismatch"
+    assert result["pinned"] is True
+    assert result["expected_sha256"] == "0" * 64
+    assert result["observed_sha256"] != "0" * 64
+
+
+def test_models_verify_missing_pinned_artifact_is_failure(tmp_path: Path) -> None:
+    """A pinned-but-absent artifact should be reported missing (not pass)."""
+    registry_path = _write_registry(
+        tmp_path,
+        [
+            {
+                "model_id": "absent_pinned",
+                "display_name": "Absent pinned model",
+                "local_path": str(tmp_path / "nope.zip"),
+                "github_release": {"sha256": "a" * 64, "asset_name": "model.zip"},
+            }
+        ],
+    )
+
+    report = cli_models.verify_models(registry_path=registry_path)
+
+    assert report["ok"] is False
+    assert report["results"][0]["status"] == "missing"
+
+
+def test_models_cli_verify_friendly_exit_code_on_mismatch(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The CLI should exit non-zero and print a human checksum-mismatch report."""
+    artifact = tmp_path / "model.zip"
+    artifact.write_bytes(b"corrupted-bytes")
+    registry_path = _write_registry(
+        tmp_path,
+        [
+            {
+                "model_id": "corrupt_model",
+                "display_name": "Corrupt model",
+                "local_path": str(artifact),
+                "github_release": {"sha256": "f" * 64, "asset_name": "model.zip"},
+            }
+        ],
+    )
+
+    rc = main(["models", "verify", "--registry", str(registry_path)])
+
+    assert rc == 2
+    out = capsys.readouterr().out
+    assert "corrupt_model" in out
+    assert "mismatch" in out
+
+
+def test_models_cli_list_friendly(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The CLI ``models list`` friendly path should list registered ids."""
+    registry_path = _write_registry(
+        tmp_path,
+        [
+            {
+                "model_id": "demo_model",
+                "display_name": "Demo model",
+                "tags": ["ppo"],
+                "local_path": str(tmp_path / "demo.zip"),
+            }
+        ],
+    )
+
+    rc = main(["models", "list", "--registry", str(registry_path)])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "demo_model" in out
+    assert "Demo model" in out


### PR DESCRIPTION
## What

Adds the `robot-sf models` and `robot-sf datasets` user-facing commands for issue #5797 — thin UX glue over the existing model registry and external-data provenance/checksum machinery. No new registry, checksum, or download internals were written; this PR wires the existing ones behind obvious commands.

```
uv run robot-sf models list
uv run robot-sf models download <id>
uv run robot-sf models verify
uv run robot-sf datasets list
uv run robot-sf datasets verify
uv run robot-sf datasets prepare <id>
```

Both expose `--format friendly|json`.

## Why

This is item #6 of the adoption/UX epic #5791 ("Model/data list-download-verify"). The repo's model registry (`model/registry.yaml` + `robot_sf.models.registry`) and dataset registry (`scripts.tools.manage_external_data` `ASSETS` + provenance/checksum machinery) already do the heavy lifting; they were just not surfaced behind a discoverable, beginner-facing CLI. `list`/`verify`/`prepare` are pure UX glue; `download` reuses the registry's existing GitHub-release/W&B download path.

## How (reuse, no duplication)

- **Models** (`robot_sf/cli_models.py`) wraps `robot_sf.models.registry`: `list` summarizes every registry row with local presence + claim boundary; `verify` compares each artifact's pinned `github_release.sha256` against the local file (pass/mismatch/missing); `download` delegates to `resolve_model_path(allow_download=True)`.
- **Datasets** (`robot_sf/cli_datasets.py`) wraps `scripts.tools.manage_external_data` (the established import target used by `robot_sf/data/external/*`): `list` reuses `check_asset`; `verify` runs the required-path layout check and, when a provenance manifest pins a `tree_sha256`, recomputes the aggregate tree checksum and compares it; `prepare` prints exact acquisition instructions (source/license/access/required layout) for license-restricted data and verifies the local layout **without downloading**.
- Added a public `robot_sf.models.registry.sha256_of_file` wrapper so the UX does not depend on a private `_sha256`.

## Acceptance mapping (#5797)

- ✅ `models list/verify` and `datasets list/verify` work against the **real** registries (verified live: 25 models, 9 datasets).
- ✅ `verify` reports checksum pass/fail **per artifact** (model pinned sha256; dataset pinned tree sha256 + layout).
- ✅ A restricted dataset prints instructions + verifies layout without downloading (`datasets prepare eth-ucy` / `sdd`).
- ✅ Tests cover list, a passing verify, and a corrupted-checksum failure (plus a missing-pinned-artifact failure and the restricted-prepare-no-download case).

## Validation (CPU-only, no campaigns/slurm/training)

```
# focused tests for the new UX (+ sibling doctor suite to confirm no regression)
$ pytest tests/test_cli_models.py tests/test_cli_datasets.py tests/test_cli_doctor.py -q
15 passed in 0.97s

# lint/format on all changed files
$ ruff check <changed files>
All checks passed!
```

Live smoke against the real registries (worktree-local, no network):
- `robot-sf models list` → 25 models registered, with per-model `[present]`/`[absent]` + claim boundary.
- `robot-sf models verify` → 25 checked, 11 pinned checksums, exit code 2 (artifacts absent in this fresh worktree, as expected).
- `robot-sf datasets list` → 9 datasets registered with status + acquisition mode.
- `robot-sf datasets verify` → 9 checked, exit code 2 (no manifests staged in this fresh worktree).
- `robot-sf datasets prepare eth-ucy` → prints source/license/required layout and reports local layout `missing` without any network attempt.

## Notes / scope

- No `output/` artifacts are relied upon as durable storage; verification is read-only over whatever is locally staged.
- `models download` and `datasets prepare` never embed private acquisition/cluster details; only public source URLs and license notes from the existing registry.
- This fully resolves the issue's stated acceptance (the four command families + test coverage). It does not add new datasets, models, or benchmark claims.

Closes #5797

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
