### PR TITLE
Issue #5798: add beginner notebook quickstarts (run/compare/visualize) (cheap-lane worker)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,9 @@ jobs:
       - name: Example smoke tests
         run: scripts/dev/ci_driver.sh examples-smoke
 
+      - name: Notebook smoke tests
+        run: scripts/dev/ci_driver.sh notebooks-smoke
+
   ci:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ uv run python examples/quickstart/03_custom_map.py
 fastest install → run → *see something* path and is CPU-only. Open
 `output/demo/latest/viewer/index.html` in a browser to replay the episode.
 
+### Beginner notebooks
+
+For an interactive, plotted walkthrough (run → compare → visualize), open the
+CPU-only notebooks under [`notebooks/`](notebooks/README.md):
+
+```bash
+uv run jupyter notebook notebooks/01_run_first_episode.ipynb
+```
+
+Each notebook is deterministic and writes its small artifact under `output/notebooks/`.
+Run all three headless with `uv run python scripts/validation/run_notebooks_smoke.py`.
+
 ### Packaging smoke (wheel install smoke)
 
 To validate a wheel install path in a clean environment:

--- a/notebooks/01_run_first_episode.ipynb
+++ b/notebooks/01_run_first_episode.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c44c8fa3",
+   "metadata": {},
+   "source": [
+    "# 01 — Run your first Robot SF episode\n",
+    "\n",
+    "This notebook runs a short, **fully deterministic** episode in a Robot SF\n",
+    "navigation environment using a random policy, then plots the per-step reward.\n",
+    "\n",
+    "**You will learn how to:**\n",
+    "1. Build a robot navigation environment with the factory function.\n",
+    "2. Reset it and step it with random actions.\n",
+    "3. Read the reward signal and plot it with matplotlib.\n",
+    "\n",
+    "> CPU-only, headless, no rendering window, no training. Runs in a few seconds.\n",
+    ">\n",
+    "> It mirrors the canonical example at\n",
+    "> `examples/quickstart/01_basic_robot.py`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3a1e4edc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-15T23:24:50.555712Z",
+     "iopub.status.busy": "2026-07-15T23:24:50.555429Z",
+     "iopub.status.idle": "2026-07-15T23:24:53.431084Z",
+     "shell.execute_reply": "2026-07-15T23:24:53.430554Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+      "I0000 00:00:1784157892.085090 1036722 port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+      "I0000 00:00:1784157892.116292 1036722 cpu_feature_guard.cc:227] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
+      "To enable the following instructions: AVX2 AVX_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+      "I0000 00:00:1784157892.683903 1036722 port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+      "I0000 00:00:1784157892.684101 1036722 cudart_stub.cc:31] Could not find cuda drivers on your machine, GPU will not be used.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Repo root: /home/luttkule/git/robot_sf_ll7.worktrees/cheap-issue-5798-20260715T225820Z\n",
+      "Artifacts will be written to: output/notebooks/01_run_first_episode\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Headless setup: no GUI window. We deliberately do NOT force a matplotlib\n",
+    "# backend here, because several robot_sf modules call matplotlib.use(\"Agg\",\n",
+    "# force=True) at import time and would clobber an inline backend set now.\n",
+    "# Instead each plotting cell re-enables the inline backend right before it\n",
+    "# draws, so figures still render into the notebook output under nbconvert.\n",
+    "import os\n",
+    "import sys\n",
+    "from IPython import get_ipython\n",
+    "\n",
+    "os.environ.setdefault(\"SDL_VIDEODRIVER\", \"dummy\")\n",
+    "\n",
+    "\n",
+    "def _inline_matplotlib() -> None:\n",
+    "    # (Re-)arm the notebook inline backend for the next figure.\n",
+    "    ip = get_ipython()\n",
+    "    if ip is not None:\n",
+    "        ip.run_line_magic(\"matplotlib\", \"inline\")\n",
+    "\n",
+    "\n",
+    "# Keep log output quiet so the executed notebook stays readable.\n",
+    "from loguru import logger\n",
+    "logger.remove()\n",
+    "logger.add(sys.stderr, level=\"ERROR\")\n",
+    "\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from robot_sf.common.seed import set_global_seed\n",
+    "from robot_sf.gym_env.environment_factory import make_robot_env\n",
+    "\n",
+    "# Resolve the repo root robustly regardless of the working directory this\n",
+    "# notebook is launched from (repo root, or its own notebooks/ folder).\n",
+    "def _repo_root() -> Path:\n",
+    "    here = Path.cwd()\n",
+    "    for candidate in [here, *here.parents]:\n",
+    "        if (candidate / \"pyproject.toml\").exists():\n",
+    "            return candidate\n",
+    "    return here\n",
+    "\n",
+    "REPO_ROOT = _repo_root()\n",
+    "\n",
+    "# Where this notebook writes its small artifact (git-ignored).\n",
+    "OUTPUT_DIR = REPO_ROOT / \"output/notebooks/01_run_first_episode\"\n",
+    "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "print(\"Repo root:\", REPO_ROOT)\n",
+    "print(\"Artifacts will be written to:\", OUTPUT_DIR.relative_to(REPO_ROOT))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9884569f",
+   "metadata": {},
+   "source": [
+    "## 1. Build and reset the environment\n",
+    "\n",
+    "`make_robot_env()` is the ergonomic entry point. We seed everything for reproducibility."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "46016a74",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-15T23:24:53.432444Z",
+     "iopub.status.busy": "2026-07-15T23:24:53.432245Z",
+     "iopub.status.idle": "2026-07-15T23:24:55.726830Z",
+     "shell.execute_reply": "2026-07-15T23:24:55.726244Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Environment created and reset.\n",
+      "Observation type: dict\n",
+      "Observation keys: ['drive_state', 'rays']\n",
+      "Action space: Box(-1.0, 1.0, (2,), float32)\n"
+     ]
+    }
+   ],
+   "source": [
+    "SEED = 87234\n",
+    "set_global_seed(SEED)\n",
+    "\n",
+    "env = make_robot_env(debug=False)\n",
+    "observation, info = env.reset()\n",
+    "print(\"Environment created and reset.\")\n",
+    "print(\"Observation type:\", type(observation).__name__)\n",
+    "if hasattr(observation, \"keys\"):\n",
+    "    print(\"Observation keys:\", list(observation.keys()))\n",
+    "print(\"Action space:\", env.action_space)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b2f8f45",
+   "metadata": {},
+   "source": [
+    "## 2. Step the environment with random actions\n",
+    "\n",
+    "Each call to `env.step(action)` returns the Gymnasium 5-tuple\n",
+    "`(observation, reward, terminated, truncated, info)`. We collect the\n",
+    "reward at every step. If the episode ends early (collision or success),\n",
+    "we reset and keep going so the budget is filled."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "85936e4e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-15T23:24:55.728275Z",
+     "iopub.status.busy": "2026-07-15T23:24:55.728199Z",
+     "iopub.status.idle": "2026-07-15T23:25:00.031895Z",
+     "shell.execute_reply": "2026-07-15T23:25:00.031436Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stepped 60 times.\n",
+      "Total reward: -4.957\n",
+      "Collisions: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "N_STEPS = 60\n",
+    "rewards = []\n",
+    "collisions = 0\n",
+    "\n",
+    "for step in range(1, N_STEPS + 1):\n",
+    "    action = env.action_space.sample()  # random policy\n",
+    "    observation, reward, terminated, truncated, info = env.step(action)\n",
+    "    rewards.append(float(reward))\n",
+    "    if bool(info.get(\"collision\")):\n",
+    "        collisions += 1\n",
+    "    if terminated or truncated:\n",
+    "        observation, info = env.reset()\n",
+    "\n",
+    "print(f\"Stepped {N_STEPS} times.\")\n",
+    "print(f\"Total reward: {sum(rewards):.3f}\")\n",
+    "print(f\"Collisions: {collisions}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdad157d",
+   "metadata": {},
+   "source": [
+    "## 3. Plot the reward over time\n",
+    "\n",
+    "We save the figure to `output/` and also display it inline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8387364e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-15T23:25:00.033332Z",
+     "iopub.status.busy": "2026-07-15T23:25:00.033261Z",
+     "iopub.status.idle": "2026-07-15T23:25:00.135809Z",
+     "shell.execute_reply": "2026-07-15T23:25:00.135414Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved: output/notebooks/01_run_first_episode/reward_curve.png\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAE1CAYAAAB6GXYWAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlcelbwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAgzdJREFUeJzt3Xd4U+XbB/Bvkrbp3oPuSVllb9lThmyUrYAiiOKriD/AAaIouBeKLBdDUGTL3pS9aVkt0E33SPfM8/6BjYR0pDNN+/1cF9dFznnOOffJ07TnzrMkQggBIiIiIiKiKpDqOgAiIiIiItJ/TCyIiIiIiKjKmFgQEREREVGVMbEgIiIiIqIqY2JBRERERERVxsSCiIiIiIiqjIkFERERERFVGRMLIiIiIiKqMiYWRER6YurUqWjUqJHW5UeMGIFx48bVYESVV9F70Vf9+/dHly5dyt3W0DWUn4eqGjBgAKZOnarrMIhKxcSCSM9s2LABEolE9U8mk8HJyQnPPvssbt68qevwEB0dDYlEghUrVug6lAbt6NGj2LNnDz744ANdh0JU63777Td06dIFtra2sLS0RJs2bfDdd9+hsLBQrZy5ubna79PH/xkYGECpVKrKXrp0CTNnzkTTpk1hamqKxo0bY9asWYiJidG4flxcHD788EO0bdsW5ubmcHZ2xsCBA7Fv375yY3/mmWcgkUjQu3dvjX1Lly7F77//jsuXL1f8TSGqBUwsiPTU9u3bIYRATk4Otm7diitXrqBbt24IDw/XdWhUB3zyySfo378/mjVrputQ6AmHDx/GuXPndB1GvfXxxx9j6tSpGDhwIEJCQhAZGYkZM2bgjTfewJw5c9TKZmZmQgih9u/KlSsAgKFDh0IqffSYVFhYiI4dOyI0NBTr1q1DUlISNm3ahPPnz6Nt27aIiopSO++nn34KExMTrF+/HomJiQgMDISTkxOGDBmC9evXlxr7mjVrEBgYCBMTkxL3d+7cGe3atcPy5cur8hYR1RgmFkR6zsjICD169MDnn38OhUKBX375RdchkY6Fhobi6NGjmDJliq5DIap1v/32G3x9ffHhhx/C3t4e1tbWePXVV9GnTx/8/vvv5R6/bt06AMDLL7+s2iaRSPC///0PR44cQbdu3WBqaoqOHTtiw4YNSExMxLfffqt2jq+//hpvv/02AgICYGJiAl9fX/z666+wtLTEqlWrSrzugwcPMHfuXHz22WcwNTUtNb7Jkydjx44diIuL0+btIKpVTCyI6ommTZsCgOqbM6VSiW+++QatWrWCsbExrK2tMWrUKNy9e1d1TFJSEiQSCb744gvs3LkTrVu3hpGRETZs2FDqdb799lu0bNkS5ubmcHFxwciRI3H16lUAQGBgINzd3QEAc+bMUXUpeO2111THFxQUYNmyZWjevDmMjY1ha2uLcePGqbW03Lt3DxKJBGvXrsX69evRuHFjGBsbo23btvjnn3/KfS8eP/6PP/5AixYtYGhoiD179gAAwsLC8Pzzz6NRo0YwMjKCr68vPvroIxQVFQEArly5AolEgm3btqnO+eDBA0gkEtjY2KjKAcDChQthbGyMnJwcAMDmzZvVulOYm5ujS5cu2LJli1qMH3zwASQSCVJTUzFnzhw4OjrCxsYGACCEwOeffw5vb2+YmJigS5cuFfqGe8+ePRBCoG/fvhr7OnTogP79+yMkJASDBg2Cubk5Jk+eDODRA0tx3FKpFPb29hgxYgSCg4NLPEdYWBgGDRoEMzMzODs7491331XrOlKZe/n555/Rtm1bmJiYwNraGoMHD8bFixdLvP7du3fRr18/mJmZoUmTJti9ezcA4NatW+jfvz/MzMzg4eGhelAsT/F5b9++jb59+8LU1BSurq549913NbrQaBtrSUobY3Ho0CEMHDgQNjY2sLS0RJ8+fXD06FEAwJQpU2BtbY2srCyN41588UWYm5sjIyNDq/ssdvr0aQwcOBAODg6wtLREp06d8Ntvv2nU4cGDB9GvXz9YWlrCxMQEnTt3Vr3XFS1X1Z9tbVhZWUEikZS4z9LSssxj8/LysGnTJri7u2Pw4MGq7TKZDJ9++qnGef38/AA8+p1SHqlUCplMBjMzM419SqUSL7zwAjp06IAZM2aUeZ6+ffuisLBQq25VRLVOEJFeWb9+vQAgtm/frrZ927ZtAoBYtGiREEKI8ePHC0tLS/Hrr7+K5ORkERYWJsaOHStsbW1FRESEEEKIxMREAUCMGDFCPP/88+LBgwfi9u3b4ujRoyVe+6effhKGhoZi8+bNIj09XSQlJYndu3eLiRMnqspERUUJAOL777/XOL6oqEgMHTpU2Nvbi82bN4vU1FQRGhoqBg8eLJydnUV8fLwQQojQ0FBVXLNnzxbR0dEiKipKzJgxQ0ilUrFv374y36Pi40eOHCleeeUVERERIa5evSrOnDkj7t69K2xtbUXv3r3F1atXRUZGhti3b59wcnISL7zwghBCCKVSKezt7cXLL7+sdu8mJiYCgDh79qxqe4cOHUS/fv1KjEOpVIqYmBjxwQcfCIlEIg4cOKDat3jxYgFAPP/882LTpk0iJSVFrFmzRgghxDvvvCMMDAzE999/L1JSUsTNmzfF4MGDRb9+/YSTk1OZ9y6EEKNHjxbOzs4l7mvfvr3o2LGjGDRokLhw4YJISEgQf/zxh0a5/Px8ERwcLIYOHSqcnZ1FcnKy2jk6deokRo0aJS5evCgUCoVYuXKlAKC6h2IVuZclS5YIqVQqPvnkE5GQkCBCQ0PF8OHDhVwuF2fOnNG4h5EjR4rr16+LlJQU8eabbwojIyMRGBgoBg0aJK5evSpSU1PFvHnzBABx7dq1ct+3x9+bS5cuibS0NLF+/XphYmIipk+fXqlY+/XrJzp37qx2bEnb1qxZIyQSiZg9e7YICQkR6enp4sSJE2LEiBFCCCHOnj0rAIhVq1apHZeamipMTU3F1KlTy72/x0VHRwszMzMxY8YMER0dLbKyssTly5fFtGnTxI0bN1TlfvnlFyGRSMS8efNEZGSkSE5OFl988YWQyWTizz//rHC5ivw8vPXWWwKAVv9iY2NVx+3du1cYGxuL999/XyQlJYm0tDSxYsUKYWBgIH755Zcy35dNmzYJAOKDDz7Q6n3cunWrACAWLlxYapmioiIREREhZs6cKczNzcXJkyc1yixfvlyYmJiI0NBQIYQQdnZ2olevXqWerzJ1TlQbmFgQ6ZknE4u8vDwRGBgofH19hYWFhXjw4IE4cOBAiQ95OTk5wtnZWcycOVMI8V9i4eXlJQoLC8u99vjx40WzZs3KLFNWYrFlyxYBQPz1119q29PS0oS1tbWYP3++EOK/xKBNmzZq5ZRKpWjevLlo1apVmTEUH9+yZUuNfcOGDROOjo4iLS1NbfuGDRsEABEUFCSEEGLcuHHCy8tLtX/MmDHi2WefFX5+fuLDDz8UQgiRnJwspFKpWL58eZnxCCFEly5dxNixY1WvixOLTz/9VK1cQkKCMDIyUtVRsdjYWGFsbKxVYtGhQwfRrl27Eve1b99eABDBwcHlnkcIIZKSkgQA8euvv6qdQyaTiZCQELWyXbt2FR07dqzUvSQmJgq5XK6WpArx6Ge2UaNGolu3bhrXv3fvnmpbdna2MDMzE5aWluLu3btqx1tYWIg5c+aUe6/t27cXEolE3Lp1S237Bx98IACotlckVm0Si7S0NGFubi6GDx9eZnzt2rXT+Ex8/fXXAoA4depUuff3uB07dggA4vr166WWSU9PF5aWlmLMmDEa+8aPH6/6fGhbrqI/25VNLIQQ4s8//xSWlpaq/YaGhuLbb78t933p16+fkMlkIioqqtyyycnJwtPTU5ibm5da3snJSRWDnZ2d2LNnj0aZ69evCyMjI/HZZ5+ptpWVWAghhJeXl+jTp0+5MRLVNnaFItJTo0aNgkQigYmJCUaNGoXWrVsjMDAQ3t7e2L17NyQSCcaMGaN2jLGxMbp164YTJ06obR86dChkMpnqtZ+fn1p3npdeegkA0Lp1a9y+fRtvvPEGLl++rNYlSBu7d++GkZERhg8frrbdysoKHTp00Ihr2LBhaq8lEgmGDx+OGzduICkpqdzrPXmd/Px8HDhwAAMHDoSVlZXavv79+wOAKoYBAwYgPDwcoaGhUCqVOHr0KAYMGIABAwbg4MGDAIAjR45AqVRiwIABqvMUFBTgk08+QatWrWBqaqp6D8+dO4d79+6VG2NgYCDy8/M1tjdq1EjrKUrT0tJgYWFR6n5fX1+0aNFCY3tMTAxeeukleHh4wMjICBKJBPb29gCgEbu/vz8aN26sti0gIAAPHjyo1L0EBgYiLy8Po0ePVttubGyMoUOH4uzZs8jOzla7vq+vr+q1iYkJPD094eTkBH9/f7Xjvb291eIqi5+fn8aA95EjRwKAqltSRWMtz8mTJ5GZmYmJEyeWWW727Nm4du0azp49q9r2008/oUmTJujevbvW1wOA5s2bw8DAALNnz8aePXuQmZlZYlzp6el49tlnNfb1798f4eHhiIiI0LpcRX+2v/jiC42B1aX9e3yq2hUrVmDcuHF46623EBcXh5SUFPzwww+YN28eFixYUOp7Eh4ejqNHj2LQoEFwc3Mr8/3Lzc3FmDFjEBkZibVr15ZaPi4uDgUFBQgNDcXo0aMxYsQI/Prrr6r9+fn5mDx5Mlq2bIm5c+eWec3HWVpaIi0tTevyRLWFiQWRniqeFaqoqAgJCQn4+++/0apVKwCP/pgJIeDg4AADAwPIZDJIpVJIpVJs3boVycnJaudydXXV6ppvvfUWPvjgA+zcuRMdOnSAnZ0dxo4dq5pFpTxxcXHIz8+HqampWlwSiQSHDx/WiMvJyUnjHMXbnixbkifvKzU1Ffn5+di4caPq+sUxFD+YFJ+3OFk4ePAgLl26hNTUVFVice7cOWRkZODQoUOwt7dH27ZtVdeYM2cOPvroI8yfPx8REREoLCyEEAL9+/dHQUFBuTEWX7+sey+PtbU10tPTS91fUn3n5eWhV69eOHfuHDZt2oTk5GQolUrk5uYCgEbszs7OGud48mGnIvdSXLaktQwaNWoEpVKJ1NTUMq9vYWFR6nZtH8LKirU4ma1orOVJSEgAUP7ncOLEibCxscHKlSsBPEps7969i+nTp2t9rWKNGzfGrl27oFQqMWLECFhbW6Nr1674+eefIYQAANXg4EmTJmn8Hin+siE5OVnrctXxs12erKws/O9//8PTTz+NRYsWwcnJCTY2NpgxYwZmzpyJzz77rNTxEL/88guEEGqDtktSUFCAsWPH4sSJE1i5cmW5a8UYGBjAz88Pq1evRvv27fHmm2+q3uMff/wRt2/fxrp169S+3ClPenq6akwWUV3CxIKoHrK3t4ehoSEyMzNRWFiIoqIiKJVKKJVKCCFUDzLFDA0N1V7fu3dP7dvAtWvXqsotXrwYYWFhCAsLw9dff43g4GD07NkT0dHRWsVlaWmJ/Px8tbiKrxMSEqJWPj4+XuMcxdvs7OzKvd6T92VlZQUDAwPMnDlTdf0nY1i0aBEAwMPDA/7+/jh48CAOHTqExo0bw8vLC3379oUQAseOHcOhQ4fQr18/tQGd69evx5QpUzBp0iQ4ODioHhZKe5h5Msbi+yrr3svj6elZ5owxT14TeDSQ9/79+/jkk0/QvXt3WFhYQCKRlBp3aYNjH1eRe7G1tS2zrFQqVXuQKu362sRVFm1+5ioaa3kcHBwAoMT1EB5nYmKCqVOn4s8//0RSUhJ+/PFHGBgY4Pnnn9f6Wo8bPHgwzpw5g9TUVOzZswdubm548cUXVbMWFbdW7dy5s8TfI0IItGvXTutyFf3ZnjdvXqlrTDz5r/jnPTIyEjk5OWjZsqXG+QICAiCEUJvAophSqcRvv/0GV1dXDB06tNT3rLCwEOPHj8c///yDFStWYObMmeW9zWpatmyJtLQ0pKSkAHiUrBYWFqJNmzZq95OcnIwTJ05AIpHgvffe04g1ISEBnp6eFbo2UW1gYkFUDw0bNgwFBQVqsxpVNy8vL0ybNg1ffPEFsrKyVK0WxTOe5OXllRhXeno69u/fr9U1imdxKiaEwO7du9GqVSvVw0xFGBsbY8CAAdi7d2+JXT+eNGDAABw7dgx79+5VtWBYWVmhU6dO+PHHHxEeHq7WDUoIAYlEArlcrnaes2fP4v79+1rF2L17dxgaGmrMppOQkKD17Dndu3dHbGwsHj58qFX5xz0ZuzbTc5YVh7b30r17dxgZGWH79u1q2/Py8vDPP/+ga9euZU7BWV3u3buHO3fuqG3buXMnAKhm2aruWHv16gVzc3Ns2rSp3LKvvPIK8vPzsXTpUuzatQtDhw6t8orVlpaWGDRoEP78809YWFjg5MmTqrgsLCw0ZjQrKX5tylXHz3Z5XF1dYWBgoDGTGQAEBQUBQIkP5IcPH0ZERASmT59easuBUqnE888/j23btuH777/H7NmzKxSbUqnEpUuX4OTkpEpOly5dWmLXLjs7O/Tq1QtCCCxdulTtPMHBwcjOzkaPHj0qdH2iWlGTAziIqPqVNivUkyZMmCCsra3FqlWrRExMjMjMzBTXrl0TixYtEosXLxZC/Dd4+/PPP9fq2s8//7z47rvvxJ07d0Rubq4IDw8XY8aMEebm5iImJkZVzsXFRQwZMkRjgHRRUZF45plnhIODg/jtt99EbGysSE9PF5cvXxbz589XxVE8+Hr48OHitddeE9HR0SI6OlrMnDlTSKVS8c8//5QZZ/HxTw5eF0KIO3fuCHt7e9GrVy9x5swZkZGRIR4+fCj27dsnhg0bpjbwt3iAKwCxY8cO1fbigdcARHh4uNr5x40bJ6ysrMTRo0dFZmamOHLkiOjcubN46qmnRIsWLTTOkZOToxHjggULhKGhofjhhx9ESkqKuHXrlhg6dKjWs0KFhIQIiUQi1q9fr7Gvffv2Jc5ilZ6eLho1aiS6du0q7t27J5KTk8WKFSvExIkTBQDVwPqyzvHWW28JmUxW6XtZtGiRkEql4tNPPxWJiYni/v37YtSoUarZnsq7fufOnUsc8NqtWze1AdWlKZ4VavDgweLy5ctCoVCIjRs3CjMzM9WMYRWNVdtZoVavXq2aFSo0NFRjVqjHDRw4UPXzt2vXLo39f/zxhwAgVq5cWeq9/vzzz2L27Nni3LlzIi0tTaSlpYmffvpJABCrV69Wlfvll1+EVCoVb7zxhggJCRHZ2dkiNDRUrFu3Ti02bctV9WdbG6+99poAIJYuXSri4+NFSkqKWL16tTA0NCx1gPy4ceOEVCrV+DwXUyqVYvr06aVOTPG4zMxM0b9/f7F3714RExMjsrOzxfXr18X48eOFRCIRv/32W7n3UNbg7a+//loYGBhoDFgnqguYWBDpGW0TC6VSKVatWiU6deokzMzMhIWFhWjbtq1YunSpaurQiiYWDx48EG+++aZo2rSpMDY2Fi4uLuLZZ58VV69eVSu3f/9+ERAQIIyMjAQA8eqrr6r2FRYWim+++Ua0a9dOmJqaCisrK9GhQwfx+eefqxKRxxODn3/+Wfj4+AgjIyPRunVrsXPnznLjLCuxEOLRzFUvv/yy8PDwEIaGhsLV1VUMHTpU7NmzRyiVSlU5hUIhDAwMhIGBgVAoFKrtgYGBAoBo3LixxrlTUlLEtGnThKOjozA3NxcDBw4Ud+/eFUOHDtU6sVAqlWLZsmXCw8NDyOVy0bFjR3H69GnxwgsvaP3w1b9/fzFw4ECN7aU9lAshxJUrV0Tv3r2Fubm5cHR0FK+++qrIzs6uUmJR0XtZvXq1aN26tZDL5cLCwkIMHDhQnDt3Tqt7qI7Eol+/fuLmzZuiZ8+ewtjYWDg7O4sFCxaI/Pz8SsWqbWIhhBD79u0Tffr0ERYWFsLKykr06dOnxKmfd+7cKQAIZ2fnEmdzW7NmjQBQ5mclKytLrFy5UnTt2lVYWloKGxsb0aVLlxIfek+cOCGGDh0qbG1thVwuF/7+/uLll1/WmD1Lm3LV8bNdnsLCQrF27VrRsWNHYWNjIywtLUXr1q3FV199JXJzczXKJycnC7lcLgYPHlzqOWNjY8uclerJn68TJ06IZ599Vri7uwsDAwPh5OQkRowYIY4dO6bVPZSVWLRv315thjmiukQixL8jiIiI6oh79+6hcePGWLNmjWrwJ1XM8ePH0a9fPwQHB2vMckQl69ChA6ytrXH48GFdh1Km48ePo0+fPliwYAGWLVumsX/KlCkICgrC1atXqzzmhOqW8+fPo2vXrrh48SLat2+v63CINHCMBRFRPdS7d28MGzYMixcv1nUoVM22bNkCiUSCF198scT9R48exccff8ykoh56//338fzzzzOpoDrLQNcBEBFRzdixY4euQ6Bqdu3aNWzYsAHjxo2Dn59fiWXKm12K9FfxGjpEdRUTCyIiIj1QvCBmnz598P333+s6HCIiDRxjQUREREREVcYxFkREREREVGV6l1gcPnwYI0aMQJcuXTBjxgxERUVVyzGVOS8RERERET2iV12hDh06hCFDhmDx4sXo2rUrvv32W1y7dg1BQUGwsrKq9DGVOe+TlEolHj58CAsLC87EQURERET1ghACGRkZcHFxgVRaTpuEDtfQqLAuXbqISZMmqV7n5OQIa2tr8emnn1bpmMqc90lRUVFlLp7Df/zHf/zHf/zHf/zHf/ynr/+ioqLKfR7WmxaLzMxMWFpaYsOGDZg4caJq+9ixY5GRkYEDBw5U6pjKnLckCoUC1tbWiIqKgqWlZRXu9D9KpRKJiYlwcHAoP0MknWJd6Q/WlX5hfekP1pV+YX3pD13XVXp6Otzd3ZGWllZuTx69mW42JiYGQgg4OzurbXdxcSl1lVRtjqnMeQEgLy8PeXl5qtcZGRkAAHNzc5ibm2t/Y2VQKpXIycmBubk5P/R1HOtKf7Cu9AvrS3+wrvQL60t/6LqulEolAGjV1V9vEouCggIAgFwuV9sul8tV+ypzTGXOCwDLli3DkiVLNLZ//fXXMDY2LutWtCaEQE5ODkxMTDhuo45jXekP1pV+YX3pD9aVfmF96Q9d11Vubq7WZfUmsbCzswMAJCcnq21PTk5W7avMMZU5LwAsXLgQc+fOVb0ubiZ688032RWqAWJd6Q/WlX5hfekP1pV+YX3pD13XVXp6Oj788EOtyupNYuHs7AwXFxdcuHABw4YNU20/d+4c+vTpU+ljKnNe4FGLxpOtHAAglUqrtdIlEkm1n5NqButKf7Cu9AvrS3+wrvQL60t/6LKuKnJNvfpJmjFjBtauXYvw8HAAwKZNm3Dnzh28+OKLqjIffvghxo4dW6FjtClDRERERESl05sWCwB499138eDBAzRp0gROTk5IS0vDmjVr0K5dO1WZyMhI3Llzp0LHaFOGiIiIiIhKpzfTzT4uKSkJiYmJ8PLygomJidq+qKgoZGdno0mTJlofU5EypUlPT4eVlRUUCkW1jrFISEiAo6MjmynrONaV/mBd6RfWl/5gXemXitRXrCIHYUlZ8LY3g7NVxZ6PqOp0/dmqyDOuXrVYFLO3t4e9vX2J+9zd3St8TEXKEBERETUUWy5GYuG2ICgFIJUAy0a3xLiOHroOi+oofqVARERERBpiFTmqpAIAlAJ4Z1swYhU5ug2M6iwmFkRERESkISwpS5VUFCsSAuFJ2boJiOo8JhZEREREpMHVWnM8hUwigZe9qQ6iIX3AxIKIiIiINFyPVgB4NLai2Mu9vDmAm0rFxIKIiIiINGw6H4FOXrY4vaAvNr7UGc0aWeDYnUQUFCl1HRrVUUwsiIiIiEjN/cRMnHuQgomdPeBsZYJufvb4/NnWCInPwC+nw3QdHtVRTCyIiIiISM0f5yNhY2qIQQGNVNsCXK0w9SlvfH0oFNGpHMBNmphYEBEREZFKbkER/r4SjTHt3GBsKFPbN3egP6xMDPHBrls6io7qMiYWRERERKRy4GYcUrMLMKGz5kJ45nIDLB7WHIdvx+PgzTgdREd1GRMLIiIiIlLZeD4SXXxs4etgXuL+QQGN0LepIz7YdRNZeYW1HB3VZUwsiIiIiAgAcC8hAxfCUjCxs2epZSQSCZYMb4GU7Hx8czikFqOjuo6JBREREREBADadj4KtmRGebuFUZjl3W1O83q8xfj4djlsP02spOqrrmFgQERERkWrQ9rPt3SA3kJVb/qXuPvCxN8O7O4KgVIpaiJDqOiYWRERERIS9QbFQ5BRgQifNQdslMTKQ4uNRLXE1Mg1/XIys4ehIHzCxICIiIiJsOh+Jbn528LI30/qYTt62eK6DGz7ddweJGXk1GB3pAyYWRERERA1cSHwGLkWkYmKn0gdtl2bB4GaQSSV4b3sQztxPQqwipwYiJH1goOsAiIiIiEi3Np2PhL25EQY0L3vQdklszYzQv5kT/rocjQO34iGVAMtGt8S4jtp1qaL6gy0WRERERA1YTv6/g7Y7uMPIoOKPhrGKHPx9JVr1WimAd7YFs+WiAWJiQURERNSA7bnxEBm5hZhQyRaGsKQsPDkpVJEQCE/KroboSJ8wsSAiIiJqwDZdiESPxvbwsDOt1PHe9maQStS3SSSAl33lzkf6i4kFERERUQN1OzYdVyPTMKlz5cdDOFuZYNnolpBJHmUXEgBGMikKCrm2RUPDwdtEREREDdQfF6LgYCFHv2YVH7T9uHEdPdDT3wHhSdmwMzfCS79dwpzNV7F1VlcYyvg9dkPBmiYiIiJqgHIKirDj2kOM6+BeLQ//zlYm6OprB38nC3w3oS1uxijwxcG71RAp6Qu9Syy+//57+Pr6wtzcHF27dsXZs2erfExgYCBGjRoFJycnuLq6Yty4cXjw4EFN3QIRERGRzh26m4qs/EKM7+Re7edu426N/w1qglUnHuBESGK1n5/qJr1KLH755RfMnz8fX375Je7fv4+nnnoKAwcORFRUVKWPKSoqwsKFCzF16lQEBQXh9OnTyM7ORr9+/ZCZmVlbt0ZERERUa2IVOdh4OQ6dvWzhZlMzg6xf6u6DXv4OmLvlGhLSc2vkGlS36FVi8fnnn2P69OkYOXIknJyc8MUXX8DS0hIrV66s9DEymQynTp3CiBEj4OjoCC8vL6xYsQLh4eE4f/58bd0aERERUa3YcjES3T87jojUPJwPS8GWi5E1ch2pVIIvn2sNqVSCuX9eh/LJOWmp3tGbxCI1NRW3b99Gnz59VNskEgn69OmDM2fOVNsxAJCcnAwAsLCwqKboiYiIiHQvVpGDhduCIP59xheo2cXs7M3l+GZcG5y+n4SfTt6vkWtQ3aE3s0LFxsYCABwdHdW2Ozg44NKlS9V2TFFREd566y20bt0a7du3LzWevLw85OXlqV6np6cDAJRKJZRKZTl3ox2lUgkhRLWdj2oO60p/sK70C+tLf7Cu9MODhMwSF7MLS8yEk4W8Rq7Z1ccWr/TyxZcHQ9DJywbtPGxq5Dr1la4/WxW5rk4TixdffBG//fZbmWXu3r0LX1/fUvdLpVIIUbGmtdKOEUJg5syZuHnzJgIDAyGTyUo9x7Jly7BkyRKN7YmJicjNrZ5+hEqlEgqFAkIISKV607jUILGu9AfrSr+wvvQH60o/WCAfEjxqqSgmlQDmIgcJCQk1dt2JLa1w6q4pXtt4Bb9PagZLY735blvndP3ZysjI0LqsTmt1zZo1WLVqVZllDAwehdioUSMAjx7cH5eQkAAnp5LnXq7IMUIIzJ49Gzt37sSxY8fg7+9fZlwLFy7E3LlzVa/T09Ph7u4OBwcHWFpalnmstpRKJSQSCRwcHPhLuo5jXekP1pV+YX3pD9aVfnBwEHCwCEFCxqNeF1IJ8PGoAAT4utX4tX+cbImh3wfiq1Nx+GFiW0gkkvIPIp1/toyNjbUuq9PEQiqVav0G2drawt/fHydOnMDo0aMBPEoGjh8/jkmTJlX5mNdeew1bt27FkSNHEBAQUG48crkccrlmk2FF7kkbEomk2s9JNYN1pT9YV/qF9aU/WFd137kHyUjIyMO349vAoCAbbfxc4GpjVivXdrczw2djW2HWhitYdSoMbdyt4W1vBmcrk1q5vj7T5WerItfUq0/+W2+9hXXr1uHAgQNQKBR47733kJKSglmzZqnKzJw5E23atKnQMa+//jr+/PNPHD16FK1atarNWyIiIiKqNevPRcDHwQzPtGyE9u4Wtf5QPyjAGV18bPHZ/ruYuOY8ui0/WmOzUlHt06sObi+//DLS0tIwbdo0JCQkICAgAHv37oWXl5eqTFFREQoLC7U+Jjk5Gd9//z0kEgnatm2rdr3Vq1dj+vTptXFrRERERDUqIT0XB4Lj8O7QZjrrhhSryMGFsBTVa6UAFmwLQntPW/g5muskJqo+ElHRkc91XPHI+bIGXj/p8UTkcTKZTOsPXnp6OqysrKBQKKp1jEVCQgIcHR3ZrFzHsa70B+tKv7C+9Afrqu779nAofjpxH+fe6QcLuUwn9XXmfhImrtFcJ8xAKkHvJo4YHNAI/Zs7wcrEULUvVpGDsKQsrbpNVaSsvtD1Z6siz7h61WKhjcq84cUDxImIiIjqo4IiJTZdiMDIti6wMjHU2dSl3vZmkEqgNuWtVALM7u2LM/eT8dZf12Eok6Cbnz2GBDgjM68QS/+5BaV4VG7Z6JYY19GjxHNvuRiJhduCtCpLNYNP1ERERET13JHb8YhPz8PkLp46jcPZygTLRrfEO9uCUSQEZBIJPhkdgHEdPTAXQJwiFwduxmFfcCzm/31DbVpcpQDm/x2E7VdjIIEEuYVFyCtQIrewCNl5RYhLz1Ur+862YPT0d6g3LRf6gIkFERERUT23/lwE2nvaoIWLla5DwbiOHujp74DwpGx42ZuqPfg3sjLGC0954YWnvLAvKBavbLyicXyRUsDF2hhyAymMDWWQG0iRlJmH7VcfqpcTAuFJ2UwsahETCyIiIqJ67F5CJk7fS8Y349roOhQVZyuTch/423hYa3Sbkkkk+G5CW41jYxU52Hntocaq4mZy7cfcVof6OMajIji6ioiIiKge23AuAnZmRhjcspGuQ6mQ4m5Tsn8n0inuNlXSA/uTZaUSwNLYAC/+dgmXI1KrFEesIgdn7ichVpFTZrktFyPRbfnRBj2NLlssiIiIiOqp7PxC/H05GlO6ekJuULvf3leHsrpNlVdWJpVg9oYrGL/6LJYMD8DEzhUfyF3SgPChrVwQkZyFiORshCVlISI5CyHxmbgWlaY6rqGO8WBiQURERFRP7bz2EJn5hZV6qK4rtOk2VVrZTTO64MM9N/HO9iAExSjwwfDmWidYsYocVVIB/Dd4fP7fQaoyFsYG8LY3g5lc85G6IY7xYGJBREREVA8JIbD+bAT6NXWEm42prsPRCSMDKZaObImWrlZ4f8dN3I1Lx0+T26NIiBLHQhQpBa5FpeLI7QTsvq45ZgMAXu3ji/7NnOBlZwZrU0NIJBLEKnLQbflRjfEgXvYN631nYkFERERUD12JTMWt2HT8b1ATXYeic+M6eqCxkwVe2XAZ/b48gcz8Qoh/uzctHtYcDhbGOHw7HsfvJiIlKx82pobo7GOH6NQctSlvZRIJJnfx1GiFeHIaXQBYOKRpg2qtAJhYEBEREdVL689GwNPOFD0bO+g6lDqhnYcN1r7QAcO+P63aphTA4l23AAD+TuYY19Ed/Zs5oo27DWRSCbZcjNRYc6O0ZKF4jMfNmHT83+ariFXklliuPmNiQURERFTPJGXmYW9QHN5+ugmkUomuw6kzMnILS9z+3fg2GN7GVWN7RQaPA/+N8ZjR0wcrj9/Hyz194GRpXC2x6wNON0tERERUz/x5KQoSCTC2vZuuQ6lTvO3N8GSeJZNI0NHbttRjnK1M0NXXrkLdmqZ394bcQIqVx+9XNlS9xMSCiIiIqB4pUgpsPBeJYa1dYGNmpOtw6pSKrI1RFZbGhni5pw82nY8sd/2L+oRdoYiIiIjqkWN3EhCTloPnu3rqOpQ6qaLdmyprajdvrA0Mww/H7mHpyJY1co26hi0WRERERPXI+nMRaO1mhVZu1roOpc6qTPemijKXG2BmT19suRiF6NTsGrtOXcLEgoiIiKieiEjOwomQREzuwtaKuuD5rp6wNDbED8fu6TqUWsHEgoiIiKgeiFXk4LP9d2BpbIBhrV10HQ4BMJMbYFYvX/x1KRqRyfW/1YKJBREREZGe23IxEt2WH8U/QXHIyC3Ezmsxug6J/jW5iyesTY3w/dFQXYdS45hYEBEREemxWEUOFm4LgvLfJaIFgHe2BTeo2YjqMhMjGWb39sW2qzEIS8rSdTg1iokFERERkR4LS8pSJRXFioRAeFL973qjLyZ29oC9uRG+P1K/Wy2YWBARERHpMTcbzZmNZBIJvOxNdRANlcTYUIZX+/hhx7UY3EvI1HU4NYaJBREREZEeW382AlIJVCtK19Sib1Q14zq6w8nSGN9VsNUiVpGDy1EZetG1jQvkEREREempAzfjsOZUGN4b2gxDWznX+KJvVHlyAxle6+uH93YE47W+fvB3sij3mC0XI1XjZ6SSECwb3RLjOnrUQrSVo5ctFhkZGQgPD0dBQUG1H5OTk4M7d+4gISGhqmESERER1ZjI5GzM++s6BrVohBe7e9fKom9UNc+2d4eLlQm+PVx2q0WRUuDgrTgs+Pu/QflKUfcH5etVYlFYWIiZM2fC3t4enTp1gpOTEzZu3Fitx0yfPh3NmjXDJ598Ut3hExEREVWL3IIivLLxMmzNjPDZs60gkUh0HRJpwchAitf7+eGfoFicDEnEmftJqkQhOTMP269G4/82X0WHpYfw8u+X8cSY/Do/KF+vukItX74c27dvR1BQEPz9/fHzzz/jhRdeQMuWLdGqVasqH7Nu3TpER0cjICCgNm6HiIiIqFI+3HMLoQmZ2D77KVgaG+o6HKqA0e3c8On+u3j+5wsAAAkAVxsTxKTlQAggwNUSkzp7opWbJWZtuKI241ddH5SvVy0Wq1atwksvvQR/f38Aj1oX/Pz8sGbNmiofc/v2bbz//vtYv349ZDJZzd0EERERURXsuBqDTecjsWR4C7RwsdJ1OFRBSZl5SM3KV70WAGJSc/DO4Ka48G4/7JnTA/OeboKBLZyxbHRLyFSD8lHnB+XrTYtFXFwcoqOj0aVLF7XtXbt2xeXLl6t0TG5uLsaPH4/PPvsMXl5e1R47ERERUXUIjc/Awm1BGN3WFeM7uus6HKqEsKQsjS5OAkCAqzUcLYzVto/r6IHufna4du8h2vi5wNXGrNbirAydJhaxsbFQKBRllvH19YWhoSGSk5MBAPb29mr77e3tcfr06RKP1faYuXPnonnz5pg8ebLWsefl5SEvL0/1Oj09HQCgVCqhVCq1Pk9ZlEolhBDVdj6qOawr/cG60i+sL/3Buqp52fmFmL3xCtxsTPDhiOYQQkCIJx9RtcP60h1PWxNIJXiiixPgYWtcYn04WcjRzs0cDhZyndRXRa6p08Tiu+++w/bt28ssc/DgQXh4eKi6J+Xn56vtz8vLg4FBybehzTGHDh3CH3/8gX379uHOnTuq/ampqbhz5w6aNm1a4rmXLVuGJUuWaGxPTExEbm5umfekLaVSCYVCASEEpFK96rXW4LCu9AfrSr+wvvQH66pmCSGw5EA4olOz8fOEpshMS0FVllljfemODMCCfp5YfiTi32lkgfn9PCHLy0BCQoZGeV3XVUaGZkyl0WlisWzZMixbtkyrsq6urpBIJIiNjVXbHhcXBzc3t0ofk5CQACcnJ0ydOlW1Pzw8HPHx8Th//jxu3rxZ4piLhQsXYu7cuarX6enpcHd3h4ODAywtLbW6p/IolUpIJBI4ODjwQ1/Hsa70B+tKv7C+9AfrqmbEKnIQnpSN69Fp2H8nBV8/1xqdm7pU+bysL916qa8jhrb3RkRyNjztyl53RNd1ZWxsXH6hf+nNGAsLCwu0b98e+/fvx4QJEwA8aok4fPgw5s2bpyoXFxeHnJwceHt7a3XMpEmTMGnSJLVrtWnTBr1798Y333xTajxyuRxyuVxju1QqrdZKl0gk1X5OqhmsK/3ButIvrC/9wbqqXo8vjgYAnb1tMapdyV+mVgbrS7dcbcy0HjOhy7qqyDX1JrEAgCVLlmD48OFo1aoVunbtiq+++grGxsaYNWuWqsx7772Hc+fOITg4WOtjiIiIiOqSWEWOWlIBABfDUxCryKnTswJRw6ZXKeqQIUOwY8cOHDhwAK+88gqMjY0RGBgIW1tbVRlnZ2f4+PhU6JgneXt7w8nJqUbvhYiIiKg0YUlZakkF8Giwb11eHI1Ir1osAOCZZ57BM888U+r+jz76qMLHPKm8AeVERERENcnb3qyEmYPq9uJoRHrVYkFERETUEDhbmeD1vo1Vr2USSZ1fHI1I71osiIiIiBqCnIIiWBkbYMXEdvBzMmdSQXUeEwsiIiKiOkapFNh57SGGt3FFD38HXYdDpBV2hSIiIiKqY86FJSMuPRcj27rqOhQirTGxICIiIqpjdlyNgYetKdp5WOs6FCKtMbEgIiIiqkNyC4qwLygOI9u4QCKR6DocIq0xsSAiIiKqQ47eSUBGXiFGsBsU6RkmFkRERER1yParMWjtZgVfB3Ndh0JUIVrPCnX8+HGtT9q7d+9KhEJERETUsKVl5+P43QS8M6SZrkMhqjCtE4s+ffpofVIhRPmFiIiIiEjNP0GxUArgmVYuug6FqMK07golhFD9+/XXXxEQEIBDhw5BoVAgLS0Nhw4dQkBAAH755ZeajJeIiIio3tpxNQbd/ezhYCHXdShEFVapMRbLly/Hn3/+if79+8PS0hJWVlbo378/tmzZgs8//7y6YyQiIiKq96JSsnExPBWjOGib9FSlEouwsDDY29trbHdwcMCDBw+qHBQRERFRQ7PzWgxMjWQY2MJJ16EQVUqlEovWrVtj/vz5yM7OVm3Lzs7G/Pnz0bp162oLjoiIiKghEEJg+9UYDGzuBFMjrYfAEtUplfrJXbVqFZ555hm4uLigRYsWEELg1q1bsLS0xJ49e6o7RiIiIqJ67ebDdNxPzML7zzTXdShElVapxKJNmza4d+8e/vrrL9y6dQsA8Morr+C5556DXM7BRkREREQVsf1qDOzNjdDdT7OrOZG+qFRiMXnyZGzYsAFTpkyp7niIiIiIGpQipcCu6w8xrLULDGRcu5j0V6V+erdv347c3NzqjoWIiIiowTlzPwmJGXmcDYr0XqUSi549e+Kff/6p7liIiIiIGpztV2PgY2+Glq5Wug6FqEoq1RUqICAAkydPxr59+9C8eXMYGRmp7X/ttdeqJTgiIiIiXYpV5CAsKQve9mZwtjKp9vPn5BfhQHAcZvbyhUQiqfbzE9WmSiUWu3fvhqenJwIDAxEYGKixn4kFERER6bstFyOxcFsQlAKQSoBlo1tiXEePar3GodvxyMovwsg27AZF+q9SicWdO3eqOw4iIiKiOiNWkaNKKgBAKYB3tgWjp79DtbZc7Lgag/aeNvCwM622cxLpCqceICIiInpCWFKWKqkoViQEwpOySz6gEpIz83AiJBEj27hU2zmJdKlKSzumpKQgMjIShYWFats7dOhQpaDKIoTApUuXEB8fj4CAAHh5eVXbMenp6bhw4QJMTU3RqVMnGBhw5UsiIqKGyNveDBIJIB5LLiQAXK2Nq+0ae27EQgJgaCsmFlQ/VOrJ+eHDh5gyZQqOHj1a4n4hRInbqyo9PR1DhgzB/fv30bRpU1y4cAFvvvkmli5dWuVjfvrpJ7z99tto1aoVTE1NoVAosGPHDri48MNORETU0DhbmaC1mxWuRSkAPBpjIYEEi3fdxMrJ7WFsKKvyNXZci0HvJg6wNTMqvzCRHqhUYvHmm2/C1tYWYWFh8Pb2RmxsLC5cuIA33ngDc+fOre4YVd577z3Ex8fj9u3bsLa2xokTJ9C7d2/07dsXffv2rfQx//zzD1599VXs3LkTzzzzDAAgKCgIWVlZNXYvREREVHelZOXjVmwGXu3ti+6NHeBlb4p7CZl4+ffLmPrLBax9oSPM5ZXv2XAhLBlXI9Pw0cgW1Rg1kW5VaozFsWPH8PXXX6u6FDk4OGD48OHYuHEjfvjhh+qMT0UIgQ0bNuDFF1+EtbU1AKBXr17o2LEjNmzYUKVjPv74YwwfPlyVVABAy5Yt0bhx4xq5FyIiIqrb/r4cDQhgendvdPW1g7OVCXo0dsDvL3bCzZh0TFp7HmnZ+ZU695aLkRi36hwAYPHOm9hyMbI6QyfSmUql2omJiXBzcwMA2NjYIDExEY0aNULr1q3x4MGDag2wWHR0NFJTU9GqVSu17a1atcK1a9cqfUxubi4uXLiAH374AVFRUbhx4wZcXFzQunVrSKWl5115eXnIy8tTvU5PTwcAKJVKKJXKStyhJqVSCSFEtZ2vJsUqchCelA0ve9Mamee7rtOnumroWFf6hfWlP+pTXSmVAhvPR2BQgBNsTA3V7qm9hzU2vNQJU3+5iPGrz+G3aR3hYCHX+tzFs00Vdxp/NNtUELr72dXq38/6VF/1na7rqiLXrfLo5NatW2PVqlWYP38+1q1bB3d3d62PvXTpEsLDw8ssM3jwYJiZmUGheNTH0cbGRm2/nZ0d0tLSSjxWm2OSk5NRVFSEI0eO4JNPPkGLFi1w48YNODg4YPfu3aoE6knLli3DkiVLNLYnJiYiNze3zHvSllKphEKhgBCizCRH13YFJ2HZkQiIf+f5XtDPE8MD7HUdVq3Sl7oi1pW+YX3pj/pUVxcj0xGenI0Ffd2QkJCgsd/JEPhxTGPM2RaKZ386je9H+8PJouxxEnmFSgQ+UGDTlfgSZpsCrt17CJm7RXXeRpnqU33Vd7quq4yMDK3LViqxGDp0qOr/H330EZ555hl88MEHMDIywvr167U+z/nz53Hs2LEyy3Tv3h1mZmaQyx99G5CdrT7NW2ZmJoyNS56hQZtjissEBwfj1q1bMDMzQ05ODrp27Yq33noLW7ZsKfHcCxcuVBtPkp6eDnd3dzg4OMDS0rLMe9KWUqmERCKBg4NDnf3QxypysPzIZdWsGUoBLDscgRxhiK5+9mjWyAJmj/VBra8tG/pQV/QI60q/sL70R32qq72HY9DY0RwD2viUuhq2oyOw9RUHTF53Aa/8HYoNL3aC3ECq9jdOCIFLEanYfvUh/gmKRUZuIZo7W0AC4PHcQiYB2vi5wLGWWyzqS33Vd7quq9Kes0tSqcRiz549qv93794dkZGRuHXrFry9veHk5KT1eV599VW8+uqrWpV1d3eHgYEBIiPV+yFGRkbCx8en0sfY29vDysoKQ4cOhZmZGQDAxMQEzzzzDDZt2lRqPHK5XJWUPE4qlVZrpUskkmo/Z3WKSMnR+OZFAPju2D18feQeJJJHU/a1cLFCUZES+27GqVo2amIFU12q63VF/2Fd6RfWl/6oD3WVkJGLQ7fi8e7QZpDJyp75ycveHH/N6opJa89j+IozyM4vVK3S3aepI0LjMxGZkg1XaxNMfcoLo9q6wsfBHFsuRuKdbcEoEgIyiQSfjA6Aq41ZLd3hf+pDfTUUuqyrilyzUonFtGnT0Lt3b/Tu3Ruenp6wtLREly5dKnMqrRkbG6NPnz7YunUrpk2bBuBRN6YjR47gyy+/VJW7fPkyUlJSMGDAAK2PGTp0KEJCQtSuFxISUmo3KPqPt73mL0KZRIJjb/VCRl4hbsak4+ZDBa5EpiEoRqEqU1MrmBIREVXFX5eiYSCTYHRb7Z4BnK1M8P2Ethj6XaBqm1IAR24n4JlWjfDZ2Fbo5GULqfS/lo9xHT3Q09+hXrbgU8NWqcRCCIHFixcjIiICXl5eqiSjONGoKcuXL0ePHj0wbdo0dO3aFWvWrIG/vz+mT5+uKrNy5UqcO3cOwcHBWh/z0UcfoXPnzpg5cya6deuG8+fPY+fOndi/f3+N3Ut9UVj0qLmieBGh4m9ePOweJRwtXKwAuOPM/SRMXHNe7djiFUz5C5WIiOqCIqXApvORGNbKBVamhlofp8gpKHH7pM5e6OJjV+I+ZysT/v2jeqdS7Sm//vorwsPDERYWhkWLFkGpVGLx4sXw8vKCt7d3dceo0q5dO1y+fBk2NjY4ceIExowZg1OnTql1SerQoQMGDhxYoWN8fHxw9epV2Nvb4+DBg7CyssKNGzfQp0+fGruX+uLAzTgYyaQ4+EZP/DGjCwIX9Cmxe5O3vRmkT3RTlUkk8LI3raVIiYiIynYyJBExaTmY1KViX5LybxzRI1WaFcrFxQV+fn6IiopCZGQkYmJiarzvV9OmTfHVV1+Vun/WrFkVPgYA3Nzc8PHHH1c5vobm4M14dPOzQ2MnCzQuY3iNs5UJlo1uqepTCgCv9vXltzVERFRnbDwfgRYulmjtZlWh4578G1fces+/cdTQVCqxWLp0KY4fP44zZ87A2dkZvXv3xvTp07F+/XqOS2hAkjLzcDEiBctGtdSqfHGf0vsJmXh98zWkZpXcdExERFTbYtJycPROApaObFnqTFBl4bgJokomFu+//z7s7e2xePFiTJkyBS4uLtUdF+mBw7fiIQHQv7n2M4EV9ykd39Ed689F4J0hzWBiVPasG0RERDVty4VImBjKMLxN5Z9pOG6CGrpK9Vs6duwYZs+ejb1798LHxwdNmjTBzJkzsXnzZsTFxVV3jFRHHbgZhw6etrA3137F0WLjOrojI7cQ/wTF1kBkRERE2isoUmLzxSiMbOsKc3mV1w4marAq9ekpngEKAHJzc3H27Fn89ttvmDx5MoqKiiCEKPsEpPcycgtw+l4y/jeoSaWO97QzQzc/O2y+EImx7dl9joiIdOfI7QQkZORhUueam9mSqCGodFoeHR2NY8eO4fjx4zh27BjCwsLg6uqKXr16VWd8VEcdv5uI/CIlnm7RqNLnGN/RA3P+uIrQ+Aw0drKoxuiIiIi0t/F8BNp6WKO5i6WuQyHSa5XqCuXn5wd3d3csXLgQubm5WLhwIUJCQhAdHY2NGzdWd4xUBx24GYfmzpZwt638VHoDWzjB1swImy9GVWNkRERE2otIzsKp0CS2VhBVg0q1WCxYsAC9evVC48aNqzse0gN5hUU4fjcRM3r4VOk8cgMZxrRzxdbL0fjfoCaQG3AQNxER1a5NFyJhaWyAZ1o56zoUIr1XqRaLl156iUlFA3bmXjIy8wrxdID2s0GVZlxHD6RmF+DAzfhqiIyIiEh7eYVF+OtSNMa2d4exIb/cIqqqSq9md+rUKUybNk1tTMVPP/2E9PT0agmM6q4DN+PgaWeKJtUwLsLP0RydvGyx+UJkNURGRESkvf3BcUjJysfEzu66DoWoXqhUYrFt2zYMGjQIhoaGOHnypGq7QqHAF198UW3BUd1TpBQ4dCseT7doVKkFhEoyvpM7ztxPRkRyVrWcj4iISBubzkeis7ct/Bw5gQhRdahUYvHhhx9i8+bNWL16tdr20aNH47fffquWwKhuuhyRiuSsfDzdourdoIoNaekMS2MDDuImIqJacy8hA+fDUjCpCwdtE1WXSiUWd+/eRf/+/QFA7VtrZ2dnxMZywbP67MDNODhYyNHW3abazmlsKMOotq7461I0CoqU1XZeIiKiksQqcvDFgbuwNjGs1i/KiBq6SiUW9vb2ePDgAQD1xOLEiRPw9GTmX18JIXDgZhwGNHeCVFo93aCKje/kgaTMPBy5nVCt5yUiInrclouR6Lb8KPbfjIcipwA7rsboOiSieqNSicXzzz+PWbNm4c6dO5BIJFAoFNiyZQteeuklTJ06tZpDpLriVmw6olNzqrQoXmmaOVuitbs1Nl/kIG4iIqoZsYocLNwWBKV49FoAeGdbMGIVOTqNi6i+qFRi8cEHH8Df3x8tWrRAUVERrK2tMWHCBAwdOhTz58+v7hipjjhwMx4Wxgbo6mNXI+ef0NEdJ0ISEZPGX/BERFT9whKzVElFsSIhEJ6UrZuAiOqZSiUWhoaGWLduHSIjI7Fr1y7s2LEDYWFhWLt2LQwMKrXmHumBgzfj0LepI4wMKj1LcZmGtXaBqaEMf3IQNxER1YDjdzW728okEnjZm+ogGqL6p0pPiK6urhg2bBhGjBgBT09PJCYm4vXXX6+u2KgOiUjOwp24jBrpBlXMTG6A4W1c8OelKBQ9+ZUSERFRFaw99QCrT4VhYHMnyP4dHyqTSPDJ6AA4W5noODqi+qHCzQv379/H0aNHkZeXh2eeeQZeXl7Iy8vDF198gU8//RQ2Njb47rvvaiJW0qEDN+NgZCBFL3+HGr3O+I4e+ONCFE6EJKBvU87UQUREVbfpfCSW/nMbs3r5Yv6gJohLz0V4Uja87E2ZVBBVowolFocOHcLw4cORm5sLAFiwYAF2796NuXPnIiIiAosWLcKcOXNqJFCqHrGKHIQlZcHb3qxCv0wP3IxHz8b2MJPXbFe3Vm5WaOZsiT8uRDGxICKiKtt+NRrv7gjCC109MX9QE0gkEjhbmTChIKoBFeoK9cEHH2DatGnIyMhAeno6Jk+ejCFDhsDJyQkhISGYN28e5HJ5TcVKVVQ8xd7ENefRbflRbNFyBqaEjFxciUzFwBrsBlVMIpFgQid3HL2TgIT03Bq/HhER1V/7g2Mx768bGNvODYuHtVCbIp+Iql+FEoubN2/io48+grm5OSwsLPDxxx8jNzcXa9asgb29fU3FSNXgySn2lEL7KfYO3YqHBED/ZrXTgjCijSsMZRL8dTm6Vq5HRET1z/G7CZjzx1UMDmiE5WNaVfv6S0SkqUKJhUKhgJ3df1ONFv/f3d29eqOiaheWVPIUe/fiM8s99uDNeHTytoWtmVENRafOysQQQ1o6Y8P5CJwOTdIq+YlV5ODMfe3KEhFR/Xb2fjJmrr+MXv4O+HpcG8iYVBDVigp3mD98+HC52/r371/5iKhGeNubQSqBRnKxbN8deNmbwd225Kn20nMLcOZ+Et4Z0qwWovyPo4UcsWm5mLTuPKQSYNnolhjX0aPEslsuRqpaY8orS0RE9VesIgcHb8Vj2d7b6ORtixUT28FQVjNTpBORpgonFgMGDCh3mxA1N1WoQqHAtm3bEB8fj5YtW2LIkCHl9pnU5pjw8HAcPHgQqamp8PDwwPDhw2FmZlZj91HbnK1MsHhYCyzedRPAoyn2ZvX2xc5rMRjy3Sl8PrYVBgU4axx37E4CCopErYyvKBaryMHqkw9Ur5UCmP93EH47EwFzYwPIDaQwkklhZCBFYZHAodvxamXf2RaMnv4OHJhHRNSAbLkYiQXbglD8CDKwuROMDWW6DYqogalQGh8VFaXVv5oSGRmJli1bYvXq1YiJicHLL7+M0aNHl5nIaHPMxo0b0aRJExw5cgQpKSn46quv0LhxY4SFhdXYvehCBy8bAMCHI1ogcEEfvP10E/zzeg9087XHrA1XsHhnMHILitSOOXgzHi1dreBqXXsP6SV12wIAJws5XK1NYGlsCIlEgqz8ohJX6eYqqkREDUvxOMLHHwc+2HWL3WOJalmFWizc3NxqKg6tzJ8/H87Ozjh16hQMDAwwZ84cNG/eHFu3bsWzzz5b6WM+/vhjTJ8+HStXrgQAFBQUwNfXF2vXrsXHH39ca/dX0yKTHz1sD23pDDvzR7N3WZkYYuXkdthwLgIf7bmNSxGpWDGxHbztzRCelIUjt+PxwlOetRpnSd22ZBIJPhnTUqMVIlaRg27Lj2qU5SqqREQNx53Y9BLHEYYnZbP1mqgW6U3Hw6KiIuzcuRNTpkyBgcGjfMjf3x89e/bE1q1bq3SMpaVlid2prKysauBOdCciJRvmcgONQdgSiQRTunph2+ynkJ1fhGe+O4UFf99Any+PI7dQiTWnwrSemrY6OFuZYNnollqtjPpf2f+2fTyKq6gSETUUQgisP6f5N4pfMhHVvppd7awaRUZGIicnB40bN1bb3rhxY5w/f75Kx6xZswYzZ87EhAkT4OnpidOnT6Nfv3547bXXSo0nLy8PeXl5qtfp6ekAAKVSCaVSWeH7K4lSqYQQotrOF5GUBQ9bEwghSuw+1tzZAjtffQpv/Xkdmy/+16Xt0biFIHT3s6u1B/Zn27uhu58dIpKz4Wn3aGXU0t6H4rJ7bsRi2b67sDM3qrb3TFvVXVdUc1hX+oX1pT90VVc/Hr+Po3cSMKmzBzZfiESRAGQSYOmoFnCykPNnpxT8bOkPXddVRa6r08Rix44duHbtWpllXn/9ddja2iIz89G0qE+2IlhbW6v2PUnbY1JSUpCYmAhnZ2colUrk5OQgLi4O2dnZMDUt+duOZcuWYcmSJRrbExMTVSuTV5VSqYRCoYAQAlJp1RuXQuPS4GQmQ0JCQpnlRjSzwqHb6mWKBHDt3kPI3C2qHIe2ZAB8zAHkZSAhIaPcssP9zbD/hjk+33cLATaiVhdCqu66oprDutIvrC/9oYu6Oh2mwJcH72F6Z2e83NUB4wKsEJWWB3drORwtjMr9e9eQ8bOlP3RdVxkZZT+DPU5vWizMzc0BPJrh6XFpaWmqfZU5pqCgAM899xxefvllfPTRRwAedaFq37495s+fj3Xr1pV47oULF2Lu3Lmq1+np6XB3d4eDgwMsLS0rcYealEolJBIJHBwcquUHKT7zFtp52cPR0bHMcm3lFpBKQp8YtwC08XOBYx3vYjR/iCHGrzmPq4kCgwJqZ0E/oPrrimoO60q/sL70R23X1YPETCzefx39mjninWGtIZVK4OgIBNT4lesHfrb0h67rytjYWOuyOk0sRo4ciZEjR2pV1t3dHSYmJggNDcXTTz+t2h4aGoomTZpU+pi4uDgkJCSgR48eqv0ymQxdu3bFxYsXS41HLpdDLpdrbJdKpdVa6RKJpFrOWVCkxENFLjztzco9l6uNGZaNbol3tgWjSAjVGAdXm7o//W4XX3t097PHt0fuYVCAc62ttBqryMG16Ey0MbbUi/epoauuzxXVDtaX/qitukrPLcDLG66gkZUxvh7XBgYGnFa2MvjZ0h+6rKuKXFNvfpIMDAwwYsQIrF+/HoWFhQCAkJAQnDx5EmPGjFGV27VrF3788Uetj3FxcYG5uTlOnTqlOkdRURHOnj0Lf3//2rq9GheTmoMipYCnrXYPveM6eiBwQR/8MaMLAhf00asF594c4I+78Rn4Jyi2Vq635WIkenx2HK/+HYIenx2v1YHuREQNjVIp8Obma0jMyMPqKe1hYWyo65CI6F960xUKAD799FN069YNPXv2RIcOHbBt2zYMGzZMbarZXbt24dy5c5g9e7ZWx8hkMnz33XeYNWsWbt++DR8fHxw5cgTx8fGlzjaljyJSHk0162mn/QwZzlYmejm7UntPG/Ru4oBvDodgSEtnyGqw1aJ47vTibmNcoI+IqGZ9dSgER+8m4JepHeHjUHJXaCLSDb1psQAADw8PBAcH46WXXoKzszN++uknbNu2TW2Q7vDhw1VJhbbHTJs2Dbdv38agQYNgZ2eHt99+G/fu3YOfn1+t3l9NikzOgoFUAmcr7fvJ6bO5A/xxPzELO6/F1Oh1SlrMr0gIXItMq9HrEhE1RHuDYrHi2D387+mm6N2k7PGCRFT79KrFAng0w9P06dNL3T98+PAKHwMAPj4+8PHxqXJ8dVVEcjbcbExgINOrXLLSWrlZY0BzJ3x7JBTDWrvAsIbu282m5FaJ/9t8FRfCU/BKL184WjaMZI6IqCbdjk3HW39ex7DWLpjVq/7+vSbSZw3jKZMQmZIND7uGNaj4zf7+iEjOxrYr0TV2jd3XYyGRAMW9rWQSYPGw5pjdxw9bL0ejx2fH8MGum4hP/28K4lhFDs7cT0KsIqfG4iIiqi9iFTk4eDMO03+7CG97M3w2plWtTidORNrTuxYLqpzIlGx08LLRdRi1qrmLJYa0bITvjtzDqLZuMDKo3jz6blwGvjkcglm9fDG5szuu3XuINn4uqlmhpnXzxq+nw7Eu8AE2XYjExE4ecLU2wbJ9t6EUj5KRZaNb6tXAeCKi2rTlYqTaOLYXunjCxIgzQBHVVWyxaACEEIhMydZ6Rqj65I3+/nioyMGfl6LKL1wBhUVKvL31OjztzPB//RrD2coE7d0t1AZsW5kY4v/6N0bggr54rY8ftl6Owsd7b2sM9GbLBRGRpicnxwCAzw+E8HcmUR3GxKIBSMzMQ3Z+ETwqMCNUfeHvZIHhrV2w4ug95BYUVdt515wKQ3CMAp+PbQVjw7K/PbM0NsTr/Rrjm/FtNfYVCYHwpOxqi4uIqD4IT8rCe9uDS5wcg78zieouJhYNQGRyxaearU/+r19jJGTk4o8L1bO+xL2EDHx9KAQzevigrYf23ctauFjiyZlvZRIJvOwbZr0QET0pKFqBVzdeQd8vj+NKZCqeHEnB35lEdRsTiwYg4t/EwsO2Yf4y9nEwx+h2bvjx+H3k5Fet1aJIKTDvrxtwszXBmwMqtoCis5UJlo1uqUouJAA+GR3A9S6IqMF5fBILIQRO30vC5LXnMWxFIIJiFPhwRADOLuyH5WNaQvbvQG2ZRMLfmUR1HAdvNwCRKdlwsJDD1KjhVvfrfRtjx9UYbDgXgRk9Kz9N4brAB7genYats7qW2wWqJOM6eqCnvwN+PHYfG89HoIuPXaVjISLSR48PyJYAcLE2QUxaDlq4WOL7CW0xOKCRamr04t+Z4UnZ8LI3ZVJBVMexxaIBiEzJbrCtFcU87EzxbAc3rDxxH/cTMis13ev9xEx8cTAEL3bzRntP20rH4mxlgneHNoOtmRw/HLtX6fMQEembJwdkCwAxaTn4dnwb7JnTHcNau2ist+RsZYKuvnZMKoj0ABOLBiAiOQueDTyxAIDX+jaGIrsA/b86gYlrzqPb8qPYclG7cRdFSoH/bb0BFytjvDWwSZVjMTaUYVYvH2y7EqMaA0NEVN/dT8jSGJANAI4WxlybgqgeYGLRADxaHI+JhVQCKIVA8d+0ikz3+svpMFyJTMVnY1tX2xzqkzp7wtrUkK0WRNQgpGbl47sjIRrbOSCbqP5gYlHPZeYVIikzv8HOCPW4sKQsPPlFWZEQuByeWu5xnx+4i6lPeaGTd+W7QD3JxEiGmT198feVaESlsNWCiOqv4BgFnvk+EKEJmXipuzcHZBPVUw13NG8DEamaEarhLY73JG97s39bLdS3v/bHVWy5FIWx7d3wdItGqkHZsYocPEjIwmcH7sDJ0hhvP131LlBPmtTFA6tO3sePx+9h2ehW1X5+IiJd+/tyNN7ZHoTGTubYMrML3GxM8WIPbw7IJqqHmFjUc5EpDXsNi8cVT/f6zrZgFAkBmUSCRcOawdhQhr8uReP/Nl+DhbEBhrd2gbWpEVYev6dKQl7u6VMjs2qZGhng5Z4++Gz/Xczu7Qd3joUhonoiv1CJpf/cwu9nIzC2vRuWjgxQfXHjbGXChIKoHmJiUc9FpmTBzEgGOzMjXYdSJ5Q2deG4jh54kJiJv69E48+L0UjMzFM7bt2pMEzr5lUjfwgnd/HEqhMP8OPx+1g2umW1n5+IqLYlpOdi9sYruB6dho9GBmByZw8OziZqADjGop6LSM6Gu60pf6E/prSpC30czPH2003x9bg2GscUCYHwpJoZB1HcavHXpShEp3KsBRHpp1hFDi5HZeDgzTg8830gIlOysfnlLpjSxZN/g4gaCLZY1HORKdnsBlVBvo6aYzFqetaSKV09serko1aLT0ax1YKI9Mvji94BgJedKf6c1RWOFsa6DYyIahVbLOq5iORseNpx4HZFFI/FqM1ZSx5vtYhJq9jCfUREuvTkonfAoy+1ikpasIKI6jW2WNRjBUVKxKTlNPhVtyujtLEYNWlKF0+sPvkAPx67h4/ZakFEeuLCgxSN2faUAghPyuYAbaIGhi0W9djDtBwUKQW7QlVSaWMxaoqZ3AAzevjgz0tReMhWCyLSAydDEvH+zmCN7Vz0jqhhYmJRj6mmmuUaFnrj+a6eMJcbYOXx+7oOhYioVEqlwA/H7uGFXy6grYcNFg9rDtm/47NlEnDRO6IGil2h6rGI5GzIpBK4WHPwnL4wkxvgpR4++PZwKGb38eUfZiKqc9JzC/DWn9dx6FY8Xu/rh//r7w+ZVIKBzR1x7d5DtPFzgasNv9AiaojYYlGPRaZkw9XaBAYyVrM+eeEpL5jKZWy1IKI6JzQ+AyNXnMa5B8lY+3wHzB3YBDLpo6YKZysTtHe34BciRA0YWyzqsYjkLI6v0EPm/461+PZwKMa0c0VWfhG87c34x5qIdCJWkYOwpCw8SMzCJ3tvw93GFLte6w5ve7ZKEJE6vUss7ty5gzVr1iA+Ph4tW7bEq6++CnNz8zKPiYiIwJo1a3Dnzh0sWbIELVq0qJbz1nURydlo72mj6zCoEp7v6okVx+5h5A9nIABIJcCy0S0xrqOHrkMjogbkyfUpWrtZ4Y+Xu8DUSO8eH4ioFuhVH5krV66gffv2SElJQY8ePbB161b06NEDeXl5pR7zxRdfoE+fPsjMzMTff/+NxMTEajlvXSeE4OJ4eiwzrxC5+UUonsFRKYB3tgUjVsHZooio6mIVOThzP6nU3yn5hUocuhWHBX+rr08RHKOAIqeglqIkIn2jV185LFy4EL1798Yvv/wCABg7dizc3d3xyy+/YNasWSUe8+yzz2Lu3Ll4+PAhvv3222o7b12XnJWP7PwieHBGKL0UlpSFJ5eWKhKC88ITUamKuyyV13Xy8VaI4tbQPk0dcSUiDVcjU3E5IhU3YhTIL1RqHFvE9SmIqAx6k1jk5eXh6NGjWL16tWqbnZ0d+vXrh71795aaAHh6etbIeeu6iOR/p5pli4Ve8rY3g1QCjUWn7MyMdBMQEdVpJSUL4zp6QAiB3AIlsvMLkZ1fhKiUbCzYFgTx7+8WpQDm/x2kOo+zlTHaedpgfktneNqZ4uXfL6n9HuL6FERUFr1JLCIjI1FYWAgPD/U+5h4eHjhx4kStnzcvL0+tq1R6ejoAQKlUQqnU/JanMpRKJYQQlTpfRFImAMDV2rja4qHSVaWuSuJkIcfHowLw3vZgFP37oCA3kGHarxfx/YQ2aONuXS3XaYiqu66oZrG+ynfroQIL/g5S6zo5/+8gLN55E7kltDqU5PU+vniuoztcrNVbIh7/PSSTAEtHtYCThbzE+mBd6RfWl/7QdV1V5Lo6TSx++OEHHDt2rMwyK1asQKNGjVQP8aam6t+UmJubIzc3t9IxVPa8y5Ytw5IlSzS2JyYmVimexymVSigUCgghIJVWbDjMrahE2JgaIFuRguxqiYbKUpW6Kk0fDzm2T2+JqLQ8uFvLoRTAe3sf4NlVZ/FadzeMb+sIiURSLddqSGqirqjmNPT6SsjIV/0OcLR41GKpFAIhCdk4HabAmfB03IzLKvHYoc1t0djBFCaGMhgbSGFsKEVOQREW7nmg1tVSKgH6+5jCID8DCQkZaud48veQo4UREhISSrxeQ68rfcP60h+6rquMjIzyC/1Lp4lF586d4eTkVGYZCwsLAICVlRUAIDU1VW1/cnIyrK2tKx1DZc+7cOFCzJ07V/U6PT0d7u7ucHBwgKWlZaXjeZxSqYREIoGDg0OFf5CS82LhbW8OR0fHaomFylaVuiqLoyMQ8Njrv191wRcHQ/DtyTDcTMzH52NbwcrEsNqu1xDUVF1RzWjI9bXlUhTe3R6s6t40vqM78ouUOBGShMSMPJjLDdCzsT1GtHXH8v13nuiyBMwdXPLq18LI9IlWiAAE+LqVGseTv4dK05DrSh+xvvSHruvK2Fj7hZZ1mlh06NABHTp00Kqsm5sbbGxscOPGDQwZMkS1/caNG2jVqlWlY6jseeVyOeRyucZ2qVRarZUukUgqdc7IlBx42pnxl0UtqmxdVYRcKsW7Q5ujs7cd3vrrOp75/jRWTGyLRlbGWg3apEdqo66o+jTE+opV5KiSCuBR96ZNF6LgbW+K0W1d0aepI9p72sDw3wVQrUwN8c62YBQJAZlEgk9GB5S6+vWETp7o3cQR4UnZ8LI3rdbfGQ2xrvQZ60t/6LKuKnJNvRljIZFIMGnSJKxbtw6zZs2CtbU1Tpw4gYsXL2L58uWqcj/99BNCQkLw1VdfVet59U1kSja6+9nrOgyqIf2bO2Hv//XAa5uuYMzKMxACXO+CqB4JS8rSmLwBAD4Z1Qpdfe00to/r6IGe/g5aJwvOVib8EoKIqp3eJBYA8PHHH+PKlSto1qwZmjVrhvPnz+Odd95B3759VWUuXbqEc+fOqV4fP34cK1asQE7Oo7m6Fy9eDAcHBzz33HN47rnntD6vPsnOL0RiRh5nhKrnXK1N8O34Nuj12XGN9S56+jvwoYFIj4UmZGpsK29GJiYLRKRrepVYWFpaIjAwEBcvXkR8fDwCAgLg7e2tVuaVV17BuHHjVK+9vb0xfvx4AMC0adNU25s3b16h8+qTyBRONdtQRKfmcL0LonpECIG1p8Lw8d7baOdhjWtRaVAKqLo38XNNRHWZXiUWwKOuS506dSp1f/v27dVee3p6lruWhTbn1SfFa1i42zKxqO9KWu+C88wT6SelUuCjf27hl9PheLWPL+YNbIK49NwaGQtBRFQTOFqnHopMzoapkQwO5pqDy6l+cbYywbLRLSF7bNrZRcOa8QGESM/kFhRhzh9X8euZcHw0ogXefropJBIJnK1M0NXXjp9pItILetdiQeWLSMmCh60p1zhoIIoHbV6JSMVrm67CQMbvC4j0iSK7ADPWX8L1qDSsnNQegwIa6TokIqJK4RNIPRSZkgMPdoNqUJytTDC0lQv6NnXE5gtRug6HdCBWkYMz95MQq8jRdShUAQ/TcvDsqjMIic/AphmdmVQQkV5ji0U9FJmchQHNy154kOqnCZ088NLvlxAUrUBLNytdh0O1ZMvFSCzcFqRaSI1TDtd9sYocnAxJxBcHQmBkIMXWWU/Bz9Fc12EREVUJWyzqmcIiJaJTc+BhV/LCSFS/9W7igEaWxvjjYqSuQ6FaEqvIUSUVwH9TDrPlou7acjESTy0/ivl/ByExMw9Tn/JiUkFE9QITi3omVpGLQqVgV6gGykAmxXMd3bHzagyy8gp1HQ7VgpIWUiuecpjqnjP3kjD/7yCIx+ps+b47TASJqF5gYlHPFE8168nEosEa19Ed2QVF2H39oa5DoVpgbWJY4vZd12KQyeSyzrj1MB2zN17GxLXnNfYxESSi+oKJRT0TkZIFmVQCVxtOTdhQuVqboJe/A/64yEHc9V16bgHe3noD5nIDSP+dBE4qAQYFNML2azHo/+UJ7A2KhRBPLqNIteVGdBpe+u0Shnx3CkExCiwY1FRVV8W49gwR1RccvF3PRCZnw8XaGIaccrRBm9DJAzPXX8bNhwq0cNHfQdyxihyEJWXB296s2ubxj1Xk4FpUBtrILeBqo79jkXLyi/DirxcRlZKNv2Z1hbWpodpCatGp2Viy+xZmb7yCnv4O+HB4C3jZV/x+a6IO9ElF7v/xsg/TcvDdkXs4EZIIH3szfPFsa4xo4wJDmRQ2ZoZ4Z1swioTgitpEVK8wsahnIlOy4Wmrvw9LVD36NnWEo4Ucmy9E4aOR+plY1MRMR+rnDNHb2ZPyC5WYteEybj5Mx/oXO6OZsyUAqD2cutmYYs3zHXD4Vjw+2H0TA785iVd6+eKV3r5Izc7X6mG5oc82VZH7f7xsMX8nc3w3oS2GtnSG7LFmiuK1Z7iiNhHVN0ws6pmI5Gy08bDWdRikY4YyKZ7r4I7fzoRj4ZCmMDXSr496yTMdBaGnv0OlH8JKOufCbUHo5GUHbwf9ScaLlAJvbrmGs/eT8fPUjmjvaVNm+f7NndDNzx4rjoXix+P3sP5cBFKz8yH+fVieP6gpnvK1R1JmHhIz85CcmY+kzDxEp2TjwK141XmKZ5uqSh3ok5J+Xub/HYSN5yIhlUpQpBQoKFKiSCmQV1CEyFT1wddSCfDL1I5wtSm5i5OzlUmDeB+JqGHRr6cNKpMQApEp2RjRxkXXoVAdMK6jO344fg97bsTiuQ7uug6nQq5GpJYw0xFw/kEyRrZ1q/D5hBDYfCFK45xKAQz69iQGBTTCsFYu6OFvD7mBTLW/rnUDEkLgnW1B2H8zDj9MbIfuje21Os7ESIa3n26K7n4OmLDmnGq7UgDL9t1RK2tpbAB7CzmMSuhOWTzIuC68FzVtX1Ccxs8LAFibGsLZygQymQQGUgkMpFIkZORqJBZK8Wix0tISCyKi+oiJRT2SkpWPzLxCTjVLAAB3W1N097PH5guRepVYxClysfyJh91ib2+9gfDkbMzq5QtjQ1mJZZ4UEp+BxTtv4uyDZI19UgkwrZsXjt9NxM5rl2BhbIBBLRphWGsXRKdm470dwXWmG5AQAh//cxtbLkXhy2dbV2qFZoGSB3F/MioAfZo6ws5MDiODRwlFrCIH3ZYfVXu4bgiDjBPSc7Fs3x1svxqjsU8mkeDTsa00EqtYRQ72BsU2uPeKiOhJHOFbj0SkPJqu0MOOf8zokYmdPHAlMg134tJ1HYpWHqblYNzqsyhUCvzv6SaQSR71S5dJJPhoRAvM6OGDH47dw8CvT+LYnYQyz5WeW4CP9tzC4G9PIS49F79M64hPx7SE7N+u7rJ/k4UFg5th/xs9cfDNnpj2lBcuhqfg+Z8v4J3twXVq0bnvj97D2sAwLBneAmPaV7zVBgC87c1KnJGoT1NHOFuZqJIK4FFXnWWjW6rqAAA+GN683rZWFBQpsfbUA/T98gROhCTi0zEt1e6/rEHWT75XHJBNRA0VWyzqkcjiNSy46jb9q39zJ9ibPxrE/cHwFroOp0xRKdmYuPYclEpgy8yucLc1xah2rhoDXEe3c8PiXcGY9utFDGzuhEXDmsPNxlTVbcnT1hTnHqRg2b47yM4vxLyBTTC9u5eqi1N3Pztcu/cQbfxc1GaF8neywNyBTfDmAH/8cSES72wPVouvSAj8cOweJnfxRBMnC0gk6k/oNTWDVVhSFi6GpeDrw6GYN9AfLzzlVenzFT8AazsjUfEg44thKXjrz+tIyy6o9LXrkifr6sy9JCzadRMPEjMxpYsn5g5oAivTR+uD9G6i3SBrDsgmImJiUa9EpmTDzswI5nJWKz1iKJPi2Q5u2HguAvMHNYWJkXbdh2pbZHI2Jqw5B5lUgi0zO8Pt337pJQ1w9XM0x4YXO2PPjVgs/ecW+n91Ar38HXDoVrxaV5RhrV3wzpCmGsc7W5lA5m4Bx1Ie/CT/foMvlUCjj/2fF6Ow4Vwk7M3l6O5nh25+9ujR2AEnQhJqdAYrAOjZ2B6v9vGr0jmBij8AO1uZYHgbV9yIVuCnE/cxvpMHHCzkVY5DV56c6amFqxWCohXo6GWDPXN6oLmLpVr5igyy5oBsImro2BWqHolIzmY3KNIwvqM70nMLsTcoVtehlCg8KQvjVp+FoUyCLTO7qJKKskgkEgxr7YIjb/XGqLauOHBTPamQSlBiUqGtkrq2fDqmJW588DQ2vtQZY9u74X5iFv739w10WXYE8/9+cgarqnWbepCYiQV/q09devpeEuLScyt9zsc5W5mgq69dhd6f1/r6QSaV4NsjIdUSQ02IVeTgzP2kUt/7kmZ6CopWYPGwZvhzZleNpIKIiCqGX23XI5Epj7qBED3O084M3fzssPliZKX75teUB4mZmLDmHMyMDPDHy13gZGlcoePN5QYY1toFf1xQX2VcKVDl2YtK+2a/m589uvk9mo0pJSsfv50Jx7dHQtWOLRIC606FYUZPnxLvqaRuUwVFSpwKTcTOaw+xPzhOY5h1UTXcU1VYmxphTt/GWL7/DqZ184avg7lO4ihNSWtOjGrrhpD4DNx6mI6bDxU4+yC5xJmemjay0ujaRkREFcfEoh6JSM5GVx87XYdBddCETh54bdNVhMZnoLGThU5jKX6olgB4ffM1WJkYYtOMznC0qFhSUax4QHJNzMhTXtcWWzMjjO/kju+Phmo8sK4LDMPawDAEuFqib1Mn9GvqiJauVvjrcpTaA/DLPX2Q8W+LUmp2AfwczTH1KU+sORVW52YZmtLVE7+eCcen++5g9fMddBrL40pbc+Ld7UEoVAISyaOfEx97c4TGZ6olbXXhfSUiqi+YWNQTOflFSMjIgwcHblMJBjZvBDszI/xxIQqLhjXXWRxPjhtwspRj88tdYG9e+T77FR2QXN1Ku/7TLRrhREgijtxOwK+nw/DdkVDYmhkhJStfdaxSAD+deAAnCzme6+iOEa1d0cz50cBwHwdznd1TaYwNZfjfoCb4v83XcCEsBZ28bXUaT7F7CZkltkRM6eqFZ1o5o2kjS5j9O/Zsy8XIOve+EhHVF0ws6onIlOIZofjNG2kyMpBibHs3bL4Yhf8NaqL1GhDV6clvlQEgMSMPBUXKKp9b1zPylHb9EW1cMaKNKwqKlLgckYoN5yKw54bmWJevx7XBU372Wp1T14a1csHaU2H4ZO9tbJ/9lM67ECVm5OGrQ5rjPmQSCV7u6aPxvtXV95WIqD7g4O16QpVYcIwFlWJcR3cocgqwPziu2s9d2qDZ4uu9vyMYo388U+LK1+FJ2dUSQ2UGJFensq5vKJOii48d3h3arMR1JLwdSm5p1PU9lUQqlWDhkKa4FpWGvUGV+1kqb5C1ti6EpWDod6cQnZqDmT19tF5Hoi6+r0RE9QFbLOqJiOQsmBjK9HoaSKpZPg7m6OJji1/PhMPRUl5t6y08OWj2xe7eMDKQIvBeMoKi06AUj1rSOnvbYue1hw26f7uuu21Vl6d87dG3qSM+O3AHA5o7qS2sV56SBllXdGpeIQTWngrD8v130N7TBismtIWjpTGmdvNiSwQRkQ7pXWLxzz//4LvvvkN8fDxatmyJJUuWwMfHp9TyQggcOHAAP/30E+7cuYPff/8dnTp1UisTFRWF7777DmfOnIGBgQG6d++Ot99+G9bW1jV8N9UnMiUbHramOu+WQHWbl50ZNl+MwsQ156tlvYWSBs2uORUGaxND9PB3wISO7ujmZw/3f1vSuvra6f1DdVXVl644CwY3xaBvTmLj+QhM6+at1TEl/by8sy0YPf0dtH4f0nML8L+/bmD/zTjM7OmDt59uAgPZo8SG60gQEemWXiUWe/fuxciRI7Fs2TJ07doVX3/9NXr06IHg4GDY2NiUeMz8+fNx/fp1jBw5Ejt37kR2tnq3i6KiIvTt2xezZs3C559/juzsbCxcuBD79+/H2bNnYWRkVBu3VmVcw4LKE6vIwZ+X/puWtTIPdU8qbdDsj5PaaYwZAOrPQ3VV1YcHYH8nCzzXwR3fHQnF6HZusDIxLPeY8w9SNH5eioTAFwfu4pXevvBzLHvGsjtx6XhlwxUkZeThp8ntMSigUVVugYiIqpleJRYffPABJk6ciHnz5gEAOnbsiEaNGuGnn37CwoULSzzmo48+glwuR3R0NGbPnq2xXyaT4datWzA0/O+PopubG5o1a4bz58+jR48eNXMz1SwyJRt9mzrqOgyqw8KSskp8qAtPyqrUQ25IfAY+/ue2xvayxgwA9eOhmh6ZO8AfO689xMrj97FgcNNSy2XnF+LHY/ex6uR9jX0SAPuC4/D3lRj4O5ljaEsXDG3VSJVkxCpycC0qA3GhWfj8YAi87Mywa053eNtzBjwiorpGbxKLzMxMXLp0CW+++aZqm5GREfr3749jx46VmljI5eWPOXg8qQAAqVS/xrRHp2YjMiUL1qblf2NIDVdJ6z0AwKf77mLpKEMEuFppdZ4ipcDqkw/w9aEQeNiZ4rW+flh57H6D7t7UUDlaGmNGTx/8dOI+pnT1hKu1er0LIbD7RiyW7b2N5Kx8zOrlC0cLOT7YdUvt52VEG1ecCk3CPzceYs2pB/j6cAiaOFnAw9YUh+/EQ/z7M9ve0wYbXuwME6Pan9WMiIjKpzeJRXR0NIQQcHZ2VtveqFEjBAcHV+u1Fi1aBE9PT42xGI/Ly8tDXl6e6nV6ejoAQKlUQqms+vSZxecSQpR5vi2XovDu9mAoBfDVoRDYmxthXAf3ark+aU+butI1Jws5Ph4VgPe2B6NIADIJ8MJTXjgZkohhKwIxvoM75g5oDLsy1pR4kJiJt7cG4Vp0GmZ098ab/RtDbijDhI5uiEjOhqfdo+5Ndfl90Ie60icvdffCxnMR+Gj3LUzp4qHq4nbrYTqW7LmFi+GpGNjcCe8MaQqPf8fa9G3qoPbzAgD9mjqgX1MH5BUU4WRoEv6+EoODt+LVrnU1MhUpWblwNmDiWhfxs6VfWF/6Q9d1VZHr6jSxWLhwIbZv315mmYMHD8LDwwNFRUUAoDHmQS6Xo7CwsNpiWrp0KXbt2oUjR46U2dqxbNkyLFmyRGN7YmIicnNzqyUWpVIJhUIBIUSJrSgJGfmqpAIAhADe3R6MFjYSOFrox9iQ+qK8uqor+njIsX16S0Sl5cHdWg5HCyNMb2eLv28kYM3Zh9hz4yFe6uKMMa0cYSCTICEjH1FpeXC1MsLxe2lYeToGjhZGWPVsE7RyMYciNRkAIAPgYw4gLwMJCRk6vcfy6Etd6ZOO7ubYfzMO+2/GQSIB2riY4/rDTHjYGOPbUY3R2dMSKMxEQkImgPJ/XlrbS1DYzEojsVAK4Nq9h5C563b1eCoZP1v6hfWlP3RdVxkZ2v9d12li8frrr+OFF14os0xxC4WdnR0AICkpSW1/UlKSal9Vff755/jkk0+wa9cudO3atcyyCxcuxNy5c1Wv09PT4e7uDgcHB1haWlZLPEqlEhKJBA4ODiX+IN3PSC5xXYBMiQkCHKvnPSHtlFdXdYmjIxDwxLY5zk6Y2M0fXx0OxTcno7D7Vip6+tvj1zMRaj9jU7t64u2nm+h1VxR9qit9EKvIwcG7KarXQgBXYzLxf339MLuPLwxllXuP28gtIJWEqP38ySRAGz8XOLKrXZ3Ez5Z+YX3pD13XlbGxsdZldZpYODs7a3RtKk2jRo3g5uaGc+fOYfjw4artZ8+exYABA6ocy5dffolFixZh165d6N+/f7nl5XJ5iS0aUqm0WitdIpGUek4fR3ONPvOPBs6a85eEDpRVV/rAwdIEy0a3wuQunnh3WzB+Ph2htl8qAWb29oWZsf6P5dH3uqpLIlJySpwZrIuvPeSGlf8T42pj9u+aH0GqrnufjG4JVxsO2q7L+NnSL6wv/aHLuqrINfXqJ2nmzJlYu3YtQkNDAQA///wz7t27hxkzZqjKvP/++2qJhza++eYbvP/++9i1a1e1JCm1pXixLW1XmyXSRgsXK/xvUBON7dW5SjbVH8WTAjyuuhY+HNfRAyf/1xs/jPHHyf/1rtKaK0REVPP0ZvA2ACxYsACRkZEICAiAlZUVCgsL8euvv6JVq1aqMrGxsXjw4IHq9fbt27Fw4ULVOIznn38epqameO211/Daa68hNTUVb775JiwsLDBnzhy16y1duhRjx46tnZurJK4LQDXB20FzBqmGtko2aaemVxN3tjKBzN2C3Z+IiPSARAhRQiN23Zaeno7k5GS4ublpTBUbFxeHnJwceHs/WglWoVAgNjZW4xz29vawt7dHUVGRqgXkSc7OzrCy0m4KzvT0dFhZWUGhUFTrGIuEhAQ4OjqymbKOq491teVipMbDYn34xrg+1lVdEKvIqZEvOFhf+oN1pV9YX/pD13VVkWdcvWqxKGZpaVnqjTVqpL4Sq5WVVZnJgUwmQ9OmpS/sRNRQsTWMKoILHxIRkV4mFkRUO/iwSERERNpi2xcREREREVUZEwsiIiIiIqoyJhZERERERFRlTCyIiIiIiKjKOHi7mhTP2puenl5t51QqlcjIyICxsTGngqvjWFf6g3WlX1hf+oN1pV9YX/pD13VV/GyrzQoVTCyqSUZGBgDA3d1dx5EQEREREVWvjIyMctd308sF8uoipVKJhw8fwsLCAhKJpFrOmZ6eDnd3d0RFRVXbontUM1hX+oN1pV9YX/qDdaVfWF/6Q9d1JYRARkYGXFxcym0xYYtFNZFKpXBzc6uRc5e1ICDVLawr/cG60i+sL/3ButIvrC/9ocu6Kq+lohg71RERERERUZUxsSAiIiIioipjYlGHyeVyLF68GHK5XNehUDlYV/qDdaVfWF/6g3WlX1hf+kOf6oqDt4mIiIiIqMrYYkFERERERFXGxIKIiIiIiKqMiQUREREREVUZ17GooxITExEeHg5PT084OjrqOhx6TFpaGoKDg9G4cWM4OTmVWCYhIQERERHw8vKCg4NDLUdIxdLT03H//n24urqW+jkqLCzEzZs3YWBggObNm1fbApdUcREREVAoFPD29oaFhUWJZWJiYhAbGwtfX1/Y2NjUcoT0pKCgICgUCnTt2hUymUxtX15eHm7evAkzMzM0adJERxE2bCEhIUhISFDbZmlpiVatWmmUDQ8PR1JSEpo2bQpzc/PaCpFK8PDhQ8THx6NFixYwMjLS2J+VlYU7d+7AxsYGPj4+OoiwDILqnHnz5gm5XC6aN28u5HK5mDNnjlAqlboOq8ELDQ0V06dPF87OzkIikYg1a9ZolFEqlWLOnDlq9ffWW2/pINqGLTQ0VIwaNUpYW1uLtm3bCnNzczFkyBCRnJysVu7MmTPC1dVVuLu7C0dHR9G0aVNx9+5dHUXdcO3fv18EBAQIX19fERAQIExMTMS8efPUfu/l5+eLiRMnCmNjY9GsWTNhbGwsli9frsOo6fTp08LIyEgAEKmpqWr79u7dK+zs7ISPj4+wsbER7du3Fw8fPtRNoA3YpEmThKOjo+jWrZvq38svv6xWJjMzUwwePFiYmZmJJk2aCFNTU7F27VodRdywxcbGigEDBghLS0vRoUMH4eXlJXbv3q1WZuPGjcLCwkL4+/sLCwsL0adPH5GWlqajiDUxsahjNmzYIExMTMTly5eFEEJcv35dmJqainXr1uk4MtqzZ49Yu3atyMrKEnK5vMTEYu3atcLc3FzcuHFDCCHExYsXhVwuFxs3bqztcBu0/fv3i23btqkeTJOSkkTz5s3FhAkTVGWys7OFi4uLmD17thBCiMLCQjFkyBDRrl07ncTckK1bt07cv39f9frcuXNCIpGI7du3q7YtXbpUODo6ivDwcCGEEAcPHhQSiUQcOXKktsMlIURqaqrw8fERb731lkZikZiYKCwsLMSHH34ohBAiJydHdOnSRQwePFhH0TZckyZNEi+88EKZZV577TXh4+MjEhMThRBCrF+/XkilUhEUFFQLEVKxgoIC0bZtW9GvXz+Rnp4uhBAiJSVF7fkhNDRUGBoaitWrVwshHn0OmzRpIqZNm6aTmEvCxKKO6du3rxg7dqzatvHjx4tu3brpKCIqSWmJxVNPPSUmT56stm3kyJGiX79+tRUaleKDDz4Q7u7uqtfbtm0TEolE7VvUwMBAAUBcvXpVBxFSMaVSKczNzcWKFStU23x8fMS8efPUynXp0kVMmjSptsMjIcTo0aPFe++9J7Zv366RWPz444/C1NRUZGVlqbZt3bpV4/NGNW/SpEniueeeE5cuXRIPHjwQRUVFavsLCgqEpaWl+OKLL9S2e3t7s7W9lm3ZskVIJBK1L1metGjRIuHs7KzWmrtixQphbGwssrOzayPMcnHwdh1z9epVtG/fXm1bp06dcPXqVR1FRBXB+qu7Ll68CD8/P9Xrq1evwsXFBc7OzqptnTp1Uu2j2pWeno7AwEDs27cPkydPhpeXFyZMmKDa9+DBA3626oiVK1ciOjoaixcvLnH/1atX0axZM5iamqq2derUCUIIXLt2rZaipGLbt2/H9OnT0bFjR/j5+eHo0aOqfQ8ePEB6errGZ6tjx478bNWyI0eOoHnz5vDx8cGtW7dw+/ZtFBQUqJW5evUq2rVrpzYWsFOnTsjNzcWdO3dqO+QScfB2HSKEQFpaGuzs7NS229nZITs7G3l5eXqx6mJDlZubi5ycnBLrLzU1FUIIDgzWkQ0bNmDfvn04ePCgaltKSopGXRkaGsLCwgIpKSm1HWKDFxERgQULFiAlJQUxMTFYtmwZbG1tAUBVHyV9tlhXtSsoKAiLFi3C2bNnYWBQ8iNESZ+t4tesr9o1cuRIfPfdd7C1tUVBQQHefPNNjBo1Cjdv3oSbm1uZn62QkBBdhNxgPXz4EBYWFujWrRtSU1ORk5ODnJwcrFmzBsOGDQPw6PPj6+urdlxd+2yxxaIOkUgkMDAwQG5urtr2nJwcAI8eeqjuKq6fkurPwMCASYWO7Nu3Dy+++CK++eYb9OvXT7Xd0NBQo66AR/VX0iwcVLNatmyJwMBA3Lp1CwcPHsTbb7+NdevWASj7s8W6ql0vvPACxowZg7i4OAQGBuL27dsAgHPnziEyMhJAyZ+t4r9jrK/aNXbsWFWCbmhoiC+//BK5ubnYt2+fahvAz1ZdYGhoiHPnzmHWrFm4desWwsLC8NJLL2HixIlITk5Wlanrny0mFnWMh4cHYmJi1LbFxMTAzc0NUimrqy6TyWRwdXUtsf48PT11FFXDtn//fowePRrLly/HnDlz1PZ5enoiLi4OSqVStS0hIQEFBQXw8PCo7VDpMZ07d0bPnj1VDz+NGjWCXC4v8bPFuqpdLi4uCA4OxoIFC7BgwQKsX78eALBkyRIcOHAAwKPPVkl1BYD1pWNyuRzW1taq+ij+28TPlu55eXnBzMwMU6ZMUW2bOXMmMjMzVd3S9OGzxSfVOmbAgAHYs2cPhBAAHnWP2rVrFwYMGKDjyEgbAwYMwO7du1X1p1QqsXv3btafDhw8eBCjRo3Cxx9/jDfffFNj/4ABA5Ceno7jx4+rtu3cuRNGRkbo2bNnLUZKWVlZaq+LiooQHh6uauKXyWTo06cPdu3apSqTl5eH/fv387NVy/bs2YPAwEDVv08++QTAo5bBGTNmAHj02bp//z5u3bqlOm7nzp2wtbVFu3btdBJ3Q1RYWIi8vDy1bdevX0dCQgICAgIAAPb29mjTpo3aZys1NRUnT57kZ6uWPf3008jJyVG1TgBAdHQ0AKjWwxowYADOnz+vtjbJzp070bhx47rzBaYuR46TprCwMGFjYyMmTZokdu3aJV544QVhaWkpQkNDdR1ag6dQKMSpU6fEqVOnhJGRkZg/f744deqU2roHISEhwtLSUkydOlXs2rVLTJw4UdjY2KimyKTaERgYKExMTMRzzz2nqrNTp06JwMBAtXJTpkwRHh4eYuPGjWLNmjXCyspKLFq0SEdRN1zNmjUTn3/+udi/f7/466+/xJAhQ4S1tbW4ffu2qsyFCxeEXC4Xb7zxhti1a5cYOnSocHNz01ibhGpXSbNCCSHEwIEDRfPmzcVff/0lvv32WyGXy8WPP/6omyAbqLS0NBEQECC++eYbsX//frFy5Urh6uoqevToIQoKClTl9u7dK2QymVi8eLHYsWOH6NGjh2jevLnIycnRYfQN08CBA0WPHj3Ezp07xebNm0XTpk3FoEGDVLNAFRQUiHbt2okuXbqIbdu2iY8//ljIZDKxdetWHUf+H4kQ/361SnVGSEgIPv/8c9y/fx/e3t6YN28emjVrpuuwGrygoCC88sorGtuffvppvP/++6rXt27dwpdffomwsDD4+vri7bffhr+/f22G2uD9/vvvWL16tcZ2AwMDtRaKgoICrFixAgcOHICBgQHGjBmDqVOncjxMLUtISMCKFStw6dIlmJiYoFWrVnjllVc0Vku/ePEivvvuOzx8+BDNmjXDggUL4ObmpqOoCQBOnTqFhQsXYv/+/WqrNWdnZ+Orr77CyZMnYWpqikmTJuHZZ5/VYaQNU1RUFL7//nvcuHEDdnZ26Nu3L6ZOnaqxSvqxY8fw008/ITk5GW3btsX8+fNhb2+vo6gbrpycHHz77bc4duwYTE1N0bt3b7zyyitq4yfS0tLw6aef4uLFi7CxscFLL72Ep59+WodRq2NiQUREREREVcYxFkREREREVGVMLIiIiIiIqMqYWBARERERUZUxsSAiIiIioipjYkFERERERFXGxIKIiIiIiKqMiQUREREREVUZEwsiogYuLCwMu3bt0qtr1WbMRESkHSYWREQNwJ07d7Bnzx6cOXMG2dnZavtOnDiB2bNn10oclbnWgwcPsHv37iqfp7qVFBcRUUPGxIKIqB7LyMjAgAED8NRTT2HlypVYuHAhmjVrhm+++UZVxtvbGyNGjNBdkOU4evQo5syZo7atLsRcUlxERA2Zga4DICKimrNkyRLcu3cPDx48gLW1NQBAoVCodSPy8PDA008/rXodGhqK0NBQDBgwADdu3EBMTAw6dOgAFxcXFBQU4MyZM8jKykKXLl1ga2urOi44OBjx8fHo16+faltkZCQuX76MUaNGlRhfXFwcjh8/DgAwMTFBkyZN0LRpU9X+mJgYXLx4EVlZWdi8eTMAoHXr1hoxF7tx4wbu3bsHZ2dndO7cGVLpf9+fFd/XwIEDcePGDcTGxqJNmzZwdXUt8z1MTk7G5cuXYWBggA4dOsDS0rLUuJo1awYAiIiIwLVr12BnZ4d27drB1NS0xPf3+vXriImJQefOndGoUaMy4yAiquuYWBAR1WPBwcFo3769KqkAACsrK0yZMkX1+sSJE3jvvfcwfPhwAMCBAwewdOlS2Nvbw8nJCZmZmbhx4wZWrFiBr776Ci4uLkhNTUVkZCROnz6Nxo0bAwC2bt2Kw4cPqyUWZ86cwWuvvVZqYhEfH48dO3YAALKysnD69GkMHjwYGzZsgEQiQWxsLK5evYrs7GxVOVNTU6SkpKjFXFhYiOeeew7Hjx9Hly5dcOPGDTRq1Aj79u2Dg4OD6r4+/vhjeHl5QS6XAwDOnz+PLVu2qM7zpB07duD5559H+/btYWRkhPv372PVqlWwsrIqMa6mTZvijTfewIYNG9ClSxckJSUhNjYWf//9Nzp27Kj2/rq6usLExARKpRLXrl3D5s2bS42DiEgvCCIiqrcWL14sTExMxI8//ihiYmJKLPPLL78IV1dX1evvv/9eABDbt29XbXvmmWcEALFv3z7Vtt69e4tXXnlF7VrdunVTO/cff/wh7OzsSr3WkxITE4Wzs7PYunWratuaNWuEp6dnmTGvWLFC2NraioiICCGEEOnp6aJVq1ZixowZGvf1+LnnzZsnWrVqVWo8HTp0EJ988onqdXJysjh+/Hipca1evVr4+vqKpKQk1balS5eKpk2basTx+eefq7YtXrxYNGrUSGRnZ5caCxFRXccxFkRE9djChQvx+uuvY/HixXB1dYW7uztmzJiB8PDwMo9zdHTEyJEjVa+7dOkCDw8PDBo0SG1bSEhIlWMsKCjAuXPnsG3bNhw+fBju7u64cOFChc6xefNmTJ48GR4eHgAACwsLvP7669iyZYtaOQcHB4wZM0b1unfv3rh7926p5zUxMUFISAhyc3MBALa2tujVq1ep5X/55Re0atUKx44dw19//YU///wT5ubmuHPnDmJjY1Xl5HK52viMefPmISEhASdPnqzQfRMR1SXsCkVEVI/J5XIsX74cy5Ytw82bNxEYGIivvvoKO3bswK1bt1TdhJ5kY2OjcZ6SthU/cFdWUFAQhgwZohpfYWZmhvj4eCQkJFToPBERERg7dqzaNl9fX6SnpyM1NVUV++NjQorvIS8vr9Tzfv/995gxYwYcHBzw1FNPYfjw4XjppZdUXameFB4ejvz8fGzdulVt+7hx45Cfn6967ezsrHYOc3NzODg4ICIiQrsbJiKqg5hYEBE1ABKJBAEBAQgICMCAAQPg5+eHQ4cOYeLEidV2DalUCqVSqbatvMTj3XffRd++ffHbb7+ptg0aNAhCiApd297eHikpKWrbUlJSYGhoCEtLywqd63GtW7fGhQsXEBsbiyNHjmDJkiU4ffo0Nm3aVGJ5S0tL9O3bF5999lmZ501LS1N7LYRAWloa7O3tKx0rEZGusSsUEVE9VlKXp+KH/ccHdFcHV1dXhIWFoaioSLXt2LFjZR4TFxeHJk2aqL0+ffq0Whlzc/NyE5Tu3btjx44daonNX3/9ha5du0Imk1XkNtTExMQAeNTCMHnyZLz++us4d+5cqXENGjQIGzduREZGRonnKZaWlqaaDQsA9u7dC6VSqRrgTUSkj9hiQURUj3322We4fPkyBg8eDC8vL8TGxmLVqlXo2rWr2uxN1WH48OF46623MHHiRDz99NM4ffo09u/fX+YxI0eOxJdffgljY2MYGBjg+++/h4GB+p+mdu3aITExEUuXLoWfnx9at26tcZ733nsPf/31F4YMGYLRo0fj7Nmz2Llzp9rDe2WMHj0aLVq0QOfOnZGTk4OvvvoKEyZMKDWuRYsW4ciRI+jYsSNmzJgBU1NTnD9/Hg8ePFAbP2FmZobnn38er7/+OpRKJZYvX47XX38d7u7uVYqXiEiXmFgQEdVjP/74Iy5fvox//vkHJ06cgI2NDZYvX44xY8bA0NAQgOZic/7+/hg6dKjaeZo2bao2cBsAAgIC1F47ODjg4sWLWL16NS5cuIDu3btj2rRp+P3331VlnrzWggUL4ObmhhMnTkAul+Pbb79FWFiY2voT/v7+2Lt3L3bt2oWbN2/C1NRU4zyOjo64du0aVq1ahcDAQDRq1AhXrlxRWxOjpPtq1KgRxo0bV+r7FxgYiI0bN+Ls2bMwMjLCt99+q7puSXE1a9YMFy5cwIYNG3D+/HkYGxujf//+GD9+vNp53dzc8Ndff2Hz5s14+PAhvvrqK7zwwgulxkFEpA8koqIdWYmIiKjSVqxYgRUrVuDOnTu6DoWIqFpxjAUREREREVUZEwsiIqJaVFKXLCKi+oBdoYiIiIiIqMrYYkFERERERFXGxIKIiIiIiKqMiQUREREREVUZEwsiIiIiIqoyJhZERERERFRlTCyIiIiIiKjKmFgQEREREVGVMbEgIiIiIqIqY2JBRERERERV9v+mrmzbrZXfagAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 800x320 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "_inline_matplotlib()\n",
+    "fig, ax = plt.subplots(figsize=(8, 3.2))\n",
+    "ax.plot(range(1, N_STEPS + 1), rewards, marker=\".\", linewidth=1)\n",
+    "ax.axhline(0.0, color=\"black\", linewidth=0.6, alpha=0.5)\n",
+    "ax.set_xlabel(\"Simulation step\")\n",
+    "ax.set_ylabel(\"Reward\")\n",
+    "ax.set_title(f\"Per-step reward (random policy, seed={SEED})\")\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "fig.tight_layout()\n",
+    "\n",
+    "plot_path = OUTPUT_DIR / \"reward_curve.png\"\n",
+    "fig.savefig(plot_path, dpi=120)\n",
+    "print(\"Saved:\", plot_path.relative_to(REPO_ROOT))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be2b0f9a",
+   "metadata": {},
+   "source": [
+    "## Done\n",
+    "\n",
+    "You built an environment, ran a deterministic episode, and inspected the\n",
+    "reward signal. Next, try **02 — Compare two planners** to see how two\n",
+    "different navigation strategies behave, or **03 — Visualize a trace** to\n",
+    "watch an episode as an interactive viewer + trajectory plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c317445a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-15T23:25:00.137187Z",
+     "iopub.status.busy": "2026-07-15T23:25:00.137112Z",
+     "iopub.status.idle": "2026-07-15T23:25:00.138658Z",
+     "shell.execute_reply": "2026-07-15T23:25:00.138430Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Environment closed. Notebook 01 complete.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Always release the environment's resources when finished.\n",
+    "env.exit()\n",
+    "print(\"Environment closed. Notebook 01 complete.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/02_compare_two_planners.ipynb
+++ b/notebooks/02_compare_two_planners.ipynb
@@ -1,0 +1,415 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "314637f1",
+   "metadata": {},
+   "source": [
+    "# 02 — Compare two planners\n",
+    "\n",
+    "This notebook runs the **same scenario** with **two different planners**\n",
+    "and compares their outcomes side by side.\n",
+    "\n",
+    "The two planners are:\n",
+    "\n",
+    "- **`simple_policy`** — a built-in goal-seeking policy that steers the\n",
+    "  robot toward its goal.\n",
+    "- **`random`** — a random policy that ignores the goal (a control/baseline).\n",
+    "\n",
+    "We reuse the benchmark episode runner\n",
+    "(`robot_sf.benchmark.runner.run_episode`), which loads each planner from\n",
+    "the baseline registry, builds observations, translates actions, and\n",
+    "computes a rich metrics dictionary. **No new logic is added** — we only\n",
+    "call the existing public API and chart the results.\n",
+    "\n",
+    "> CPU-only, deterministic (fixed seed), no model weights required.\n",
+    ">\n",
+    "> The metrics here are a small illustrative sample for a single seed —\n",
+    "> they are **not** a benchmark result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "2a691310",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-15T23:25:02.273317Z",
+     "iopub.status.busy": "2026-07-15T23:25:02.273010Z",
+     "iopub.status.idle": "2026-07-15T23:25:05.910148Z",
+     "shell.execute_reply": "2026-07-15T23:25:05.909805Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+      "I0000 00:00:1784157904.579386 1036915 port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+      "I0000 00:00:1784157904.610802 1036915 cpu_feature_guard.cc:227] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
+      "To enable the following instructions: AVX2 AVX_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+      "I0000 00:00:1784157905.183786 1036915 port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+      "I0000 00:00:1784157905.183983 1036915 cudart_stub.cc:31] Could not find cuda drivers on your machine, GPU will not be used.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Repo root: /home/luttkule/git/robot_sf_ll7.worktrees/cheap-issue-5798-20260715T225820Z\n",
+      "Artifacts will be written to: output/notebooks/02_compare_two_planners\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "from IPython import get_ipython\n",
+    "\n",
+    "os.environ.setdefault(\"SDL_VIDEODRIVER\", \"dummy\")\n",
+    "\n",
+    "\n",
+    "def _inline_matplotlib() -> None:\n",
+    "    # (Re-)arm the notebook inline backend for the next figure.\n",
+    "    ip = get_ipython()\n",
+    "    if ip is not None:\n",
+    "        ip.run_line_magic(\"matplotlib\", \"inline\")\n",
+    "\n",
+    "\n",
+    "# Keep log output quiet so the executed notebook stays readable.\n",
+    "from loguru import logger\n",
+    "logger.remove()\n",
+    "logger.add(sys.stderr, level=\"ERROR\")\n",
+    "\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from robot_sf.training.scenario_loader import load_scenarios\n",
+    "from robot_sf.benchmark.runner import run_episode\n",
+    "from robot_sf.baselines import list_baselines\n",
+    "\n",
+    "# Resolve the repo root robustly regardless of launch directory.\n",
+    "def _repo_root() -> Path:\n",
+    "    here = Path.cwd()\n",
+    "    for candidate in [here, *here.parents]:\n",
+    "        if (candidate / \"pyproject.toml\").exists():\n",
+    "            return candidate\n",
+    "    return here\n",
+    "\n",
+    "REPO_ROOT = _repo_root()\n",
+    "\n",
+    "OUTPUT_DIR = REPO_ROOT / \"output/notebooks/02_compare_two_planners\"\n",
+    "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "print(\"Repo root:\", REPO_ROOT)\n",
+    "print(\"Artifacts will be written to:\", OUTPUT_DIR.relative_to(REPO_ROOT))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f77101a",
+   "metadata": {},
+   "source": [
+    "## 1. Load the shared scenario\n",
+    "\n",
+    "We use the bundled `quickstart_demo_crossing_basic` scenario so both planners face the identical situation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e60b3a78",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-15T23:25:05.911699Z",
+     "iopub.status.busy": "2026-07-15T23:25:05.911485Z",
+     "iopub.status.idle": "2026-07-15T23:25:05.914707Z",
+     "shell.execute_reply": "2026-07-15T23:25:05.914481Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded scenario: quickstart_demo_crossing_basic\n",
+      "Map file: ../../../maps/svg_maps/francis2023/francis2023_circular_crossing.svg\n",
+      "Registered baseline planners: ['baseline_sf', 'brne', 'dr_mpc', 'drl_vo', 'orca', 'ppo', 'random', 'sac', 'sicnav', 'social_force']\n",
+      "(plus the built-in goal-seeker known as 'simple_policy' / 'goal')\n"
+     ]
+    }
+   ],
+   "source": [
+    "SCENARIO_PATH = REPO_ROOT / \"configs/scenarios/single/quickstart_demo.yaml\"\n",
+    "SCENARIO_NAME = \"quickstart_demo_crossing_basic\"\n",
+    "\n",
+    "scenarios = load_scenarios(SCENARIO_PATH)\n",
+    "scenario = next(s for s in scenarios if s[\"name\"] == SCENARIO_NAME)\n",
+    "print(\"Loaded scenario:\", scenario[\"name\"])\n",
+    "print(\"Map file:\", scenario.get(\"map_file\"))\n",
+    "print(\"Registered baseline planners:\", sorted(list_baselines()))\n",
+    "print(\"(plus the built-in goal-seeker known as 'simple_policy' / 'goal')\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f034804d",
+   "metadata": {},
+   "source": [
+    "## 2. Run each planner for one episode\n",
+    "\n",
+    "`run_episode` returns a record whose `metrics` dictionary contains the\n",
+    "quantities we compare. We keep the horizon short so the notebook stays\n",
+    "fast."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1d96e3e2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-15T23:25:05.915824Z",
+     "iopub.status.busy": "2026-07-15T23:25:05.915755Z",
+     "iopub.status.idle": "2026-07-15T23:25:08.360795Z",
+     "shell.execute_reply": "2026-07-15T23:25:08.360049Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " simple_policy: steps= 60  collisions=27  avg_speed=0.984  path_length=6.00  success=False\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        random: steps= 60  collisions= 0  avg_speed=0.910  path_length=5.55  success=False\n"
+     ]
+    }
+   ],
+   "source": [
+    "SEED = 270\n",
+    "HORIZON = 60\n",
+    "DT = 0.1\n",
+    "PLANNERS = [\"simple_policy\", \"random\"]\n",
+    "\n",
+    "records = {}\n",
+    "for algo in PLANNERS:\n",
+    "    rec = run_episode(scenario, SEED, horizon=HORIZON, dt=DT, algo=algo)\n",
+    "    records[algo] = rec\n",
+    "    m = rec[\"metrics\"]\n",
+    "    print(\n",
+    "        f\"{algo:>14s}: steps={rec['steps']:>3d}  \"\n",
+    "        f\"collisions={int(m['collisions']):>2d}  \"\n",
+    "        f\"avg_speed={float(m['avg_speed']):.3f}  \"\n",
+    "        f\"path_length={float(m['socnavbench_path_length']):.2f}  \"\n",
+    "        f\"success={bool(m['success'])}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0c45fca",
+   "metadata": {},
+   "source": [
+    "## 3. Compare key metrics\n",
+    "\n",
+    "We chart four beginner-friendly metrics for both planners:\n",
+    "\n",
+    "| Metric | Meaning |\n",
+    "| --- | --- |\n",
+    "| `collisions` | Number of pedestrian/obstacle collisions in the episode |\n",
+    "| `avg_speed` | Mean robot speed (m/s) |\n",
+    "| `socnavbench_path_length` | Total path length travelled (m) |\n",
+    "| `path_efficiency` | Ratio of straight-line to actual path (1.0 = perfectly direct) |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c90cad61",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-15T23:25:08.362155Z",
+     "iopub.status.busy": "2026-07-15T23:25:08.362034Z",
+     "iopub.status.idle": "2026-07-15T23:25:08.871845Z",
+     "shell.execute_reply": "2026-07-15T23:25:08.871471Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved: output/notebooks/02_compare_two_planners/planner_comparison.png\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABP4AAAFmCAYAAAD9DVRJAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlcelbwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAtglJREFUeJzs3XdYE9n7NvA7FAGRJqAooqIoKPbexd5772vvjbXu6rroKnb9umth7b2uYu+9sGvvvSEiCkoLLZTM+4cv8zMmQIIkgXB/rotrN2fOmXlmcjiGJ3POSARBEEBEREREREREREQGxUjfARAREREREREREVHWY+KPiIiIiIiIiIjIADHxR0REREREREREZICY+CMiIiIiIiIiIjJATPwREREREREREREZICb+iIiIiIiIiIiIDBATf0RERERERERERAaIiT8iIiIiIiIiIiIDxMQfERFla69evcKIESPw+PFjfYdC/9+DBw8wYsQIvHr1St+hUDahrd9TqVSK0aNH4+nTp1m636zy5csXjBgxApcvX9Z3KDql6zGA/w6k7fbt2xg3bhxkMpm+QyEiomzKRN8BEBGR9nz58gW//vqrWnUHDRqEGjVqaDkizYWEhMDPzw8dO3ZE2bJl9R1OrvH06VMsX74cEyZMgIeHh8K2wMBA+Pn5oW/fvihZsqSeIqTsRFu/p/PmzcPZs2exYsWKLNtnVpJKpfDz80OlSpVQv379H95fTEwMjhw5gocPH0IQBLi7u6Nbt26wsLBQqHfmzBns27cvzf20bt0a7du3Vyj78OEDdu3ahcDAQDg5OaF79+6Z/v3V9RhgaP8O3Lx5EydOnEB4eDjKly+Pnj17Kr3HgHrvWdmyZbF//34UKVIEU6ZM0dUpEBFRDsI7/oiIDFiePHlQqVIlhZ+LFy9i06ZNSuV2dnb6Dpeykffv38PPzw/v37/XdyiUA7i5uWH16tXw9PTMsn1++vQJy5Ytw9SpU2FsbJxl+82utm/fjsKFC8PHxwd58uSBhYUF5s+fDzc3N1y7dk2hrqOjo9IYXqlSJTx48AB+fn6IjY1VqH/p0iWUKVMGp06dgqurKx48eABPT890k4fZiTb6lz4kJSVhwIABaNGiBcLDw1G8eHHcvHkTlStXRnR0tEJddd8zc3NzTJw4EXPnzoVUKtXl6RARUQ7BO/6IiAyYlZUVRowYoVC2b98+BAUFKZUTEWWWk5NTlo8p69evh7GxMbp165al+82unj59irFjx8LHxwcmJl8/ok+aNAlVqlRBz5498ebNGzEBWrFiRVSsWFGhfXJyMnx8fGBvb4/OnTuL5fHx8ejduzdq1qyJ48ePQyKRAACGDh2KQYMGoUGDBihQoICOzjJztNG/9MHb2xsnT57E3bt34eLiIpa/f/8epqam4mtN37M+ffpg6tSp2LZtG0aOHKm7EyIiohyBiT8iolxMJpNhwoQJ6NixI1q0aCGW//rrr/jy5QsWLlwIa2trAGlP/bx69SpOnTqFiIgIFC1aFN26dUOxYsXSPe6DBw+wcuVKTJ48GcbGxti6dSvCw8NRo0YNdO/ePcO7e8LCwjBz5kzxtbm5OUqWLIkuXbqgcOHCKo9jYWGBzZs349OnT6hWrRp69eqlcBxN6qZ69uwZDh48iPfv38Pe3h4dOnRApUqVVO7TzMwM27dvx7t37/D777/D0dERb9++xT///IPg4GAUKFAADRs2RO3atdM991QZXffMnM+3+/7f//4HAPjf//4n3mHSs2dPeHl5KdT98OFDllyrtGR0jTLTF0xMTLB161ZER0ejbdu2aNCgAQDg3bt32Lp1Kz5//ozGjRujXbt2KmPS1rmkevHiBQ4dOoSgoCA4Ozujffv2cHd31ygGTd7/zFzD7/tzdHQ0Fi1ahHHjxilNxczMGAEA27ZtQ9OmTZEvX75MX0t13yt16x06dAgXL16EpaUlevbsibx582Z4HuoaM2YMChYsqFBmbm6Odu3aYeHChXj+/DnKlCmTZvujR4/i48ePmDhxIszMzMTyI0eOIDg4GKtXrxYTSAAwbtw4rFu3Dlu3bsXPP/+c6bjVHQM0GbPU6V9Tp05FVFSUypiGDBmCatWqZerYmo6X6nr79i1WrVqFpUuXKiT9AKBIkSIKrzV9z5ycnFCzZk1s3bqViT8iIlLCqb5ERLmYmZkZLl26hNWrV4tlHz9+xLx58+Dn54fz58+L5f/88w/WrVsHJycnsWzIkCFo0KABgoOD4ezsjGPHjsHd3R27du1K97ip60MdPXoUffr0gUQigZGREYYNG4bmzZsjMTExw7i/nd5WsGBB7N69G6VLl8aNGzeUjnPmzBn07t0bKSkpMDExweDBg9G/f3+VMalTFwB8fX3h6emJ69evo2jRovjw4QOqV6+O+fPnK+3z2LFj6NGjB2QyGUJCQhAVFYXDhw/Dzc0N169fh4uLC2JjYzFlyhRMnTo13XNX97prej7fsre3F9eRKlmypHidHR0dFeo9evQoy66VKupcI037wvHjx/HTTz/ByMgI4eHh8PLywvbt2/Hff/+JfTE2Nhbt27fH8uXLdXouAPDHH3/Aw8MD58+fh5OTEz5//oxu3brhn3/+0SgGTd5/Ta+hqv6cugbbu3fvFPad2TEiNDQUT548Qa1atTJ9LdV9r9SpJwgCunfvjm7duiEhIQEWFhYYMWIETp06pRSfTCbDiBEj1PrZsWOH2O77pF+q1GuaUZJxw4YNAL7eFfatq1evAgCqV6+uUF6uXDnkzZtX3J4Z6o4BmoxZ6vYvT09PpanOd+/eVaqX1eNlZt/fgwcPQi6Xo3HjxtixYwe8vb0xdepUHDp0CHK5XOEYmXnPateujRs3biAmJibd94yIiHIhgYiIcpUmTZoIlpaW4uvx48cL1tbWQlJSkiAIgrB161bB0tJSqF69ujBq1CixXsOGDYVatWqJrzdt2iQAENatWyeWyeVyoUuXLoK5ubkQFBSUZgyHDx8WAAjVqlUTYmJixPLLly8LAIS5c+cqlR0/fjzd85LL5ULTpk2F2rVrKx2ndu3aQmxsrFi+bNkyAYDw4MGDTNU9cuSIAEBYtmyZQgwbNmwQJBKJcOPGDYV9Vq1aVZBKpYIgCEJKSooQGxsr1K9fX2jevLnSeTx//jzd81T3umtyPqqcPn1aACCcPn1aaZs2rpUqmb1G6fWFunXrCvHx8WJ5nz59hCJFigidOnUS4uLixPIBAwYI9vb2QkJCgs7Oxd/fXwAgzJ8/X6FOUlKS8PbtW41i+NH3P71rqKo/q/o9/ZEx4uzZswIAYc+ePUrb1LmW6l4ndett2LBBACDs27dPrJOYmCi0aNFCACCsXr1aLJdKpQIAtX6GDx+e5jUQBEG4d++eYGJiItSoUSPdeh8/fhRMTEyEevXqKW3r0qWLIJFIBLlcrrStRIkSQrVq1dLdtyqa9C9Nxyx1+9f39u7dK0gkEqFNmzZCcnJypo6tzvlk9v0dPny4AEDw9PQUqlatKvj6+gpjx44VzMzMhMaNGyuMS5l5z/z8/AQAwvXr19O8RkRElDvxjj8iolyuWbNmiI6Oxr///gsAOH36NBo2bIi2bdvi9OnTAIDY2FgEBASgWbNmYrutW7fCyckJAwcOFMskEgmmT5+OhIQE7N69O8Nj9+3bF5aWluLrevXqoW7dutiyZUuGbaOjo7FlyxZMmTIFI0eOxMiRIxEeHo67d+9CEASFuv369VO4W6Zt27YAgFu3bintV526q1evRv78+TFu3DiFtj/99BPy5cuHnTt3KpT36dNHnK5oZGSEvHnzQhAEvHnzBh8/flSoW6pUqXTPW9Prrsm5a0ob1+pb6l4jTfpC3759YW5uLr5u3rw53r9/j8aNGys8VbN58+b48uUL3rx5o7NzWbNmDRwdHZWmXZqYmIjTEjWNQd33X5NrqKo/q/IjY0RYWBgAIH/+/Erb1LmW6l4ndett27YNrq6u6NKli1jH1NQUQ4YMUYrP3Nwcq1evVuunT58+aV6D8PBwdO3aFcbGxlizZk2a9QBg8+bNSE5OxrBhw5S2JSQkwMTERGHKaCozMzPEx8enu+/0qNO/NO0H6vavb/3777/o168fKlWqhF27dolTc7UxXmb2/U29E8/ExATXrl3DtGnTsGLFCuzYsQPnzp3DwoULxbqZec/s7e0B/N/vDhERUSqu8UdElMs1bNgQpqamOHnyJOrVq4czZ85g8uTJqFmzJmbNmoW3b9/i8ePHSExMVEj8vXz5Eu7u7jAyUvwOKXX9pZcvX2Z47O/XLQMADw8PbN68Od12T58+RaNGjWBnZ4eOHTvC09MTJiYmCAoKwu3btyGTyRSSO98nilIXRf/w4YPSvtWp++jRI5iamorJAkEQxB9jY2OFZBEAlC5dWuk4s2fPRteuXVG0aFHUqVNHTLZ+P7Xre5ped03OXVPauFbfUucaadoX3NzcFI7h4OCQbnlISIi4pqUuzsXDw0N8sIMqmsagznuk6TVU1Z9V+ZExIvUapKSkKG1T51qqe53Urffy5UuV6+t9u97pt7H/6IMopFIpWrVqhTdv3mDv3r2oXLlyuvU3bNgAOzs7lQ9CsbS0RFJSElJSUpTWqouLi1NYvkFT6vQvTfuBuv0r1evXr9G+fXs4ODjgyJEjCmtCamO8zOz7m/ol18CBA5EnTx6xvHPnzihYsCD8/f3x22+/iXU1fc+SkpLE+IiIiL7FfxmIiHK5fPnyoXbt2jh16hR69uyJDx8+oHnz5nB3d4etrS1OnTqFJ0+eIF++fArrbRkbG4t/aHwrtUydxdBVtU9MTMyw7W+//QZBEPDff//ByspKLL99+7bK+t8mLQCIfwSqSiqoU9fIyAjW1tYoV66cUvuKFSsqPbjAxsZGqV6jRo3w9u1bnDp1CpcuXcLevXsxe/ZsDBkyBGvXrlV5HoDm112Tc9eUNq7Vt9S5RlnVF7LDuRgbG2e4vqWmMahzXppeQ1X9WZUfGSNS17v78uWL0jZ1rqW610ndemmdi6r3SyaTYfz48Wme27caNGiA3r17K5TFxcWhTZs2uH37Nnbu3ImOHTumu4+rV6/i2bNnGDdunNL7DQAlSpQAAAQFBaF48eJieXJyMkJCQlCnTh21YlVFnf6laT9Qt38BX++KbN26NWQyGc6ePavwMJrMHFud88ns+5v65YKqtRwLFiyIz58/i68z856Fh4enuX8iIsrdmPgjIiI0a9YMs2bNwu7du1G4cGHxbohGjRrh9OnTePLkCby8vGBqaiq2KV++PC5duoSEhASFP5ZSp0SVL18+w+PevXtX6cmpd+/ezbDtmzdvULZsWYUkhSAIuHbtWsYnmwWqVq2Kc+fOYfDgwQrXRFNWVlbo0qWLOH1wxIgR8PPzw6xZs5Se8pgqK667OlL/IP5+mqemfvRaZXSNdNkXtH0uVatWxfHjxxEdHS0+TTurY1BFW9fwR/pqxYoVYWxsjEePHqncrs61VOc6qVuvfPny+O+//5CcnKxwR9WdO3eU6iYlJcHPzy/NfX3v28RfQkIC2rdvj2vXrmHHjh3o2rVrhu3Xr18PACqn+QKAl5cX5s+fjytXrigkkf79918kJiaicePGaseaGdoas2QyGTp16oRXr17h6NGjKvejjWNn9v1t0qQJgK93KH4rOTkZ7969U4glM+/Z/fv3kTdvXqWnahMREXGNPyIiQrNmzSCXy7Fs2TKF6bzNmjXD8ePH8ejRI4VyABg1ahQiIiIwZ84csSwmJgYzZsyAg4MDevbsmeFxDx06pPD0xS1btuDBgwcYOXJkuu3Kli2Le/fuKdwNtGLFCkRHR2d4zKwwZcoUREdHw9vbW+luklu3buH+/fsZ7mPHjh1ISEhQKLO0tISxsTHMzMzSbJcV110dzs7OAIDg4OAf2s+PXCt1rpEu+4K2z+Xnn39GfHw8JkyYoLD/jx8/ik/XzYq+9z1tXcMf6atWVlaoXr06AgIClLapcy3VvU7q1hsxYgQ+ffqEpUuXits/f/6s8NTWVJldAy4pKQldunTBhQsXsH37dnTv3j3N65MqJiYGe/fuRe3ateHp6amyTtOmTVG+fHksWrQIsbGxAL7ewfbHH3+gcOHC6NWrl0L933//Xa2ni6tLG2OWIAgYNGiQ+FT65s2b6+zYmX1/q1SpgqZNm2LNmjUIDQ0Vy5cvX47IyEiFpzFr+p4BQEBAABo0aJBlXwgQEZHh4B1/RESEatWqwdbWFpGRkQp/QDVv3hyjRo0CAKXEX/PmzbFs2TJMnz4dp06dQqlSpXD16lXI5XIcPnxYrela3t7e6NKlC4oXL46IiAicP38eo0ePxqBBg9Jt5+Pjg4sXL6J8+fJo0qQJXr16heLFi+Onn35S+ANPW6pVqwZ/f38MHToUR44cQfXq1SGRSPDkyRNYWFiId+Ck58aNG5g2bRrKlCmDwoUL4/Xr17hz5w5WrFgBR0fHNNtlxXVXR+nSpeHl5YXJkyfj/PnzsLCwQM+ePeHl5aXRfn7kWqlzjXTZF7R9LjVq1MDu3bsxfPhwXLhwATVq1EBkZCTevHkjTmHNir73PW1dwx/tqwMHDsTo0aPx6dMnhemL6lxLda+TuvVatWoFHx8fTJ8+HYcOHUKRIkXw5MkTzJ07F+fOnVOIO7NrwPn4+ODYsWNwd3fH+fPncf78eYXtEyZMUFpTcPfu3YiJiUnzbj/g6927+/fvR9u2bVG+fHk0aNAAt2/fRnh4OPz9/RUesAQAO3fuRExMDBYsWKDxOaiijTHrw4cP2LFjBwoUKICbN2/i5s2bCtuHDBmCatWqaeXYP7KG444dO9ChQweUK1cOTZo0QUhICK5evYrffvsN/fr1E+tp+p49f/4c9+/fx6+//pqpuIiIyLBJhB+dw0NERDnKkSNH8OnTJwwePFih/NChQ/jw4QN69OgBOzs7sXzDhg1ISUlRuBvhW2FhYbh06RKioqLg4uKCBg0apHvHWmoM7dq1w+XLl1GtWjWcOnUK4eHhqF69utJdKx8/foS/vz/atGkDFxcXsTw+Ph4XLlxAWFgYypUrhypVqoh/AA4dOhTGxsZ49+4djh07ho4dOyoshp6cnIx169ahRo0aqFKlCgBoVDdVUlISAgIC8Pr1a1hZWaFMmTIK06zS2meqyMhI3LhxA8HBwShYsCDq1q2b5hTP72V03TNzPt9LSkrCxYsX8fbtWyQnJ6N+/frw9PTUyrVKizrX6Ef6QlBQEI4ePYr27dsrrA8WHByMw4cPo127duLdj7o4F+DrGm+XL1/Ghw8f4OLigjp16ig92TSzfS+t9+hHriGQ9u8pkLkxAvj6NPHixYtjypQpmDx5cqaupbrvlbr1Xr16hatXr8LS0lL8kmT79u1o0KDBD0+xvHz5cppTmwGo7ItnzpzBy5cvMWDAAIWnUquSlJSES5cuITAwEE5OTmjUqJFSm5iYGOTPnx/e3t6YP39+mvvKzBiQ2TELUO5fsbGx2Lp1a5rxNWvWDCVLlvzhY2syXqordT3Np0+fwsLCAvXq1VN6X1Op854BwPTp07F9+3a8evWKd/wREZESJv6IiEjnvk381atXT9/hEFE2tXLlSsyZMwevXr1SusuJst7Ro0fRp08fvHnzRuELIMq+wsPDUbx4caWpxURERKk41ZeIiIiIsqXhw4fD1NQUYWFhTPzpQOHChbF//34m/XKQsLAwLF++XOnp0ERERKmY+CMiIiKibMnExCTd9esoa1WuXFnfIZCG3N3d4e7uru8wiIgoG+NTfYmISOcqVKiA1atXw83NTd+hEBERERERGSyu8UdERERERERERGSAeMcfERERERERERGRAWLij4iIiIiIiIiIyAAx8UdERERERERERGSAmPgjIiIiIiIiIiIyQEz8ERERERERERERGSAm/oiIiIiIiIiIiAwQE39EREREREREREQGiIk/IiIiIiIiIiIiA8TEHxERERERERERkQFi4o+IiIiIiIiIiMgAMfFHRERERERERERkgJj4IyIiIiIiIiIiMkBM/BERERERERERERkgJv6IiIiIiIiIiIgMEBN/REREREREREREBoiJPyIiIiIiIiIiIgPExB8REREREREREZEBYuKPiIiIiIiIiIjIADHxR0REREREREREZICY+CMiIiIiIiIiIjJATPwREREREREREREZICb+iIiIiIiIiIiIDBATf0RERERERERERAaIiT8iIiIiIiIiIiIDxMQfERERERERERGRAWLij4iIiIiIiIiIyAAx8UdERERERERERGSAmPgjIiIiIiIiIiIyQEz8ERERERERERERGSAm/oiIiIiIiIiIiAwQE39EREREREREREQGiIk/IiIiIiIiIiIiA8TEHxERERERERERkQFi4o+IiIiIiIiIiMgAMfFHRERERERERERkgJj4IyIiIiIiIiIiMkBM/BERERERERERERkgJv6IiIiIiIiIiIgMEBN/REREREREREREBoiJPyIiIiIiIiIiIgPExB8REREREREREZEBYuKPiIiIiIiIiIjIADHxRzpTr149eHl5Zaoss/snIqKv1qxZA4lEgrdv36pV39fXFyVLlkRycrJ2A9PAzJkzUa5cOaSkpOg7FCKDdfPmTUgkEuzbty9T7V++fAmJRIJNmzZlbWBa8qPnm+rt27cwNzfH+fPnsyiyr54/fw5TU1MEBARk6X6JSDOLFy+GRCLB58+ftX6sx48fo3HjxrC2toZEIoG/vz8AYOfOnXB3d4epqSkkEgkSEhLQsWNHeHh4aLT/devWafSZkHI+Jv4oTUeOHEGHDh1QqFAhmJmZwdnZGfXq1cPy5csRERGh7/CIKJeZO3cuJBIJKlasqO9QDN6nT5/g6+uLWbNmwcTERCvHSExMhI2NDZYsWaJ2m59//hnBwcH4+++/tRITUXa2b98+SCQS8cfY2BgFCxZE586dce/ePY329fDhQ0gkEmzbtk1L0WYvujjfKVOmoE6dOmjUqFGW7rd06dLo27cvJk6cCEEQsnTfRIZgzJgxCmNjnjx5ULx4cYwePVrjJN1ff/0FiUSC9+/fayla9fTp0wfGxsYICgqCIAjo2LEjgoODMXDgQPTr1w+xsbEQBAHm5uZ6jZNyDib+SIlcLseAAQPQqVMnlC9fHhcuXEB0dDRu3ryJvn37wtfXFzNnztTa8a9cuYILFy7orB0RZX+CIGDDhg0oUqQI7t+/j+vXr+s7JIP2559/wszMDL169dLaMVL/benQoYPabWxtbdGnTx8sWLAAcrlca7ERZWc7d+6EIAiIj4/HgQMH8OjRI9SrVw8vXrzQd2i51osXL7Bv3z6MHTtWK/sfPXo0/vvvP5w7d04r+ycyBCEhIRAEAV++fMGCBQuwadMmNG7cGElJSfoOTSORkZG4e/cu2rdvDxsbG7E8ICAAMpkMPXr0QJ48ecRyf39/PH36VKNjDBkyBIIgoHjx4lkVNmVzTPyRkrlz52LLli3YsmUL/vjjD7i7u8PMzAyFChXCiBEjcP/+fXh6euo7TCLKRc6ePYvXr19j48aNcHZ2xtq1a/UdksFKTk7G+vXr0aNHD5iammrtOAcPHkTZsmXh5uamUbu+ffsiMDAQx48f11JkRDlDnjx5UKdOHSxbtgwxMTFYt26dvkPKtfz8/GBra4s2bdpoZf/VqlWDu7s71qxZo5X9ExkSKysr9OjRA6NHj8aDBw9w5swZfYekkdDQUACAhYWFWuVE6mDijxTExcVh0aJFqF27dpp3ehQsWBAjR45UKPPz80PFihVhbm4OW1tbtG3bFnfu3MlUDKrW6rt48SKaNGkCBwcH2NjYoFatWti+fbvClIe01vhTJ7Zy5cqhbdu2ePHiBZo1a4a8efOicOHC8PHxUZpWoU4sRJS11q5di7Jly6Jp06YYOnQodu3ahZiYGHH7//73P0gkEpXjzoYNGyCRSBTWR/rnn39QoUIFmJubw93dHdu3b1d7Dby3b9+iT58+cHZ2Rt68eeHp6YnZs2cjNjZWrDNmzBjky5cPkZGR6NOnD2xsbGBnZ4cBAwaonHby+PFjdO/eHY6OjsiTJw88PDywbNkypXFF3Xr+/v7iuJd6fuq6ceMGPn78iMaNGyttSz2vqKgo9OvXDzY2NnBycsKiRYsAABEREejXrx/s7OyQP39+TJo0Kc078w4dOqRwt5861xUAatSogXz58uHQoUNqnxORIUtd2ykoKAgxMTEKU97MzMxQqlQpzJw5EzKZDMDXpVzKly8PAOjXr59Yd8aMGUr73rJlC0qVKgVzc3NUrVoVly5dynScCQkJmDVrlviFsqOjI/r374+QkBCxzrfr7alz7MDAQHTu3BlWVlbInz8/hg0bhvDwcEgkEvz+++86O9/Dhw+jXr16CnfhfH8+fn5+KFGiBPLly4f27dsjLCwMALB69WqULFkS5ubm8PLywqtXr1Qeo3Hjxjh+/Hi2WneVKDv7dmw8cuSIwthoaWmJ6tWrY/PmzWL9SZMmiXfturi4iHW/TxwmJydj6tSpKFCgACwtLdG2bVu1pwa/f/8egwcPRuHChZEnTx64urpi5syZSExMBPD1Tjx3d3cAwNChQxViHj16tFJsqT/fr/EXFBSEoUOHomjRojA3N0fZsmWxePFi8ThprfGXUXzA/611+PHjR7WuQ3qxHD16NM01Vk+fPg2JRIIdO3aodW0pfUz8kYJr165BKpWiVatWarf55ZdfMHr0aPTv3x/BwcG4fv06UlJSULduXdy6deuHY3r79i1atWqFMmXK4MGDBwgJCcHKlStx8uTJDKe1aBJbZGQkpk6dioULF4oD2e+//67wB/OPxEJEmfP582f4+/uLXzgMGzYMCQkJ2LVrl1inX79+MDMzw4YNG5Tab9iwAWXKlEHt2rUBAAcOHEC3bt3g5eWF169f4+zZs7h27RpOnDihVjytW7dGUFAQzp49i4iICOzfv1/c7/dGjhyJXr16ISgoCP7+/jh//jyaN2+u8AHq1q1bqFGjBuLj43HhwgV8+fIF8+bNw+zZszF58mSN6x06dAidO3dGvXr18Pr1a5w5cwYXL15U+/yuXLkC4OsdJmkZP348+vXrh6CgICxYsABTpkzBjh07MGTIEPTp0weBgYH4888/sXTpUpV3Z966dQvv379XSPype12NjIx+OAFBZEiePXsG4Osfg/ny5YMgCOLPp0+fsHDhQqxatQpTp04FALRt2xYPHjwAAGzdulWs+8cffyjsd9++fXj69CkuXbqEFy9ewNbWFh07dkR0dLTGMSYlJaFFixZYt24dFi5ciLCwMFy6dAmBgYGoV68eoqKiND52VFQUGjZsiOfPn+PcuXN4+/YtmjVrhokTJyrsS9vnGxYWhufPn6c7Zu7cuRMhISH477//cP36dTx58gT9+vXD33//jQ8fPiAgIAD37t3Dx48f0bdvX5X7qFGjBmJjY7PkszVRbvDt2Ni2bVvxd18ul+PVq1fo2rUrBg0aJH7OWLx4Mf78808AENfWEwQBTZs2VdjvjBkzUK5cObx48QIXLlzAvXv38NNPP2UYT2BgIKpVq4YnT57g0KFDiIiIwPr167Fp0yb07t0bwNeE3JMnTwB8/dL72/FcVWyCICgtmfLmzRtUrVoVt27dwo4dOxAWFob9+/cjNDQUFy9e/KH4NL0OGcXSqlUruLq6YtWqVUr7X7VqFWxtbdG5c+cMry2pQSD6xrp16wQAwqZNm9SqHxwcLJiYmAiDBg1SKJdKpYK9vb3QpEkTsaxu3bpCw4YNFeqpU7Zr1y4BgPDs2bN0Y/m+nSaxeXp6CqampsLbt28V6lauXFmoX7++xrEQUdZZsmSJkC9fPiEqKkos69q1q1CjRg2Fej179hTs7OyEhIQEsezp06cCAGHx4sVimbu7u1ClShWl45QvX14AILx58ybNWD5+/CgAEPz8/NKNefTo0QIAYePGjQrlJ06cEAAIGzZsEMtq164tlChRQiFuQRCE5cuXC8bGxkJQUJBG9cqUKSNUqlRJoY5cLhfKli2b4fkJgiCMGTNGACAkJiameV67du1SKK9Tp45gaWkpbNu2TaG8fv36QvXq1ZX2M3PmTMHJyUmQy+WCIKh/XVP17NlTsLCwUKsukaHYu3evAEDYuXOnIAiCkJiYKAQEBAgeHh6CpaVlup9N/vjjDyFv3rzi79yDBw8EAMLWrVuV6t64cUMAIDRv3lyh/N69ewIAYf369enG+eLFC6Xxz8/PTwAgnD59WqFuSEiIYG5uLvj6+mp8bF9fXwGAcO/ePYW6ixcvFgAIs2bNEsu0eb43b94UAAh///13mvtu2bKlQvnff/8tABA6dOigUL5+/XoBgPDo0SOlfaX++7F79+504yHKbVI/m4SEhAiC8PVvvT179giWlpZC2bJlBZlMlmbbpk2bKvx+/vnnnwIA8TPVtxYtWiQAEObNm6dQ/r///U8AILx69SrdOHv16iXY2toKYWFhCuX+/v4CACEgIEAQBEF48uSJAEBYu3atQr20YuvQoYPg7u4uvu7atauQL18+4dOnT2nGsnbtWqXPhOrGp8l1UCeWBQsWCACEJ0+eiGXv378XjI2NhdGjR6fZjjTDO/7oh1y6dAnJyclKmfh8+fKhZcuW4vYfUa5cORgZGWHYsGE4fvy40rSvrIqtXLlyKFasmNKxX79+/cOxEFHmrVu3Dn369IG1tbVYNmrUKFy/fl28iwMABg8ejIiICIU7xDZs2ABTU1P069cPwNeFn589e4a2bdsqHaddu3YZxuLg4IDChQvD19cXmzdvxqdPn9Kt3759e4XXLVq0gIWFhbhA++fPnxEQEID27dvDzMxMoW7Tpk2RkpKCq1evql0vJCQET548UToXiUSiFEtaIiMjYWZmlu76ft/fFe7h4YHY2Fil8jJlyiiMoakOHjyI9u3bQyKRAND8ulpbWyM+Pl7hzkmi3KJXr17iNN527drB3d0dly9fRunSpQF8/f1q1KgR7OzsYGRkJE5rjYuLw4cPH9Q+zvfr1Xl6esLIyEjl73RGDh8+DDs7OzRp0kSh3MnJCeXKlVO6C0WdY58/fx5FixZFhQoVFOqqO9Z9L7PnGxkZCeDrumJpUTVmAkCDBg0UysuUKQMAKo+Z+m9g6vGISFGhQoUgkUhgZ2eHSZMmoV+/fjh//jzy5MmDlJQULF68GJUrV4alpaXCNN6XL19qdJzvx4py5coBUP17+63Dhw/Dy8sLDg4OCuWp42J6d+Np4vjx42jatCkKFCigUTtN41PnOqgTy+DBg2Fubo7Vq1eLZX5+fkhJScHgwYM1OgdKGxN/pCA18fXu3Tu16n/58gXA1w9u33NyckJSUpLS9A1NeXp64sCBA0hISEDbtm1ha2uLunXrYsuWLVkaW6FChZTqWVtbK3zAymwsRJQ5V69exZMnT+Dn56ewlknq+nPfTiNt0qQJXF1dsX79egBf12DZsmUL2rVrJ37gSB0XVH0AUecDkrGxMU6dOoXy5ctjxIgRcHJyQtmyZTF79mzExcUp1DUxMUH+/PlVHid1nb/UBNeKFStgYmICY2NjGBsbw8jISPwA9eXLF7XrpZ5fwYIFlY6rqkwVW1tbyGSyNJNqefPmVUjCAl//4M2TJ4/S+VpZWSn9kRoYGIj79++jY8eOYpkm1xUAoqOjkTdvXqX1tIhyg9Sn+srlcoSFhcHf3x+VK1cG8PUPt44dO6Jy5cq4desWEhISIAgCli9fDgAaPd3y+89FxsbGsLCwyFTi6ePHj4iIiICpqak4hqUmJW/evCmOXZoc+8uXL5key1XJ7Pna2toCQLpTgr/fd2qSMK1yVcdM3b+dnV268RDlVqlP9U1KSkJgYCBWr14tjgdTp07FL7/8grFjx+L169dITk6GIAjo2LGjxk/9/f73Vp2kfGxsLGJiYnDw4EGlz3Gpv/ffj4OZERsbi9jYWDg7O2vcTtP4MroO6sZib2+P7t27Y/PmzYiLi0NycjLWrVuHypUri/+20Y9j4o8U1KlTB1ZWVmo/LTH1jzxVd2d8+vQJpqamCo8hz6z27dvj33//xZcvX3Dw4EE4OjpiwIAB2LRpU5bFlnrniTZiIaLMWbt2Lby8vBTWMkn9Wbt2LbZt24aEhAQAX3+HBw4ciLNnzyIwMBDHjh3Dx48fFb4ttLe3B/B/T0b7lqoyVTw9PXHo0CFERkbi6tWraNOmDXx8fDBq1CiFesnJyQgPD1d5nNQ4Ur9V/eWXX5CcnIyUlBSkpKRALpeL5zlq1Ci166XuN61xTx2pXwB9/PhR5fa0xkp1x9CDBw8iX758Sg8PUfe6Al8/3H9/hzYRfV3DrlChQli6dClKlCghJsffvHmj8b7U/Z1Wh4ODA4oUKYLk5GRxDPt2/Lp+/brGx7a3t/+hsfx7mT3fokWLAkh7zExv35ocM/UhKBz7iDS3ZcsWcU2/ggULwtjYGIDuxsa8efPCwsICffr0SfNz3MKFCzXer6rj5M2bF8HBwVqPL6ProEkso0ePRlRUFHbs2IEDBw4gJCSEd/tlMSb+SEHevHkxefJkBAQEYM+ePSrrfPr0SbwVt2HDhjAxMVFafD02NhYnTpxAgwYNYGJikmXx2draonXr1ti/fz/MzMzSXdxd27FpEgsRaS46Ohp79+5Fy5YtVW5v1aoVIiIi8M8//4hlAwcOhEQiwcaNG7F+/Xo4OzujRYsW4vZChQrB3d0dR48eVdqfqrL0mJmZoU6dOli0aBEaNWqkcgw4fPiwwutTp04hPj5enDZRsGBBVK9eHQcOHEj3G2d16xUqVAgeHh44cuSIQrkgCEqxpKVevXoAvj6NUhsOHjyIli1bKk1ZTpXRdZXL5bh16xbq16+vlfiIcrrvf7dkMpnSZzpLS0txmy60a9cO79+/x7Vr17Jsn40aNcK7d+8UlnwAoDT+Ado9X0dHR7i7u2ttzEx1/fp1WFpaokqVKlo9DpGh+n5svH//Pu7fv69Qpq2xQiKRoG3btjh9+jQiIiKydN/fH6dNmzY4e/asRl+CaCM+TWKpUaMGqlWrhtWrV2PVqlUwNzdX+UARyjwm/kjJr7/+iv79+6Nv37747bff8OLFCyQmJuLjx4/w8/NDhQoV8OjRIwBA4cKF4e3tjY0bN2LZsmUIDw/Hixcv0KNHD8TExMDX1/eH4/Hz88P48eNx48YNSKVSREZGYuXKlZDJZGjUqFGa7bQRW2ZjISLNbd++HXFxcWkm/pydnVG+fHmF6b5FihRBixYt4Ofnh2PHjuGnn34Sv9VN5evri9u3b2PixIkICQnBhw8fMG7cOBQvXjzDmO7cuYPOnTvj9OnTCA0NRXx8PE6fPo1bt24pjQGWlpY4efIkjh07BqlUikuXLmHYsGGoUKGCwoeZ1atX4927d+jUqRNu3bqFuLg4vH//HocOHUKzZs3EqRXq1ps3bx7u3r2LsWPH4sOHDwgODsbIkSPh5uam1nWvVq0anJycxHUIs1JkZCQuXbqk9AQ6Ta7r9evXERMTk+l1vIgMWfv27fH27VssXLgQUqkUT58+RefOnVGnTh2FekWKFIGNjQ1Onz6NmJgYrcc1ZMgQNGzYEN27d8fu3bsRFhaG6Oho3LhxAxMnToSfn5/G+xw5ciSKFSuGPn364NatW5BKpfjnn39w7949pbraPt927drhypUrWl139Ny5c2jVqlWWfqFOlFu0b98ee/bswcmTJxEbG4vLly9j2LBhaNiwoUK91OVTjh49muW/zwsXLoSRkRHatGmDy5cvQyqV4tOnTzhz5gy6dOmCO3fuZMlxFixYAHNzc7Rq1QpXrlxBTEwMnj17hilTpuD06dM6jU+TWEaNGoXbt2/jwoUL6Ny5M5c1yGJM/JESIyMjbN68Gf/88w/u3r2LevXqIV++fKhSpQq2bt2KX375BXPmzBHrL1iwAH/++Sc2btyIQoUKoVq1apDL5bhy5QqqV6/+w/H07dsXpUqVwtixY+Hs7IwSJUpg165d2L59u7hgf1qyOrYfiYWINLN27Vo4OTmhYsWKadZp1aoVLl68iOfPn4tlQ4YMwcePH5GSkoJBgwYptenUqRP27t2LM2fOoHjx4vDy8kLNmjXFBFNad6IBQMWKFTFgwAAsXboU5cuXh6OjIyZMmIBJkyZh1apVSvVXrlyJLVu2wNnZGe3bt0f9+vVx5swZhWNUrVoVt2/fhoODAzp06CCuHbp582ZMnz5dnL6rbr1OnTph3759uHjxIlxdXeHl5YU6deqkmUD9nomJCYYMGYLdu3drvO5NRlLvqvx+QWhNruu2bdtQrFgxpcXyiejr55QlS5bAz88PBQoUQPfu3TF48GA0bdpUoZ6pqSk2bNiAe/fuIX/+/OIDQLQlT548OHXqFMaOHYt58+ahaNGiKF68OMaOHYsSJUqgb9++Gu/TxsYGFy9ehJubG7y8vFCsWDGcPHlS/GL323FW2+c7fPhwREZGanznuLpu3ryJZ8+eYcSIEVrZP5GhW7ZsGfr164cBAwagYMGC+P3337F27Vql9Y+rV6+O3377DQsWLICFhYX4AJCsULx4cdy+fRtVqlRB//79YW9vjypVqmDJkiXo169fup93NeHq6oqbN2+iYsWK6N69OxwcHNClSxcULFhQKdGp7fg0iaVnz57iUl2c5pv1JIIgCPoOgoiISN8mT56M//3vf4iJifnhh0aMGTMGmzZt0smdNNoQGhoKNzc3/PXXX+jfv3+W7bd79+74/Plzpu8mjIqKQvHixTFv3jyMHDkyy+IiIsPx6NEjlCtXDhs2bMDAgQN1dtyePXsiNDRUK3dLDxw4EE+ePEFAQECWrr1IRJRdyOVyuLi4wMzMDK9eveJYl8V4xx8REeV6KSkpOHjwIGrVqsUnxeLrUzF/+eUXzJ49G8nJyVmyz8TERJw4cUJpmq8mlixZAmdnZwwbNixLYiIiw/PPP/9AIpGgQYMGOj3u/Pnzce3atSxP/D1//hzbtm3DsmXL+IcwERmsy5cv48OHDxgyZAjHOi3gHX9ERJSrREVFYezYsRg/fjw8PDwQFBSEWbNm4Z9//sHJkyfFB2/8iJx+xx8RUU4wffp01KhRA/Xr10dKSgr8/f3h7e2Nbt26YdOmTfoOj4iI1BAVFYUuXbrg9u3bePXqFdf30wLe8UdERLmKjY0NWrRogTFjxqBw4cKoXr06Pn36hBMnTmRJ0o+IiHRjwIAB2LlzJypVqoSiRYtiyZIlmDp1KtatW6fv0IiISA2pa/sFBwdjz549TPppCe/4IyIiIiIiIiIiMkB8HryOpC4W//3aUZ8+fVL51ERHR8d0nyyZkJCA2NhY8SmOmm4nItKnlJQUhIeHI3/+/DA2Ns6wvlwuR0REhPg0Rk23ExFlN0lJSYiNjYWtra1a9T9//gwrK6s0Px9mtJ2IKDv4/PkzEhISAHx94vb3T9ZNS3R0NCQSCaysrDK1nbK3L1++ID4+HgBgYmICJycntdpJpVIIggBra+tMbc8tONVXy44dO4YaNWrA2dkZNjY2aNSoEV68eCFu79OnD2rVqiX+VKpUCS4uLnj8+LHK/cnlcowZMwa2trYoWrQoPDw8cOvWLbW3ExHp24YNG+Do6IgSJUqgQIEC2LJlS5p1k5OTMWHCBFhZWaFkyZIoUqQIDh06JG4XBAHe3t6wsrJC6dKlYWVlhalTp+riNIiIMiU+Ph7Dhw+HjY0NSpYsiQYNGiAwMDDN+tevX0fp0qVRvHhx2NraYsKECZDL5WpvJyLKTiZOnIhatWqhXLlyaNiwYYb1w8LC0LRpUxQoUAAODg5o0aIFvnz5ovZ2yhl+/vln1KpVC+XLl0e9evUyrP/lyxc0b94cDg4OcHR0RLNmzRAWFqb29twm2071lcvl+PDhA6ysrHL03RuTJ09G7969UalSJcTGxmLo0KH4+PEjzp8/r7L+nDlzcPz4cVy7dk3l9tWrV2P58uU4fvw4ihUrht9//x3//PMP7ty5AzMzswy3ExkSQRAglUpRuHBhGBkZ3vcYhjIOfuvevXto3LgxduzYgRYtWuDo0aPo378/Ll26BE9PT6X6S5cuxbp163Ds2DEUL14c//zzD0aOHInr16+jePHi2Lt3L7y9vXHmzBm4u7vj0aNHaN68OVauXImOHTvq/gSJdIhjYM7Ut29ffPnyBevXr0fhwoVx48YNfPjwQeUTr+Pj41GpUiX07t0bM2bMwNu3b9GyZUtMmTIFQ4cOzXA7kSHjGJizrVq1Chs2bMDNmzfTrdenTx9ER0dj165dEAQB3bt3h4ODg/jFcUbbKWf5+++/sWrVKty9ezfdev3798eXL1+we/duSCQS9OjRAzY2Nti+fbta2w2FuuNgtk38vX//Hi4uLvoOg4hygKCgIBQpUkTfYWQ5joNEpA6OgUSUm3EMJKLcLqNxMNuu8Zc6Nz8oKMig5mOPGDEC79+/x5EjR5S2+fv7Y9SoUXj69Gma5+zg4IANGzagffv2Yln16tXRt29fjB8/PsPtRIYkOjoaLi4uOl3LIzk5GcbGxjr55tUQx8GOHTuidOnSWLhwoVg2ceJEvH//Hnv37lVZv1SpUli0aBGAr99qeXp6okaNGti0aRNevnyJli1b4o8//kD16tUREBAAHx8fnD59GsWLF9fVaRHphT7GQF0yxDFw3bp1WLRoEVq3bo19+/YhMTERNWrUwOrVq1V+YF+8eDH279+vMBPkn3/+wZgxYxASEpLhdiJDxjEwZ1Pnjr///vsPzZs3x5s3b5A/f34AQGhoKEqVKoVz584hOTk53e1Vq1bVyblQ1lHnjr9bt26hcePGePnyJRwdHQEA4eHhcHV1xenTp2FsbJzu9ho1aujiVHRC3XEw2yb+Uv+otra2NpiBbuXKlThx4gQCAgJUntOWLVvQq1evNDO1SUlJSEpKQsGCBRXa29raIiUlBRYWFuluN5TrSPQ9bSfhoqOjsW3bNqxevRoPHz7Ezp070bNnzwzbrVu3DnPnzkVQUBBKlSqFBQsWKCTlM2KI46BMJoO9vb3C+Tg4OODVq1cqz7Ffv34YN24cmjZtigoVKmDdunUIDQ1FUlISrK2tUblyZUycOBFjx46FlZUVpFIp5syZg/LlyxvktBgiVQy1rxviGJiYmIiPHz/CxsYGERERiI+PR+fOnTFx4kScPHlSqX5KSgpsbGwUzt/JyQlxcXGwsrLKcLuh9g2ibxlqPzfEMfBb5ubmMDIyUuvcnJ2dYWpqCgDif79939PabojXzdBp0i8KFy4MCwsLABD/q852Q+wXGY2DhrcYQja1YsUK+Pj44Ny5c3B3d1fa/vLlS5w7dw4jRoxIcx+mpqawtLREeHi4Qnl4eDjs7Owy3E5EmbN582Y8fPgQmzdvVrvNoUOHMGrUKMyfPx8REREYNmwYunTpgtu3b2sx0uzPzs5OozFq4MCBWLJkCZYtW4Z27doBAJo3by4+6WvOnDnYvHkz3rx5g8+fP+Ply5f4+++/xTsEiYiyk9Qn+E6dOhVGRkawtLTEuHHjcP78eSQnJyvVT2vMtLW1hUQiyXA7EVFOlvr58NtxLvX/7ezsMtxOhon9QnNM/OnAvHnzMH/+fJw/fx6VKlVSWWfNmjWoWrWq0u3I0dHR+PTpk/i6WrVquHr1qvg6JCQEr1+/RrVq1dTaTkSaGzt2LFatWoUKFSqo3WbJkiXo1KkTevToASsrK0ycOBEVKlTAihUrtBhp9vf9GAUAV69eFccomUyG9+/fi0+kFAQBw4YNw7Vr1/D8+XP8+uuvuHbtGlq0aAEACAgIQJMmTVC4cGEAgIuLCxo3box///1Xh2dFRKSe6tWrAwBiYmLEMqlUCnNzcxgbGwP4uq5XfHw8gK9j5osXLxAaGirWv3LlisLnvvS2ExHlNGFhYYiMjAQAlC1bFhYWFgqfHa9cuQJLS0t4eHhkuJ0Mx+fPnxEREQEA8PDwgKWlpdL7bmFhgbJly2a4PVcSsqmoqCgBgBAVFaXvUH7IL7/8IuTPn184f/68EBQUJP6kpKSIdRISEgR7e3th7dq1Su1nzZoluLu7i6/9/f0FCwsLYceOHcKdO3eE1q1bCzVq1BDkcrla24kMia7HiaSkJAGAsHPnznTrpaSkCGZmZsLKlSsVyidNmiSUKlVK7eMZyjj4raCgIMHKykqYMWOG8PDhQ2H69OmCjY2NEBwcLAiCIJw/f14AIISEhAiCIAjXr18Xxo0bJ9y7d0+4ePGi0LBhQ6FRo0biGLpgwQLBwcFBOHjwoPDy5Uth//79gp2dnbBixQq9nSORruSEMWL79u1C69athVq1agkzZswQ4uLi1G6bE84vM7y8vIQWLVoId+/eFS5fvix4eHgIY8aMEbd/++9MSkqKULVqVaFdu3bC3bt3ha1btwoWFhbCkSNH1NpOZMh0OUZEREQIy5cvF2rUqCG0a9dOrTZxcXHCrFmzhFq1agn16tUTli5dKiQnJ6t9TEMdA6OiooSgoCDh999/F0qWLCkEBQWJnwMFQRAaNmwoDB8+XHw9YcIEwc3NTbh8+bJw8eJFwdXVVZg8ebLa2ylnSO0Xc+bMEYoXL67UL5o0aSIMHjxYfD1p0iTB1dVVuHTpknDp0iWhZMmSwsSJE9XebijUHSey7Rp/hsLf3x8WFhbo27evQvmDBw/E20xPnz6N/Pnzo1evXkrtra2txSltANChQwf4+flh6dKliIiIQN26dbFx40ZxOkdG24lI+yIjIyGTycTFZFMVKFBA4Q7e78lkMshkMvF1dHQ0AEAul4t3wOV0hQsXxqlTpzBjxgxs374dbm5uOH36NJycnCCXy2FqagpnZ2dIJBLI5XJUrVoVN2/exIABAyCXy9GuXTtMmzYNwNfr4u3tDWNjY8yfPx+hoaEoWLAgZs2ahVGjRhnMNSNKS3bv4+PHj8eOHTuwcOFCVKhQAefPn8fs2bPh6+ur79D0av/+/fjll1/QvXt3WFlZoXfv3pgyZYq43dnZGXnz5gUAGBkZ4ciRI5g8eTK6dOkCe3t7rFu3Dm3atFFrOxFljQoVKqBjx45wc3PDrVu31GrTp08fPHz4EMuXL0dsbCxGjRqF9+/fY8mSJVqONntbuXIlVq5cKb6uVasWbGxs8OjRIwCAo6OjwnTMhQsXwtLSEsOGDYNEIkHfvn3x22+/qb2dcgY/Pz/873//E1/XqlULlpaWePbsGYCv/SL1AS4A4OvrCwsLCwwfPhwA0LNnT8yaNUvt7bmNRBAEQd9BqBIdHQ0bGxtERUUZ5OKLRPTjdD1OJCcnw9TUNMOHe4SHh8Pe3h579uxBt27dxPIFCxbA19dXnL7wvd9//x0+Pj5K5c+fPzfYJ9YRUeZJpVKULl06W35WunbtGurWrYvTp0+jadOmYnlSUpK48HpG+FmQiNKjyzEiPj4eFhYWmDFjBvbt24enT5+mW//OnTuoUqUKrly5grp16wL4+iDHwYMHIyQkBA4ODhkek2MgEWVE3XGCd/wREWUxW1tbmJubK6y5BHxds+TbO3i/N336dHh7e4uvUx/P7ujoyA98RKTE3Nxc3yGkaceOHShRooRC0g+A2kk/IqLsRNUTQ9Nz/vx52NjYoE6dOmJZmzZtkJycjMuXL6NTp05ZHSIRUZqY+CMiygJyuRyCIMDY2BhGRkaoXbs2zp8/j9GjR4t1zp49q/AB8HtmZmYwMzNTKjcyMoKREZ/FRESKsvO48OTJE1SuXBlr1qzB1q1bYWZmhoYNG2LSpEmwtLRU2SY3LHdARFknO48LQUFBcHJyUlhuyd7eHnny5EFQUJDKNhwDiUhT6o4NBpf4a/fzQX2HQGo6vKSDvkMgUosgCEhJSUFKSgqArwNscnKyQkLut99+w5o1a/D582cAwKRJk9ChQwds3rwZrVu3xvr16/H48WNs3rxZq7FyDMw5OAaSIUtMTMSJEycAfF1/KSIiApMnT8aVK1dw6tQplWsP+/r6qlzuICwsDAkJCWodd876/34scNKZmYNr6jsEyuGkUqm+Q0hTcnIy8uTJo1SeJ08eJCUlqWzDMTB30eUY+HFP7l5bNydx6j5do/rqjoMGl/gjIspqp0+fRuvWrQEAxsbG6N+/P/r374/hw4eLixMbGxvDxOT/htTWrVtjw4YNmDt3LkaOHAl3d3ccPHgQFSpU0Ms5EBHpkoODAyQSCbZv3y7eyWxhYYGmTZvi5cuXKFWqlFKbrFjuICg8a+In7StQoIC+Q6AcLjsvd2Bvb48vX74olMlkMsTExKS5vh/HwNxFl2NgrDRYZ8eiH6Npv1B3HGTij4goA82bN0dycnK6dXx8fJS+pe3Xrx/69eunzdCIDEZwcDAWLlyIly9fws3NDZMnT0aRIkXSrH/79m38/fffeP/+PcqVK4dJkyaJf0w9f/4co0aNEutOnz4dTZo00fo50P+pXr06/v33X4XlC1Lfn7S+nc6K5Q6y5RPrSKXsPFVdH1q3bo3ExESFsoMHD6Y5NT6j+pruLyfKzn2oatWq8PHxQVBQEFxcXAAAAQEB4jZVOAbmLrrsvxL2jBxD036hbn0m/oiIiEivoqOjUadOHdSoUQMDBw7E3r17Ubt2bTx8+BA2NjZK9S9fvoymTZti2rRpaNmyJbZu3YoGDRrg9u3bMDc3R6FChTBt2jQAQJcuXRASEqLrU8r1BgwYgHnz5mHbtm3o27cvkpOTsWzZMri4uMDT01Pf4RFlO+fOncPSpUtRunRpsUxVEkjd+pruj35MSkoKKlasiF9//RW9evVC8+bNUbx4ccycORMbNmxAYmIiZs+ejTp16qBcuXL6DpeIchkm/oiIiEivNmzYAEEQsGvXLhgbG6Nz584oWbIk1q1bh59//lmp/vLly9GtWzfxLts2bdrAxcUF27Ztw5AhQ2BlZSU+TZZPkdUPZ2dn7N+/H4MGDcL06dMRGxuLokWLwt/fn8kHojTUqFED1apVy7L6mu6P0tanTx/cu3cPoaGhiIqKEpN3Fy9ehL29PQRBwKNHj8TpvWZmZvD390ePHj1gb2+PpKQkeHp6Yu/evfo8DSLKpZj4IyIiIr26evUqmjRpAmNjYwBfpy00adIEV69eVZn4Cw0NRb169cTXpqamcHJywuXLlzFkyBCdxU3pa968Od69e4e3b9/C2to6zXWtiOirmTNnwtTUFKVKlcKYMWPg6ur6Q/U13R+lbc6cOYiLi1MqT70r3cTEBA8ePEDhwoXFbRUrVsTTp0/x9u1bmJiYpLt8BRGRNjHxR0RERHoVFham9Aepo6Mjnj17prJ+zZo1cfjwYfz666/Ily8f7t69i8ePH6NQoUK6CJc0YGRkhBIlSug7DKJs7/jx40hJSUF0dDT8/f3h6emJ69evpzktNKP6mu6P0qfOOJbWtS1evHgWR0NEpBkm/oiIiEiv8uTJg4SEBIWyhISENKeEzpgxA9evX0eJEiVQsmRJfP78GdWrV0fevHl1ES4RUZZr1KiR+P+dO3dGaGgoli5dig0bNmSqvqb7IyIiw8XEHxEREelVqVKl8Pz5c4WyFy9ewM3NTWV9W1tbXLx4ES9evEBYWBgqV66MWrVqoU2bNroIl4hI60qVKoXXr19nWX1N90dERIYjU8+QjoqKwl9//YVBgwZhwoQJOHnypFKdWbNmoWvXrgo/S5Ys+eGAiYiIyLB0794d586dw7179wAADx48wOnTp9G9e3cAwMOHD9G0aVN8/vwZAPD69WvcuHEDpUuXRt26dbFhwwYEBQVh0KBBejsHIqLMunr1Ku7cuSO+fvv2Lf755x/Ur19fLGvRogXOnj2rVn119kdERLmHxnf8BQYGomHDhmjfvj3q1auH4OBgdO/eHSNGjMCCBQvEehcvXoSDgwN69uwplnFBUyIiIvpew4YNMXnyZNSpUwdly5bF48ePMXHiRDRu3BgAEBkZibNnz4rTge3s7DBo0CBERUUhOjoaycnJOHToEJycnAAAcrkczZs3BwBER0dj/vz52LRpE4YPH45u3brp5ySJiNJQsGBB/PTTTwgLC4ONjQ0ePnyIbt26KTzc6OzZs+jXr59a9dXZHxER5R4aJ/7s7e1x79498QlGwNeE3uDBg/Hrr7/C2tpaLPfw8EDXrl2zJlIiIiIyWHPnzsWoUaPw6tUrlCxZEs7OzuK28uXL4/Tp03B0dATwNfF3/vx5PHjwACkpKahQoYL4RGAAkEgkmDZtGgCI/wWA0qVL6+hsiIjU5+bmhitXruDVq1f4/PkzSpYsqfQU7FOnTqFs2bJq1Vdnf0RElHtonPjLly+fUlmRIkUgCAKioqIUEn9nzpzBmzdvUKhQIbRq1QpNmjT5sWiJiIjIYDk7Oysk/FLZ2NigadOmCmUSiQQVKlRQuR+JRKJUn4gouytZsiRKliypclvqHdDq1ldnOxER5Q5Z8nCPP//8E2XKlIGLi4tYljdvXlSoUAFVqlTBo0eP0K5dO4wfPx6+vr4q9yGTySCTycTX0dHRAL5O15HL5WrHIsnkOZDuafK+EqnCPkRERERERESUth9O/M2ZMwdnzpzBxYsXFcq3b98OOzs78XW1atXQq1cvDBgwAB4eHkr78fX1hY+Pj1J5WFiYuKaPOlzyaxA86VVoaKi+Q6AcTiqV6jsEohzh9dwu+g6B1FTi13/0HQKRweEYmHNwDCQiyno/lPhbtmwZ5s2bB39/f1SvXl1h27dJPwDo0KEDAODmzZsqE3/Tp0+Ht7e3+Do6OhouLi5wdHRUmD6ckaBwTc6A9KlAgQL6DoFyOHNzc32HQERERERERJRtZTrxt3z5cvzyyy84cOAAWrRokWF9qVQKQRAUFt/+lpmZGczMzJTKjYyMYGRkpHZcgto1Sd80eV+JVGEfIiIiIiIiIkpbpv5q/vPPPzF9+nQcOHAALVu2VNoeFBSEs2fPiq9TUlIwY8YMWFpa8gEfREREREREREREOqDxHX/37t3DuHHjUKJECaxbtw7r1q0Tt/3xxx/w8PCApaUlli1bhtGjR6NEiRJ48uQJBEHA/v37Ob2TiIiIiIiIiIhIBzRO/BUpUgR79+5Vuc3R0REAkD9/fhw5cgRv3rzB06dP4eTkBE9PT+TJk+fHoiUiIiIiIiIiIiK1aJz4s7e3R9euXdWq6+rqCldXV42DIiIiIiIiIiIioh/DlfGJiIiIiIiIiIgMEBN/REREREREREREBoiJPyIiIiIiIiIiIgPExB8REREREREREZEBYuKPiIiIiIiIiIjIADHxR0REREREREREZICY+CMiIiKiLHXx4kWYmJgo/Tx69EjfoRERERHlKib6DoCIiIiIDIsgCEhJSUFCQgKMjY3FchMTfvQkIiIi0iV++iIiIiIirTA2Nmayj4iIiEiPONWXiEhNUqkUL168QHx8vNptoqKi8PLlS8TExGgxMiKi7KlIkSLInz8/6tWrh+PHj+s7HCIiIqJch4k/IqIMCIKASZMmwdHREV5eXnBwcMCyZcvSbRMSEoImTZqgcOHCaNmyJRwdHdG1a1cmAIkoV8iTJw/mzJmD//77Dw8fPkTLli3Rpk0bnDhxIs02MpkM0dHRCj8AIJfL1f6RAPzJIT+avK8/+iNAwp8c8qPpe0tERBnj3AsiogysXbsWfn5+CAgIQOXKlXH8+HG0bdsW5cqVQ7NmzVS2mThxIsLCwvDhwwfY2Njg/fv3qF69OubOnQtfX18dnwERkW7VqVMHderUEV/PmDEDN27cwMKFC9GyZUuVbXx9feHj46NUHhYWhoSEBLWO65I/c/GS7oWGhursWFIrZ50di36MJv1CKpVqMRIiIsPBxB8RUQb8/PzQo0cPVK5cGQDQqlUr1K9fH35+fmkm/t6/f4/atWvDxsYGwNfpbuXLl0dQUJDO4iYiyk4qVqyIjRs3prl9+vTp8Pb2Fl9HR0fDxcUFjo6OsLa2VusYQeE/HCbpSIECBXR2rFhpsM6ORT9Gk35hbm6uxUiUnThxAidPnoSJiQk6deqk8OWGKgkJCdi5cycePHgAY2NjVK9eHV26dFF44BERkS5wqi8RUTqSk5Nx//591KxZU6G8Tp06uHXrVprtJk2aBH9/f2zfvh23bt3CX3/9hTt37mDcuHHaDpmIKFt6+PAhChUqlOZ2MzMzWFtbK/wAgJGRkdo/AsCfHPKjyfv6oz/6n8DKH3V/NH1vdeW3335Djx49YGVlBblcDi8vL6xfvz7N+vHx8ahduzYWL14MZ2dn2NnZ4eeff0bbtm11FjMRUSre8UdElI6oqCgkJyfD3t5eodze3h6fP39Os12LFi3QsWNHDBkyBIULF8aHDx8wdepUVKtWLc02MpkMMplMfP39+lbqkKhVi7IDXa5NJLBn5Bia9IvsvL7V1KlTUbt2bTRs2BAAsH79ehw4cADbtm3Tc2RERJoJDAzEvHnzsGPHDnTv3h0A4ODggJ9//hm9e/eGhYWFUpuAgADcvXsXz58/R6lSpQAA1apVQ4sWLfDmzRu4urrq9ByIKHdj4o+IKB0mJl+HycTERIVymUwGU1PTNNv17dsXQUFBCA4ORv78+REUFIQGDRogLi4OCxcuVNmG61vlLlzfilQxlPWthg4dilmzZmHo0KGQyWQoW7Ys/P390aFDB32HRkSkkePHjyNPnjwK41fv3r3xyy+/4NKlS2jRooVSm8KFC8PIyAhhYWFi4i80NBSWlpaws7PTWexERAATf0RE6bKxsYGVlRVCQkIUykNCQuDi4qKyTVJSEg4ePAg/Pz/kz/81E+fi4oK+fftiy5YtaSb+uL5V7sL1rUiV7Ly+lSbc3Nywfft2fYdBRPTDXr58iUKFCsHMzEwsK1q0KIyNjfHy5UuViT8PDw9s374dQ4YMQbly5ZCYmIg3b97g0KFDsLW1VXkczvzIXTjzg1TRtF+oW5+JPyKiDDRq1AjHjh3DxIkTAXwdYFOf7JsqNDQU4eHh8PDwgKmpKfLly6c0FTgsLCzdb3nNzMwUPlSm0mQdG0GtWpQd6HJtIgl7Ro6hSb/QZR8iIsqt4uPjYWVlpVAmkUhgaWmJ+Ph4lW1SvwSWSCSoXr06ZDIZ7t69i6NHj6Jx48Yq23DmR+7CmR+kiqb9Qt3ZH0z8ERFlYObMmahbty6mT5+O1q1bY8OGDfjy5YvC3XkrVqzAmjVrxGTf0KFDMX/+fBQoUADlypXDtWvXsHHjRixdulRfp0FEREREGrK2tkZERIRCWUpKCqRSaZozMrZt2wZ/f38EBgaKd3K3b98eFStWRPv27cX1T7/FmR+5C2d+kCqa9gt1Z38w8UdElIFq1arh3LlzWLRoEU6ePAl3d3dcuXIFRYsWFesULFgQZcqUEV/Pnz8fpUuXxr59+7Bq1So4Oztj27Zt6Natmz5OgYiIiIgyoVy5cvjw4QMiIyPFabqPHj2CIAgoV66cyjavXr2Ck5OTwh/x5cqVE6cHq0r8ceZH7sKZH6SKpv1C3fqcI0JEpIa6devC398ft2/fxs6dO+Hp6amwfezYsbh8+bL42tjYGEOHDsXRo0dx48YN+Pv7M+lHRERElMO0bt0aefPmxZo1a8SyP//8E66urqhVqxaAr8vADBkyBOfPnwcAVKxYEUFBQbh3757Y5ujRo0hJSUGFChV0ewJElOvxjj8iIiIiIiIiFezs7LBu3Tr89NNPOHfuHOLi4vDo0SMcOnRIvNtGLpdj/fr1qFSpEho1aoSuXbvi4MGDqFu3Llq0aIHExEScPn0aU6dORfXq1fV8RkSU2zDxR0RERERERJSGbt26oW7durh06RJMTEzQuHFj5M//f0/SMDY2xtq1a1GnTh0AXx/+sW3bNjx+/BiPHj2CiYkJVqxYAVdXV32dAhHlYplO/EVERODBgwewtrZG2bJlkSdPHqU6crkct27dglQqReXKldN9miURERERERFRdlS4cGH07NlT5TaJRIIhQ4YolZctWxZly5bVdmhEROnSOPEXHR2N8ePH49ixY3B3d0dISAiSkpKwdetW1K9fX6z3/v17tGjRAtHR0XBycsKTJ0/g5+eHPn36ZOkJEBERERERERERkTKNH+4RFRWFhg0bIjg4GJcuXcLz58/RsmVLdOnSBSkpKWK9oUOHIn/+/Hj16hVu3LiB+fPnY/DgwQgKCsrSEyAiIiIiIiIiIiJlGif+XFxc8NNPP8HE5OvNghKJBL169UJYWBgCAwMBAJ8+fcLJkycxceJEcQrw8OHDYWFhgd27d2dh+ERERERERERERKRKljzc48qVK7C0tISLiwsA4MGDBxAEARUrVhTrmJqaomzZsgqPNP+WTCaDTCYTX0dHRwP4uk6gXC5XOxZJZk6A9EKT95VIFfYhIiIiIiIiorT9cOLv1q1bmDt3Ln7//XeYmpoCACIjIwFA4UlHAGBvby9u+56vry98fHyUysPCwpCQkKB2PC75M65D2UNoaKi+Q6AcTiqV6jsEIiIiIiIiomzrhxJ/T548QevWrdG7d29MnjxZLE+d3hsXF6fwJN+4uDjY2Nio3Nf06dPh7e0tvo6OjoaLiwscHR1hbW2tdkxB4ZqeBelLgQIF9B0C5XDm5ub6DoGIiIiIiIgo28p04u/p06do3Lgx2rRpg7Vr10Ii+b9Jtq6urgC+PtnX2dlZLA8KCkKlSpVU7s/MzAxmZmZK5UZGRjAyUn8pQkHtmqRvmryvRKqwDxERERERERGlLVN/NT979gyNGjVCq1atsG7dOoWkHwCUK1cORYoUwf79+8WyBw8eiE8AJiIiIiIiIiIiIu3S+I6/jx8/onHjxsifPz86duyIY8eOidvq1q0LOzs7SCQSLF68GH379oW5uTmKFi2KBQsWoHXr1mjatGmWngAREREREREREREp0zjxFx4ejsqVKwMA/v77b4VtJUqUENf069GjBwoUKICtW7fi8ePHGDVqFEaNGpUFIRMREREREREREVFGNE78lS1bFkeOHFGrbqNGjdCoUSONgyIiIiIiIiIiIqIfw5XxiYiIiIiIiIiIDBATf0RERERERERERAaIiT8iIiIi0qrAwEC8fftW32EQERER5TpM/BERERGR1hw+fBiurq6oVauWvkMhIiIiynWY+CMiIiIirQgODsaoUaPQt29ffYdCRERElCsx8UdEREREWU4ul6NPnz6YOnUqypYtq+9wiIiIiHIlJv6IiIiIKMvNnj0befPmxZgxY/QdChEREVGuZaLvAIiIiIjIsFy6dAl+fn64e/eu2m1kMhlkMpn4Ojo6GsDXOwflcrla+5BoFCXpk7rvaVYQ2DNyDE36hS77EBFRTsbEHxERERFlGZlMJk7xlUqlkEql+PLlC1JSUvDy5Us4OTkhX758Su18fX3h4+OjVB4WFoaEhAS1ju2S/4fDJx0JDQ3V2bGkVs46Oxb9GE36hVQq1WIkRESGg4k/IiIiIsoycXFxMDMzw19//YW//voLABAZGYnIyEi0bNkSS5YsQYcOHZTaTZ8+Hd7e3uLr6OhouLi4wNHREdbW1modOyg8a86BtK9AgQI6O1asNFhnx6Ifo0m/MDc312IkRESGg4k/IiIiIsoydnZ2ePnypULZ/PnzsXz5cqXyb5mZmcHMzEyp3MjICEZG6i1LLWgWKumRuu9pVpCwZ+QYmvQLXfYhIqKcjKMlERERERERERGRAWLij4iIiIi0ys7ODq6urvoOg4iIiCjXYeKPiEhNjx49wvHjx/Hq1Su12yQkJODy5cu4evUqEhMTtRgdEVH2NXz4cAQEBOg7DCIiIqJch2v8ERFlIDExEd27d8fFixdRoUIF3Lp1CwMGDMBff/0FiUSSZrv9+/dj2LBhcHFxgYODA8LCwrB3716UKlVKh9ETERERERFRbsXEHxFRBpYsWYJr167hwYMHKFKkCO7evYuaNWuiQYMG6NGjh8o2N2/eRPfu3bFq1SoMGzYMAPDy5UtER0frMnQiIiIiygLv37/HxYsXYWJigiZNmsDBwSHDNoIgICAgAC9evED58uVRpUoVHURKRKSIU32JiDKwdetW9OrVC0WKFAEAVKpUCc2aNcOWLVvSbOPr64uqVauKST8AcHNz4wc+IiIiohxm165dKF26NLZv345Vq1bBzc0NFy9eTLfNp0+fUKdOHfTq1Qvnz5/H+PHjMXr0aB1FTET0f3jHHxFROmQyGZ49e4ZJkyYplFeqVAmbN29Os92FCxcwduxYfP78Gbdu3UKBAgVQvnx5mJikPezKZDLIZDLxderdgXK5HHK5XK140554TNmNuu9pVhDYM3IMTfqFLvsQEVFuFRERgWHDhsHHxweTJ08G8HXd0gEDBuDVq1cwNjZW2a5nz56QSCR4+vQpLCwsAHz9fEhEpGtM/BERpUMqlUIul8POzk6h3N7eHpGRkSrbpKSkIDw8HA8ePECVKlXg7u6O58+fI2/evPD394e7u7vKdr6+vvDx8VEqDwsLQ0JCglrxuuRXqxplA6GhoTo7ltTKWWfHoh+jSb+QSqVajISIiADg6NGjSEhIUJjFMXbsWPz999/4999/UbduXaU2N27cwIULF3DhwgUx6QcAXl5eugiZiEgBE39EROnIkycPACAuLk6hPCYmBmZmZirbGBsbw9jYGAEBAbh37x4cHR2RmJiIli1bYsSIETh//rzKdtOnT4e3t7f4Ojo6Gi4uLnB0dIS1tbVa8QaFq1WNsoECBQro7Fix0mCdHYt+jCb9wtzcXIuREBERADx69AiFCxeGjY2NWFamTBlIJBI8evRIZeLv6tWrMDc3R7Vq1XD48GFIpVJUqFAB5cqVS/M4nPmRu3DmB6miab9Qtz4Tf0RE6bC2toa9vT2CgoIUyoOCguDq6ppmuxIlSqBmzZpwdHQE8DWB2LlzZ0yZMiXNNmZmZiqTiUZGRjAyUm9JVkGtWpQdqPueZgUJe0aOoUm/0GUfIiLKraKjo2Fra6tQZmxsDCsrqzQf2vb582fky5cPTZo0gb29PaysrDBs2DD06tULa9euVdmGMz9yF878IFU07Rfqzv5g4o+IKAOtWrXCgQMHMHXqVEgkEiQkJODIkSMYMmSIWOfJkyd4+/YtWrVqBQBo06YNAgICFPbz8uVLODvzH14iIiKinMLCwkLpj2tBEBAbG4u8efOm2ebz58/4/fffxQd63Lp1C9WqVUPnzp3Fz4vf4syP3IUzP0gVTfuFurM/mPgjIsrArFmzUL16dfTs2RMtW7bE9u3bkSdPHkyYMEGss337dqxZswafP38GAEybNg3VqlVDv3790KpVKzx48ABr1qzBxo0b9XQWRERERKSpUqVKISQkBDKZTJyZERgYiJSUFLi5ualsU7p0aQBQSPBVrVoVDg4OuH//vsrEH2d+5C6c+UGqaNov1K3POSJERBlwc3PD7du34eLiguPHj6N27dq4fv068uf/v/kUZcuWRevWrcXXBQsWxK1bt+Dq6oqDBw8iISEBly9fRq9evfRxCkRERESUCa1atUJSUhIOHDgglm3btg22traoX78+gK93AK5ZswaPHj0CADRr1gyWlpa4e/eu2CYoKAjh4eEoUaKETuMnIsrUHX9SqRTbtm3DunXrEBwcjAcPHojrWKXq3Lkzrl27plDWrl27NNc0ICLKzlxdXbF48eI0t/fu3Ru9e/dWKCtQoABmz56t7dCIiIiISEuKFi2KGTNmYNiwYbh//z7i4uKwatUq/P333+ITe1NSUjBy5Ej8+eef8PT0hK2tLZYsWYIhQ4bg1q1bsLKywvr169GwYUN07txZz2dERLlNphJ/AwcOhIODA/r27Qtvb2+kpKQo1QkPD0evXr0wdepUsYxPnyMiIiIiIqKcZNasWahTpw5OnjwJc3NzXL58GTVr1hS3GxkZYfjw4QpP7R0+fDgqVaoEf39/REREYO7cuejatSsfzEREOpepxN+ePXtgZGSEM2fOpFvP0tISTk5OmQqMiIiIiIiIKDto1qwZmjVrpnKbkZER1qxZo1Res2ZNhQQhEZE+ZOrrBnW/pdi4cSOKFSuGWrVqwcfHB/Hx8Zk5HBEREREREREREWlIa0/1dXd3x6hRo1ClShU8evQI3t7euHbtGk6ePKmyvkwmg0wmE19HR0cDAORyOeRyudrHlfxY2KRDmryvRKqwDxERERERERGlTWuJvzVr1kAi+ZqGc3Nzg6OjI+rWrYuAgADUrl1bqb6vry98fHyUysPCwpCQkKD2cV3yZ1yHsofQ0FB9h0A5nFQq1XcIRERERERERNmW1hJ/qUm/VDVq1IBEIsGTJ09UJv6mT58Ob29v8XV0dDRcXFzg6OgIa2trtY8bFJ75mEm3ChQooO8QKIfjA4OIiIiIiIiI0qa1xN/3Xr16BUEQ4ODgoHK7mZkZzMzMlMqNjIw0evKRkOkISdf4RCv6UexDRERERERERGnTyl/NT58+hY+PDz5//gwAePfuHYYOHYrixYun+SQkIiIiIiIiIiIiyjqZSvzNnTsXTk5O6N69OwCgQoUKcHJywsGDBwEArq6uMDMzQ8WKFWFtbQ1PT08ULFgQFy5cgIWFRdZFT0RERERERERERCplaqrv+PHjMXjwYKVyW1tbAF+n7U6bNg3Tpk2DVCqFlZXVDwVJRERERDnP27dv8fr1axQuXBgeHh76DoeIiIgo18lU4i9fvnzIly+fWnWZ9CMiIiLKXZ49e4bhw4cjODgYRYsWxf3791GsWDEcPHgQzs7O+g6PiIiIKNfgyvhERERElKW+fPmCxYsX48WLFzh79izevXsHmUyG6dOn6zs0IiIiolxFZ0/1JSIiIqLcoU6dOgqvLSws4O7ujvDwcD1FRERERJQ7MfFHRERERFpx8uRJxMbG4saNGwgICMCBAwfSrCuTySCTycTX0dHRAAC5XA65XK7W8SQ/Fi7pkLrvaVYQ2DNyDE36hS77EBFRTsbEHxERERFpxcaNGxEWFoZ79+6hRYsWKFmyZJp1fX194ePjo1QeFhaGhIQEtY7nkj/ToZKOhYaG6uxYUiuuK5lTaNIvpFKpFiMhIjIcTPwRERERkVbs2rULABATE4MWLVqgT58+OHHihMq606dPh7e3t/g6OjoaLi4ucHR0hLW1tVrHC+JM4hyjQIECOjtWrDRYZ8eiH6NJvzA3N9diJEREhoOJPyIiIiLSqnz58qFv376YMGFCmnXMzMxgZmamVG5kZAQjI/WeRydkNkDSOXXf06wgYc/IMTTpF7rsQ0REORlHSyIiIiLKUqoe4vHgwQMUKlRID9EQERER5V6844+IiIiIstTUqVMhl8tRr149mJmZ4cKFC9i4cSO2bNmi79CIiIiIchUm/oiIiIgoS/3999/Yu3cvTp8+jbi4OLi6uuLJkydwc3PTd2hEREREuQoTf0RERESUpSQSCbp3747u3bvrOxQiIiKiXI1r/BERERERERERERkgJv6IiIiIiIiIiIgMEBN/REREREREREREBoiJPyIiIiIiIiIiIgPExB8REREREREREZEBYuKPiIiIiIiIiIjIAJnoOwAiopwgMTERx48fx7t371C6dGk0b94cEolErbbv37/Hrl274OHhgbZt22o5UiIiIiIiIqKvmPgjIspAVFQUGjVqhLi4ONStWxcLFy5EuXLlcOjQIZiamqbbNiUlBb169cLdu3fRpk0bJv6IiIiIciBBEPD69WuYmJigWLFiGrUNDAxEREQEypQpAzMzMy1FSESkGhN/REQZmDt3LiIiInDv3j1YW1sjKCgIZcuWxfr16zFixIh02/7+++8oXLgwLC0tdRQtEREREWWlO3fuoHv37oiIiEBiYiJKly6Nffv2oXjx4hm2ffXqFapWrYqoqCg8efIEHh4e2g+YiOgbXOOPiCgDe/fuRc+ePWFtbQ0AcHFxQevWrbFnz550250/fx5bt27FmjVrdBEmEREREWUxmUyGjh07on79+ggLC8Pnz59ha2uLXr16Zdg2KSkJvXr1woABA3QQKRGRarzjj4goHfHx8Xj79i3c3d0Vyj08PHDp0qU0233+/Bn9+/fH1q1bYWdnp9axZDIZZDKZ+Do6OhoAIJfLIZfL1dqHeqsOUnag7nuaFQT2jBxDk36hyz5ERJRbnTx5EkFBQZg9ezYkEgny5MmDmTNnwsvLCw8ePED58uXTbDtt2jS4u7ujV69eWLFihQ6jJiL6P0z8ERGlIyYmBgBga2urUG5rawupVKqyjSAI+Omnn9C7d294eXmpfSxfX1/4+PgolYeFhSEhIUGtfbjkV/twpGehoaE6O5bUyllnx6Ifo0m/SGsMIiKirHPr1i0UKlQIRYoUEctq164NALh9+3aaib/jx4/jwIEDuHv3Lh4/fqyTWImIVGHij4goHXnz5gXwf3ffpYqKikpz3b4TJ07gzJkzqFOnDhYvXgwAePv2LSwsLLB48WKMGDEC+fLlU2o3ffp0eHt7i6+jo6Ph4uICR0dHcZpxRoLC1apG2UCBAgV0dqxYabDOjkU/RpN+YW5ursVIiIgIAL58+QJ7e3uFsjx58iBfvnz4/PmzyjYhISEYNGgQ9u7dq/ZnOM78yF0484NU0bRfqFs/04m/yMhI7Ny5E8HBwZg2bZrKP2Lfv3+PAwcOQCqVom7dumjYsGFmD0dEpBeWlpZwdnbGq1evFMpfvXqFUqVKqWxTpEgRjBkzBuHh/5eFS/0g9/HjR6SkpKhsZ2ZmpvJJb0ZGRjAyUm9JVkGtWpQdqPueZgUJe0aOoUm/0GUfIiLKrUxNTRUScqkSExNhamqqss2IESPQoEED5MuXD3fv3sWLFy8AAE+fPoWlpSVcXFyU2nDmR+7CmR+kiqb9Qt3ZH5lK/M2ZMwerV6+Gp6cnzpw5gzFjxigl/gICAtC8eXM0atQIxYoVQ8eOHTF48GDx7hciopyiQ4cO2LNnD3755ReYmZnhy5cvOHLkCGbMmCHWuXr1Ku7du4dRo0ahfPnySmPdw4cPYWtryzGQiIiIKAdxcXHBp0+fIAgCJJKvd059/vwZiYmJKhN4wNdk4bNnz/DTTz8BAOLi4gB8nd3Rq1cv/Pbbb0ptOPMjd+HMD1JF036h7uyPTCX+GjRoAG9vbwQEBODMmTMq64wcORIdOnTAtm3bAABt27ZFy5Yt0bdvX1SqVCkzhyUi0otZs2bh+PHj8PLyQuPGjeHv7w83NzeMGjVKrHP8+HGsWbNGoYyIiIiIcrbGjRvj559/xtWrV1GvXj0AwJEjR2Bqaor69euL9e7evYsiRYrAwcEB+/btU9jHv//+i9q1a+PAgQPw8PBQeRzO/MhdOPODVNG0X6hbP1O9rWHDhmmubQV8nQJ37949DBo0SCxr0aIFnJ2dsX///swckohIbwoUKIC7d+9iwIABEAQBU6ZMwZUrV2BhYSHWqVevHkaPHp3mPrp27Yp27drpIlwiIiIiyiKVKlVC165dMXDgQBw6dAi7du3CpEmTMGHCBDg4OAAAkpOTUblyZezatUvP0RIRKdPKwz2ePXsGAHBzc1Mod3NzE7d9LysWMwW4oGlOossFTckw6bIPWVtbY8SIEWlub9myJVq2bJnm9iFDhmgjLCIiIiLSsq1bt2LRokVYuHAhTExMMGvWLIUvfCUSCSpWrAhHR0eV7S0tLVGxYkU+lImI9EIrib/Y2FgAUFqLwMbGRtz2vaxYzBTggqY5iS4XNCXDpO5ipkREREREmWVubo6ZM2di5syZKrcbGxvj7t27abYvX758utuJiLRJK4m/1Ad9REVFwdbWViyPjIxEoUKFVLbJisVMAS5ompPockFTMkz81pSIiIiIiIgobVpJ/KUuWPr8+XMUK1YMACAIAl6+fIlGjRqpbJMVi5kCXNA0J9HlgqZkmNiHiIiyr4iICFy4cAGhoaHw8PBAw4YN9R0SERERUa6jlb+aXV1dUblyZaxfv14sO3r0KEJCQtC5c2dtHJKIiIiIsonVq1ejcuXK2Lp1K27fvo2+ffuiXr16aS75QkRERETakak7/k6dOoVLly7h7du3AIAFCxbA0tISPXr0QPny5QEAfn5+aNasGVq0aIGiRYti9+7dmD59OipUqJBlwRMRERFR9uPh4YGHDx+Ky7+Eh4fDw8MDS5cuTXONLCIiIiLKeplK/JmamsLc3BweHh6YM2eOWG5sbCz+f/Xq1fHs2TMcPHgQUqkUp06dQq1atX48YiIiIiLK1r5f2iV//vwoV64cXrx4oaeIiIiIiHKnTCX+GjVqlOZafd8qWLAghg0blplDEBEREZGBCA4Oxn///Zfuki8ymQwymUx8HR0dDQCQy+WQy+VqHUfyY2GSDqn7nmYFgT0jx9CkX+iyDxER5WRaebgHERERERHwNaHXs2dPlCpVCkOGDEmznq+vL3x8fJTKw8LCkJCQoNaxXPJnOkzSsdDQUJ0dS2rlrLNj0Y/RpF9IpVItRkJEZDiY+CMiIiIirUhMTESXLl3w8eNHXLx4Eebm5mnWnT59Ory9vcXX0dHRcHFxgaOjI6ytrdU6XlD4D4dMOlKgQAGdHStWGqyzY9GP0aRfpDeeEBHR/2Hij4iIiIiyXFJSErp164anT5/iwoULKFy4cLr1zczMYGZmplRuZGQEIyMjtY4pZCpS0gd139OsIGHPyDE06Re67ENERDkZR0siIiIiylKpSb9Hjx7h/PnzKFKkiL5DIiIiIsqVeMcfEREREWWp8ePH4+DBgxg/fjx2794tlhcrVgzdunXTY2REREREuQsTf0RERESUpSpVqoSff/4ZAPDx40exXN21+oiIiIgoazDxR0RERERZatiwYfoOgYiIiIjANf6IiIiIiIiIiIgMEhN/REREREREREREBoiJPyIiIiIiIiIiIgPExB8REREREREREZEBYuKPiIiIiIiIiIjIADHxR0REREREREREZICY+CMiIiIiIiIiIjJATPwREREREREREREZICb+iIiIiIiIiIiIDBATf0RERERERERERAaIiT8iIiIiIiIiIiIDxMQfERERERERERGRAWLij4iIiIiIiIiIyACZ6DsAIqKcIDQ0FBs3bsS7d+9QunRpDB48GPny5Uu3zalTp3Dx4kWkpKSgRo0a6NSpEyQSiY4iJiIiIiIiotyOd/wREWXg/fv3qFSpEs6cOYPixYtj27ZtqFWrFqRSaZptGjRogGXLlsHS0hLW1tYYP348WrdujZSUFB1GTkREREQ/KiwsDH379oWjoyMKFSqE0aNHIy4uLs36MpkMq1atQq1atWBvb48KFSpg2bJlkMvlOoyaiOgr3vFHRJQBHx8fODo64vjx4zAxMcHw4cNRsmRJ/Pnnn/jll19Utlm7di3c3d3F1506dULZsmVx+vRptGzZUlehExEREdEPEAQBHTt2BABcvXoVsbGx6N69OyIjI7F9+3aVbbZt24ZHjx5hxYoVcHNzw7///ovevXsjMjISPj4+OoyeiEiLd/wFBwfj5cuXCj8fP37U1uGIiLTm8OHD6Nq1K0xMvn5XYm1tjbZt2+Lw4cNptvk26QcAJUuWhLGxMT59+qTVWImIiIgo61y5cgXXrl3DmjVrULp0aVSuXBmLFi3Czp07ERQUpLLN4MGDsXLlStSoUQP58+dH69atMWLECOzYsUPH0RMRafGOvz59+uD+/fvInz+/WNaqVSv8+eef2jokEVGWi4mJwadPn1C8eHGFcldXVxw5ckTt/WzYsAESiQQNGjRIs45MJoNMJhNfR0dHAwDkcrnaU0O4gmDOocvpPgJ7Ro6hSb/glDEiIu27cuUK7O3tUb58ebGsSZMmEAQBV69eRc+ePdXaT2RkZIbrQxMRaYNWp/qOGjUKf/zxhzYPQUSkVfHx8QAAKysrhXIrKytxW0b+++8/eHt7Y/bs2XB1dU2znq+vr8rpH2FhYUhISFDrWC75M65D2UNoaKjOjiW1ctbZsejHaNIv0ltnlIiIskZISAgKFCigUGZlZQULCwu1Z7Tdu3cPmzZtwqJFi9Kswy+Acxd+AUyqaNov1K2v1cRfSkoKgoKCUKBAAZiZmWnzUEREWmFlZQWJRIKIiAiF8vDwcFhbW2fY/vbt22jVqhVGjBiB6dOnp1t3+vTp8Pb2Fl9HR0fDxcUFjo6Oah0LAILC1apG2cD3f0RoU6w0WGfHoh+jSb8wNzfXYiRERJTKyEh5hSyJRAJBEDJsGxgYiHbt2qF9+/YYM2ZMmvX4BXDuwi+ASRVN+4W6XwJrNfG3YMECbNy4EeHh4WjYsCFWr14NNzc3bR6SiChLmZubo2TJknj8+LFC+aNHj1CuXLl02965cwdNmzZF//79sXTp0gyPZWZmpvJLEiMjI5UfOFXJ+OMnZRfqvqdZQcKekWNo0i902YcyIyUlBceOHcOJEydQt25d9O7dW98hERFprGDBgggLC1Moi4uLQ1xcHAoWLJhu23fv3qFRo0aoVq0atm/fDokk7Tuv+AVw7sIvgEkVTfuFul8Cay3x16VLF2zfvh3Ozs4ICwtD79690aZNG9y9excWFhZK9bPi1maAtzfnJFybiH6UrvpQr169sGHDBkydOhUODg548eIFTpw4gZUrV4p1/P39cfHiRSxbtgzA1ykdqUm/5cuX6yROIqLs4vnz52jRogXKli2Lx48fIyUlhYk/IsqRateujRkzZuDp06fw8PAAAJw7dw4AUKtWrTTbBQUFoVGjRqhQoQJ2794NU1PTdI/DL4BzF34BTKpo2i/Ura+1xN/YsWPF/3d0dMSaNWvg5uaGK1euoFmzZkr1s+LWZoC3N+ckury9mQyTrta3mjp1Ki5cuIDKlSujRo0auHTpEtq2bYv+/fuLdW7evImtW7eKib/mzZsjKSkJMTExGDJkiFivU6dOaNOmjU7iJiLSFzs7O1y8eBFFixZFvXr19B0OEVGmeXl5oXLlyhg3bhy2bt2K+Ph4/PLLL+jQoQNKlCgB4OsdzpaWlli+fDlGjBiB4OBgMem3Z8+eDJN+RETapNWpvt8qWrQoJBIJAgMDVW7PilubAd7enJPo8vZmMky6Wt/K0tISFy5cwKVLl/Du3TtMmTIFNWvWVKjTqVMn8Vtg4OuXGaruSHR25hobRGT4HB0d9R0CEVGWMDIywqFDhzB8+HAULVoURkZG6Ny5s8LMD0EQIJPJkJycDADYtGkTXr16haCgIIUHxJmYmCAmJkbn50BEuZtWEn/JyckwMVHc9bVr1yAIQppr/GXFrc0Ab2/OSbL72kSU/emyDxkZGcHLyyvN7VWrVkXVqlXF14MGDdJBVEREhoNPtMxd+ERLUkWTfqHLPlSkSBEcPXoUgiCoXKfPxMQE8fHx4p1906ZNw88//6xUL701/oiItEUrib9nz55h4sSJGDVqFEqUKIGHDx9i6tSpaNy4MRo2bKiNQxIRERFRDsYnWuYufKIlqaJJv9DVki/fSi9x9+1MFGNjYxgbG+siJCKiDGkl8efp6YnffvsNf/75J54+fQonJydMmjQJo0aN4rccRERERKSET7TMXfhES1JFk36hqyVfiIhyOq2t8VevXj0u5kxEREREauETLXMXPtGSVNGkX3DZICIi9XC0JCIiIiIiIiIiMkA6e6ovEREREeUOycnJGDNmDADg1atXiIiIwIgRI+Dk5ITff/9dv8ERERER5SJM/BERERFRlpJIJKhUqRIAiP8FADs7O/0ERERERJRLMfFHRERERFnK2NgYI0aM0HcYRERERLke1/gjIiIiIiIiIiIyQEz8ERERERERERERGSAm/oiIiIiIiIiIiAwQE39EREREREREREQGiIk/IiIiIiIiIiIiA8TEHxERERERERERkQFi4o+IiIiIiIiIiMgAMfFHRERERERERERkgJj4IyIiIiIiIiIiMkBM/BERERERERERERkgJv6IiIiIiIiIiIgMEBN/REREREREREREBoiJP6JsRi6XZ2l9TfdHRERERERERIaBiT+ibGLOnDmwt7dHnjx5UKdOHTx+/PiH6mu6PyIiIiIiIiIyLEz8EWUDGzduxLJly3D06FFERESgYsWKaNu2LRITEzNVX9P9EREREREREZHhYeKPKBtYu3YthgwZglq1asHKygoLFizAhw8fcPbs2UzV13R/RERERERERGR4mPgjygbu37+PqlWriq+tra3h5uaG+/fvZ6q+pvsjIiIiIiIiIsPDxB+RngmCgNjYWFhbWyuU29jYQCqValxf0/0RERERERERkWFi4o9IzyQSCfLly4fIyEiF8oiICNjY2GhcX9P9EREREREREZFhYuKPKBuoXLkyrl+/Lr6OiIjAy5cvUalSJQBASkqKwoM5Mqqf0XYiIiIiIiIiMnxaTfwdOXIEPXr0QOvWrTF37lzExcVp83BEOdaoUaOwfv16nDx5EsHBwRg3bhxKliyJRo0aAQB8fX1RtmxZtetntJ009/DhQwwdOhQtWrTA2LFj8e7dO620ISIyFOHh4Zg2bRpatmyJ/v374+rVq/oOiYgoU5KTk/HXX3+hXbt26NSpE7Zu3aqVNkRE2qC1xN/mzZvRuXNnVK1aFQMGDMDOnTvRrl07CIKgrUMS5Vg9e/bEH3/8gZEjR8LT0xNfvnzBsWPHYGJiAgAwMTGBmZmZ2vUz2k6aefToEWrVqgUAGDFiBIKCglCzZk18+vQpS9sQERmK+Ph41KtXDwEBARg6dCgKFy4MLy8vnDt3Tt+hERFpbOjQoViwYAG6deuG5s2bY/To0Zg9e3aWtyEi0gatZAHkcjmmT5+OqVOnYsqUKQCASpUqwcPDAydPnkTLli21cViiHG3cuHEYN26cym3Tpk3DtGnT1K6vznZS3+zZs1G5cmWsXbsWANC2bVuULFkSy5Ytw/z587OsDRGRodi0aRMCAwPx77//wtraGl26dEFgYCB++eUX/Pvvv/oOj4hIbY8fP8amTZtw5swZNGnSBABgZGSE8ePHY9y4cbC1tc2SNkRE2qKVO/4ePHiAkJAQtG/fXixzd3eHh4cHTp06pY1DEhFpzenTpxXGM1NTU7Rp0ybd8SwzbYiIDMWpU6fg5eWl8IT5jh074r///kNUVJQeIyMi0szp06dhZWUFLy8vsaxjx46QyWS4dOlSlrUhItIWrdzxFxgYCABwdnZWKHd2dha3fU8mk0Emk4mvUz8URkZGQi6Xq33sZBnXEcwpvn/qLJGmoqOjAUCrSwhER0cjIiJCo/EsM22ArBkHOQbmHLocA6MTknV2LPoxmvQLXYyBmRUYGIhq1aoplKWOie/evUP58uWV2nAMzF04BpIq2XEMDAwMhJOTE4yNjcWyggULwtTUNM3PdZlpwzEwd+EYSKpo2i/UHQe1kvhLffqohYWFQnnevHkVnkz6LV9fX/j4+CiVFytWLOsDpGzBbqW+IyBDIZVKYWNjo5V9Z2Y8y0wbgONgbsMxkFT6w07jJtocAzMrMTFR5RiYuk0VjoG5C8dAUikbjoGqxjMAMDc3T/ezoKZtOAbmLhwDSaVMjIFAxuOgVhJ/dnZfg/3y5Yv4/6mvS5YsqbLN9OnT4e3tLb6Wy+UIDw+Hvb09JBKJNsLMEaKjo+Hi4oKgoCCF6TKUu7FffCUIAqRSKQoXLqy1Y1hbW8PIyAhfvnxRKP9+fPvRNgDHQVXY10kV9ouvdDEGZpadnZ3KMTB1myocA1VjfydV2C90NwaqGs+SkpIglUrTHM8y04ZjoGrs66QK+8VX6o6DWkn8VaxYEUZGRrh9+zbc3NwAfL11+eHDh+jatavKNmZmZgpPLQXARU+/YW1tnas7NKnGfgGt3+WSJ08eeHp64vbt2wrlN27cQOXKlbOsDcBxMD3s66QK+4X2x8DMqly5Ms6cOaNQduPGDdja2qJ48eIq23AMTB/7O6mS2/uFLsbAypUrY968efj48SOcnJwAfB3PUrdlVRuOgenL7X2dVGO/UG8c1MrDPRwcHNC2bVssWbIE8fHxAIAVK1YgKSkJPXr00MYhiYi0ZuDAgdi1axdevnwJAAgICMD58+cxcOBAsc769evRoUMHjdoQERmqn376CU+fPsX+/fsBAGFhYVi7di0GDBgAIyOtfPwkItKKli1bokCBApg3bx6Ar3fizZ8/H5UqVRKTeCkpKfDy8sKBAwfUbkNEpCtaueMPAPz8/NCuXTu4uLjA0dERISEh2LZtW7acjkJElJ5x48bh3r17qFChAkqVKoVnz55h8uTJ6Nixo1jnzZs3uHr1qkZtiIgMVZUqVfDnn3+ib9++KFmyJAIDA1GnTh3MnTtX36EREWkkb9682Lt3L7p164YjR44gISEBlpaWOHz4sFhHEARcvHhRnN2mThsiIl3RWuLPyckJN27cwOPHjyGVSlG+fHlxUWdSn5mZGWbNmqV02zflbuwXumVsbIxNmzZhzpw5CAoKgpubGwoUKKBQZ/DgwWjVqpVGbShj7OukCvtFzjB69Gj06dMHT548gaOjo7j8C2mG/Z1UYb/QrXr16iEwMBD379+HiYkJKlSooHD3srGxMc6fP49SpUqp3YbUw75OqrBfaEYiaPv550RERERERERERKRz/MqBiIiIiIiIiIjIADHxR0REREREREREZICY+CMiIiIiIiIiIjJATPwREREREREREREZICb+iIiIiIiIiIiIDBATf9nM9evXERMTo+8wiIj04u3bt3j9+rW+wyAi0ovIyEjcunVL32EQEelFUlISLl++rO8wiAwOE3/ZyPPnz1GzZk1ERUXpOxTKBj5+/Ihr165BJpPpOxQinalTpw4CAgL0HQZlA1KpFNeuXUN4eLi+QyHSmVGjRmHNmjX6DoOygeTkZNy+fRuvXr3SdyhEOrNx40YMGjRI32FQNvH8+XPcvn0bgiDoO5Qcj4k/PYmKisLz588VypKSkgAApqam+giJsgm5XI4xY8agTJkyaNeuHTw9PREUFKTvsIiyVFJSEu7cuaOynGMgbdy4Ea6urujatStcXFxw5swZfYdElOVu376NlJQUhTKOgQQAN27cgLu7Ozp27IhSpUph3rx5+g6JKMu9ffsWoaGhCmUcAwkAwsLC0LhxYzRo0AB169ZF27ZtkZycrO+wcjQm/rLQ/fv31a67YMEC1KpVC0+fPhXLUjszB7vc58yZM/D29oavry/+97//ITQ0FO/fv8f79+9hb2+PadOm6TtEogy9evUKsbGxatU9c+YMatSogZ07dyqUJycncwzMhZ4+fYqZM2di6tSpOHbsGJYsWYLbt2/jw4cPGDx4MIYOHSp+OUaUXYWHh6v9Rd379+/RqlUrjBkzRqGcY2Du9OXLFyxduhTjxo3D+fPn0bdvX2zcuBHv3r3Dvn378Ntvvyn8zUCUHSUmJqrdT1NSUtC/f3+0bt1a4bMjx8DcKTExEVu3bsWYMWOwZcsWjBs3Dq1bt0ZISAgeP36Mq1evYuPGjfoOM0dj4i+L3L59GxUrVlR5O/779+8xdepUtG3bFtOmTUNycjLmzp2L5s2bo1WrVvj06ROA/0v8mZiY6DR20o+7d+/ixIkTmDhxIiZNmoSEhAQsWrQI3t7emDNnDiwtLWFhYYFZs2Zhz549CAsL03fIRGlKTk5GjRo1sHv3bqVt8fHxWLJkCTp27Ijhw4fj7du3aNWqFVasWIGBAwcqrOWSnJzMMTCXCAkJwZYtW7Bv3z40bdoU4eHhOHjwINq0aYOxY8eiaNGiAAAfHx+EhITg6NGjeo6YKH0//fQTfv31V5Xb9uzZg169eqFnz564ePEiihQpgqNHj2Lr1q1YuHChWI9jYO4RHx+PdevW4f79+6hYsSLu37+Px48fo3HjxqhSpQoaNGgAAOjcuTOqVKnCKeCU7f31119o2bKlymmZN27cwNChQ9GhQwesW7cOxsbG8Pf3R2xsLHr27Cne/cwxMHc5cuQIbt++jQYNGmDnzp2QSqUYOHAgLly4gEmTJkEikcDV1RXDhg3DypUr9R1ujsbEXyYlJyejfv36uHDhAgCgSpUqaNy4sVLi786dO6hYsSJiYmLg7e2N2rVrIywsDBKJBJs3b0axYsXQrl07xMXF8Y6/XObIkSPo06cP7ty5g9u3b2PVqlXYtWsXACh889WiRQs4ODiI24iyC29vb3H6kYmJCQYOHKg0ZSMqKgq1atXC8ePHMWTIEPTo0QOfP38GAIwcORITJ05Ex44d8ezZMwD8pjc3efXqFQYOHIhp06bh1q1bWLlyJa5cuQJra2uFMdDOzg7t2rXD1q1b9RgtkbKdO3eiU6dO4ut+/fpBKpUq1UtNCLZu3RpjxowR+3e1atWwe/duzJgxA3v27AHAMTC38fb2RqNGjbBp0yZs2rQJp0+fRt26dZXunh8wYAB27tzJqW6UrTx+/BgVKlQQH0zZs2dP2NnZISQkRKHe+vXr0bx5c5QuXRpTpkyBhYUFBEFA/vz5cfz4cdy8eRPjx48HwDEwt1m+fDmaNWuGpk2b4tixY9i8eTOmTp2KuLg4hQTygAEDcO/ePTx8+FCP0eZwAmVa8+bNhUGDBomvpVKpsG3bNoU6derUEUaMGJHmPiIiIgRPT0+hQ4cOwsWLFwUAQnJystZiJu0YM2aMsHjxYpXboqKihOPHjwsnT54UZDKZWP7mzRtBIpEIixYtUqjv6ekp/PbbbwplEyZMEGrUqJH1gRP9gHnz5gklSpQQX8vlcuHw4cNCcHCwWPbLL78I5cuXF5KSklTuQy6XC3379hVKlCghfPr0STAxMRHOnDmj9dgpa23evFno0aOHym1JSUnCpUuXhIMHDwqfP38Wy+VyueDq6iq0adNGof7o0aOFBg0aKJT5+/sLZmZmQnh4eNYHT5RJ165dEyQSifD27Vux7NatW8L169fF16dOnRLMzc0V6nzv77//FszNzYUrV64ITZs2FWbMmKHVuCnr3b17V6hUqZIQHx+vcvu9e/eE/fv3Cy9evFAo/+mnnwRLS0uFsr179wqWlpaCVCoVy8LCwgRTU1Ph2LFjWR88USbFx8cLNjY2wpYtW8SyoKAg4ciRI+LryMhIIW/evMKuXbvS3M/t27eFfPnyCYsXLxb++OMPoV69elqNm7JeQkKCULt2bSEgIEDl9qCgIOHAgQPCv//+q1C+adMmAYBw48YNsSwkJEQwNjYWzp07p1C3UqVKwpQpU7I++FyCib8fsHXrVsHa2lqIi4sTBEEQAgMDBYlEIly9elUQBEFITk4WJBKJ4O/vn+5+3r17Jzg7Ows1a9YUmIvNmWbOnCmULVtWqXzLli1CwYIFhZo1awr29vZC8eLFhUePHonb69evLwwbNkyhja+vr0IyRRC+/iEBQHj69Kl2ToAoE1LHvCtXrohlJUuWFObOnSu+btCggTBhwoR095OYmCg0adJEHAMvXLigtZhJO86ePSsYGxsLHz58UCi/fv26ULZsWcHT01Nwc3MTLC0thb1794rbZ86cKZQuXVqhTUBAgFIyJTExUbC3txf8/Py0eyJEGnJzcxP++OMP8fWgQYOEZs2aia9/++03oVKlShnuZ+bMmYK9vb3g5uYm/P7771qJlbRHKpUKefPmFfbs2aNQ/unTJ6FNmzZCkSJFhCpVqggSiUThD9ezZ88KABS+MEtNpmzevFlhX+3atRN69eql3RMh0tDgwYOFpk2biq+3bNmi8PfxuXPnBABCZGRkuvs5ceKEkCdPHqF69eqCl5eXVmMm7ahfv74watQohbKUlBTB29tbcHBwEGrXri3kyZNHaNKkifjFRurYuWPHDoV2LVq0EAYOHKhQ9v/au++4qI72beDXLr0JUkQQQRG7iF1R7AUsMRZEUBaNscQSuyaW2BJrijHxIerPEo2aqAQVS9Rgy2NX7FEBlQiKDQuIIm2v9w9ezpOTNQlJpGju738zp+zMR5w9Z3bmvj/99FOWK1eOubm5hduR15Rs9f0HunfvDr1ej61btwIA3N3d0aJFC2U7kpGRESwtLXHz5s0/vE/58uWxc+dOXL58WZY2v6J0Oh0uXbqEmJgYpe7kyZMYPHgwoqKicOzYMdy4cQPu7u7o2bOnslVDp9MhMjJSFbS+b9++SEhIwKFDh5S6evXqoXXr1rh+/XrRdUqIP+Hu7o6WLVuqtmCGhoaqytbW1n86BpqYmCAyMhIZGRlKWbxaWrVqBVdXV6xfv16pS0tLQ48ePTBw4EBcvHgR8fHxGDZsGEJDQ3H16lUAeWNgXFwczp49q1zXpEkTeHl5qf6OTExMXriVXIji9tsxT6fTYe/evUhOTgaQNwbeunXrT+8za9YsvPHGG7h69aqMga8ga2trdOvWDWvWrFHVDxo0CBYWFrh+/TpiYmKwefNmfPrpp1i7di2AvLHTzc1N2eoNAObm5ujVq5fBvfr164e0tLTC74wQf4FOp8O+ffuUca5Hjx7Izc1FVFQUgLz/GwD+9FnQ398fS5cuxcmTJ2UMfEXpdDps2LABWVlZSt2iRYsQFRWFS5cu4ciRI7h48SIuXbqE0aNHA/jf2PnbGOE6nQ4RERHKuwEA9OnTB/b29gX6ThUvUNwzj6+6sLAwdurUSSmvWLGC9vb2ypbObt26sXHjxgbXvWgr26pVq2hpaVl4jRWFIjU1lbdv32aTJk04atQopf7dd99l69atVefGx8fTyMiIERERJPO2epuZmXHr1q2q81q3bm2wElCIkmjlypUsXbo0nz9/TpK8evWqasn+559/Tmtra967d0913dGjR/n06VNVXUJCAgGotsmJku/58+dMSkrihAkT6OPjo9R///33NDY2Vv0ym52dzUqVKnHEiBFKXePGjTlmzBjVPWfOnGmwElCIkujatWuqcUuv19PDw0MJ43H27FkCMNiimZKSwjNnzqjqsrOz6eXlxQULFhRJ28XLkZuby8TERG7evJnGxsbK992DBw8IgAcPHlSdHxYWxlq1ainl9957j3Xr1lWdc/DgQWq1Wt68ebPwOyDEP5A/5v163NLpdEoYj+zsbDo6Ohps0dTr9dy7d6/B/fr166d6txavhjt37jAhIYHm5ubcvHmzUu/t7c2ZM2eqzl25ciWNjY15584dkuQPP/xAExMT3r9/Xznn6dOntLa2NlgJKP4+WfFXAIcPH0aHDh1Qrlw5tG7dGkeOHFGO6XQ67NmzR1mFEBgYiIyMDCX74OTJk3Hq1ClMnjxZWdW1Zs0aTJs2zeBz7OzslF9FRMmXkpKCoKAguLm5KdnYfh14OSsryyAIs5eXFxo0aIDo6GgAef/mLwpaP3HiRLRq1apI+iHEn0lMTES/fv3g7u4OHx8frFq1SjkWGBiI58+fK2NepUqV0LRpU+VvesCAAbCzs0Pfvn3x6NEjAMDx48cxaNAgpKamqj7Hzs4OAGQcfEXk5ubigw8+gJOTE3x9fREeHo5z587hwoULAPLGQI1Go/rl19jYGIGBgcoYCOR9j65fv17J6AcAYWFhCAsLU62GFqK4PH36FB988AGqVq0KT09PTJo0CZmZmQAAT09PNGvWTBnzNBoN+vbtq5R9fHzQtWtXDB06FJcuXQIAJCcno1evXgarFoyNjWFlZSVj4Ctk48aNcHNzQ9OmTdG/f3/k5OQoydjyx77fPguGhITg4sWLuHv3LoC8MfDMmTP4+eeflXOaN2+OSZMmFVEvhPhjJPH111+jQYMGcHNzQ0hIiDJ+aTSaF6583r17N+7duwdjY2NMnjwZixYtQmRkJADg+fPnGD16NHbt2mXwWfI+/Go5e/YsGjRogJo1a6JevXogqfpbeNH7cK9evQBASZLavn17ODg4qFb9WVpaYv78+fD09Cz8TvxbFPfMY0kXGRlJe3t7rl69msePH2efPn1obm6urGbJzc1luXLl+PnnnyvX9O7dm927d1fKGzdupL29PW1sbGhjY0M/Pz8mJCQYfNaoUaMMApqLkiswMJDt2rVjWloac3NzOWfOHALgjh07SOat/jQ3N+eDBw9U1wUFBTE4OFgpb926lWZmZnz06FFRNl+IAvnll19oZ2fHGTNmMCYmhrNnz6ZWq+XixYuVc4KDg9mtWzel/NVXX9HJyUlJ6HHhwgVWr16dJiYmdHJyooeHxwt/5Y2MjKS5ubnBSkBRMi1evJiurq5KsPo9e/bQwsKCEyZMIPm/1Z+/XekUHh7OsmXLKuWUlBSamJjwhx9+KLrGC1FA2dnZbNCgAXv27Mljx47xu+++o4ODAwMDA5VzlixZohrzLl++TAA8d+4cybzg9l26dCEAli1bljY2Nly0aJHBZyUmJtLKysogoLkomc6dO0cTExMlkUFCQgK9vLzYsGFD5Zzy5csbrHS6dOmSQdzmunXr8r333iuahgvxF40aNYre3t7cvXs39+7dy/r169PT05OpqakkyStXrhAAz549SzLv/djV1VUZ5/R6Pd9//32amJjQ0dGR5ubmHDBggLJbJF9GRgYbNWpkkORQlEzPnj2ju7s733//febm5vLp06d88803aWpqqiRj0+l0L0xQWaZMGS5ZskQpjxkz5oW7JMXLIxN/f8LDw4OfffaZUtbr9WzRogVbtmyp1E2YMIH16tVTytu3b6epqalqwicjI4OnT59+4YQfSb711lusVasWT58+/dL7IP6ZCxcucP369apMbOnp6dRqtdy9e7fqXD8/P2VSLzU1lXZ2dhw5cqRyPDMzkxUqVODChQuVuqysLFUmIyFKkrCwMHbt2lVV98EHH9DGxkZ54NuxYwdNTU2VjK0PHjygqampKqubXq/nzz//zIsXL74wKO/XX39NZ2dng8zoovjdvHmTGzdu5JEjR1T1jRo14qRJk1R1U6dOpaurq/Jv3Lp1azZs2FD1cB8SEsI333xTdd3Jkyd/N/OzEMVp5cqVdHJyUv0N5ydk2L9/P0ny4cOHNDMzY1RUlHJOgwYNOH78eNW9EhMTefr0aSXo/a/FxsbSzs6O48ePp16vL5zOiL/lyZMn3L59O7dt26aE8iHJiRMn0tfXV3VudHS0alJv5syZtLGxUSUrWrp0KR0dHVVj3s8//6x8pwpRkly7do0ajUb1jpqSkkI7OztOnz5dqWvYsCHHjh2rlMePH88GDRqo7vXgwQOeOnVKtaUzn16vp5eXFzt37qxMGomSITc3lz/99BM3bNigPOuT5M6dO6nRaFTfjw8fPmSpUqWUSb2DBw8SACMjI5VzLl++TK1Wqwp3cevWLd64caPwO/MvJhN/zItDVLt2bWq1WjZp0kT5ss7KyiIAg6y8UVFRBKBkLzx//jwBKNlas7OzWaZMGYaHhxe4DbLaq2T55Zdf+OjRIwYGBtLNzY116tShmZkZf/zxR5J5gxoAg1iNy5cvp4WFhfLw9t1331Gr1TIkJISfffYZGzZsSD8/vxc+9AtRXM6dO8cOHTrQ2NiYFStWVMWcbNq0qUFW3kePHtHIyIjffvstyf+Nef/5z3+Uc7p3786goKACtyE9PZ1ZWVn/sCfiZXn8+DGTkpL48ccf08HBgU2aNKGJiQk//PBD5ZzatWtz6tSpquvyV/nt2bOHZN7Dnb29PZs0acKFCxcyKCiIrq6ujI2NLdL+CPFHHjx4wAEDBtDGxoZ2dnaqv/PJkye/MCtvvXr1OGTIEKXco0cP9urVSykvWrSIrq6uzMnJKXA7/izrpSg62dnZjI2N5d69e+ns7MwmTZrQzs6O7du3V37YGDlyJP38/AyudXNz4+TJk0nmrYipX78+y5cvz7lz53LMmDG0tbVVYj0LURLk5ORw9uzZdHV1pZmZGYODg5Wsq3v27HlhVt6xY8eyatWqSvmLL75g2bJllTHv3LlzBMBLly4VuB3yPlyyXLx4kTdv3mStWrXo7e1NDw8Puru7K1nIIyMjaWxsbLByMzQ0lE2bNlXKw4YNo7m5OSdOnMiPPvqIrq6uHDduXJH2RfzLY/wFBARg+PDhGDduHObPn48zZ86gTJkyaN68OW7fvg0TExOULVsW58+fV13n6+sLAIiLiwMAeHt7w8fHR9nPbmxsjK1btyIkJKTAbcmPbSWKX25uLho0aIC2bdvC0dERCQkJOHPmDPr37493330XJFG6dGl4eHhg//79qmurVauGjIwMREREAAB69+6NQ4cOwdraGufOncOoUaOwf/9+WFhYFEfXhFCZMWMGBgwYAH9/fwQGBuLixYvo06cPevToocRdcXd3NxgD7ezsUK1aNcTGxgLIG/NCQkJUMT3mzJmD+fPnF7gtVlZWksWtBHnrrbfwxhtvICIiAnFxcTh69CjWrFmDDz/8EDdu3AAA1K1b12AMrFSpEoyNjZW/hWrVquHMmTPw8/PDiRMn0KhRI1y8eBFVqlQp8j4J8Vvbtm1Du3bt0LVrV1hbW+PEiRNYvHgx5s2bh6lTpwLIGwNjY2NVsSqBvGfB/DEQyItptW3bNiV2aWhoKDZv3gwjI6MCt8fW1vYl9Eq8DOHh4WjdujWGDRuG6OhoHD16FDExMTh06JCSgbdu3bqIiYnBkydPVNdWq1YN69atA0lYWFjgp59+wogRI3D+/HmYm5vj5MmT6NmzZ3F0SwiVGzduwNvbG0OHDkV0dDS2bt2K3bt348yZM+jYsSNIwt3dHQBe+D4cHx8PkgCA4OBgPHjwQInhW7t2bURHR8PLy6vA7ZH34ZLj/PnzqFWrFrp27YqJEyfi/PnzuHz5Muzt7TFr1iwAQJ06dZCTk4P//ve/qmurVauGI0eO4Nq1awCA//znP1ixYgWSk5ORnJyMdevW4ZNPPinyPv3rFe+8Y/EKCgoiANXWsqysLFauXJnDhg0jSQ4dOpQeHh6qlSixsbEGv2CsXbuWX331VdE1Xrw0v/2Vgsz7ZQKAKpvarVu3qNVqla09CxYsoL29vSpb6ZIlS6jVatmqVatCb7cQ/1R4eDgBcODAgar6/v37s1atWtTr9dywYQO1Wq1qvNPr9SxXrpxqVfO5c+c4cuTIv7S6RZQMv966lm/jxo0G348kWa1aNWVrz4kTJwxWPl+5coVarZZWVlZMT08v1HYL8U/lx1qrXLmyanvt119/TTMzMyYlJfHmzZs0Njbm0qVLVdeGhISoVjVnZWWxf//+qi2d4tWQk5Nj8N11+/ZtGhkZGXw/vvPOO0q4n/T0dJYpU0a18jkrK4vu7u7UaDQ8cOBAobddiH8iJyeHLi4uBu88V69epbGxMTdu3EiSrF69OkNCQlTXLl26lGXKlFHVTZ06VXlPEq+WFz0L1qhRg15eXqq67777TvWM16lTJ7Zs2VI1hgYHB1Or1XLGjBmF22jxl/yrJ/62bdumitGSb9GiRbS1tWVubi5v3LhBGxsbBgcHMyUlhbdu3WJAQADbtWtXPI0WL8WpU6c4atQourm5EQBr1KihijNw9OhR1fbtfO3bt+fbb79NMm/7RoMGDVizZk2uXr2aCxYsoLOzM8PDwzl69GiJ0SNKvPxYfL+O0UL+b3tGTEwMc3JyWL9+fdasWZOxsbFMT0/npEmT6OzsbJC4Rrw6bty4wTlz5rB27doEQEdHR65bt045npGRQVtbW9X2bZKcPXu26iFw2LBhtLW15aJFi7hy5UpWrVqVH3/8MXU6neolQoiSqn79+qq4zWTey7CjoyM//fRTknmB7UuVKsUffviBWVlZjIiIoLm5OQ8ePFgMLRYvQ2pqKlesWME2bdrQxMSE5ubmHDdunOrZzd/fX7V9myQPHz5MjUajxKL69ttvaWxszHHjxnHDhg3s2LEje/XqxfHjx/O///1vkfZJiL9j3Lhx1Gq1BvGXu3fvzjfeeINk3pZOjUbDBQsWMCMjgzExMaxYsSI/+uij4miyeAmys7O5Y8cOBgcHs1SpUtRoNOzUqZMqvuLcuXPp5OSkuu7Zs2csVaoUv/nmG5J5P6A5OjqyS5cu3LBhA0eOHEkvLy8uXLiQy5cvL9I+iT/2r574y87OppOTkyp5B0keP35cFcPv8OHDrFq1KjUaDa2srPjOO+9IAN5XUFJSEjMzM3nw4EFWqlSJ06dP58WLF5mSksIhQ4bQ3d2dGRkZyvmVK1fm7NmzVfdYvXo1bW1tlfPS0tL47rvvsmHDhgwLC+OFCxeKtE9C/FPdu3c3SN6h1+tpaWnJ9evXkySTk5PZoUMHajQaGhsbMyAgQJWNULwa0tLSeO/ePT579ozly5fnkCFD+NNPP/HRo0dctWoVjY2Nef78eeX8gQMHsn379qp7/PLLL9RoNKpEH5999hmbNm3Kzp07c9u2bUXWHyFehkWLFrF06dIGK746duzIwYMHk8x7Xhw+fDhNTU2p0Wjo4+NjkK1alHw5OTnKikx/f39269aNkZGRvH//Po8cOUIHBwfVSva1a9eyVKlSBnGZPT09OWfOHKW8c+dOtmvXji1atOCiRYskUZF4peT/2PvbBJPz589nlSpVlPKyZcvo4OBAjUZDV1dXfvrpp7LI4RV07do1kuSsWbPo6+vL8PBwJiUl8fr162zSpIlqJXtiYiK1Wi0PHz6susdbb73FDh06KOUrV64wKCiIjRs35oQJE16YvEUUv1dq4m/KlCmcMmXKC489e/aMkZGRXLx4sZJKvCBGjhzJKlWqqB74du7cSRMTE4Mv+ocPH8qX+SvmyZMnzMjI4KBBg+jo6MjTp08bfEnduHGD06ZNIwB+/fXXSv3MmTNZrVo1g/tZWVlxw4YNRdJ+IX5t8+bN9Pf3f+ExvV7P/fv3c/Hixfzhhx8KfM/8wLz5DwJk3t+5kZGRkswmX1pamiSmecXk5OTw6dOn/PLLL+no6KhsV/z1OJiamspVq1bRzs6O/fv3V+oPHjxIrVZrsHKvRYsWHDp0aNF0QIhfuXbtGmvVqvW7q41//vlnLlmyhOvXr+fTp08LdM979+7R2NiYa9asUdU3atTI4Jnz+fPnkoDjFZSamsoDBw7Q09OTYWFhJNVjYP7KFx8fH1asWFE59vTpU1pbWyuJrPJNmzaN1atXL7oOCPH/6fV6tmvXjtu3b3/h8Tt37nDNmjVctmyZkoChIGrXrs0BAwao6iZOnMhmzZqp6nJzc5mSkiITfq+Y1NRUJiYmslWrVqxcuTIzMzMN/g1PnTrFwMBAajQaXr9+Xalv3bq1KpEVSe7bt49GRkbKIinxanilJv6++OILuri4GPwqu2fPHjo7O7NNmzYMCgqipaUlv/jiiwLd8+TJkwTAkJAQ3rx5k2fPnqWPjw9HjRpVCD0QRSktLY3W1tZs2bIl+/Tpo2Snynfr1i327NmTDg4OHDp0KP39/dmmTRvleH76+hMnTqiumzJlCjdt2lQkfRDi1/IziP82Q1pCQgLr1q1Lb29vhoaG0tnZmUFBQQV6MMvMzKS9vT1r167NCxcuMCkpicHBwaxbt67Btg/x6mnRogVbtmzJ2rVrG8Qey8zM5MSJE2lnZ8cePXpw2LBhtLa2ViZM9Ho9K1SowAULFqiu++677zht2rQi64MQ+fIziP96VRaZNyEXHBxMV1dX9u3bV8lAeOfOnQLdt3PnzrS1teWOHTv44MEDfvLJJ7SysmJSUlJhdEMUoWnTprFevXp0cXF54dbsVatWsVy5cmzatCnnzZtHAPzpp5+U42FhYezUqZPqmvj4eAYFBUkcU1EsevTooVqVlW/BggW0s7Njz5492bZtW5YuXbrA280//vhjZSvvgwcPuGPHDtra2nLz5s0vufWiqEVHR9PGxoYNGjTgwoULDd4Njh49yvr169PT05MzZsygu7s7Z82apRxfuXIlS5curYqJr9fr2atXL9UuEVHyvVITf/m/yu7atUupS05Opp2dHffs2aPURUVF0dTUVDVb/UeqV69ONzc3li1bll5eXvzoo49UyTzEq6t9+/YEoErAQea98FauXJmDBw9WJgS/+uorarVa1YO+n58fR4wYUaRtFuKP+Pj48P3331fV1a9fXxVANzk5mdbW1qqYbX9k6NChtLa2ZuXKleni4sK3337b4P+MeDXNnj2bAJQA3b/Wr18/+vr6KhOCly9fJgDV383UqVNZq1atImuvEH9m1KhRbNKkiapu7NixDAgIUFYkZ2dns3Hjxhw0aFCB7rlhwwYCoLe3Nx0cHOjv7/+Xdo+Ikuvw4cMEoCTt+7VVq1axTJkyqskRZ2dn1d9NdHQ0jY2NCzyJLERh27x5M83NzVWrj6Oiouju7q7EniTzxsXq1asXKOlacnIyjYyMWKVKFTo4OLBevXqyyOE1kZGRwVKlSrFGjRoGxy5fvkxLS0suW7ZM+bG/d+/erFy5snJOWloaLSwsGBERUWRtFoVDW3T5g/85JycnBAQE4JtvvlHqtm7dirp166J9+/Y4d+4cxo0bh8GDB6NOnTq4c+dOge6r0+lgZmaG27dvIz4+HlOmTIGJiUlhdUMUIZ1O98L6S5cuIT4+HnPmzIG1tTUA4Pbt29Dr9Vi3bp1y3owZM9C1a9ciaasQBaHT6bBu3TqQBABcuXIFFy5cwOTJk5GcnIyPP/4Y7du3h6OjIzIyMgp8z6dPnyI6OhrJyclYvnw5nJycCrMbooiEhoZCo9G88NiWLVswbtw4eHh4AMgbAwGovmMHDBiAkSNHQq/XF35jhSgAnU6HY8eO4erVq0rdunXrMGnSJOj1eqxZswYBAQGIj4+HmZlZge7ZtWtX2NraYuLEiUhJScGuXbvg4+NTWF0QRahp06aoVKnSC49t2bIFQUFB8PPzAwA8e/YMqamp2LRpEzIzMwEArVu3xrx58+S9QJQYnTp1gpWVFTZt2qTUrVu3Dm+//Tbc3NywZ88e9O3bFytWrICXlxcePnz4p/d0cXFB27Zt0bx5c6SkpCAmJgaBgYGF2Q1RRMzNzX/333LXrl3w9PTEoEGDoNXmTQvlz4ccP34cAGBjY4OvvvoKNWrUKLI2i8JRoif+srOz8eTJE1VdWFgYNm/ejPT0dADAkydPEBcXBx8fH3Tr1g0WFhY4ePAgjh8/Dl9f3wJ9TmhoKK5fv44jR4689D6I4tWjRw9YWVkhOjpaVV+hQgVYWFjg22+/hV6vx44dO7BkyRIEBQUhLi5OOa9t27Zo3759UTdbCAAASTx69EhV17dvXyQnJ+PAgQMA8sbA7OxsdOnSBd7e3oiLi0N4eDiuX7+Ot99+u0Cf4+vri0qVKmHt2rUvuwuimLm7u6NFixYGYyAA1KhRAxEREcjOzsbFixcxatQo6HQ63LhxA1lZWQCAihUrqh4IhShqqampyM3NVcr169dHjRo1VBPUT548wQcffAA3NzdERERgyJAhSE5Oxpdfflmgz8h/MVqzZs1Lb78ofqGhob87Bv74449ISUnB/fv30b9/f3Tu3BnW1ta4fPkyAECr1WLcuHGwt7cv6mYLASBvQvr58+dK2dTUFL179zYYAyMjI1G+fHl88MEH8PX1xdWrVxEVFVXgH3J1Oh02bdpU4B+NxatDp9Ph8uXLuHXrlqq+Ro0aiIuLw6lTp5CZmYn58+fjzp07aNGiBS5cuKCc169fP1SvXr2omy1etuJecvhber2ez58/55gxY2hlZUUAbNeunZIdJiMjg7a2tly9ejXJvPh++P9JGX67Zz0mJqbAW3ZfFLhSvB5CQ0MN4rOQedmpTExMaGRkRB8fHx44cECC1YoSQa/Xc9myZSxXrhwBsHLlyjx16pRy3N/fn2+99RbJvEQcpqamHDJkiCr+Bkk+ePCA8fHxBfrMmTNnsmrVqi+vE6LEWL58OUuXLs3MzExV/fHjx1mmTBkaGRmxbNmyDA8PlzFQlAh6vZ6HDh1ivXr1CIClS5fmqlWrlONz586lp6enUm7atCnr169vkElQr9cbxOn9Pb+XzEa8+q5evUoABn8LDx48YL169ajVamllZcWRI0fy2bNnMg6KYqfX63nz5k127dqVRkZGNDEx4ahRo5Rtu0ePHqVGo2FCQgJJcvLkybS0tOTFixcN7nXs2LECfebvJbMRrz69Xk93d3eDmM0k2b9/fwKgiYkJu3Tpwl9++UXGwNdUiZr4u379Ol1dXdmrVy+++eabTEhI4MWLF1m/fn36+Pgog93AgQPZrl07knkZCz09PdmhQwfVS82JEydYtWrVP8w2k5SUxHnz5jEiIoJbtmzh559/XrgdFMVi9+7dNDY25t27dw2OPXnyROK2iBKlUaNGDA4OZrVq1Xjy5EneunWL/fr1o42NjfKAt3btWtrY2CjxrMLCwliuXDnVC2tycjL9/Py4c+fO3/2stLQ0rlq1irNnz+b169c5fPhwydr7GkpNTaW5uTkjIyMNjmVlZTExMVEe8kSJMW7cOL755pssU6YMIyMjmZKSwoULF9LIyEiJMZSYmEiNRsNDhw6RzAs+rtVquXfvXuU+GRkZHDZsGN97773f/aycnBzu3LmTQ4YMYU5ODt955x3GxcUVbgdFsfD19eXIkSMN6vV6PZOSkiS2tygxNm3axLp167JOnTqcOXMm79+/z127dtHe3l4Vd7xy5cr86KOPSJJxcXE0Njbm9OnTVfdatWoVmzZt+oefFxMTw9GjR/PKlSucP3++Kpa+eH1MmjSJtWvXfuGxe/fuMS0trYhbJIpaiZr40+v19PDwMEjGcPPmTZqZmSmr/H77q+yRI0dYqlQpent7c8yYMezSpQsrVKjAw4cPG3xG/otumzZt6ODgwCFDhkgA59dcbm4uXV1duWjRouJuihB/SqfTGSRj0Ov19Pb2Vlb55f8qu379epJ5X9g1atSgs7Mzhw0bRp1OR2dnZy5dutTg/vkvuiEhIbSzs2O3bt24bdu2oumcKDa9e/dm9+7di7sZQvypFStWvDAZw4gRI+jl5aUEIG/dujUHDx5MMm+M7N27N01NTanT6Th06FBWqFCBgwYNemFg+9OnT3P06NF0dnamr68vw8PDDVbEitfLV199RScnJ2ZnZxd3U4T4Q9euXSMAg2QMERERNDY25tWrV0ka7tT48ssvqdVq2aFDB44ePZoNGjRgs2bNXrjAIX/xS82aNVmpUiVOnz6dt2/fLtyOiWKVn8Dt3Llzxd0UUUyKJWhPXFwc3nzzTTg4OKBNmzbKfnONRoPQ0FBotVqULl1aOb9cuXLo1q0bvv32WwBA8+bN4e7uriRh8PX1xZUrV9C/f3+YmpqiV69euHTpEpo2barc48KFC+jTpw/c3d2xdetWDB8+HMnJyViyZIkEcH7NabVaTJs2DeXLly/upggBIC8Wy4gRI+Dq6opq1arh4MGDyrGwsDAAgKOjo1Kn0WgwbNgwbNq0Cbm5ubC0tESPHj2U+C5OTk6IiYlRktU0aNAAp0+fxuDBg5V7PHz4EGPHjoWbmxs+/PBDNG/eHNeuXcPmzZvRpUuXIuq5KC5Dhw5Fw4YNi7sZQgDIi1+6aNEiVK1aFS4uLvjiiy+UY7169YKFhYVqDASA4cOH4+rVqzh58iSAvJhFGzduRGZmJjQaDb777jtERkaiXLlycHNzw+bNm7Fs2TIYGRkp9/jkk09Qq1YtBAYGolSpUjh06BCOHDmCoUOHwtTUtGg6L4pFUFAQAgMDDWKHC1Fcdu3ahSZNmsDe3h6DBg1SYut6enqiWbNmBmNgjx494OTkhIiICAB5sStjY2Nx4sQJAMCIESNw+vRpNG3aFNbW1pg1axYOHToEZ2dn5R5RUVFo27Yt6tSpg4SEBCxduhRXr17FjBkzULZs2SLquSgO1apVw/jx44u7GaI4vYzZwydPnvDdd9/93W21er2ex44d48GDB3n//n16enpy6dKlPH36NJs3b84WLVoo5165coUADOIRLFiwQJVaesqUKaxVq1aB23j27FmGh4fzwYMHf7F3Qgjx5z777LM/3B4RFxfHXbt2MS0tjf7+/hw7dizPnj3LESNG0NbWlg8fPiSZt0K1XLlynDdvnur6EydOEABv3bpFkvzxxx9pZGRU4K3qz54948yZMwsc808IIf6KHTt2/OHK+nv37nHXrl1MTEzk3Llz2aFDBx4/fpwrVqygkZER9+3bp5wbHBzMgIAAg3tYWVlx3bp1JPN2cFhYWCjbfwti4cKFyvZgIYR4mS5fvsxRo0b97vFnz55x3759PHv2LA8dOsQqVapw+/bt3LdvH8uWLctp06Yp5y5ZsoSlSpUyWIncqVMnDho0SCk3a9ZMtf33z3z//ff8/vvvZYWzEP9CL2XiLz9g5CeffKKqT0pKYlxcHGvWrEl3d3caGRnR2dlZNbBduXKFGo2GR48eVeoaNmzIoKAg1b1Gjx7NVq1aKeW4uDgOHTrUIJi9EEIUh9DQUHbp0kVVd+vWLaanp7Nr1650cnKitbU1nZ2dVT92ZGVl0d3dnXPnzlXqJkyYQHd3d9X4tmXLFpqbmyt1ubm5fPvtt2UiTwhRIixfvpz29vaqF8r09HQ+evSIM2bMYOnSpVmmTBmam5vTxcWF6enpynkhISH09/dXyjt27KBWq1UFqn/48CG1Wi0PHDig1H344YcSj0oIUSLEx8cTgCoZW05ODpOTkxkVFUVnZ2eWL1+eAOjs7Kz6sWPp0qW0tbVlRkYGybzxzszMjOHh4arPqFOnDmfMmKGUN23axIULFxZux4QQr4WXFuNv+/btPH/+vFLesWMHLS0t2bBhQ27ZsoVkXiw+rVZrMIj5+fmpYrl8+eWXBMCJEycyNjaWq1evprW1Nffs2fOymiuEEC/VmTNnVIk0Hj16RFNTU/r5+XHixInMycnhvXv36O7ubvDDxtSpU1WxXC5cuEAA7NixI8+ePcvo6GhWrlyZU6ZMKbL+CCHEX/H48WMuX75c9YNFw4YN6efnx7Zt2/Lx48fMyclhly5dWKZMGdW10dHRNDIyUmJM5eTk0NnZmZUqVeL+/ft55swZdurUiX5+fkXaJyGE+CtWrlyp2okxYcIEent7s3r16oyNjSVJzp8/nwB46dIl5by0tDRaWlqq4jv37NmTFhYWXL16NWNjY/n++++zdOnSqjj4QghRUC9t4u/Zs2ds166dEjDy+fPntLOzU63SI8nu3bsbvPQuXbqUDg4OSkat+/fv08TEhHXr1mXVqlXZoUMH7t+//2U1VQghCsXYsWO5bNkypRwQEEATExNVtsBFixbRxcVFFXA+NjaWABgTE6PU1alTh56enqxVqxabNGnCJUuWSOZVIUSJtnbtWr7zzjtKed68eQSgWqV37tw5g5fe/BAHn376qVI3evRo2tjY0NfXl97e3nzvvff45MmToumIEEL8DWfPnmWrVq2UJDLHjh0jANUqvaysLDo7OxsshAkJCeEbb7yhlLds2UIAbN68OatWrcq+ffvy+vXrRdMRIcRr528n9yCJpKQkpKWlAQAsLCzw+PFjrFmzBgBgZmaGXr164enTp6rr+vXrh6ioKKSmpip1QUFBSE9Px86dOwHkBbUPCAhAjRo1cOXKFezevRutWrX6u00VQohCcf/+fdy7d08pa7VaLF26VCnrdDrk5ubi+fPnSl2fPn2QkpKCvXv3KnVVqlRBo0aNlGQd+ddmZ2fj/PnzOHr0KIYMGQKNRlPIPRJCiIJ78uQJbt68Cb1eDwCws7PDypUr8fDhQwBA3759odVqVc+CtWvXRp06dVTjnVarRd++fQ3GwCdPnmDNmjU4f/485s2bB2tr6yLqmRBC/LmsrCwkJiYiMzMTAODu7o4jR45g165dAIDGjRujSpUqqjHQxMQEISEhqvEOyBvzdu3ahZSUFABAp06d4ODggLCwMFy5cgVr165FxYoVi6hnQojXzd+a+Fu3bh0qVqwIPz8/NG7cGFFRUQDyBqz169cjNzdXKcfExChZe4G8QczKygqbNm1S6uzs7NC5c2d8//33Sl1YWBg2b96M9PT0v9UxIYQoLCdPnkTTpk1Ro0YNtG3bFpMnTwbwvzHv8uXLAIBu3brBysoK27dvV651dHSEv7+/8iNJvtDQUERGRirlPn36IDk5Gfv37y+CHgkhRMHdvXsXISEhcHNzQ8eOHdGuXTsAgL+/P+zs7LBhwwYAgJubG1q1aoWtW7eqrg8NDcXatWtBUqnT6XQ4e/Ysrl27BgCoV68eatasaTBWCiFEccvJycHUqVPh4uKC9u3bw9vbG3fv3kXp0qXRuXNn1aReaGio8q7867qjR4/i6tWrSl2HDh1QunRp5VwTExMEBwfLGCiEeDn+6hLBHTt20MHBgUeOHFHq8pcz37t3j8bGxty9ezfJvKQfFStW5Pz581X3GDp0qCq4PUnevn1bFRA6f6vwqlWr/moThRCi0Ny5c4c2NjZctmyZsvU2fwwkydq1a3PSpElKuX///uzYsaPqHhs2bKClpaVq21paWppB1vGAgAD269evEHohhBB/X8OGDTlw4EAlQcevQxeMHDmSvr6+Svnrr7+mnZ2dKvZfcnKyQSZfkvzll19U5Xnz5rFixYoS5kAIUaJMmDCBDRs2ZFJSklKX/ywYGRlJc3NzPn78mCSZkJBAjUbD48ePq+5RvXp1VcJLkrxx44aqfOzYMWo0GtniK4T4x/7yir9Dhw7Bz88Pvr6+Sp2xsTEAwMnJCf7+/sqvHBqNBqGhoS9cypyVlaUsiwaAsmXLwtTUVCmbmZlh3rx58PLy+qtNFEKIQnPu3DkYGRlh4MCBytbb/DEQyBvf1q1bp6xk0el02LNnD+7evauc07VrV1SpUkVZ2QIANjY2sLe3V33WuHHj0Lp168LsjhBC/CWZmZk4deoUhg8fDisrKwCAkZGRclyn06lWsvTs2RNZWVnYtm2bco6Liwt69uyJxMRE1b09PDxU5dDQUISFhameF4UQorgdOnQIffr0gZubm1KX/yzYuXNnWFpaIiIiAgBQoUIF+Pn5GazcGzBgAB48eKCqc3d3V5UbN26MKVOmQKv929G5hBACAKAhf7XPogAOHjyI9u3bo3fv3jA1NcWtW7eg1+sREhKCt956Cxs3bsSAAQNw9+5dWFlZIT4+HlWqVMHp06dRt27dwuqHEEIUicePH6NSpUpo0KABKlSogNu3byM9PR1NmjTBzJkzkZKSgvLlyyM6OhqtWrWCXq+Hh4cHxo4dizFjxhR384UQ4h9r06YN7t+/Dz8/P6SkpCAlJQUeHh6YM2cOXF1dUaNGDQQFBWHGjBkA8mL9paenG2z5FUKIV9GsWbOwePFidO/eHU+fPsWdO3dgZWWF999/H76+vhg2bBguXbqEAwcOAAD+7//+D5MmTcLt27dhYmJSvI0XQvwr/eWJPyBv8u+///0vbG1t4ezsjJ9//hkffvghrly5And3d5QtWxZffvkldDodAGDu3LkIDAxE5cqVX3oHhBCiqMXHxyMyMhJGRkZwcXHB8+fPMWbMGHz22WcYOHAg/P394ebmhhUrVgDIi4vq4uKCNm3aFHPLhRDin0tNTcXq1avx7NkzODs7w9LSEh999BF8fHywdu1azJ07FytWrFBW/R07dgznz5/H4MGDi7nlQgjxz5HE+vXrkZCQACcnJ9jb22Pjxo04evQobt68iaNHj6JZs2ZISEiAh4cHHj9+jIULF2L8+PGwsbEp7uYLIf6F/tbE329lZWXB2toaP/74I1q2bIlhw4ahbNmymDZt2stooxBClHitWrVC69atMX36dKxbtw5r1qzB7t27i7tZQghRJGbMmIGDBw9i//79SExMRNu2bXHgwAGUK1euuJsmhBCF7sCBAwgICEBaWhpMTU3RuHFjzJgxAx07dizupgkhxN+b+Hv27BmuX78OJycnXLlyBfPmzUNmZiZ+/PFHVZwXIYR4XZ07dw4uLi64desWvvnmG2zatAlHjhxB+fLli7tpQghR6OLj42FtbY20tDRER0dj+vTpWLt2LQICAoq7aUIIUeju3LmDZ8+ewdTUFCdOnMCkSZMQHByMmTNnFnfThBDCgPGfn2LIzMwMH3zwAS5dugRnZ2cEBgZiyJAhMuknhPjX+P7777FlyxaYmJigTZs2OHXqFJydnYu7WUIIUSTOnz+PBQsW4MmTJ6hfvz727duH2rVrF3ezhBCiSKSlpWHw4MG4ffs2vLy88PHHH6Nr167F3SwhhHihl7LVVwghhBBCCCGEEEIIUbJIbnAhhBBCCCGEEEIIIV5DMvEnhBBCCCGEEEIIIcRrSCb+hBBCCCGEEEIIIYR4DcnEnxBCCCGEEEIIIYQQryGZ+BNCCCGEEEIIIYQQ4jUkE39CCCGEEEIIIYQQQryGZOJPCCGEEEIIIYQQQojXkEz8CSGEEEIIIYQQQgjxGpKJPyGEEEIIIYQQQgghXkMy8SeEEEIIIYQQQgghxGtIJv6EEEIIIYQQQgghhHgNycSfEEIIIYQQQgghhBCvIZn4E0IIIYQQQgghhBDiNfT/APLM8v0JFd9nAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1300x340 with 4 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "metric_keys = [\"collisions\", \"avg_speed\", \"socnavbench_path_length\", \"path_efficiency\"]\n",
+    "metric_labels = [\"Collisions\", \"Avg speed (m/s)\", \"Path length (m)\", \"Path efficiency\"]\n",
+    "\n",
+    "values = np.array(\n",
+    "    [[float(records[a][\"metrics\"][k]) for k in metric_keys] for a in PLANNERS],\n",
+    "    dtype=float,\n",
+    ")\n",
+    "\n",
+    "_inline_matplotlib()\n",
+    "fig, axes = plt.subplots(1, len(metric_keys), figsize=(13, 3.4))\n",
+    "x = np.arange(len(PLANNERS))\n",
+    "for j, (ax, label) in enumerate(zip(axes, metric_labels)):\n",
+    "    ax.bar(x, values[:, j], color=[\"#4C72B0\", \"#DD8452\"])\n",
+    "    ax.set_xticks(x)\n",
+    "    ax.set_xticklabels(PLANNERS, rotation=20, ha=\"right\")\n",
+    "    ax.set_title(label)\n",
+    "    ax.grid(True, axis=\"y\", alpha=0.3)\n",
+    "    for xi, vi in zip(x, values[:, j]):\n",
+    "        ax.text(xi, vi, f\"{vi:.2f}\", ha=\"center\", va=\"bottom\", fontsize=9)\n",
+    "fig.suptitle(f\"Two planners on the same scenario (seed={SEED}, horizon={HORIZON})\", y=1.04)\n",
+    "fig.tight_layout()\n",
+    "plot_path = OUTPUT_DIR / \"planner_comparison.png\"\n",
+    "fig.savefig(plot_path, dpi=120, bbox_inches=\"tight\")\n",
+    "print(\"Saved:\", plot_path.relative_to(REPO_ROOT))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3cdd8aa",
+   "metadata": {},
+   "source": [
+    "## 4. Summary table\n",
+    "\n",
+    "A compact, machine-readable comparison written to `output/` alongside the\n",
+    "figure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6f5cfc3e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-15T23:25:08.873229Z",
+     "iopub.status.busy": "2026-07-15T23:25:08.873159Z",
+     "iopub.status.idle": "2026-07-15T23:25:08.875629Z",
+     "shell.execute_reply": "2026-07-15T23:25:08.875304Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved: output/notebooks/02_compare_two_planners/comparison_summary.json\n",
+      "{\n",
+      "  \"simple_policy\": {\n",
+      "    \"collisions\": 27,\n",
+      "    \"avg_speed\": 0.9836065573770492,\n",
+      "    \"socnavbench_path_length\": 5.999999999999993,\n",
+      "    \"path_efficiency\": 1.0\n",
+      "  },\n",
+      "  \"random\": {\n",
+      "    \"collisions\": 0,\n",
+      "    \"avg_speed\": 0.9096203392707587,\n",
+      "    \"socnavbench_path_length\": 5.548684069551628,\n",
+      "    \"path_efficiency\": 1.0\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "\n",
+    "summary = {\n",
+    "    \"schema_version\": \"robot_sf_notebook_02_planner_compare.v1\",\n",
+    "    \"scenario\": SCENARIO_NAME,\n",
+    "    \"seed\": SEED,\n",
+    "    \"horizon\": HORIZON,\n",
+    "    \"dt\": DT,\n",
+    "    \"claim_boundary\": (\n",
+    "        \"Single-seed illustrative comparison for a beginner notebook; \"\n",
+    "        \"not a benchmark result.\"\n",
+    "    ),\n",
+    "    \"planners\": {\n",
+    "        algo: {\n",
+    "            k: records[algo][\"metrics\"][k] for k in metric_keys\n",
+    "        }\n",
+    "        for algo in PLANNERS\n",
+    "    },\n",
+    "}\n",
+    "summary_path = OUTPUT_DIR / \"comparison_summary.json\"\n",
+    "summary_path.write_text(json.dumps(summary, indent=2) + \"\\n\", encoding=\"utf-8\")\n",
+    "print(\"Saved:\", summary_path.relative_to(REPO_ROOT))\n",
+    "print(json.dumps(summary[\"planners\"], indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5324bd37",
+   "metadata": {},
+   "source": [
+    "## Interpretation\n",
+    "\n",
+    "- The **goal-seeker** (`simple_policy`) usually travels further and faster\n",
+    "  because it actively aims for the goal — but on a crowded map it may\n",
+    "  collide with pedestrians along the way.\n",
+    "- The **random** planner wanders without purpose, so it tends to stall,\n",
+    "  cover less ground, and time out — but without committing to a direction\n",
+    "  it may also happen to avoid collisions.\n",
+    "\n",
+    "The exact numbers depend on the seed and the single short horizon; this is\n",
+    "a teaching comparison, not a rigorous evaluation. To draw real conclusions\n",
+    "you would repeat over many seeds and scenarios (see the benchmark tooling\n",
+    "under `scripts/benchmark*`).\n",
+    "\n",
+    "Next: **03 — Visualize a trace**."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/03_visualize_trace.ipynb
+++ b/notebooks/03_visualize_trace.ipynb
@@ -1,0 +1,427 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7779093f",
+   "metadata": {},
+   "source": [
+    "# 03 — Visualize an episode trace\n",
+    "\n",
+    "This notebook records one deterministic episode to disk (JSONL), then\n",
+    "produces **three artifacts** that let you *see* what happened:\n",
+    "\n",
+    "1. A **2D trajectory plot** (robot path + pedestrian positions) via matplotlib.\n",
+    "2. A **top-down map thumbnail** (PNG).\n",
+    "3. An **interactive Three.js browser viewer** (open `index.html`).\n",
+    "\n",
+    "It reuses the exact recording + playback + viewer pipeline that powers\n",
+    "`uv run robot-sf demo` (see `scripts/demo/quickstart_demo.py`) — no new\n",
+    "logic, only the existing public APIs.\n",
+    "\n",
+    "> CPU-only, headless, deterministic (fixed seed)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "6a50629c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-15T23:25:10.990926Z",
+     "iopub.status.busy": "2026-07-15T23:25:10.990532Z",
+     "iopub.status.idle": "2026-07-15T23:25:11.207944Z",
+     "shell.execute_reply": "2026-07-15T23:25:11.207448Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Repo root: /home/luttkule/git/robot_sf_ll7.worktrees/cheap-issue-5798-20260715T225820Z\n",
+      "Artifacts will be written to: output/notebooks/03_visualize_trace\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "from IPython import get_ipython\n",
+    "\n",
+    "os.environ.setdefault(\"SDL_VIDEODRIVER\", \"dummy\")\n",
+    "\n",
+    "\n",
+    "def _inline_matplotlib() -> None:\n",
+    "    # (Re-)arm the notebook inline backend for the next figure.\n",
+    "    ip = get_ipython()\n",
+    "    if ip is not None:\n",
+    "        ip.run_line_magic(\"matplotlib\", \"inline\")\n",
+    "\n",
+    "\n",
+    "# Keep log output quiet so the executed notebook stays readable.\n",
+    "from loguru import logger\n",
+    "logger.remove()\n",
+    "logger.add(sys.stderr, level=\"ERROR\")\n",
+    "\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "# Resolve the repo root robustly regardless of launch directory.\n",
+    "def _repo_root() -> Path:\n",
+    "    here = Path.cwd()\n",
+    "    for candidate in [here, *here.parents]:\n",
+    "        if (candidate / \"pyproject.toml\").exists():\n",
+    "            return candidate\n",
+    "    return here\n",
+    "\n",
+    "REPO_ROOT = _repo_root()\n",
+    "\n",
+    "OUTPUT_DIR = REPO_ROOT / \"output/notebooks/03_visualize_trace\"\n",
+    "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "print(\"Repo root:\", REPO_ROOT)\n",
+    "print(\"Artifacts will be written to:\", OUTPUT_DIR.relative_to(REPO_ROOT))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d648e53",
+   "metadata": {},
+   "source": [
+    "## 1. Run one deterministic, recorded episode\n",
+    "\n",
+    "We build the environment with JSONL recording enabled, drive it with the\n",
+    "bundled random planner at a fixed seed, and stop the recording when the\n",
+    "episode finishes. The per-step simulation states are written to a `.jsonl`\n",
+    "file we can replay."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0dfd0d20",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-15T23:25:11.209425Z",
+     "iopub.status.busy": "2026-07-15T23:25:11.209319Z",
+     "iopub.status.idle": "2026-07-15T23:25:20.047849Z",
+     "shell.execute_reply": "2026-07-15T23:25:20.047408Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+      "I0000 00:00:1784157912.545883 1037094 port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+      "I0000 00:00:1784157912.577213 1037094 cpu_feature_guard.cc:227] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
+      "To enable the following instructions: AVX2 AVX_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+      "I0000 00:00:1784157913.142550 1037094 port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+      "I0000 00:00:1784157913.142745 1037094 cudart_stub.cc:31] Could not find cuda drivers on your machine, GPU will not be used.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Episode finished after 120 steps.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from robot_sf.gym_env.environment_factory import make_robot_env\n",
+    "from robot_sf.gym_env.robot_env import RobotEnv\n",
+    "from robot_sf.training.scenario_loader import load_scenarios, build_robot_config_from_scenario\n",
+    "from robot_sf.baselines.random_policy import RandomPlanner\n",
+    "\n",
+    "SEED = 270\n",
+    "SCENARIO_NAME = \"quickstart_demo_crossing_basic\"\n",
+    "SCENARIO_PATH = REPO_ROOT / \"configs/scenarios/single/quickstart_demo.yaml\"\n",
+    "\n",
+    "scenario = next(\n",
+    "    s for s in load_scenarios(SCENARIO_PATH) if s[\"name\"] == SCENARIO_NAME\n",
+    ")\n",
+    "config = build_robot_config_from_scenario(scenario, scenario_path=SCENARIO_PATH)\n",
+    "\n",
+    "env: RobotEnv = make_robot_env(\n",
+    "    config=config,\n",
+    "    seed=SEED,\n",
+    "    debug=False,\n",
+    "    recording_enabled=True,\n",
+    "    use_jsonl_recording=True,\n",
+    "    recording_dir=str(OUTPUT_DIR / \"recordings\"),\n",
+    "    suite_name=\"notebook\",\n",
+    "    scenario_name=SCENARIO_NAME,\n",
+    "    algorithm_name=\"random\",\n",
+    "    recording_seed=SEED,\n",
+    ")\n",
+    "\n",
+    "planner = RandomPlanner({\"mode\": \"velocity\", \"v_max\": 1.5}, seed=SEED)\n",
+    "env.reset(seed=SEED)\n",
+    "planner.reset(seed=SEED)\n",
+    "\n",
+    "steps = 0\n",
+    "terminated = truncated = False\n",
+    "while not truncated:\n",
+    "    decision = planner.step({\"dt\": 0.1, \"robot\": {}, \"agents\": []})\n",
+    "    action = np.array([float(decision[\"vx\"]), float(decision[\"vy\"])], dtype=np.float32)\n",
+    "    _obs, _reward, terminated, truncated, _info = env.step(action)\n",
+    "    steps += 1\n",
+    "    if terminated:\n",
+    "        break\n",
+    "\n",
+    "env.end_episode_recording()\n",
+    "env.close_recorder()\n",
+    "env.exit()\n",
+    "print(f\"Episode finished after {steps} steps.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "95a696be",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-15T23:25:20.049453Z",
+     "iopub.status.busy": "2026-07-15T23:25:20.049233Z",
+     "iopub.status.idle": "2026-07-15T23:25:20.052837Z",
+     "shell.execute_reply": "2026-07-15T23:25:20.052616Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Recorded episode: notebook_quickstart_demo_crossing_basic_random_270_ep0000.jsonl\n",
+      "Stable copy: output/notebooks/03_visualize_trace/episode.jsonl\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Locate the recorded JSONL (the recorder names it with suite/scenario/algorithm/seed).\n",
+    "candidates = sorted((OUTPUT_DIR / \"recordings\").glob(\"*.jsonl\"))\n",
+    "episode_jsonl = candidates[-1]\n",
+    "# Promote a stable copy next to the other artifacts.\n",
+    "stable_jsonl = OUTPUT_DIR / \"episode.jsonl\"\n",
+    "stable_jsonl.write_bytes(episode_jsonl.read_bytes())\n",
+    "print(\"Recorded episode:\", episode_jsonl.name)\n",
+    "print(\"Stable copy:\", stable_jsonl.relative_to(REPO_ROOT))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ae419b3",
+   "metadata": {},
+   "source": [
+    "## 2. Load the recording and plot the trajectory\n",
+    "\n",
+    "`JSONLPlaybackLoader` reads the JSONL back into a list of visualizable\n",
+    "states. Each state exposes the robot pose and the pedestrian positions, so\n",
+    "we can draw the robot's path and the pedestrians' final footprint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "dfedb3ed",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-15T23:25:20.054158Z",
+     "iopub.status.busy": "2026-07-15T23:25:20.054095Z",
+     "iopub.status.idle": "2026-07-15T23:25:20.210629Z",
+     "shell.execute_reply": "2026-07-15T23:25:20.210315Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded 120 recorded states.\n",
+      "Saved: output/notebooks/03_visualize_trace/trace_trajectory.png\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnwAAAHBCAYAAADzUWZgAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlcelbwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAYJJJREFUeJzt3Xd4U+XbB/Bv0pF0t9BSWtqyW6Ds0YIIFNlTxAGCg6EICCooCCIiOEAFQRw4XhHcqMAPZQmyFBBKyx62ZbWFMlpGd9NxnveP2khI0p60CWkO3891cWmePOec+zz3SXrnTJUQQoCIiIiIFEtt7wCIiIiIyLZY8BEREREpHAs+IiIiIoVjwUdERESkcCz4iIiIiBSOBR8RERGRwrHgIyIiIlI4FnxERERECseC71/16tXDhAkT7vhyO3fujP79+9/x5VKpyubd19cX06ZNs0FEjoPbrn3s2LEDWq0Wf/75p71DAQCsXbsWWq0WBw8evKPLtcU4HDhwAJ6enkhMTLTaPK0lMTERWq0W33zzjb1DcRhKG7Pt27fD19cXqamplZre4Qq+Vq1aQavVmvzn6elZ6fkWFBSgqKjIipHKo9PpUFhYaLX51a5dG5MnT7ba/JSusnm35vZi65zZav7W3nZJnpKSEuh0OkiSZO9QANgvHlssd8qUKRg6dCjCw8OtNk9rkSQJOp0OJSUl9g7FYVhzzHJzc7F8+XL07t0bderUQUhICHr27ImNGzca9V2wYIHZOkWr1WLhwoVGcS5ZsgTNmzeHj48PmjZtinfeeQfFxcUG/e677z60aNECM2bMqNQ6OFzBp9Pp0LBhQ9y8edPo37Vr1yo93+TkZHz66adWjNQ+7FW4OqrqkHdb54zbhLLcd999yM/PR9euXe0dil1Zexx27NiBPXv24LnnnrPK/EhZXn/9dTz33HO47777sH//fvz999+Ijo7GgAEDMH/+fIO+06ZNM1mjdO3aFTqdDn379jXo/9JLL2HWrFl4/fXXkZycjEWLFmH+/PmYOHGiURyTJk3CDz/8gLNnz1q8Dg5X8AGASqUyWTVrNJpKz1Oj0cDZ2dmKUZIjYN7J0ajVami1WqjVDvn1bTXWHodPP/0UTZo0Qfv27a0yP1KWsLAwxMbGYsaMGQgJCUFoaCjeeust9OvXD/PmzUNeXp6+r5OTk1F9kpGRgW3btqFTp05o3ry5vm9SUhI++OADTJs2DQ899BB8fX3Rv39/zJ07F1988QUOHz5sEMf9998PT09PfP755xavg6K/McrOs9qzZw/uuece+Pr6okWLFvjqq6+M+po6l2v9+vWIiYlB7dq1UadOHfTv3x+7du0y6FNSUoKFCxeiVatW8PHxQWhoKMaMGYMLFy4Y9CssLMTMmTNRr149+Pv7Y8iQIUZ9bvXjjz+iS5cuqFGjBgICAjB48GAcOXLEbP/MzExotVpkZmbi//7v//QbWe/evY3GY9++fYiJiYGvr69+13J0dLTBofGGDRti/PjxuHr1qtGyfvrpJ8TExMDf3x8hISEYPny40TkvcuKfO3cutFot9u7da3a9Khq/288ju3btGrRaLZYsWWI0j+joaAwePNigzdw5fHLW8XYffPABPDw8MG/ePH1beduQnJzJzYup3L7xxhsVzl8OW2y7ZfHu3bsXnTt3Ro0aNdClSxccPXoUALB792506dIFfn5+aNOmjdHnDpD/2ZOropyX9/lJTU3FmDFjEBoaCh8fH7Rq1QoLFy40OJSk0+kwZ84cREZGws/PD02bNsWzzz6Ly5cvW9TH1Llrt55H99FHH6Fx48bw8/NDnz59kJCQYLSup06dwqBBg1CjRg3UrVsX8+bNwz///FPl853effddNGjQADVq1ED//v1x4sQJg/dPnjyp3w7d3Nzg5+eHDh064JNPPoEQosrjAABZWVmYNWsWmjdvDl9fXzRv3hxvvPEG8vPzzcZdUlKCTZs2oUePHkbvlY1tfHw8Fi9ejIiICLi7u+PixYuy18fS/CQkJGDw4MEG+TF36FrOtnfrOixcuBANGjRAYGAgnnnmGeh0On3uGjVqhBo1amDYsGG4ceOG2fEqj5zcAaV5mjlzJpo0aQJvb280aNAAL730EnJzcyvVz5Ixq4zJkyejWbNmRu1NmjRBQUEBLl68WO70K1asgCRJGDdunEH7mjVrIEkSHnzwQYP2stc//fSTQbtWq8U999yDdevWWb4SwsFERESIyMhIWX01Go0YMGCAGDhwoDh69KhITU0Vr732mgAgPvroI4O+gYGBYuzYsfrXe/fuFWq1WsydO1dcuHBBXLlyRWzZskV0795dFBcX6/s99thjQqvVis8//1xcvnxZ7N27VzRv3lwEBQWJtLQ0fb+HH35YeHl5ie+++05cuXJFbNu2TfTt21e0aNFC9OjRwyCWWbNmCRcXF/HOO++I8+fPizNnzogxY8YIDw8PcfToUbPrm5+fL3x8fMRTTz0l8vPzRX5+vtDpdAbjMXDgQDFw4EBx+PBhkZCQINauXSuEEEKn0+mnuX79uti+fbto3ry56Ny5sygpKdHP4+WXXxbOzs7itddeE4mJiSItLU2sWrVKPPnkkxbHP2vWLAFA/PXXXxVkUv74paenCwDivffeM5pHq1atRJ8+fQzabs+73HXUaDTi+eefF0IIUVRUJCZMmCBcXV3FV199pe8jZxuqKGdy82IutxXNXw5bbLsajUYMGjRIPPzww+LkyZMiOTlZ9OnTRwQHB4t9+/aJIUOGiOPHj4uUlBQxYMAA4ePjIzIzMw2WJfezJ4fcnJsa47S0NBEUFCSaN28u9uzZIy5fviy++OILodVqxciRI/XTT548WQQEBIgtW7aI69evi6SkJLFs2TIxZcoUi/ps3bpVABA7duzQt/38888CgBg1apR4++23xYULF8Thw4dF06ZNRdOmTQ22lZSUFFGjRg3RsWNHcfDgQZGWliYWL14sHn30UQHAYBuWo2zZw4YNE2+99ZZ+2ffee6/w8/MT586d0/eVJEm/Hebn54sLFy6Ijz76SLi6uhp8J1d2HG7evCmaNWsmQkNDxZo1a8Tly5fFiRMnxJw5c8Ty5cvNrkNcXJwAIFasWGF2/YYPHy7eeOMNkZKSIlatWiUuXrwoe30syc+FCxeEv7+/iIqKEnFxceLixYvivffeE8OHDzfKj9xtr2z5I0eOFIsWLRJpaWlix44dokaNGmLSpEli3rx54t133xVpaWli165dwt/fXzz++OMV5t4UObnLysoSLVq0EI0aNRIbN24U6enp4q+//hIRERGiS5cu+u9Huf0sGbOMjAyh0Whk/XvppZfKXdeSkhIRGRkp3NzcRG5urtl+kiSJhg0bCh8fH6N+jz76qFCpVCa/l728vMSAAQOM2svqmCtXrpQb3+0csuBTqVQmk9OvXz+DvhqNRnh7e4ubN28atA8ZMkT4+vqKvLw8fdvtf/jffPNNoVarRVFRkdlY9u/fLwCIefPmGbSfPn1aODk5iWeffVYIIcTff/8tAIjFixcb9Nu5c6cAYPBH89SpU0KlUolZs2YZ9C3bsAYPHlzO6Ajh4+MjnnnmGZPvaTQa4eXlZTQe5mzfvl0AEPHx8UIIIY4dOyZUKpWYNm2a2Wksib+oqEjk5+cLSZLKjcOS8atqwSdnHYX4r+DLzMwUvXv3FjVq1BA7d+406CNnGxKi/JyZcnteyuIxl1tL538rW227Go1G+Pv7i5ycHH3bsWPHBABRr149kZWVZTBfAOKLL77Qt8n97MlhSc5NjfGkSZOEk5OTSExMNGh/4403BADx999/CyGEaNKkiRgxYkS5y5DTp7yCb8yYMQZ916xZY9R34sSJQqPRGBXFEyZMqFLB99hjjxm0X716Vbi7u4vRo0dXOI8xY8aIpk2b6l9XdhxmzJgh1Gq1OHTokEXr8MsvvwgA4vfffzd6r2z9Hn30Udnzu319LMnPs88+K1xdXcXFixcN+j711FNG+ZG77ZUt/6mnnjLo9/LLLwutVivGjRtn0D5r1izh7Oxs8DmUS07uXn31VaFWq8Xx48cN2uPj4wUA8dNPP1nUz5IxK/sbIedf2Y96c959910BQLz44ovl9iv7zp44caLRe7169RIeHh4mpwsLCxPR0dFG7Z9++qkAIGJjY8td7u0c8pBu06ZNTZ4QaWoXZ48ePeDj42PQ9uCDD+LmzZs4cOCA2WVERkZCkiSMGjUKsbGxJq/y2bp1KwDg4YcfNmhv2LAh2rVrhy1btgAA/vjjDwDA0KFDDfp169YNNWvWNGj79ddfIYTAsGHDDNrVajV69OiBHTt2mI1Zju7duxuNB1B6iGfkyJGoV68ePD09odVq9SeWnj59GkDp4UkhBJ544gmz87ckfmdnZ2i1WqhUqnJjtmT8qkrOOpZJTk7GPffcg3PnzuHvv/9Gt27dDN6Xsw1VRE5eypjLbVXYctuNiYmBh4eH/nXTpk2hVqvRunVreHl56dsjIiLg7OxssL5yP3tyWJJzU2P8xx9/oHXr1mjcuLFBe9k4lMUSGRmJdevWYcmSJUhJSTE5fzl9ynP7KQutWrUCAJw5c0bftm3bNkRFRSEoKMig75AhQyxe3q0eeOABg9cBAQHo0qWLfhsq8/333yMmJga1atWCm5sbtFotVq5caZDfyo7Db7/9hhYtWqB169YWxX7z5k0AgLe3t9k+t69fGTnrU0ZOfv744w9ER0cjODjYoO/th/zK+srZ9soMHDjQ4HVkZCQKCgqMTvOIjIxEcXExkpOTTa5zeeTkbt26dWjevDkiIyMN2tu2bYsaNWrovyvk9rNkzPz9/ZGfny/r3+1X095q/fr1mDlzJtq1a4c333yz3DFZvnw5ABgdzi1j7m+gSqUyODWgTNl3kKWH3R2y4DN30YaLi4tR38DAQKO22rVrAwDS09PNLmPIkCFYunQp9u/fj+joaPj6+mLw4MEGf7QyMjIAwOiLs6yt7P2y/5YXS5lLly4BADp16gRPT094eHjA3d0d7u7u+OSTT5CdnV2lW2HUqVPHqC0tLQ2dOnVCWloaVq1ahdTUVNy8eRM7d+4EAP3yrly5AgAICQkxO39bxG/J+JXH1AfndnLWscyuXbtw4sQJPPHEEyZv4yBnGyqP3LyUMZXbqrLltnv7l7OTkxPc3NyM2lUqFTw8PJCZmWkUV0WfPTksybmpMc7IyDAbx62xLlu2DI888gjmzJmDunXron79+njuuef04ya3T3luH7uyAqasoCmLx1Q+TbVZwtw2cuv37GeffYaRI0eie/fu2LNnD9LT03Hz5k1MnDjR4Eryyo7DlStXZOXxdr6+vgCA7Oxss31M5V7u+pSpSn5MfdfJ3fbMLb/sh5W59ls/c3LJyd2lS5dw4sQJeHp6GnxXuLm54caNG/q45fazZMwAlHvLlFv/mbugb9u2bXj44YfRrFkz/P7779BqtWbHIzMzE6tXr0ZUVJS+wL9VjRo1kJeXZ3J7uXnzJmrUqGHUnpWVBeC/7VYuhyz4LGHqooOyNlMDeavJkycjKSkJycnJWLZsGa5cuYKePXvqLzLw8/Mrdxll8y/7b3mxlCnba3Lo0CFkZGTg2rVruH79Oq5fv47s7Gzk5+fD1dW13LjLY2raNWvWIDMzE59//jmio6Ph5+cHrVZr9OXq7+8PAOV+6doifkvGz8vLCyqVCjk5OUZ95fzRlLOOZZ544gnMmjULs2fPNrhQ41YVbUPlkZuXMlXZLsyx5bZb3q9aU24t2OV+9uSwJOemxtjPz0/W90xAQACWL1+Oa9euIT4+HuPGjcM333yDbt266U8ul9OnPHLHztSPXVPrYAk5ufjqq68QFRWFOXPmoHHjxvq91rdfaFPZcfD395ddHN8qNDQUAIwuLLiVqdzLXZ8ycvJTo0YNWZ83QP62V9Hy5cQll5zc1axZEx07dkRGRobBd8WNGzeQl5eH7777zqJ+loxZ2YV9cv6Zurn+X3/9hcGDB6Nhw4bYtm1bhUeZfvjhB+Tn55vdu9eiRQtIkoSkpCSD9suXLyMzMxMtWrQwmqZsGw8LCyt32bdTfMG3a9cug8ulgdJdsR4eHujQoYOseYSFheGxxx7Djz/+CEmS9FcMdu/eHUDpoaxbXbhwAfHx8fr3Y2JiAMDoBo2xsbFGX7xlV5yuX7/e7EZYHnd3d4v3oJUdarz18BoAfPvttwav+/XrB6D0Kkxzqhq/KZaMn0ajQXBwsNHVgXFxceXu0S0jZx1v9eabb+L999/H66+/jilTppj9gjS3DQHmcyY3LxWpzDZR5k5uu5aQ+9mTw9Kcm4rl0KFDRne//9///mcQaxlnZ2e0bdsWM2fOxNSpU5GUlGR0hZ+cPpUVExODAwcOGN23dNOmTVWa7+3byM2bN7Fnzx6D9S8pKTHantPT0/H777+bnKel49CvXz8cOXIEp06dsij2Nm3awN3dHXFxcRZNZ+n6yFGWn9s/X+vXrzfqa+m2dyeVl7v+/fsjPj4eV69eLfdondx+loyZEAI6nU7Wv9v3uu3fvx8DBgxA/fr1sX37dgQEBFQ4Dl9++SW8vb0xfPhwk+/ff//9AIy/y8pyePvpNEDp92+jRo0sOsIFQPlX6fbs2VMMGzZMpKamiuzsbPHBBx8ItVot3nrrLYO+t5+8P3fuXPH222+LhIQEUVRUJDIzM/VXld56cv7AgQOFt7e3WL16tcjPzxenTp0SnTp1En5+fuLs2bP6fr179xY1a9YUmzZtEgUFBeLgwYOif//+omnTpkZXOj733HPCzc1NLF26VFy5ckUUFxeL06dPiw8//NDgSidTevbsKSIjI8X169dNjoepk1BPnDghXFxcxBNPPCFu3rwpMjIyxGuvvSbuv/9+AUB88803+r4TJkwQGo1GLF68WKSnp4vc3FyxZcsWg5Pk5cb/+uuvC41GI/bs2VPuOlk6fq+99ppwdXUVv/76q9DpdCI2NlYMHTpUREREyLpKV8463j6Wy5cvF05OTmLUqFH6K8fkbkPmcmZJXszltrz5y2WLbddcvB4eHiYvuDB14Yncz54clcl5mXPnzgk/Pz/RqVMncerUKZGfny9Wr14tvL29xcCBA/X9+vbtK1avXi0uXbokJEkSp0+fFlFRUaJ+/fr6C3vk9Cnvoo0DBw4YxGbqIqbTp08LLy8v0bt3b3Hu3DmRm5srVq5cKR588MEqXbRx//33i2XLlomcnByRnJws+vfvL9zd3cXJkyf1fefMmSOcnJzEzz//LAoLC8XJkydFTEyM6Nu3r7j1z1FlxyE9PV3Ur19fREREiB07doj8/Hz9VcjffvttuevxwAMPiJYtW5pdv9vH1pL1qUx+evToIc6ePStyc3PF8uXLxQMPPGCUH7nbnrnlr1271uDijjK//fabyTsohIeHi/Dw8HJGUV7uMjIyROPGjUWLFi3E9u3bRW5ursjOzhYHDhwQEyZMEBs2bLConyVjJoQwuLK6vH+3XnB3+PBh4evrKyIjI2VfHXv06FEBQIwfP77cfmPGjBHe3t5i69atoqSkROzZs0f4+/uLYcOGGfXV6XTC19e3wlrAFIcs+MxdpavRaMSZM2f0fcu+oDds2CAiIiKEWq0WderUEQsXLjSa7+1/+C9duiReffVV0aRJE+Hq6iq8vLxEly5dxK+//mowXUFBgZg5c6YICQkRKpVKeHh4iPvvv1/8888/Bv2ys7PFuHHjhLe3t3BxcRFdunQRCQkJol27dkZ/NIUQYsWKFSIqKkq4uroKV1dX0ahRI/HCCy8Y3OLAlEOHDok2bdoIJycnodFoRK9evYzGw5S1a9eKpk2bCicnJxEYGChmz54tjhw5YlRYSJIkPv74YxEZGSmcnJyEr6+v6Nevn8EVo3Ljt+S2LJaMX35+vnjqqaeEh4eHcHV1FX369BGpqamyb8siZx1NjeWaNWuERqMRDzzwgCgoKJC9DZWXM7l5KS+35c1fDltsu9Yo+OR+9uSobM7LnDp1Stx///3Cw8NDqFQqERISImbOnCkKCgr0fXbv3i0eeeQRUbt2beHs7CwCAwPFqFGjDMZFTp+qFnxCCHHgwAHRuXNn/bpOmTJFf2uS7777zqKxK1v2vn37xLRp04Sfn59Qq9WiY8eOYt++fQZ9dTqdmDJlivD39xfOzs6iVatWYsuWLeLll182KJAqOw5CCHHlyhUxbtw4ERgYKNRqtQgJCREvvviiuHHjRrnr8fvvvwsA4siRIybXz1TBJ3d9LM1PXFycuPfee4WTk5Pw8fERzz33nL54uL14kbPtWavgCwgIEFFRUWZGsJSc3AkhxPXr18WUKVNE3bp1hVqtFj4+PiI6Olp8+umnIj8/3+J+loxZZYwaNUoAEM7OziZrD1M7Lp5//nmjOyqYUlhYKGbPni2Cg4OFWq0WgYGBYtq0aQbrV6bsyu7KfM+phKjEQXo7KiwsLPccDo1Goz8fQavVYvz48fqb8EqSZPau7DqdDk5OTiZP0hRCVHglKVC6e9/JyanCfrfGUVhYCJVKZfKCE1P95RJC6Odddu5Jeet463Rl6yr+3fXt6upqcvlyx8Vc/MXFxSguLjbImRy3zq99+/bw9fU1uhLQVF9TY13RmJhbR3PTFRUVoaSkxGjM5IyVqZyZmt5UXuTm1tz85bLWtmsuXkvby8j97Mlhac4rE4vc7cFUH0mSUFhYaJD/sjZTn6WCggK4uLiYjOnW/GzcuBEDBgzAtm3bcN9995Ubm6l4bl22nO+sW9ev7LvA1GF/S8ahvPWriBACUVFRaNOmjcFTDMobW7nrY438lH3uzfUFzG975pZvSfupU6fQrFkzrFu3zuhqYzljUh65eZLTz9Ixk6vsu90cU7ktLCyEEMKip4BVtI69evWCl5cX1qxZI3ueZRzumVJVOTG9vEEsLyFyixG5G9StcchZn8o8OkilUhmtk5yN7tZ1LbsaWk7f8piL39nZuVKPNbNkPCoa64rGxNw6mpvOxcXFZAEkZ6xM5czU9KbyIje3VXn8IGC9bddcHJa2l7FWsQdYnvPKxCJ3ezCl7JFiFbWVKe8zfGt+/ve//8HNzc3iR4uZi6cit65fed8FloyDqT5yqVQqvP/+++jRowdmzJiBBg0ayF7O7XHevj7WyE9F38eA+W3P3PItad+2bRs6duwou9gri1kOuXmS08/SMZPL3Hd7eSpTr5S3jn/++Sf+/PNPnDx50uL5AnfBRRtERGTo+eefx59//on8/HxkZGRg0aJF+Oqrr/DCCy+Uey86pevSpQuys7NRt25de4dS7YwfPx5//fWXvcO4q91zzz3Izs5Gw4YNKzU9Cz6iu9AjjzxS4S0JKnp2cHV3N6xjZT300EOYO3cugoODUatWLXz22WdYsGAB3nrrLQBAbm5uhWPXuXNnO6+FbWg0GqvuMVaKyh6RIetxdnau0lFOhzuHzxJyz7khxyXnPDIyVtH5KIDpc1Icyd2wjtZg7pyhgoKCcqdTq9U2ufcjEdmGogs+IiIiIuIhXSIiIiLFc/hjnZIkIS0tTf9ILSIiIiIlEUIgOzsbwcHBlbpzB6CAgi8tLU3/HEQiIiIipUpNTUVISEilpnX4gs/LywtA6SAo5XYCkiQhPT0dAQEBla7kyT6YO8fF3Dku5s4xMW/yZWVlITQ0VF/zVIbDF3xlh3G9vb0VVfAVFBTA29ubHwIHw9w5LubOcTF3jol5s1xVTl3jCBMREREpHAs+IiIiIoVjwUdERESkcA5/Dh8REd05kiShsLDQ3mEYkCQJRUVFKCgo4LlgDoR5+4+Li4vNH+nHgo+IiGQpLCzEuXPnIEmSvUMxIISAJEnIzs7m/VgdCPNmyNfXF7Vr17bZWLDgIyKiCgkhcOnSJTg5OSE0NLRa7ZERQqC4uBjOzs4sHBwI81ZKCIG8vDxcvXoVABAUFGST5bDgIyKiChUXFyMvLw/BwcFwd3e3dzgGWDg4JubtP25ubgCAq1evolatWjY5vFt9fqIREVG1VVJSAgBwdXW1cyREylT2Q6qoqMgm82fBR0REst3te2KIbMXWny0WfERERBXIzc1FamqqvcOoMqWsB1mOBR8RESlWRkYGzp8/j/Pnz+PixYv6Q9OWWrt2LTp06FDlePLy8pCSklLl+VR2WdZaD3I8LPiIiEixXnrpJTRp0gQxMTGIjo6Gu7s7hg4divT0dLvEs3HjRrRs2VJxy6LqjwVfFRWXSDiUcBWb9p5D/D9XkFdgm5MtiYiocjp27Ijz58/jwoULSExMRHx8PJ5//nmjfiUlJbh06RLy8/PLnZ8kSbhy5QqEECbfNzefgoICpKenQ5Ik/V7HGzduGE1/62FXc8vS6XT6eVy+fNloHnKWJUkSMjIyyl1XUg4WfFWw92gaxs3/A699/jc+WX0Ur3+xD4/N2YwFKw/g2OkMs18GRERkH3Xr1sUjjzyCnTt3GrQvW7YMtWrVQrNmzeDr64snnngCeXl5Bn1KSkrwwgsvoGbNmmjQoAEaN26MuLg42fM5fPgw5syZg5ycHMTExCAmJgaff/65UYxr165F27Zty13WyZMn9fNo1aoVvL298fbbb+vfL29ZJSUlmD59OmrVqoWGDRsiLCwM+/fvr9K4UvXHgq8SSkokfLbmKOavPID0G4a/4IqKJew5moZXlu3Bix/8ibhT5n8FEhHRnZeTkwNn5/9uQ7t7925MnjwZX375JW7cuIFTp07hr7/+wpw5cwymy8jIQGpqKi5duoTMzEzExMTgkUce0d9Go6L5dOzYEZ988gm8vb31e91efvllkzFWtKw2bdro53HlyhXs2rULixYtwsaNGytcVkZGBvLy8nDp0iXcuHED3bt3x/jx4607yFTt8MbLFiopkbDo+4P46/BFfVub8AB0bBGE85ey8PfRS7iZowMAJKXexNz/24fmDWvi6ftboEEdH3uFTURkdVMW78SNbN0dX66flwaLp8TI7l9QUIDz58+juLgY+/fvx9dff41XXnlF//5HH32E/v37Y8iQIQCABg0aYNasWXjuuefwzjvvGDxV5P3334dWqwUALFy4EIGBgdi8eTMGDRpk0XzkKG9ZZUpKSnD16lX4+fkhJiYGmzdvRv/+/cudr5OTE9577z24uLgAAEaPHo0ePXqgqKhI30bKw4LPQl+sO64v9pydVBg/tBV6R4fp758zbkgL7DmShtU7knAuLQsAcPzMNUxZvBODuzbEY/2aQuNi2wckExHdCTeydbiWWWDvMCp0+PBhxMTEQKfT4fLly3jggQcwa9Ys/fuJiYkYMGCAwTStW7dGfn4+Ll68iNDQUACAp6cn6tatq+/j6+uLsLAwJCUlWTQfOSpaVlZWFsaNG4e1a9fCy8sLnp6euH79Onr16lXhvP39/fVPdihbliRJyM3Nha+vr+wYybGw4LPAroMXsGHPOQClxd6s0dFo3zTQoI+zkxrd2oagS+s62HssDV9vPIVLGbmQBPC/XWcQ/89VzHiiPcJqe9tjFYiIrMbPS+MQy+3YsaP+nL29e/eiT58++Pjjj/Hss88CALRaLXQ6wz2VZa/L9rABpU9AEEIY3CC3oKBA30fufOSoaFmvvfYazpw5g+TkZNSuXRsAMGrUKNy8edOi5dDdgwWfTJk5Ony29qj+9bMPtTIq9m6lVqtwb6s6iI6sjf/tOoMftiSgqFhC6pVsvLT0T0x7rD06NKt9J0InIrIJSw6rVhf33HMP5syZg5kzZ+Lhhx9GrVq10Lp1a+zatcug386dOxEUFISAgAB9m06nw4EDBxAVFQUAOHPmDNLS0tCqVSsAkDUfjUaD4uLiCuOsaFnHjx9H37599cVecXEx9uzZg8jISP085C6L7g68aEOmn7YlIjuv9GTZLq3roGdU3QqmKOXi7ISHe4Tjg6kxqBdUulcvX1eCN7+Kxa6DF2wWLxERmTZ58mTUqFED8+bNAwBMnz4dx44dw9SpU3HkyBGsXLkSCxYswNy5cw2mU6vVGDNmDHbu3Im9e/dixIgRuPfee9G5c2fZ8wkPD0dubi7WrVtn9rYscpbVoUMHfPfdd9i1axfi4+Px+OOP4+zZswbzkLssujuw4JMhr6AIv+9LBgC4ujjhqfubWzyP0EAvvPdcF3RuFQwAkCSB9384iEMJV60aKxER/cff31+/F6yMRqPBggULsGXLFly6dAn16tXDX3/9hTNnzuDhhx/G559/jg8++ABPP/20fhpPT0+0bdsW8+bNw1tvvYUxY8agWbNmWL16tb6PnPlERETg/fffx5tvvonu3bubvC0LAAQEBJS7rNmzZ+P+++/HpEmTMHbsWISGhmLq1KmoVatWucvy9PQ0OpdQo9Ggbt26Fl9UQo5FJRz8niFZWVnw8fFBZmYmvL1tc17croMXsPC7eABAv071MPGhVpWelyQJfLL6iL6A9HJ3wQdTuyPAz+2WPhKuXr2KWrVq8QPoYJg7x8Xcla+goADnzp1D/fr1LT4fzdaEECguLoazs7PNH0B/J3z77bd46aWXTN5QWUmUlreqKu8zZo1ah99qMvyTfF3//x1bBFVpXmq1ChMebIUOzUrP/8vOK8LSnw7xXn1ERERkMyz4ZLh87b+7rdcPqvpeRCe1ClMfbQt/n9IK/nBiOnYfSavyfImIyPGZOuxKVFUs+GTIyv3vMnsfT+vchsDT3RUTbjk0/N3mfyBJ3MtHRHS3GzJkCA4cOGDvMEhhWPDJUFaHWfsUgw5NAxHZoCYA4GJ6Do6d5kOsiYiIyPpY8Mng++9ePSGAG9nWu6u8SqXCwHvr61/vPsrDukRERGR9LPhkqFvbS///x89cs+q82zcJhLNTaRq4h4+IiIhsgQWfDG0i/ruv0dbYZKvOW6txhr9v6cUbN3Pu/EPIiYiISPn4aDUZWjT0R1BND1y6losjSRk4nHgVrcNrISUzBdvObkN2YTa8XL3Qo0EPhPmEWTTvrNxCXL2RDwAI8HWroDcRERGR5VjwyaBWqzCsVziW/HgIAPDaT6tQXO93bD6zEQICapUakpCgggoDwwdidtfZ6FCng6x5/7wtUX91buvwgAp6ExE5Nmv8UCYiy7Hgk6l7u1BsjU3BHynrcbB4IXBGQKC0UJOEBAAQENiYtBGbTm/CqodWYWjToWbnJ4TA3mOX8Otfpc8+dHFWY3CXhrZfESIiO4i9GIs3/nwDGxI3VPmHMhFZjufwyaRWq9CtewkOui2EQAkEJJP9SkQJSqQSDPtlGA5cNL6P0o2sAmzaew4vfvAnFqw8oN+7N6xnuMHj1YiIlGLNqTXovLwzNiVtMvtD+Z7l92DNqTVWX3ZxcTE+//xz9OvXD23btsVDDz2En3/+2eDpRhMmTMD8+fOttkxrz4/IGriHzwLLjiyCWg2UVHB/ZAEBIQTe/PNNfNHsHVw8dR7n07Jw+sJNXLyao+9Xtj+vTZNaeMgvBzh4EPD3B0JCbLcSRER3UOzFWAz7ZRhKpBJ9sXe7ElEClVBh2C/DsHfMXqvu6Zs0aRJ+++03vPvuu2jWrBmSk5OxatUqnD17Fi+//DIAIDU1FRqNdW6qb4v5EVmDSjj4Q1yt8UBhOVIyU1BvST2zX1imhN4Ekj50hqakWP6CtFpIp07hqlbLh7g7IEmScPXqVebOATF35Svvwe7lGfzDYGxM2ogSUVJhXyeVEwaED8C64essik0IgeLiYjg7O0N1yx3yi4uL4eXlhaVLl+Lpp582mKawsBCurq6YOXMmPvzwQ7i6uqJWrdI7MmzatAkrV67Ejz/+CACoWbMmOnbsiNmzZ8PX11c/jzFjxiA8PBwFBQXYuHEjmjZtiuDgYJPzq1+/PsiQubzdrcr7jFmj1uEePpm2nd1mUbEHAP55sKzYA4CCAiAjg3v5iMjhpWSmYH3ietnfnSWiBL8l/IaUzBSrXMhRVkScP3/e6D1XV1cAwHPPPYd9+/YhLCwMM2fOBADUqVMHEyZMwPDhwwEAV65cwdtvv43Bgwfjzz//1M8jJSUF33zzDSZNmoRPPvkEtWrVgouLi8n5EdkbCz6Zsguz9ScZExFRxSrzQ1lAYPu57RjVelSVl+/k5ITZs2fj1VdfxdatW9G9e3d07twZ9913Hzw9PQEAQUFB8PDwgJ+fH5o0aaKfNjAwEIGBgQCAJk2aoHXr1vDz88M///xj0K99+/ZYvHixwXJNzY/I3njcQiYvVy8We0REFij7oWwJtUqNLF2W1WJ45ZVXEB8fj759+yI+Ph7Dhw9H3bp1sWHDhnKnu3r1KqZPn46uXbuiWbNmiI6OBgCcO3fOoF9UVJTVYiWyJe7hk6lHgx5QQWXxr1UiortVZX4oS0KCt8a652O3adMGbdq0AVB6LtQjjzyCUaNG4erVq2bPHevXrx9q1aqFWbNmITg4GC4uLmjZsiV0OsMnIrm58e4K5Bi4h0+mMJ8wDAwfCCeVk6z+KqFGzeJmNo6KiKj6KvuhbAkVVLiv/n02igjw9vbGsGHDkJGRgezsbAClh35vvX7x0qVLOHjwID744AP06dMHLVq0gLOzM4qKimQt4/b5EVUHLPgsMLvrbKhUqgq/wFRQQa1Wo1/oo3coMiKi6sfSH8pOKicMihhktSdvFBYW4plnnsHJkyf1benp6VixYgVatWqlv9oxKCjI4FCtr68vNBoNdu3aBQDIycnB5MmTZS/39vkRVQcs+CzQoU4HrHpoFZzUTma/wJxUTnBSO+Hnh3/C1MH973CERETViyU/lFUqFV7t8qrVlu3i4oL27dtj+PDh8Pb2Rt26dRESEgI3NzesXr1a3+/pp59GbGwsQkJC0KRJE1y+fBmffPIJXnjhBYSGhqJ27doICwuTffj29vmx+KPqgPfhq4QDFw/gjT/f0N9u4NZHBA2KGIRXu7xaeuPQgweBdu0snr904ACuhoTwfmAOiPdyc1zMXfkqex8+oPRJG8N+GQYhhMn78TmpnKBSqfDTQz/hgaYPWBybnPu55eTk4Pr166hdu7b+liy3KikpQVpaGnJzc9GgQQO4urpCp9MhLS0NAQEB8PT0RGJiIoKDg/VX+KampkKr1SIgwPg56KbmR4Z4Hz5DvA9fNdShTgf8+uivSMlMwfZz25Gly4K3xhv31b+PDwEnIrrN0KZDsXfMXrM/lAeED/jvh7KNeHp66gs1U5ycnBAaGmrQptFoDG6YHB4ebvD+7f0rmh+RPbHgq4IwnzCr3CuKiEjp+EOZyL5Y8BER0R3DH8pE9mH3gu/o0aP4448/cPPmTXTs2BH9+yvoQgd/f0CrLX1cmlxabel0RERERFZi14Jv8eLFmDVrFp588kn4+/tj0qRJ6NKlC1auXGnPsKwnLAxISCh9Nq5c/v6lz9G9etV2cREREdFdxW4FX2ZmJqZPn44PP/wQ48ePBwBMnDgRDRo0wIgRI9CnTx97hWZdYWGl/ywh8RFuREREZD12u/fAuXPnUFxcbPAcwqCgIISGhhrcH4mIiIiIqsZue/gaNmwIjUaDHTt2oG3btgBKi8Dk5GQkJCSYnU6n0xk8yzArq/Qh25IkQVLInjFJkiCEUMz63E2YO8fF3JWvbHzK/lU3ZTFVx9jIPObtP2WfLVP1jDW+l+xW8Hl5eWHx4sWYMmUK9uzZA39/f2zbtg1NmzZFXl6e2enmz5+PuXPnGrWnp6ejwJKLI6oxSZKQmZkJIQRvAOtgmDvHxdyVr6ioCJIkobi4GMXFxfYOx4AQAiUlpTd05g18HQfzZqi4uBiSJOHatWtwcXExeK/suc9VYfcnbZw5cwa7d+9Gfn4++vXrh0mTJqGwsBC///67yf6m9vCFhobixo0bd+xJG7YmSRLS09MREBDAPzwOhrlzXMxd+QoKCnD+/HnLn7SRkmL5hWuWnveM0oL09j+Stvbtt9/CxcUFw4YNu6PLVRJ75K26KnvSRr169Uw+acPPz8+xn7TRsGFDNGzYEEBp4v/+++9yH1Kt0Wig0WiM2tVqtaK+pFUqleLW6W7B3Dku5s48tVpd+kzcf//JkpICNGli+a2pEhIsKvqEEPqYbo/t+++/R2xsrNE0QUFBePnll+XHZcLvv/8OrVaL4cOHV2k+d6vy8nY3KvtsmfoOssZ3kl2/1Q4ePKjfnQsA77zzDoqKivD000/bMSoiIrKKjAzLij2gtL8lewQrsGXLFqxfvx716tUz+FenTh2rLYPIEdh1D9/Ro0cxduxYdOrUCQkJCTh8+DB++eUXBAcH2zMsIiJSkJCQELzwwgtm31+2bBlCQ0MRGBiIbdu2oaSkBEOHDkXTpk0N+h05cgSrV6+Gl5cXevXqZeOoiazLrnv4Ro0ahVWrVqFVq1YYN24czpw5ww8RERHdUatXr8bkyZMxadIkFBUV4cSJE2jTpg2OHz+u77N582Z06NABycnJyMrKwoMPPohdu3bZMWoiy9j9HL7w8HCEh4fbOwwiIlKo06dPG+3h69Spk8HFFlqtFrt379ZfQNC1a1d8+eWXWLx4MYQQmDp1Kl544QW8++67AIDRo0cjIiLijq0DUVXZveAjIiKyJa1Wi3r16hm01axZ0+B1r169DK4WjYyMRGpqKgDg4sWLOHXqFL7//nv9+w0aNMA999xju6CJrIwFHxERKVpF5/ABgLu7u8FrJycn/f0Gr1y5AgAICAgw6FOrVi3rBUlkY7z3ABERUTnKrui9ePGiQfuFCxfsEQ5RpbDgIyIiKkft2rXRoUMHLFu2TN8WFxeH/fv32zEqIsvwkC4RESmaqYs2NBoN3nnnHdnzWLp0KXr16oWzZ8+ibt262LlzJy84JIfCgo+IiBRrxIgRaN26tVG7q6ur/v8nTpyIwMBAg/cfeughg+eXduzYEQkJCdi0aRO8vLywYMECHDt2DE5OTjaLnciaWPAREZFi9e7dG7179y63z9ChQ43aYmJijNqCg4MxduxYg9dEjoLn8BERkW34+5c+G9cSWm3pdERkVdzDR0REthEWBiQkWPZsXH//0umIyKpY8BERke2EhbGAI6oGeEiXiIiISOFY8BEREREpHAs+IiIiIoVjwUdERESkcCz4iIiIiBSOBR8REZEF8vLysHnzZuh0uju+7OzsbGzevBlFRUV3fNm3u3z5sv55wvaMKyUlBdu2bcPBgwfv+LLlSk9Px99//23XGFjwERHRHSeEuCPLOXbsGDZv3ozNmzdj27ZtSExMrPKy09LS0K9fP6Snp1slxqysLGzevBnFxcUV9j1z5gz69euHzMxMqyy7KsaOHYsDBw4AsH5ccsdkyZIlaNmyJebPn49169ZZZdm24ObmhqFDh+LIkSN2i4H34SMiIpsTQkCXloSsuE3ITYyFKCyAylULj/AoeLfvB01wY6hUKqsvd9GiRfj1118RFRWFoqIiHDlyBCEhIVizZg0aNGhg9eVVRmJiIvr164cbN27A19e33L7e3t7o06ePwbOA7WHnzp2Ii4vD2rVrbTJ/uWOyePFiLF68GKNHj7ZJHNbi6emJiRMnYubMmdi4caNdYmDBR0RENiVKipG+YRlyju0E1GpAkkrbCwuQc2I3co7/Cc+WMQjoPwEqJ+v/WWrZsiU2b94MoPTQY3R0NCZPnowNGzYAKD1Ee+jQIWg0GkRGRsLNzc1oHsnJyUhJSUFERITZ5VQ0n+LiYhw/fhz5+flo0aIFPD09kZ+frz/Ut23bNnh4eCAoKAh169bFvn370Lt3b5w9exbnz59H27ZtERAQgBdeeEE/78LCQmzfvh0A4OLigvr16xsVsjdv3tTP68qVKzhz5gwaNGhg9CxgU/GZs3TpUowcOdJs4SknrluXWVBQUOGYtGrVSj9dTk4Odu/ejcuXLyM1NRWbN29Gq1at4ObmZnLcPD09LRqny5cv4/Tp02jUqJF+nJKSknDp0iU0b94cNWrUMFqXivL/xBNP4PXXX8eZM2fQsGFDs2NrKyz4iIjIZoQQ/xZ7u0ob/i32/utQ+jrnaOn7AQMn2WRPXxkvLy8MHjwYy5cvBwB89913mDx5Mho2bAghBFJSUrBixQr0799fP82cOXPwzjvvoFWrVkhNTUXXrl2N5lvRfE6fPo3evXvDyckJtWvXxrlz57BgwQL06tULP/zwAwBg2bJlcHZ2RkxMDO69917069cPI0eOxN69e9G4cWO89957kCRJfzjZ398fubm5WLJkCYDSIuvo0aNo164d1qxZAw8PDwDA8ePH0a9fPzz++OPYu3cvatWqhfj4eCxevBgTJ04sN77HHnvMaF0LCwvx+++/46effjI7znLiOn36NPr06SN7TG4t+K5du4YlS5aguLgY69atw969ezF9+nS4urqaHLfQ0FDZ4zRo0CAkJCTAx8cHBw8exIcffog//vgDJ0+ehLu7O5KSkrB+/XqD7UDOdlS3bl00bNgQv/32G1544QWzY2czwsFlZmYKACIzM9PeoVhNSUmJuHTpkigpKbF3KGQh5s5xMXfly8/PFydPnhT5+fmWTXchQZx5c6jsf/kXEiyOTZIkUVhYKCRJMnrvySefFN26dTNoe/TRR0WzZs3EoUOHhKenp/j777/17/3www/Cz89PXL9+XQghRGxsrFCr1WLnzp1CCCFyc3NFp06dBACRmpoqhBCy5jN+/HgxePBg/fs5OTli1apVQgghDhw4IACIGzdu6N//66+/BADx1FNPGWyThw4dEgBEenq6ybHIyckR7dq1E2+88YbRvJ5//nn9GH3++efC3d1dFBQUVBjf7cpiOH/+fJXieuaZZ8TAgQP1MVU0JqZoNBrx22+/Ga3r7eMmJ56yaadOnapvmzp1qgAgXnnlFX3buHHjRNeuXQ3WvaL8l3nwwQfFo48+ajKm8j5j1qh1uIePiIhsJituk8Fh3HKp1ciK3wxtnXCrxnD9+nX9BQB79uzBqlWr8PHHH2P58uVo0qQJcnJysHXrVggh4Ofnh/z8fMTGxqJPnz749ttv0bVrV3Tr1g0A4O7ujmnTpmHo0KH6+cuZj0qlQk5ODvLy8uDu7g4PDw888sgjFcY+ffp0qNUVX195/vx5JCcnIz8/H82aNcOePXuM+rz00kv6vad9+/ZFXl4ezp8/j4iICIviK7tYxdRhTUviUqlUyM3NRV5eHjw8PGSPiRzmxk3OOE2ZMkX//927d8f7779v1LZmzRr9azn5L1OzZk2cOXPGKutoKRZ8RERkM7mJsfKKPQCQJOQm7Ld6DBcuXMCSJUvg4uKCkJAQbN68Gb169UL//v1x+fJlLFy40KB/t27d4OTkBAA4d+6c0flWjRo1Mnh9+vTpCuczY8YMjBgxAoGBgejatSv69u2LMWPG6A8nmhMSElLu+1lZWRgyZAji4+MRGRkJb29vnD9/3uR5iP7+/vr/L3s/Pz/f4vjc3d3103p5eVU6rrJl1q5d26IxkeP2cavsOGm1WpNtZeMGyMt/mbKC2h5Y8BERkU0IISAKCyybprAAQgirnsd360Ubt/Lw8EBkZKTJ98r4+fkhKyvLoO3213LmExYWht27d+PChQvYsWMHFi9ejBUrViA+Pr7c2CsahyVLliAjIwOXL1/WFy+zZs3SX5AilyXxlRXAycnJqFWrVqXjCgsLw86dO3H58mXs3LlT9pjIcfu4WWucTJGT/zIpKSlo3759lZdZGbwPHxER2YRKpYLKVWvZNK5am160cauePXti165dOHfunEF7dna2/gbCHTt2xM6dOw326Kxfv97i+Vy/fh1A6Z6nxx9/HEuWLMHBgweRlZWl3+NTWFho8TqkpqYaXBEqSVKlipjy4rtd7dq10bRpU+zdu7dKcdlqTCobT2XJyT9Qui5xcXHo0aOHVZZrKe7hIyIim/EIj0LOyd2yz+HziIi2fVD/Gj16NH788Ud07doV06dPR1BQEI4dO4bvv/8e8fHxcHFxwejRo7Fo0SL0798fzzzzDE6dOoXPPvvM4vlMnjwZzs7O6NGjB7RaLT7++GPce++98Pb2Rv369eHj44N33nkHPXv2NLpdSnn69u2LkSNHYtGiRQgJCcHKlSv1txOxRHnxmTJ27FisWrUKzz//fKXjeu6556BWq9GzZ0+4ublVOCa3XqVrKWuNkyly8g8AGzZsQI0aNdC7d+8qL7MyWPAREZHNeLfvh5zjf8rrLEnwbtfXqstv0aKF2cOOrq6u2LJlC77++mts27YNRUVFaN26Nfbu3asvdLRaLXbv3o13330XP/30E5o0aYLt27djxowZ+vO75Mzn66+/xvfff48//vgDOp0OgwYNwrhx4wCUnk+3YcMGfPnll/jwww/RtWtXDBo0SH/LklvdfuPlBx98ECUlJVi7di3+/vtv9OnTB4899pjBxQh+fn5G83J1dUWfPn1kxWfK008/jffeew/x8fFo165dpeJauXIlvvnmG2zfvl3WmJgq+Hr37m2QX1PrWpVx8vf3N7joAgACAwPRq1cvg7GsKP8A8PHHH2P69OlwdrZP6aUS4g4938ZGsrKy4OPjg8zMTLO/RByNJEm4evUqatWqJevqLKo+mDvHxdyVr6CgAOfOnUP9+vX1hY4cQgik//bRv/fhK+/PjQqeLbtV6j58QggUFxfD2dn5jh0OJuDnn3/GmTNnMGPGjEpNfzfl7ezZs3j11Vfx9ddfmy34yvuMWaPW4R4+IiKyGZVKhYABEwAVkHN0p/EtWv597dmyW+mTNhT+h19JHn74YXuH4DAaNGiA77//3q4xsOAjIiKbUjk5I2DgJHi37YOs+M3ITdj/37N0I6Lh3a6vzZ6lS0SlWPAREZHNqVQqaOuE62+qbO1brxBR+XiiChER3XEs9ojuLBZ8RERERArHgo+IiGRz8Bs7EFVbtv5sseAjIqIKld2bzFpPPiAiQ3l5eQCgv1GztfGiDSIiqpCzszPc3d2Rnp4OFxeXanWvwrvpfm5KwryVEkIgLy8PV69eha+vr9FNo62FBR8REVVIpVIhKCgI586dQ3Jysr3DMSCEgCRJUKvVd3Xh4GiYN0O+vr6oXbu2zebPgo+IiGRxdXVF48aNq91hXUmScO3aNdSsWbNa7Xmk8jFv/3FxcbHZnr0yLPiIiEg2tVpt0aPV7gRJkuDi4gKtVnvXFw6OhHm7szjCRERERArHgo+IiIhI4VjwERERESkcCz4iIiIihasWBV9aWhpOnDiBzMxMe4dCDo5PASAiIjJm16t0T548iREjRiAlJQVBQUE4e/Yshg4diuXLl0Oj0dgzNHIQQgjo0pKQFbcJuYmxEIUFULlq4REeBe/2/aAJbsz7OxER0V3PrgXf+PHjERAQgP3790Oj0eDMmTNo06YNPv74Y0ydOtWeoZEDECXFSN+wDDnHdgJqNSBJpe2FBcg5sRs5x/+EZ8sYBPSfAJUT70BERER3L7se0r106RI6deqk35vXsGFD1K1bF5cuXbJnWOQAhBD/Fnu7Shv+Lfb+61D6OufoLqRvXMZDvUREdFez626P2bNn45VXXkFERATq1q2LLVu2IDMzExMmTLBnWOQAdGlJpXv2KiSQc3QnvNv2gbZOuI2jIiIiqp7sWvANGDAAv/32GyZNmoSgoCCkpqbi9ddfR/369c1Oo9PpoNPp9K+zsrIAlN6xW7p9L4+DkiRJ/4xBMi3zwEaDw7jlUquRGbcJrkGNbB4Xc+e4mDvHxdw5JuZNPmuMkV0Lvv79+6NWrVpIS0uDm5sbzp49i44dO6KoqAgzZswwOc38+fMxd+5co/b09HQUFBTYOuQ7QpIkZGZmQgjBx82YkZcYK6/YAwBJQm7CfojoYbYNCsydI2PuHBdz55iYN/mys7OrPA+VsNPJTRcvXkRISAg2bNiA/v3769vHjRuHw4cPIzY21uR0pvbwhYaG4saNG/D29rZ53HeCJElIT09HQEAAPwQmCCGQvOARi6erO+Mnm1+xy9w5LubOcTF3jol5ky8rKwt+fn7IzMysdK1jtz18fn5+UKvVuHz5skH7pUuXULNmTbPTaTQak7dsUavVitpgVCqV4tbJmlSuWohC+Xt0Va5aODk52TCiW5bF3Dks5s5xMXeOiXmTxxrjY7eCz93dHU8++SReeeUVqNVqNGjQAFu2bMGGDRvwv//9z15hkYPwCI9Czsndss/h84iItn1QRERE1ZRdz+H77LPP8H//93/43//+h2vXrqFu3brYsWMHunXrZs+wyAF4t++HnON/yussSfBu19e2AREREVVjdi34XFxcMGHCBN6GhSymCW4MzxYx/96Hr7zTUFXwbNkNmuDGdyo0IiKiaocHzckhqVQqBAyYAM+W/+4Nvv38hn9fe7bsVvqkDT5ejYiI7mJ83hQ5LJWTMwIGToJ32z7Iit9ceuuVsmfpRkTDu11fPkuXiIgILPjIwalUKmjrhOufoiGEYIFHRER0Gx7SJUVhsUdERGSMBR8RERGRwrHgIyIiIlI4FnxERERECseCj4iIiEjhWPARERERKRwLPiIiIiKFY8FHREREpHAs+IiIiIgUjgUfERERkcKx4CMiIiJSOBZ8RERERArHgo+IiIhI4VjwERERESkcCz4iIiIihWPBR0RERKRwLPiIiIiIFI4FHxEREZHCseAjIiIiUjgWfEREREQKx4KPiIiISOFY8BEREREpHAs+IiIiIoVjwUdERESkcCz4iIiIiBSOBR8RERGRwrHgIyIiIlI4FnxERERECseCj4iIiEjhWPARERERKRwLPiIiIiKFY8FHREREpHAs+IiIiIgUjgUfERERkcKx4CMiIiJSOBZ8RERERArHgo+IiIhI4VjwERERESkcCz4iIiIihWPBR0RERKRwLPiIiIiIFM7ZnguPjIxEbm6uUftjjz2GN9980w4RERERESmPXQu+TZs2QZIk/eu4uDg8/PDD6NSpkx2jIiIiIlIWuxZ8YWFhBq8XLFiAkJAQ9O3b104RERERESlPtTmHLy8vDz/88APGjh0LJycne4dDREREpBh23cN3q59//hk5OTkYM2ZMuf10Oh10Op3+dVZWFgBAkiSDw8OOTJIkCCEUsz53E+bOcTF3jou5c0zMm3zWGKNKFXxCCJw4cQIXLlwAAISGhqJZs2ZQqVSVDuTLL79Enz59jA7z3m7+/PmYO3euUXt6ejoKCgoqvfzqRJIkZGZmQggBtbra7IQlGZg7x8XcOS7mzjExb/JlZ2dXeR4qIYSQ2/mff/7B0qVLsWrVKly/ft3gvZo1a2L48OGYPHkyIiIiLAoiKSkJ4eHhWLNmDR544IFy+5rawxcaGoobN27A29vbouVWV5IkIT09HQEBAfwQOBjmznExd46LuXNMzJt8WVlZ8PPzQ2ZmZqVrHdl7+CZPnowVK1Zg0KBB+PDDD9GhQwcEBgYCAK5cuYLY2FisX78e7du3x+jRo7F06VLZQXz55ZcIDAzEoEGDKuyr0Wig0WiM2tVqtaI2GJVKpbh1ulswd46LuXNczJ1jYt7kscb4yC74XF1dce7cOfj7+xu95+3tjcaNG2PkyJHIyMjA/PnzZQdQXFyMr7/+GqNHj4azc7U5pZCIiIhIMWRXWIsWLZLVz9/fX3ZfANi4cSMuX76MsWPHyp6GiIiIiOSz+y61rl27Ijk5GaGhofYOhYiIiEiRKl3w7du3D3v27MGNGzeM3rPksWi+vr7w9fWtbBhEREREVIFKFXzz58/Hq6++ihYtWrBYIyIiIqrmKlXwLVmyBBs3bkSfPn2sHQ8RERERWVmlrvPNz89H586drR0LEREREdlApQq+fv36YfXq1daOhYiIiIhsoNKHdFu0aIGff/4ZDRs2NHqk2pIlS6wRGxERERFZQaUKvtdffx1ZWVm4efMmzpw5Y+2YiIiIiMiKKlXw/fDDD9i6dSu6detm7XiIiIiIyMoqdQ6fm5sb2rZta+1YiIiIiMgGKlXwdevWDd999521YyEiIiIiG6jUIV1JkjBhwgT8/PPPaNSokdFFG59++qlVgiMiIiKiqqv0o9UefPBBAMC1a9esFgwRERERWV+lCr5ffvnF2nEQERERkY3IPocvISFB9kwt6UtEREREtiW74OvevTtGjx6N/fv3m3xfCIHdu3fjySefRExMjLXiIyIiIqIqkn1I9+TJk3jjjTfQs2dPuLm5oV27dggMDIQQApcvX0ZcXByKiorw9NNP49SpU7aMmYiIiIgsIHsPn6+vLxYtWoSLFy9iyZIlaNCgAa5fv46bN2+iUaNG+Oijj3Dx4kUsWrQIvr6+NgyZiIiIiCxh8UUb3t7eGDFiBEaMGGGLeIiIiIjIyip142UiIiIichws+IiIiIgUjgUfERERkcKx4CMiIiJSuEoVfPfddx++/fZb5OfnWzseIiIiIrKyShV8jRs3xrPPPougoCCMHz8eBw4csHZcRERERGQllSr4PvvsM1y+fBkffvghEhISEB0djRYtWmDx4sVIT0+3doxEREREVAWVPofPzc0Njz/+OHbs2IHTp09j0KBBmDFjBurUqYOHHnoIe/bssWacRERERFRJVb5oIyEhAZ9//jlWrFgBd3d3jBs3Dmq1Gt27d8frr79uhRCJiIiIqCosftIGAOTk5OCnn37C8uXLsXfvXnTp0gXvvvsuHnroIWi1WgBAbGwsevTowaKPiIiIyM4qVfDVrl0bnp6eePLJJ/HVV1+hcePGRn2ioqJQt27dKgdIRERERFVTqYLv66+/xqBBg+Di4lJuv+PHj1cqKCIiIiKynkoVfEOHDrV2HERERERkI3zSBhEREZHCseAjIiIiUjgWfEREREQKx4KPiIiISOFY8BEREREpHAs+IiIiIoVjwUdERESkcCz4iIiIiBSOBR8RERGRwrHgIyIiIlI4FnxERERECseCj4iIiEjhWPARERERKZyzvQMAgP3792PHjh1wd3fHww8/jKCgIHuHRERERKQYdt3DJ4TA008/jX79+uHSpUu4dOkS+vTpg4SEBHuGRURERKQodt3Dt2zZMnz33Xc4dOgQIiIiAAAvv/wyCgoK7BkWERERkaLYteD78MMPMWLECH2xBwC+vr72C4iIiIhIgexW8GVnZ+Off/7BzJkzsX79esTHxyM4OBhDhgxBQECA2el0Oh10Op3+dVZWFgBAkiRIkmTzuO8ESZIghFDM+txNmDvHxdw5LubOMTFv8lljjOxW8GVmZgIAlixZAj8/P3Tu3Bm//PILpk2bhj/++APt27c3Od38+fMxd+5co/b09HTFHAqWJAmZmZkQQkCt5oXUjoS5c1zMneNi7hwT8yZfdnZ2leehEkIIK8RisZs3b8LPzw/dunXDzp079e19+vSBJEnYunWryelM7eELDQ3FjRs34O3tbeuw7whJkpCeno6AgAB+CBwMc+e4mDvHxdw5JuZNvqysLPj5+SEzM7PStY7d9vD5+voiKCgIUVFRBu3R0dH45ptvzE6n0Wig0WiM2tVqtaI2GJVKpbh1ulswd46LuXNczJ1jYt7kscb42HWEhw8fjr/++gtlOxmFENi1axdatGhhz7CIiIiIFMWuV+m+9tpruO+++xAVFYVOnTohNjYWFy9exPbt2+0ZFhEREZGi2LXg8/X1xb59+7BhwwYkJycjJiYGffv2hbu7uz3DIiIiIlIUuz9azdXVFQ888IC9wyAiIiJSLJ4lSURERKRwLPiIiIiIFI4FHxEREZHCseAjIiIiUjgWfEREREQKx4KPiIiISOFY8BEREREpHAs+IiIiIoVjwUdERESkcCz4iIiIiBSOBR8RERGRwrHgIyIiIlI4FnxERERECseCj4iIiEjhWPARERERKRwLPiIiIiKFY8FHREREpHAs+IiIiIgUjgUfERERkcKx4CMiIiJSOBZ8RERERArHgo+IiIhI4VjwERERESkcCz4iIiIihWPBR0RERKRwLPiIiIiIFI4FHxEREZHCseAjIiIiUjgWfEREREQKx4KPiIiISOFY8BEREREpHAs+IiIiIoVjwUdERESkcCz4iIiIiBSOBR8RERGRwrHgIyIiIlI4FnxERERECseCj4iIiEjhWPARERERKRwLPiIiIiKFY8FHREREpHAs+IiIiIgUjgUfERERkcI523PhFy5cQEZGhkGbm5sbIiIi7BQRERERkfLYteB788038eOPP6JevXr6tkaNGuGXX36xX1BERERECmPXgg8AevbsyQKPiIiIyIbsfg5fcXExEhMTceXKFXuHQkRERKRIdi/4fv31V/Tt2xeNGjVCeHg4duzYYe+QiIiIiBTFrod0Y2Ji8MorryAsLAyFhYWYOnUq7r//fhw7dgx169Y1OY1Op4NOp9O/zsrKAgBIkgRJku5I3LYmSRKEEIpZn7sJc+e4mDvHxdw5JuZNPmuMkUoIIawQi1UUFRWhZs2aeOONN/D888+b7PP6669j7ty5Ru2JiYnw8vKydYh3hCRJyMzMhI+PD9Rqu++EJQswd46LuXNczJ1jYt7ky87ORnh4ODIzM+Ht7V2pedj9oo1bubi4oFatWkhNTTXbZ+bMmZg6dar+dVZWFkJDQxEQEFDpQahuJEmCSqVCQEAAPwQOhrlzXMyd42LuHBPzJp9Wq63yPOxW8AkhUFRUBFdXV33b+fPncf78eTRp0sTsdBqNBhqNxqhdrVYraoNRqVSKW6e7BXPnuJg7x8XcOSbmTR5rjI/dCr6ioiK0b98ekyZNQmRkJFJSUjB37lw0bdoUI0eOtFdYRERERIpjt5La1dUV69atw/HjxzFjxgz88MMPGDt2LA4cOAA3Nzd7hUVERESkOHY9h69+/fpYunSpPUMgIiIiUjweNCciIiJSOBZ8RERERArHgo+IiIhI4VjwERERESkcCz4iIiIihWPBR0RERKRwLPiIiIiIFI4FHxEREZHCseAjIiIiUjgWfEREREQKx4KPiIiISOFY8BFVQ0IIe4dAREQK4mzvAIiotMDTpSUhK24TchNjIQoLoHLVwiM8Ct7t+0ET3BgqlcreYRIRkYNiwUdkZ6KkGOkbliHn2E5ArQYkqbS9sAA5J3Yj5/if8GwZg4D+E6By4keWiIgsx0O6RHYkhPi32NtV2vBvsfdfh9LXOUd3IX3jMh7qJSKiSmHBR2RHurSk0j17qKiQE8g5uhO6tCTbB0VERIrDgo/IjrLiNpUexpVDrUZW/GbbBkRERIrEgo/IjnITY40P45ojSchN2G/bgIiISJFY8BHZiRACorDAsmkKC3geHxERWYwFH5GdqFQqqFy1lk3jquXtWYiIyGIs+IjsyCM8yqJz+Dwiom0bEBERKRILPiI78m7fz6Jz+Lzb9bVtQEREpEgs+IjsSBPcGJ4tYgBUdJhWBc+WMdAEN74DURERkdKw4COyI5VKhYABE+DZsltpw+2Hd/997dmyW+mTNnj+HhERVQKf00RkZyonZwQMnATvtn2QFb8ZuQn7/3uWbkQ0vNv15bN0iYioSljwEVUDKpUK2jrh0NYJB1B6yxYWeEREZC08pEtUDbHYIyIia2LBR0RERKRwLPiIiIiIFI4FHxEREZHCseAjIiIiUjgWfEREREQKx4KPiIiISOFY8BEREREpHAs+IiIiIoVjwUdERESkcCz4iIiIiBSOBR8RERGRwrHgIyIiIlI4FnxERERECseCj4iIiKiShBD2DkEWZ3sHQEREROQohBDQpSUhK24TchNjIQoLoHLVwiM8Ct7t+0ET3BgqlcreYRphwUdEREQkgygpRvqGZcg5thNQqwFJKm0vLEDOid3IOf4nPFvGIKD/BKicqleJxUO6RERERBUQQvxb7O0qbfi32PuvQ+nrnKO7kL5xWbU71FttCr6PP/4YjRo1wltvvWXvUIiIiIgM6NKSSvfsoaJCTiDn6E7o0pJsH5QFqkXBd+jQIbz33nsoLi5Genq6vcMhIiIiMpAVt6n0MK4cajWy4jfbNiAL2b3gy8nJwfDhw/Hpp5/C19fX3uEQERERGclNjDU+jGuOJCE3Yb9tA7KQ3Qu+iRMnok+fPujbt6+9QyEiIiIyIoSAKCywbJrCgmp1Hp9dLyFZuXIlDh48iLi4ONnT6HQ66HQ6/eusrCwAgCRJkORW3tWcJEkQQihmfe4mzJ3jYu4cF3PnmBwtbypXrUVFn8pVW1ooWqHos8YY2a3gS0pKwosvvojt27dDq9XKnm7+/PmYO3euUXt6ejoKCiyrvqsrSZKQmZkJIQTUcs8XoGqBuXNczJ3jYu4ck6PlTR3aAiVn4/VX45ZLpYY6rCWuXr1qlWVnZ2dXeR4qYaf9jR999BGmTZuGOnXq6NtSU1Ph5uYGf39/JCQkwMnJyWg6U3v4QkNDcePGDXh7e9+R2G1NkiSkp6cjICDAIT4E9B/mznExd46LuXNMjpa3gouJuPz1LNn9g554G5o6ja2y7KysLPj5+SEzM7PStY7d9vA9/vjjRuftDR48GNHR0Zg1a5bJYg8ANBoNNBqNUbtarXaIDUYulUqluHW6WzB3jou5c1zMnWNypLy5hUTAs0XMv/fhK29fmQqeLbtBGxJutSduWGN87Fbw+fj4wMfHx6DN1dUVPj4+aNSokZ2iIiIiIjKmUqkQMGACoAJyju40eNIGAP1rz5bdSp+0Uc0er1a9nvtBREREVE2pnJwRMHASvNv2QVb8ZuQm7P/vWboR0fBu15fP0pXjt99+g5ubm73DICIiIjJJpVJBWycc2jrhAEpv2VIdC7zbVauCLzQ01N4hEBEREcnmCMUeUA1uvExEREREtsWCj4iIiEjhWPARERERKRwLPiIiIiKFY8FHRERkhp0eRkVkddXqKl0iIiJ7EkJAl5aErLhNyE2M/e8ea+FR8G7fr9reY42oIiz4iIiIAIiSYqRvWIacYzsNnqIgCguQc2I3co7/Cc+WMaVPUXDin09yLDykS0REdz0hxL/F3q7ShlsfmQUAovR1ztFdSN+4jId6yeGw4CMiorueLi2pdM8eKirkBHKO7oQuLcn2QRFZEQs+IiK662XFbSo9jCuHWo2s+M22DYjIyljwERHRXS83Mdb4MK45koTchP22DYjIyljwERHRXU0IAVFYYNk0hQU8j48cCgs+IiK6q6lUKqhctZZN46rl7VnIobDgIyKiu55HeJRF5/B5RETbNiAiK2PBR0REdz3v9v0sOofPu11f2wZEZGUs+IiI6K6nCW4MzxYxACo6TKuCZ8sYaIIb34GoiKyHBR8REd31VCoVAgZMgGfLbqUNtx/e/fe1Z8tupU/a4Pl75GD4bBgiIiIAKidnBAycBO+2fZAVvxm5Cfv/e5ZuRDS82/Xls3TJYbHgIyIi+pdKpYK2Tji0dcIBlN6yhQUeKQEP6RIREZnBYo+UggUfERERkcKx4CMiIiJSOBZ8RERERArHgo+IiIhI4VjwERERESkcCz4iIiIihXP4+/AJIQAAWVlZdo7EeiRJQnZ2NrRaLdRyH+ZN1QJz57iYO8fF3Dkm5k2+shqnrOapDIcv+LKzswEAoaGhdo6EiIiIyHays7Ph4+NTqWlVoirlYjUgSRLS0tLg5eWlmBtkZmVlITQ0FKmpqfD29rZ3OGQB5s5xMXeOi7lzTMybfEIIZGdnIzg4uNJ7Qx1+D59arUZISIi9w7AJb29vfggcFHPnuJg7x8XcOSbmTZ7K7tkrw4PmRERERArHgo+IiIhI4VjwVUMajQZz5syBRqOxdyhkIebOcTF3jou5c0zM253l8BdtEBEREVH5uIePiIiISOFY8BEREREpHAs+IiIiIoVjwVdN5eXlYffu3UhMTLR3KGSB3NxcHDx4EOnp6fYOhSxw48YNHDp0CImJiSguLrZ3OFSOw4cPIz4+3uz7xcXFOHLkCE6cOFGlx1CRdRUUFGDv3r04f/682T4XL17E0aNHkZOTc+cCu4uw4Kumxo8fj27dumHevHn2DoVkmjdvHgIDAzF69GhERUVh0qRJ9g6JKiBJEiZMmIA6depgzJgx6NmzJxo0aIBt27bZOzS6zccff4zIyEh0794dw4YNM9knNjYW9evXx6BBg9CjRw80adIE//zzzx2OlG6VkZGBF198EQ0aNEDPnj3x0UcfGfXZsGEDWrVqhejoaDz22GMIDAzEq6++aodolY0FXzX0zTffIDExEV26dLF3KCTTO++8g0WLFmHHjh04cuQIzp07h+bNm6OkpMTeoVE5Vq9ejc8//xx///03Dh06hOTkZPTq1QtPPPGEvUOj25w9exarVq3C888/b/J9nU6HBx98EP3790dKSgrS0tLQpEkTs8Uh3RnJyckIDg7GsWPHEB4ebrLPuXPn8N133+HChQs4evQotmzZgvfeew/ff//9HY5W2VjwVTNJSUmYPn06vv32Wzg7O/yT7+4K+fn5mD9/Pl566SV06NBB3z5+/Hg4OTnZMTKqSHp6Ojw8PNCyZUsAgEqlQqdOnXD9+nVIkmTn6OhWixYtQvPmzc2+v2XLFly4cAGzZ88GUPrYzVdeeQVHjx5FXFzcnQqTbtOuXTu8+OKLqFmzptk+kyZNMsht586d0bJlS+zevftOhHjXYMFXjRQWFmLYsGF466230KhRI3uHQzLFxcUhMzMTgwYNwuXLl3Hw4EHcvHnT3mGRDI8++igaNGiAp556Clu2bMH333+PBQsWYP78+ZV+QDnZx6FDhxAYGGjwbPX27dtDpVLh0KFDdoyMLJWZmYmkpCT+HbQy7kKqRqZNm4b69etjzJgx9g6FLJCWlgYAWLlyJX788UcEBgYiISEBTz31FJYuXQqVSmXnCMkcPz8/TJ48GS+//DLi4uJw7do1NG7cGIMGDbJ3aGSh69evG+1FcnJygq+vL65fv26nqKgyxo8fD09PT4wePdreoSgKC75qYs+ePfjiiy/w448/6ndjZ2ZmwsnJCbt370Z0dDRcXFzsHCWZUpaXM2fOIDk5Ga6urjh06BA6deqE1q1bY+zYsXaOkMxZuXIlnnvuOezduxetWrWCJEl44YUX0L17dyQkJMDNzc3eIZJMLi4uKCgoMGovKCiAq6urHSKiypgyZQo2b96M7du3w8/Pz97hKAqPWVQTBQUFaNu2Ld59913MmDEDM2bMQFJSEg4dOoQZM2YgOzvb3iGSGfXq1QMAjB49Wv+HpU2bNoiOjsZff/1lx8ioIuvXr8e9996LVq1aASg972vChAlITU3lYUAHU7duXVy5csXgQqnr168jPz8fYWFhdoyM5Jo2bRpWrFiBrVu3ok2bNvYOR3G4h6+a6NGjB3r06GHQ1rNnT9SuXRvffvutnaIiOVq1aoXatWvj4sWL+jYhBNLS0hAVFWXHyKgiAQEBOHXqFIQQ+kPvqamp+vfIcfTs2RO5ubnYtm0bevfuDQBYt24dXFxc0K1bNztHRxWZPn06vvjiC2zduhXt27e3dziKxIKPqIqcnJzwzjvvYOrUqXB2dkb9+vXx3Xff4erVq5gwYYK9w6NyPPPMM1i+fDlGjRqFRx99FFevXsWcOXPQt29fnjBezRw7dgyZmZlISUlBQUGB/tSXqKgouLq6okmTJhg9ejTGjh2LBQsWoKCgAC+99BKmTZsGf39/O0d/9youLsa+ffsAlN6Y/uLFi9i9eze8vLz0e9bnzZuHhQsXYtGiRdDpdPrc1qxZE02bNrVb7EqjErwVebU1ZcoU1KhRQ3+bAareNm7ciK+++gpZWVlo0qQJpkyZoj/cS9XXyZMn8cknnyApKQleXl7o0qULnnnmGWi1WnuHRreYOHEijh49atS+du1a/d7Y4uJifPTRR9i8eTOcnZ0xZMgQjB07lhdO2VFmZiYGDBhg1N6kSRP83//9H4DSH14nTpww6tO1a1e8/fbbNo/xbsGCj4iIiEjheNEGERERkcKx4CMiIiJSOBZ8RERERArHgo+IiIhI4VjwERERESkcCz4iIiIihWPBR0RERKRwLPiIiGQ4cuRIlZ+ve+rUKezfv99KERERyceCj4ioArm5uRg0aBCKi4urNB9XV1cMHDgQ6enpVoqMiEgeFnxERBX48MMP0bRpU3To0KFK82nYsCF69eqFBQsWWCkyIiJ5WPAR0V1l3bp1OHjwoEHbgQMH8Ntvv5nsL4TAJ598glGjRunbkpKSsHHjRhQVFSE+Ph6//vor0tLSAABFRUXYtWsXNm7ciOvXrxvN7/HHH8fy5ctRUFBgvZUiIqqAs70DICK6k5KTkzFq1CgcOXIEYWFhOHPmDHr06IGFCxea7H/kyBGkpqaie/fu+rbff/8db775Jvz9/REYGIicnBwcPXoUH330Ed5//30EBwfjxo0bSElJwZ49e9C4cWP9tF27dkVOTg52796Nnj172nx9iYgA7uEjorvM5MmT0bFjRzz++OPQ6XQYOXIk7rvvPowbN85k/4MHD6JGjRqoXbu2QfuVK1fw5ptvYtu2bdi/fz969uyJp556CosWLcLWrVsRFxeHyMhILF682GA6Dw8P1K9fHwcOHLDZOhIR3Y4FHxHdVVQqFVasWIF//vkHHTp0QEpKCv7v//7PbP+MjAz4+fkZtdeqVQtDhgzRv+7YsSPCwsLQt29fg7bExESjaf38/JCRkVG1FSEisgALPiK66wQGBmLSpEk4duwYZs+eDX9/f7N9PT09kZuba9R+exGo0WhMtpk6Vy83NxdeXl6VjJ6IyHIs+IjornPhwgUsXrwYzZo1w/vvv4+cnByzfcPDw5Genm6y6KsMSZKQkpKCiIgIq8yPiEgOFnxEdFeRJAlPPPEEoqKiEBsbC2dnZzz//PNm+99zzz1wdXXFvn37rLL8o0ePIjc31+AiECIiW2PBR0R3lYULF+LYsWP46quv4OHhge+//x7ffvst1qxZY7K/u7s7RowYgR9++MEqy1+1ahUGDhxodBEIEZEtseAjortGVlYWTpw4gW+++QZBQUEAgDZt2uDTTz/F9u3bUVJSYnK6GTNmYM2aNbh69SqA0sO8AwYMMOjTpEkTgws2AKB58+YGt17Jzc3FihUrMGvWLGuuFhFRhVRCCGHvIIiIqrtPPvkEwcHBBlfmWmrHjh3Yt28fZs6cab3AiIhkYMFHREREpHA8pEtERESkcCz4iIiIiBSOBR8RERGRwrHgIyIiIlI4FnxERERECseCj4iIiEjhWPARERERKRwLPiIiIiKFY8FHREREpHAs+IiIiIgUjgUfERERkcL9P8etkZdwjootAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x640 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from robot_sf.render.jsonl_playback import JSONLPlaybackLoader\n",
+    "\n",
+    "episode, map_def = JSONLPlaybackLoader().load_single_episode(stable_jsonl)\n",
+    "states = episode.states\n",
+    "print(f\"Loaded {len(states)} recorded states.\")\n",
+    "\n",
+    "robot_path = np.array([s.robot_pose[0] for s in states])\n",
+    "# Final pedestrian positions (last recorded frame).\n",
+    "final_peds = states[-1].pedestrian_positions\n",
+    "\n",
+    "_inline_matplotlib()\n",
+    "fig, ax = plt.subplots(figsize=(6.4, 6.4))\n",
+    "ax.plot(robot_path[:, 0], robot_path[:, 1], \"-\", color=\"#4C72B0\", linewidth=2, label=\"Robot path\")\n",
+    "ax.plot(robot_path[0, 0], robot_path[0, 1], \"o\", color=\"green\", markersize=9, label=\"Start\")\n",
+    "ax.plot(robot_path[-1, 0], robot_path[-1, 1], \"s\", color=\"red\", markersize=9, label=\"End\")\n",
+    "if final_peds.size:\n",
+    "    ax.scatter(final_peds[:, 0], final_peds[:, 1], c=\"#DD8452\", s=70, label=\"Pedestrians (last frame)\", zorder=5)\n",
+    "ax.set_aspect(\"equal\")\n",
+    "ax.set_xlabel(\"x (m)\")\n",
+    "ax.set_ylabel(\"y (m)\")\n",
+    "ax.set_title(f\"Episode trace: {SCENARIO_NAME} (random, seed={SEED})\")\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "ax.legend(loc=\"best\")\n",
+    "fig.tight_layout()\n",
+    "plot_path = OUTPUT_DIR / \"trace_trajectory.png\"\n",
+    "fig.savefig(plot_path, dpi=120)\n",
+    "print(\"Saved:\", plot_path.relative_to(REPO_ROOT))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d3f0bec",
+   "metadata": {},
+   "source": [
+    "## 3. Render a top-down map thumbnail\n",
+    "\n",
+    "We reuse the map visualizer that the one-command demo uses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2e2c7033",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-15T23:25:20.211835Z",
+     "iopub.status.busy": "2026-07-15T23:25:20.211757Z",
+     "iopub.status.idle": "2026-07-15T23:25:20.253701Z",
+     "shell.execute_reply": "2026-07-15T23:25:20.253152Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved: output/notebooks/03_visualize_trace/map_thumbnail.png\n"
+     ]
+    }
+   ],
+   "source": [
+    "from robot_sf.maps.map_visualizer import visualize_map_definition\n",
+    "\n",
+    "thumbnail_path = OUTPUT_DIR / \"map_thumbnail.png\"\n",
+    "visualize_map_definition(map_def, output_path=thumbnail_path, title=f\"{SCENARIO_NAME} (random)\")\n",
+    "print(\"Saved:\", thumbnail_path.relative_to(REPO_ROOT))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dda16f2",
+   "metadata": {},
+   "source": [
+    "## 4. Export the interactive browser viewer\n",
+    "\n",
+    "`export_threejs_viewer` turns the JSONL recording into a static\n",
+    "`index.html` Three.js scene you can open in any browser (no server\n",
+    "needed). Run the cell, then open the printed path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "025f8860",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-15T23:25:20.255034Z",
+     "iopub.status.busy": "2026-07-15T23:25:20.254966Z",
+     "iopub.status.idle": "2026-07-15T23:25:20.567231Z",
+     "shell.execute_reply": "2026-07-15T23:25:20.566776Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Open this file in a browser to watch the recording:\n",
+      "   output/notebooks/03_visualize_trace/viewer/index.html\n",
+      "Viewer files: ['index.html', 'scene.json', 'viewer.js']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from robot_sf.render.threejs_viewer import export_threejs_viewer\n",
+    "\n",
+    "viewer_dir = OUTPUT_DIR / \"viewer\"\n",
+    "result = export_threejs_viewer(stable_jsonl, viewer_dir)\n",
+    "print(\"Open this file in a browser to watch the recording:\")\n",
+    "try:\n",
+    "    viewer_rel = Path(result.html_path).relative_to(REPO_ROOT)\n",
+    "except ValueError:\n",
+    "    viewer_rel = Path(result.html_path)\n",
+    "print(\"  \", viewer_rel)\n",
+    "print(\"Viewer files:\", sorted(p.name for p in viewer_dir.iterdir()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "749bbcbf",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "Artifacts written under `output/notebooks/03_visualize_trace/`:\n",
+    "\n",
+    "| File | What it is |\n",
+    "| --- | --- |\n",
+    "| `episode.jsonl` | The recorded per-step simulation states |\n",
+    "| `trace_trajectory.png` | Robot path + pedestrians (matplotlib) |\n",
+    "| `map_thumbnail.png` | Top-down map thumbnail |\n",
+    "| `viewer/index.html` | Interactive Three.js browser viewer |\n",
+    "\n",
+    "You have now run an episode, **and** seen it three ways. These three\n",
+    "notebooks together form the beginner quickstart: **run → compare →\n",
+    "visualize**."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,61 @@
+# Robot SF — Beginner Notebook Quickstarts
+
+Three short, **CPU-only, deterministic** notebooks that take you from *install →
+run → see something* in a few minutes. No GPU, no training, no model weights.
+
+> Part of the adoption/UX epic (#5791); see [Issue #5798](https://github.com/ll7/robot_sf_ll7/issues/5798).
+
+## Run a notebook
+
+From the repository root:
+
+```bash
+# Option A — execute a notebook in place and render its plots
+uv run jupyter notebook notebooks/01_run_first_episode.ipynb
+
+# Option B — run all three headless (the CI smoke path)
+uv run python scripts/validation/run_notebooks_smoke.py
+```
+
+Each notebook writes its small artifacts under `output/notebooks/` (which is
+git-ignored), so the repository stays clean.
+
+## The three notebooks
+
+| # | Notebook | What you learn | Artifact(s) under `output/notebooks/` |
+| --- | --- | --- | --- |
+| 01 | [`01_run_first_episode.ipynb`](./01_run_first_episode.ipynb) | Build an environment, step it with a random policy, read & plot the reward | `01_run_first_episode/reward_curve.png` |
+| 02 | [`02_compare_two_planners.ipynb`](./02_compare_two_planners.ipynb) | Run the **same scenario** with two different planners (`simple_policy` vs `random`) and compare metrics | `02_compare_two_planners/planner_comparison.png`, `comparison_summary.json` |
+| 03 | [`03_visualize_trace.ipynb`](./03_visualize_trace.ipynb) | Record an episode to JSONL and **see** it three ways: a trajectory plot, a map thumbnail, and an interactive browser viewer | `03_visualize_trace/trace_trajectory.png`, `map_thumbnail.png`, `viewer/index.html`, `episode.jsonl` |
+
+The notebooks only call **existing** env/planner/trace APIs — they add no new
+simulation logic:
+
+- [`robot_sf.gym_env.environment_factory.make_robot_env`](../robot_sf/gym_env/environment_factory.py)
+- [`robot_sf.benchmark.runner.run_episode`](../robot_sf/benchmark/runner.py)
+- [`robot_sf.render.threejs_viewer.export_threejs_viewer`](../robot_sf/render/threejs_viewer.py)
+
+## Reproducibility & scope
+
+- **Deterministic.** Every notebook fixes its seed, so re-running reproduces the
+  same outputs on a clean CPU checkout.
+- **Teaching, not benchmarking.** Notebook 02 compares two planners over a single
+  short episode for one seed. It is an illustration, **not** a benchmark result —
+  rigorous evaluation needs many seeds/scenarios via the benchmark tooling under
+  `scripts/benchmark*`.
+
+## Regenerating the notebooks
+
+The notebooks are generated from a single readable script so their structure
+stays in sync:
+
+```bash
+uv run python scripts/dev/generate_quickstart_notebooks.py
+```
+
+## CI
+
+The notebooks are exercised headless on every PR via
+`scripts/dev/ci_driver.sh notebooks-smoke` (see
+[`scripts/validation/run_notebooks_smoke.py`](../scripts/validation/run_notebooks_smoke.py)
+and the `examples-smoke` job in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)).

--- a/scripts/dev/ci_driver.sh
+++ b/scripts/dev/ci_driver.sh
@@ -12,6 +12,7 @@ Phases:
   typecheck        Ty type check (advisory; reports findings but exits zero)
   test             Main pytest suite, excluding example smoke tests
   examples-smoke   Example script smoke tests
+  notebooks-smoke  Quickstart notebook smoke tests (nbconvert)
   smoke            Validation and benchmark smoke checks
   artifact-policy  Canonical artifact root policy guard
 
@@ -35,7 +36,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./common_setup.sh
 source "$SCRIPT_DIR/common_setup.sh"
 
-readonly PHASES=("lint" "typecheck" "test" "examples-smoke" "smoke" "artifact-policy")
+readonly PHASES=("lint" "typecheck" "test" "examples-smoke" "notebooks-smoke" "smoke" "artifact-policy")
 
 list_phases() {
   printf "%s\n" "${PHASES[@]}"
@@ -213,6 +214,10 @@ run_examples_smoke_phase() {
   uv run python scripts/validation/run_examples_smoke.py --skip-perf-tests
 }
 
+run_notebooks_smoke_phase() {
+  uv run python scripts/validation/run_notebooks_smoke.py
+}
+
 run_fast_feedback_benchmark_reconciliation_guard() {
   local shard_count="${PYTEST_SHARD_COUNT:-1}"
   local shard_index="${PYTEST_SHARD_INDEX:-1}"
@@ -265,6 +270,9 @@ run_phase() {
       ;;
     examples-smoke)
       run_examples_smoke_phase
+      ;;
+    notebooks-smoke)
+      run_notebooks_smoke_phase
       ;;
     smoke)
       run_smoke_phase "$event_name" "$github_ref"

--- a/scripts/dev/generate_quickstart_notebooks.py
+++ b/scripts/dev/generate_quickstart_notebooks.py
@@ -1,0 +1,714 @@
+#!/usr/bin/env python3
+"""Generate the three CPU-only beginner quickstart notebooks for Issue #5798.
+
+Writes:
+    notebooks/01_run_first_episode.ipynb
+    notebooks/02_compare_two_planners.ipynb
+    notebooks/03_visualize_trace.ipynb
+
+Each notebook is headless (``SDL_VIDEODRIVER=dummy`` / ``MPLBACKEND=Agg`` set in
+its first code cell), deterministic (fixed seeds), and writes its small artifact
+under ``output/notebooks/``. The notebooks reuse existing env/planner/trace APIs
+and add no new simulation logic.
+
+Regenerate with:
+    uv run python scripts/dev/generate_quickstart_notebooks.py
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import nbformat as nbf
+
+ROOT = Path(__file__).resolve().parents[2]
+OUT_DIR = ROOT / "notebooks"
+
+
+def _dedent(src: str) -> str:
+    """Strip surrounding blank lines and common leading indentation.
+
+    Notebook source is written as indented triple-quoted strings inside this
+    generator; cells must be emitted as clean top-level code/markdown.
+    """
+    return textwrap.dedent(src).strip("\n")
+
+
+def _code(src: str) -> nbf.notebooknode:
+    return nbf.v4.new_code_cell(_dedent(src))
+
+
+def _md(src: str) -> nbf.notebooknode:
+    return nbf.v4.new_markdown_cell(_dedent(src))
+
+
+# --------------------------------------------------------------------------------------
+# Notebook 01: run a first episode
+# --------------------------------------------------------------------------------------
+def build_notebook_01() -> nbf.notebooknode:
+    """Build the "run a first episode" notebook."""
+    nb = nbf.v4.new_notebook()
+    nb.metadata = {
+        "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+        "language_info": {"name": "python"},
+    }
+    cells = [
+        _md(
+            """
+            # 01 — Run your first Robot SF episode
+
+            This notebook runs a short, **fully deterministic** episode in a Robot SF
+            navigation environment using a random policy, then plots the per-step reward.
+
+            **You will learn how to:**
+            1. Build a robot navigation environment with the factory function.
+            2. Reset it and step it with random actions.
+            3. Read the reward signal and plot it with matplotlib.
+
+            > CPU-only, headless, no rendering window, no training. Runs in a few seconds.
+            >
+            > It mirrors the canonical example at
+            > `examples/quickstart/01_basic_robot.py`.
+            """
+        ),
+        _code(
+            """
+            # Headless setup: no GUI window. We deliberately do NOT force a matplotlib
+            # backend here, because several robot_sf modules call matplotlib.use("Agg",
+            # force=True) at import time and would clobber an inline backend set now.
+            # Instead each plotting cell re-enables the inline backend right before it
+            # draws, so figures still render into the notebook output under nbconvert.
+            import os
+            import sys
+            from IPython import get_ipython
+
+            os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+
+            def _inline_matplotlib() -> None:
+                # (Re-)arm the notebook inline backend for the next figure.
+                ip = get_ipython()
+                if ip is not None:
+                    ip.run_line_magic("matplotlib", "inline")
+
+
+            # Keep log output quiet so the executed notebook stays readable.
+            from loguru import logger
+            logger.remove()
+            logger.add(sys.stderr, level="ERROR")
+
+            from pathlib import Path
+
+            import matplotlib.pyplot as plt
+
+            from robot_sf.common.seed import set_global_seed
+            from robot_sf.gym_env.environment_factory import make_robot_env
+
+            # Resolve the repo root robustly regardless of the working directory this
+            # notebook is launched from (repo root, or its own notebooks/ folder).
+            def _repo_root() -> Path:
+                here = Path.cwd()
+                for candidate in [here, *here.parents]:
+                    if (candidate / "pyproject.toml").exists():
+                        return candidate
+                return here
+
+            REPO_ROOT = _repo_root()
+
+            # Where this notebook writes its small artifact (git-ignored).
+            OUTPUT_DIR = REPO_ROOT / "output/notebooks/01_run_first_episode"
+            OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+            print("Repo root:", REPO_ROOT)
+            print("Artifacts will be written to:", OUTPUT_DIR.relative_to(REPO_ROOT))
+            """
+        ),
+        _md(
+            "## 1. Build and reset the environment\n\n`make_robot_env()` is the ergonomic entry point. We seed everything for reproducibility."
+        ),
+        _code(
+            """
+            SEED = 87234
+            set_global_seed(SEED)
+
+            env = make_robot_env(debug=False)
+            observation, info = env.reset()
+            print("Environment created and reset.")
+            print("Observation type:", type(observation).__name__)
+            if hasattr(observation, "keys"):
+                print("Observation keys:", list(observation.keys()))
+            print("Action space:", env.action_space)
+            """
+        ),
+        _md(
+            """
+            ## 2. Step the environment with random actions
+
+            Each call to `env.step(action)` returns the Gymnasium 5-tuple
+            `(observation, reward, terminated, truncated, info)`. We collect the
+            reward at every step. If the episode ends early (collision or success),
+            we reset and keep going so the budget is filled.
+            """
+        ),
+        _code(
+            """
+            N_STEPS = 60
+            rewards = []
+            collisions = 0
+
+            for step in range(1, N_STEPS + 1):
+                action = env.action_space.sample()  # random policy
+                observation, reward, terminated, truncated, info = env.step(action)
+                rewards.append(float(reward))
+                if bool(info.get("collision")):
+                    collisions += 1
+                if terminated or truncated:
+                    observation, info = env.reset()
+
+            print(f"Stepped {N_STEPS} times.")
+            print(f"Total reward: {sum(rewards):.3f}")
+            print(f"Collisions: {collisions}")
+            """
+        ),
+        _md(
+            "## 3. Plot the reward over time\n\nWe save the figure to `output/` and also display it inline."
+        ),
+        _code(
+            """
+            _inline_matplotlib()
+            fig, ax = plt.subplots(figsize=(8, 3.2))
+            ax.plot(range(1, N_STEPS + 1), rewards, marker=".", linewidth=1)
+            ax.axhline(0.0, color="black", linewidth=0.6, alpha=0.5)
+            ax.set_xlabel("Simulation step")
+            ax.set_ylabel("Reward")
+            ax.set_title(f"Per-step reward (random policy, seed={SEED})")
+            ax.grid(True, alpha=0.3)
+            fig.tight_layout()
+
+            plot_path = OUTPUT_DIR / "reward_curve.png"
+            fig.savefig(plot_path, dpi=120)
+            print("Saved:", plot_path.relative_to(REPO_ROOT))
+            plt.show()
+            """
+        ),
+        _md(
+            """
+            ## Done
+
+            You built an environment, ran a deterministic episode, and inspected the
+            reward signal. Next, try **02 — Compare two planners** to see how two
+            different navigation strategies behave, or **03 — Visualize a trace** to
+            watch an episode as an interactive viewer + trajectory plot.
+            """
+        ),
+        _code(
+            """
+            # Always release the environment's resources when finished.
+            env.exit()
+            print("Environment closed. Notebook 01 complete.")
+            """
+        ),
+    ]
+    nb.cells = cells
+    return nb
+
+
+# --------------------------------------------------------------------------------------
+# Notebook 02: compare two planners
+# --------------------------------------------------------------------------------------
+def build_notebook_02() -> nbf.notebooknode:
+    """Build the "compare two planners" notebook."""
+    nb = nbf.v4.new_notebook()
+    nb.metadata = {
+        "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+        "language_info": {"name": "python"},
+    }
+    cells = [
+        _md(
+            """
+            # 02 — Compare two planners
+
+            This notebook runs the **same scenario** with **two different planners**
+            and compares their outcomes side by side.
+
+            The two planners are:
+
+            - **`simple_policy`** — a built-in goal-seeking policy that steers the
+              robot toward its goal.
+            - **`random`** — a random policy that ignores the goal (a control/baseline).
+
+            We reuse the benchmark episode runner
+            (`robot_sf.benchmark.runner.run_episode`), which loads each planner from
+            the baseline registry, builds observations, translates actions, and
+            computes a rich metrics dictionary. **No new logic is added** — we only
+            call the existing public API and chart the results.
+
+            > CPU-only, deterministic (fixed seed), no model weights required.
+            >
+            > The metrics here are a small illustrative sample for a single seed —
+            > they are **not** a benchmark result.
+            """
+        ),
+        _code(
+            """
+            import os
+            import sys
+            from IPython import get_ipython
+
+            os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+
+            def _inline_matplotlib() -> None:
+                # (Re-)arm the notebook inline backend for the next figure.
+                ip = get_ipython()
+                if ip is not None:
+                    ip.run_line_magic("matplotlib", "inline")
+
+
+            # Keep log output quiet so the executed notebook stays readable.
+            from loguru import logger
+            logger.remove()
+            logger.add(sys.stderr, level="ERROR")
+
+            from pathlib import Path
+
+            import matplotlib.pyplot as plt
+            import numpy as np
+
+            from robot_sf.training.scenario_loader import load_scenarios
+            from robot_sf.benchmark.runner import run_episode
+            from robot_sf.baselines import list_baselines
+
+            # Resolve the repo root robustly regardless of launch directory.
+            def _repo_root() -> Path:
+                here = Path.cwd()
+                for candidate in [here, *here.parents]:
+                    if (candidate / "pyproject.toml").exists():
+                        return candidate
+                return here
+
+            REPO_ROOT = _repo_root()
+
+            OUTPUT_DIR = REPO_ROOT / "output/notebooks/02_compare_two_planners"
+            OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+            print("Repo root:", REPO_ROOT)
+            print("Artifacts will be written to:", OUTPUT_DIR.relative_to(REPO_ROOT))
+            """
+        ),
+        _md(
+            "## 1. Load the shared scenario\n\nWe use the bundled `quickstart_demo_crossing_basic` scenario so both planners face the identical situation."
+        ),
+        _code(
+            """
+            SCENARIO_PATH = REPO_ROOT / "configs/scenarios/single/quickstart_demo.yaml"
+            SCENARIO_NAME = "quickstart_demo_crossing_basic"
+
+            scenarios = load_scenarios(SCENARIO_PATH)
+            scenario = next(s for s in scenarios if s["name"] == SCENARIO_NAME)
+            print("Loaded scenario:", scenario["name"])
+            print("Map file:", scenario.get("map_file"))
+            print("Registered baseline planners:", sorted(list_baselines()))
+            print("(plus the built-in goal-seeker known as 'simple_policy' / 'goal')")
+            """
+        ),
+        _md(
+            """
+            ## 2. Run each planner for one episode
+
+            `run_episode` returns a record whose `metrics` dictionary contains the
+            quantities we compare. We keep the horizon short so the notebook stays
+            fast.
+            """
+        ),
+        _code(
+            """
+            SEED = 270
+            HORIZON = 60
+            DT = 0.1
+            PLANNERS = ["simple_policy", "random"]
+
+            records = {}
+            for algo in PLANNERS:
+                rec = run_episode(scenario, SEED, horizon=HORIZON, dt=DT, algo=algo)
+                records[algo] = rec
+                m = rec["metrics"]
+                print(
+                    f"{algo:>14s}: steps={rec['steps']:>3d}  "
+                    f"collisions={int(m['collisions']):>2d}  "
+                    f"avg_speed={float(m['avg_speed']):.3f}  "
+                    f"path_length={float(m['socnavbench_path_length']):.2f}  "
+                    f"success={bool(m['success'])}"
+                )
+            """
+        ),
+        _md(
+            """
+            ## 3. Compare key metrics
+
+            We chart four beginner-friendly metrics for both planners:
+
+            | Metric | Meaning |
+            | --- | --- |
+            | `collisions` | Number of pedestrian/obstacle collisions in the episode |
+            | `avg_speed` | Mean robot speed (m/s) |
+            | `socnavbench_path_length` | Total path length travelled (m) |
+            | `path_efficiency` | Ratio of straight-line to actual path (1.0 = perfectly direct) |
+            """
+        ),
+        _code(
+            """
+            metric_keys = ["collisions", "avg_speed", "socnavbench_path_length", "path_efficiency"]
+            metric_labels = ["Collisions", "Avg speed (m/s)", "Path length (m)", "Path efficiency"]
+
+            values = np.array(
+                [[float(records[a]["metrics"][k]) for k in metric_keys] for a in PLANNERS],
+                dtype=float,
+            )
+
+            _inline_matplotlib()
+            fig, axes = plt.subplots(1, len(metric_keys), figsize=(13, 3.4))
+            x = np.arange(len(PLANNERS))
+            for j, (ax, label) in enumerate(zip(axes, metric_labels)):
+                ax.bar(x, values[:, j], color=["#4C72B0", "#DD8452"])
+                ax.set_xticks(x)
+                ax.set_xticklabels(PLANNERS, rotation=20, ha="right")
+                ax.set_title(label)
+                ax.grid(True, axis="y", alpha=0.3)
+                for xi, vi in zip(x, values[:, j]):
+                    ax.text(xi, vi, f"{vi:.2f}", ha="center", va="bottom", fontsize=9)
+            fig.suptitle(f"Two planners on the same scenario (seed={SEED}, horizon={HORIZON})", y=1.04)
+            fig.tight_layout()
+            plot_path = OUTPUT_DIR / "planner_comparison.png"
+            fig.savefig(plot_path, dpi=120, bbox_inches="tight")
+            print("Saved:", plot_path.relative_to(REPO_ROOT))
+            plt.show()
+            """
+        ),
+        _md(
+            """
+            ## 4. Summary table
+
+            A compact, machine-readable comparison written to `output/` alongside the
+            figure.
+            """
+        ),
+        _code(
+            """
+            import json
+
+            summary = {
+                "schema_version": "robot_sf_notebook_02_planner_compare.v1",
+                "scenario": SCENARIO_NAME,
+                "seed": SEED,
+                "horizon": HORIZON,
+                "dt": DT,
+                "claim_boundary": (
+                    "Single-seed illustrative comparison for a beginner notebook; "
+                    "not a benchmark result."
+                ),
+                "planners": {
+                    algo: {
+                        k: records[algo]["metrics"][k] for k in metric_keys
+                    }
+                    for algo in PLANNERS
+                },
+            }
+            summary_path = OUTPUT_DIR / "comparison_summary.json"
+            summary_path.write_text(json.dumps(summary, indent=2) + "\\n", encoding="utf-8")
+            print("Saved:", summary_path.relative_to(REPO_ROOT))
+            print(json.dumps(summary["planners"], indent=2))
+            """
+        ),
+        _md(
+            """
+            ## Interpretation
+
+            - The **goal-seeker** (`simple_policy`) usually travels further and faster
+              because it actively aims for the goal — but on a crowded map it may
+              collide with pedestrians along the way.
+            - The **random** planner wanders without purpose, so it tends to stall,
+              cover less ground, and time out — but without committing to a direction
+              it may also happen to avoid collisions.
+
+            The exact numbers depend on the seed and the single short horizon; this is
+            a teaching comparison, not a rigorous evaluation. To draw real conclusions
+            you would repeat over many seeds and scenarios (see the benchmark tooling
+            under `scripts/benchmark*`).
+
+            Next: **03 — Visualize a trace**.
+            """
+        ),
+    ]
+    nb.cells = cells
+    return nb
+
+
+# --------------------------------------------------------------------------------------
+# Notebook 03: visualize a trace
+# --------------------------------------------------------------------------------------
+def build_notebook_03() -> nbf.notebooknode:
+    """Build the "visualize a trace" notebook."""
+    nb = nbf.v4.new_notebook()
+    nb.metadata = {
+        "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+        "language_info": {"name": "python"},
+    }
+    cells = [
+        _md(
+            """
+            # 03 — Visualize an episode trace
+
+            This notebook records one deterministic episode to disk (JSONL), then
+            produces **three artifacts** that let you *see* what happened:
+
+            1. A **2D trajectory plot** (robot path + pedestrian positions) via matplotlib.
+            2. A **top-down map thumbnail** (PNG).
+            3. An **interactive Three.js browser viewer** (open `index.html`).
+
+            It reuses the exact recording + playback + viewer pipeline that powers
+            `uv run robot-sf demo` (see `scripts/demo/quickstart_demo.py`) — no new
+            logic, only the existing public APIs.
+
+            > CPU-only, headless, deterministic (fixed seed).
+            """
+        ),
+        _code(
+            """
+            import os
+            import sys
+            from IPython import get_ipython
+
+            os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+
+            def _inline_matplotlib() -> None:
+                # (Re-)arm the notebook inline backend for the next figure.
+                ip = get_ipython()
+                if ip is not None:
+                    ip.run_line_magic("matplotlib", "inline")
+
+
+            # Keep log output quiet so the executed notebook stays readable.
+            from loguru import logger
+            logger.remove()
+            logger.add(sys.stderr, level="ERROR")
+
+            from pathlib import Path
+
+            import matplotlib.pyplot as plt
+            import numpy as np
+
+            # Resolve the repo root robustly regardless of launch directory.
+            def _repo_root() -> Path:
+                here = Path.cwd()
+                for candidate in [here, *here.parents]:
+                    if (candidate / "pyproject.toml").exists():
+                        return candidate
+                return here
+
+            REPO_ROOT = _repo_root()
+
+            OUTPUT_DIR = REPO_ROOT / "output/notebooks/03_visualize_trace"
+            OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+            print("Repo root:", REPO_ROOT)
+            print("Artifacts will be written to:", OUTPUT_DIR.relative_to(REPO_ROOT))
+            """
+        ),
+        _md(
+            """
+            ## 1. Run one deterministic, recorded episode
+
+            We build the environment with JSONL recording enabled, drive it with the
+            bundled random planner at a fixed seed, and stop the recording when the
+            episode finishes. The per-step simulation states are written to a `.jsonl`
+            file we can replay.
+            """
+        ),
+        _code(
+            """
+            from robot_sf.gym_env.environment_factory import make_robot_env
+            from robot_sf.gym_env.robot_env import RobotEnv
+            from robot_sf.training.scenario_loader import load_scenarios, build_robot_config_from_scenario
+            from robot_sf.baselines.random_policy import RandomPlanner
+
+            SEED = 270
+            SCENARIO_NAME = "quickstart_demo_crossing_basic"
+            SCENARIO_PATH = REPO_ROOT / "configs/scenarios/single/quickstart_demo.yaml"
+
+            scenario = next(
+                s for s in load_scenarios(SCENARIO_PATH) if s["name"] == SCENARIO_NAME
+            )
+            config = build_robot_config_from_scenario(scenario, scenario_path=SCENARIO_PATH)
+
+            env: RobotEnv = make_robot_env(
+                config=config,
+                seed=SEED,
+                debug=False,
+                recording_enabled=True,
+                use_jsonl_recording=True,
+                recording_dir=str(OUTPUT_DIR / "recordings"),
+                suite_name="notebook",
+                scenario_name=SCENARIO_NAME,
+                algorithm_name="random",
+                recording_seed=SEED,
+            )
+
+            planner = RandomPlanner({"mode": "velocity", "v_max": 1.5}, seed=SEED)
+            env.reset(seed=SEED)
+            planner.reset(seed=SEED)
+
+            steps = 0
+            terminated = truncated = False
+            while not truncated:
+                decision = planner.step({"dt": 0.1, "robot": {}, "agents": []})
+                action = np.array([float(decision["vx"]), float(decision["vy"])], dtype=np.float32)
+                _obs, _reward, terminated, truncated, _info = env.step(action)
+                steps += 1
+                if terminated:
+                    break
+
+            env.end_episode_recording()
+            env.close_recorder()
+            env.exit()
+            print(f"Episode finished after {steps} steps.")
+            """
+        ),
+        _code(
+            """
+            # Locate the recorded JSONL (the recorder names it with suite/scenario/algorithm/seed).
+            candidates = sorted((OUTPUT_DIR / "recordings").glob("*.jsonl"))
+            episode_jsonl = candidates[-1]
+            # Promote a stable copy next to the other artifacts.
+            stable_jsonl = OUTPUT_DIR / "episode.jsonl"
+            stable_jsonl.write_bytes(episode_jsonl.read_bytes())
+            print("Recorded episode:", episode_jsonl.name)
+            print("Stable copy:", stable_jsonl.relative_to(REPO_ROOT))
+            """
+        ),
+        _md(
+            """
+            ## 2. Load the recording and plot the trajectory
+
+            `JSONLPlaybackLoader` reads the JSONL back into a list of visualizable
+            states. Each state exposes the robot pose and the pedestrian positions, so
+            we can draw the robot's path and the pedestrians' final footprint.
+            """
+        ),
+        _code(
+            """
+            from robot_sf.render.jsonl_playback import JSONLPlaybackLoader
+
+            episode, map_def = JSONLPlaybackLoader().load_single_episode(stable_jsonl)
+            states = episode.states
+            print(f"Loaded {len(states)} recorded states.")
+
+            robot_path = np.array([s.robot_pose[0] for s in states])
+            # Final pedestrian positions (last recorded frame).
+            final_peds = states[-1].pedestrian_positions
+
+            _inline_matplotlib()
+            fig, ax = plt.subplots(figsize=(6.4, 6.4))
+            ax.plot(robot_path[:, 0], robot_path[:, 1], "-", color="#4C72B0", linewidth=2, label="Robot path")
+            ax.plot(robot_path[0, 0], robot_path[0, 1], "o", color="green", markersize=9, label="Start")
+            ax.plot(robot_path[-1, 0], robot_path[-1, 1], "s", color="red", markersize=9, label="End")
+            if final_peds.size:
+                ax.scatter(final_peds[:, 0], final_peds[:, 1], c="#DD8452", s=70, label="Pedestrians (last frame)", zorder=5)
+            ax.set_aspect("equal")
+            ax.set_xlabel("x (m)")
+            ax.set_ylabel("y (m)")
+            ax.set_title(f"Episode trace: {SCENARIO_NAME} (random, seed={SEED})")
+            ax.grid(True, alpha=0.3)
+            ax.legend(loc="best")
+            fig.tight_layout()
+            plot_path = OUTPUT_DIR / "trace_trajectory.png"
+            fig.savefig(plot_path, dpi=120)
+            print("Saved:", plot_path.relative_to(REPO_ROOT))
+            plt.show()
+            """
+        ),
+        _md(
+            "## 3. Render a top-down map thumbnail\n\nWe reuse the map visualizer that the one-command demo uses."
+        ),
+        _code(
+            """
+            from robot_sf.maps.map_visualizer import visualize_map_definition
+
+            thumbnail_path = OUTPUT_DIR / "map_thumbnail.png"
+            visualize_map_definition(map_def, output_path=thumbnail_path, title=f"{SCENARIO_NAME} (random)")
+            print("Saved:", thumbnail_path.relative_to(REPO_ROOT))
+            """
+        ),
+        _md(
+            """
+            ## 4. Export the interactive browser viewer
+
+            `export_threejs_viewer` turns the JSONL recording into a static
+            `index.html` Three.js scene you can open in any browser (no server
+            needed). Run the cell, then open the printed path.
+            """
+        ),
+        _code(
+            """
+            from robot_sf.render.threejs_viewer import export_threejs_viewer
+
+            viewer_dir = OUTPUT_DIR / "viewer"
+            result = export_threejs_viewer(stable_jsonl, viewer_dir)
+            print("Open this file in a browser to watch the recording:")
+            try:
+                viewer_rel = Path(result.html_path).relative_to(REPO_ROOT)
+            except ValueError:
+                viewer_rel = Path(result.html_path)
+            print("  ", viewer_rel)
+            print("Viewer files:", sorted(p.name for p in viewer_dir.iterdir()))
+            """
+        ),
+        _md(
+            """
+            ## Summary
+
+            Artifacts written under `output/notebooks/03_visualize_trace/`:
+
+            | File | What it is |
+            | --- | --- |
+            | `episode.jsonl` | The recorded per-step simulation states |
+            | `trace_trajectory.png` | Robot path + pedestrians (matplotlib) |
+            | `map_thumbnail.png` | Top-down map thumbnail |
+            | `viewer/index.html` | Interactive Three.js browser viewer |
+
+            You have now run an episode, **and** seen it three ways. These three
+            notebooks together form the beginner quickstart: **run → compare →
+            visualize**.
+            """
+        ),
+    ]
+    nb.cells = cells
+    return nb
+
+
+def main() -> int:
+    """Generate the three notebooks into ``notebooks/``."""
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    builders = {
+        "01_run_first_episode.ipynb": build_notebook_01,
+        "02_compare_two_planners.ipynb": build_notebook_02,
+        "03_visualize_trace.ipynb": build_notebook_03,
+    }
+    for name, builder in builders.items():
+        nb = builder()
+        path = OUT_DIR / name
+        nbf.write(nb, path)
+        try:
+            display = path.relative_to(ROOT)
+        except ValueError:
+            display = path
+        print(f"Wrote {display}")
+    print("Done. Validate with:")
+    print(
+        "  SDL_VIDEODRIVER=dummy uv run jupyter nbconvert --execute "
+        "notebooks/*.ipynb --to notebook --inplace"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/run_notebooks_smoke.py
+++ b/scripts/validation/run_notebooks_smoke.py
@@ -1,0 +1,131 @@
+"""Execute the CPU-only quickstart notebooks headless via nbconvert.
+
+This is the CI smoke for ``notebooks/`` (Issue #5798). It executes every
+``notebooks/*.ipynb`` top-to-bottom under a headless kernel
+(``SDL_VIDEODRIVER=dummy``) and fails closed if any cell errors or nbconvert
+exits non-zero.
+
+The notebooks themselves are deterministic and write their small artifacts under
+``output/notebooks/`` (git-ignored); this script only checks that they execute
+cleanly.
+
+Usage:
+    uv run python scripts/validation/run_notebooks_smoke.py
+    uv run python scripts/validation/run_notebooks_smoke.py --list
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NOTEBOOKS_DIR = REPO_ROOT / "notebooks"
+PER_NOTEBOOK_TIMEOUT = 600  # seconds; these are tiny CPU episodes
+
+
+def discover_notebooks() -> list[Path]:
+    """Return the sorted list of notebook paths under ``notebooks/``."""
+    if not NOTEBOOKS_DIR.is_dir():
+        return []
+    return sorted(NOTEBOOKS_DIR.glob("*.ipynb"))
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line options."""
+    parser = argparse.ArgumentParser(
+        description="Execute the CPU-only quickstart notebooks headless via nbconvert.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List the notebooks that would be executed without running them.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=PER_NOTEBOOK_TIMEOUT,
+        help=f"Per-notebook execution timeout in seconds (default: {PER_NOTEBOOK_TIMEOUT})",
+    )
+    return parser.parse_args(argv)
+
+
+def _headless_env() -> dict[str, str]:
+    """Return an environment forcing headless execution for the kernel."""
+    env = dict(os.environ)
+    # Headless SDL (no window) is required for any pygame/SDL code paths.
+    env.setdefault("SDL_VIDEODRIVER", "dummy")
+    # Do NOT set MPLBACKEND=Agg: the notebooks re-arm the inline backend per
+    # plotting cell; forcing Agg here would suppress inline figure output.
+    return env
+
+
+def run_notebook(notebook: Path, *, timeout: int) -> tuple[bool, str]:
+    """Execute a single notebook in-place headless. Returns (ok, summary)."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "jupyter",
+        "nbconvert",
+        "--to",
+        "notebook",
+        "--execute",
+        "--stdout",  # write executed notebook to stdout instead of mutating the file
+        f"--ExecutePreprocessor.timeout={timeout}",
+        str(notebook),
+    ]
+    proc = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        env=_headless_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    summary = (
+        f"exit={proc.returncode} "
+        f"{proc.stderr.strip().splitlines()[-1] if proc.stderr.strip() else ''}".strip()
+    )
+    return proc.returncode == 0, summary
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the notebooks smoke. Returns a process exit code."""
+    args = parse_args(argv)
+    notebooks = discover_notebooks()
+    if not notebooks:
+        print(f"No notebooks found under {NOTEBOOKS_DIR.relative_to(REPO_ROOT)}/", file=sys.stderr)
+        return 1
+
+    if args.list:
+        print(f"Notebooks ({len(notebooks)}):")
+        for nb in notebooks:
+            print(f"  {nb.relative_to(REPO_ROOT)}")
+        return 0
+
+    print(f"Executing {len(notebooks)} notebook(s) headless via nbconvert...")
+    failures: list[str] = []
+    for nb in notebooks:
+        rel = nb.relative_to(REPO_ROOT)
+        ok, summary = run_notebook(nb, timeout=args.timeout)
+        status = "OK " if ok else "FAIL"
+        print(f"  [{status}] {rel}  ({summary})")
+        if not ok:
+            failures.append(str(rel))
+
+    if failures:
+        print(f"\n{len(failures)} notebook(s) failed: {', '.join(failures)}", file=sys.stderr)
+        return 1
+    print(f"\nAll {len(notebooks)} notebook(s) executed cleanly.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_quickstart_notebooks.py
+++ b/tests/test_quickstart_notebooks.py
@@ -1,0 +1,130 @@
+"""Tests for the CPU-only beginner quickstart notebooks (Issue #5798).
+
+These tests cover the *structure and generator* of the notebooks cheaply:
+existence, valid nbformat, expected cells, and that the generator reproduces
+them. The full headless execution of every notebook is the dedicated CI smoke
+(``scripts/validation/run_notebooks_smoke.py`` / ``ci_driver.sh notebooks-smoke``);
+a slow-marked test here also executes them end-to-end for local confidence.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import nbformat
+import pytest
+
+from scripts.validation.run_notebooks_smoke import discover_notebooks
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_NOTEBOOKS = (
+    "01_run_first_episode.ipynb",
+    "02_compare_two_planners.ipynb",
+    "03_visualize_trace.ipynb",
+)
+
+
+def _load(name: str) -> nbformat.notebooknode:
+    """Load a committed notebook from ``notebooks/``."""
+    path = REPO_ROOT / "notebooks" / name
+    return nbformat.read(path, as_version=4)
+
+
+@pytest.mark.parametrize("name", EXPECTED_NOTEBOOKS)
+def test_notebook_exists_and_is_valid(name: str) -> None:
+    """Each expected notebook exists and is a valid nbformat document."""
+    nb = _load(name)
+    assert nb.cells, f"{name} has no cells"
+    # At least one markdown intro and one code cell.
+    assert any(c.cell_type == "markdown" for c in nb.cells)
+    assert any(c.cell_type == "code" for c in nb.cells)
+
+
+def test_notebooks_write_to_gitignored_output() -> None:
+    """Notebooks must not commit artifacts: they write under output/ (git-ignored)."""
+    for name in EXPECTED_NOTEBOOKS:
+        nb = _load(name)
+        joined = "\n".join(c.source for c in nb.cells if c.cell_type == "code")
+        assert "output/notebooks" in joined, f"{name} should write artifacts under output/notebooks"
+
+
+@pytest.mark.parametrize(
+    "name,needle",
+    [
+        ("01_run_first_episode.ipynb", "make_robot_env"),
+        ("02_compare_two_planners.ipynb", "run_episode"),
+        ("03_visualize_trace.ipynb", "export_threejs_viewer"),
+    ],
+)
+def test_notebook_uses_existing_public_api(name: str, needle: str) -> None:
+    """Each notebook relies on the existing env/planner/trace API (no new logic)."""
+    nb = _load(name)
+    joined = "\n".join(c.source for c in nb.cells if c.cell_type == "code")
+    assert needle in joined, f"{name} should use the existing {needle!r} API"
+
+
+def test_notebooks_resolve_repo_root_robustly() -> None:
+    """Notebooks anchor paths to the repo root so they run from any cwd."""
+    for name in EXPECTED_NOTEBOOKS:
+        nb = _load(name)
+        joined = "\n".join(c.source for c in nb.cells if c.cell_type == "code")
+        assert "_repo_root" in joined or "pyproject.toml" in joined, (
+            f"{name} should resolve the repo root independent of launch directory"
+        )
+
+
+def test_smoke_script_discovers_all_notebooks() -> None:
+    """The notebooks smoke discovers exactly the expected notebooks."""
+    names = {p.name for p in discover_notebooks()}
+    assert set(EXPECTED_NOTEBOOKS) <= names
+
+
+def test_generator_produces_valid_notebooks(tmp_path: Path) -> None:
+    """Regenerating notebooks yields valid nbformat documents with code cells."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "gen", REPO_ROOT / "scripts" / "dev" / "generate_quickstart_notebooks.py"
+    )
+    assert spec and spec.loader
+    gen = importlib.util.module_from_spec(spec)
+    # Point the generator's output dir at a temp location.
+    spec.loader.exec_module(gen)
+    gen.OUT_DIR = tmp_path
+    gen.main()
+    for name in EXPECTED_NOTEBOOKS:
+        nb = nbformat.read(tmp_path / name, as_version=4)
+        assert nb.cells, f"generated {name} has no cells"
+
+
+@pytest.mark.slow
+def test_all_notebooks_execute_headless() -> None:
+    """Slow: execute every notebook headless via nbconvert (the CI smoke path)."""
+    notebooks = discover_notebooks()
+    assert notebooks, "no notebooks discovered"
+    env = {
+        "SDL_VIDEODRIVER": "dummy",
+    }
+    import os
+
+    full_env = {**os.environ, **env}
+    for nb in notebooks:
+        cmd = [
+            sys.executable,
+            "-m",
+            "jupyter",
+            "nbconvert",
+            "--to",
+            "notebook",
+            "--execute",
+            "--stdout",
+            "--ExecutePreprocessor.timeout=600",
+            str(nb),
+        ]
+        result = subprocess.run(cmd, cwd=REPO_ROOT, env=full_env, capture_output=True, check=False)
+        assert result.returncode == 0, (
+            f"{nb.name} failed to execute headless:\n"
+            f"{result.stderr.decode(errors='replace')[-2000:]}"
+        )


### PR DESCRIPTION
## What

Adds the three CPU-only beginner notebook quickstarts requested in **Issue #5798** (part of adoption/UX epic #5791), plus a CI smoke that executes all of them headless.

| Notebook | What it does | Artifact(s) under `output/notebooks/` |
| --- | --- | --- |
| `notebooks/01_run_first_episode.ipynb` | Build an env, step a random policy, read & **plot the per-step reward** | `01_run_first_episode/reward_curve.png` |
| `notebooks/02_compare_two_planners.ipynb` | Run the **same scenario** with two planners (`simple_policy` vs `random`) via `run_episode` and **compare metrics** (collisions, avg speed, path length) | `02_compare_two_planners/planner_comparison.png`, `comparison_summary.json` |
| `notebooks/03_visualize_trace.ipynb` | Record an episode to JSONL and **see it three ways**: a trajectory plot, a map thumbnail, and an interactive Three.js browser viewer | `03_visualize_trace/trace_trajectory.png`, `map_thumbnail.png`, `viewer/index.html`, `episode.jsonl` |

Each notebook is **deterministic** (fixed seeds), **headless** (`SDL_VIDEODRIVER=dummy`), writes small artifacts under the git-ignored `output/notebooks/`, embeds its plot inline, and prints **repo-relative** paths so committed output stays portable.

## Why

There was no `notebooks/` directory. Newcomers get a *run → compare → visualize* interactive walkthrough (with rendered plots viewable directly on GitHub) alongside the existing `examples/quickstart/*.py` scripts and `robot-sf demo`. This directly serves the adoption/UX goal of "install → run → *see something*".

## How (no new logic)

The notebooks call only **existing public APIs** — they add no simulation logic:

- `robot_sf.gym_env.environment_factory.make_robot_env`
- `robot_sf.benchmark.runner.run_episode` (loads planners via the baseline registry, builds obs, translates actions, computes metrics)
- `robot_sf.render.threejs_viewer.export_threejs_viewer` + `JSONLPlaybackLoader`
- `robot_sf.maps.map_visualizer.visualize_map_definition`

This mirrors the recently-merged one-command demo (`scripts/demo/quickstart_demo.py`, #5792) for the recording→viewer pipeline.

## Tooling added

- `scripts/dev/generate_quickstart_notebooks.py` — regenerates all three notebooks from one readable source (keeps structure in sync).
- `scripts/validation/run_notebooks_smoke.py` — executes every `notebooks/*.ipynb` headless via nbconvert; fails closed on any error.
- New `ci_driver.sh notebooks-smoke` phase, wired into the existing **`examples-smoke`** CI job in `.github/workflows/ci.yml` (so it's gated by the `ci` aggregate job).
- `tests/test_quickstart_notebooks.py` — cheap structural/generator tests (validity, expected cells, API usage, repo-root resolution, smoke discovery) plus a `@pytest.mark.slow` end-to-end execution test.
- `notebooks/README.md` + a README quickstart pointer for discoverability.

## Validation

CPU-only, on the worktree's local venv (no campaigns / Slurm / training):

```
# All three notebooks execute headless and embed their plots (1 inline PNG each, 0 errors)
SDL_VIDEODRIVER=dummy uv run jupyter nbconvert --to notebook --execute notebooks/*.ipynb --inplace
→ exit 0

# Dedicated CI smoke passes
SDL_VIDEODRIVER=dummy uv run python scripts/validation/run_notebooks_smoke.py
→ Executing 3 notebook(s) headless via nbconvert...
→ All 3 notebook(s) executed cleanly.

# Focused tests (incl. slow-marked end-to-end execution of all notebooks)
SDL_VIDEODRIVER=dummy MPLBACKEND=Agg uv run pytest tests/test_quickstart_notebooks.py -q
→ 11 passed in 36.83s

# Lint/format on changed files
uv run ruff check <changed files>      → All checks passed!
uv run ruff format --check <changed>   → 3 files already formatted
bash -n scripts/dev/ci_driver.sh       → OK
```

Per-notebook results (single seed, horizon 60) for notebook 02 — a **teaching** comparison, not a benchmark:

```
 simple_policy: collisions=27  avg_speed=0.984  path_length=6.00
 random:        collisions= 0  avg_speed=0.910  path_length=5.55
```

`output/notebooks/` is git-ignored; **no artifacts are committed**. Committed notebooks carry clean executed outputs (inline plots, repo-relative paths).

## Claim boundary

These are **beginner/UX** notebooks. The planner comparison in notebook 02 is a single-seed illustration, **not** a benchmark result — the markdown says so explicitly and points to the benchmark tooling for rigorous evaluation.

## Artifact propagation

`output/` is worktree-local and git-ignored by repo policy; nothing to promote. The committed artifacts are the notebook sources (with rendered outputs) and the smoke tooling.

Closes #5798

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
