### PR TITLE
Issue #5827: notebook 03 JSONL discovery (cheap-lane worker)

### DIFF
--- a/notebooks/03_visualize_trace.ipynb
+++ b/notebooks/03_visualize_trace.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7779093f",
+   "id": "cd499273",
    "metadata": {},
    "source": [
     "# 03 — Visualize an episode trace\n",
@@ -23,26 +23,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "6a50629c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-15T23:25:10.990926Z",
-     "iopub.status.busy": "2026-07-15T23:25:10.990532Z",
-     "iopub.status.idle": "2026-07-15T23:25:11.207944Z",
-     "shell.execute_reply": "2026-07-15T23:25:11.207448Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Repo root: /home/luttkule/git/robot_sf_ll7.worktrees/cheap-issue-5798-20260715T225820Z\n",
-      "Artifacts will be written to: output/notebooks/03_visualize_trace\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "38adbaa5",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import os\n",
     "import sys\n",
@@ -86,7 +70,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d648e53",
+   "id": "fd82a84e",
    "metadata": {},
    "source": [
     "## 1. Run one deterministic, recorded episode\n",
@@ -99,44 +83,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "0dfd0d20",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-15T23:25:11.209425Z",
-     "iopub.status.busy": "2026-07-15T23:25:11.209319Z",
-     "iopub.status.idle": "2026-07-15T23:25:20.047849Z",
-     "shell.execute_reply": "2026-07-15T23:25:20.047408Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
-      "I0000 00:00:1784157912.545883 1037094 port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
-      "I0000 00:00:1784157912.577213 1037094 cpu_feature_guard.cc:227] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
-      "To enable the following instructions: AVX2 AVX_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
-      "I0000 00:00:1784157913.142550 1037094 port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
-      "I0000 00:00:1784157913.142745 1037094 cudart_stub.cc:31] Could not find cuda drivers on your machine, GPU will not be used.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Episode finished after 120 steps.\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "d2f0403b",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from robot_sf.gym_env.environment_factory import make_robot_env\n",
     "from robot_sf.gym_env.robot_env import RobotEnv\n",
@@ -189,30 +139,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "95a696be",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-15T23:25:20.049453Z",
-     "iopub.status.busy": "2026-07-15T23:25:20.049233Z",
-     "iopub.status.idle": "2026-07-15T23:25:20.052837Z",
-     "shell.execute_reply": "2026-07-15T23:25:20.052616Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Recorded episode: notebook_quickstart_demo_crossing_basic_random_270_ep0000.jsonl\n",
-      "Stable copy: output/notebooks/03_visualize_trace/episode.jsonl\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "0160e541",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "# Locate the recorded JSONL (the recorder names it with suite/scenario/algorithm/seed).\n",
-    "candidates = sorted(recording_dir.glob(\"*.jsonl\"))\n",
-    "episode_jsonl = candidates[-1]\n",
+    "# Consume the exact path reported by the recorder. Do not glob the directory:\n",
+    "# a previous notebook run may have left a newer-looking, stale recording there.\n",
+    "env_path = getattr(env, \"last_recorded_jsonl\", None)\n",
+    "if env_path is None:\n",
+    "    raise FileNotFoundError(\n",
+    "        \"No JSONL recording was produced; the episode recorder did not report \"\n",
+    "        \"an output path.\"\n",
+    "    )\n",
+    "episode_jsonl = Path(env_path)\n",
+    "if not episode_jsonl.is_file():\n",
+    "    raise FileNotFoundError(\n",
+    "        f\"The episode recorder reported a missing JSONL file: {episode_jsonl}\"\n",
+    "    )\n",
     "# Promote a stable copy next to the other artifacts.\n",
     "stable_jsonl = OUTPUT_DIR / \"episode.jsonl\"\n",
     "stable_jsonl.write_bytes(episode_jsonl.read_bytes())\n",
@@ -222,7 +166,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ae419b3",
+   "id": "30be8a4d",
    "metadata": {},
    "source": [
     "## 2. Load the recording and plot the trajectory\n",
@@ -234,36 +178,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "dfedb3ed",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-15T23:25:20.054158Z",
-     "iopub.status.busy": "2026-07-15T23:25:20.054095Z",
-     "iopub.status.idle": "2026-07-15T23:25:20.210629Z",
-     "shell.execute_reply": "2026-07-15T23:25:20.210315Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loaded 120 recorded states.\n",
-      "Saved: output/notebooks/03_visualize_trace/trace_trajectory.png\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnwAAAHBCAYAAADzUWZgAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlcelbwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAYJJJREFUeJzt3Xd4U+XbB/Bv0pF0t9BSWtqyW6Ds0YIIFNlTxAGCg6EICCooCCIiOEAFQRw4XhHcqMAPZQmyFBBKyx62ZbWFMlpGd9NxnveP2khI0p60CWkO3891cWmePOec+zz3SXrnTJUQQoCIiIiIFEtt7wCIiIiIyLZY8BEREREpHAs+IiIiIoVjwUdERESkcCz4iIiIiBSOBR8RERGRwrHgIyIiIlI4FnxERERECseC71/16tXDhAkT7vhyO3fujP79+9/x5VKpyubd19cX06ZNs0FEjoPbrn3s2LEDWq0Wf/75p71DAQCsXbsWWq0WBw8evKPLtcU4HDhwAJ6enkhMTLTaPK0lMTERWq0W33zzjb1DcRhKG7Pt27fD19cXqamplZre4Qq+Vq1aQavVmvzn6elZ6fkWFBSgqKjIipHKo9PpUFhYaLX51a5dG5MnT7ba/JSusnm35vZi65zZav7W3nZJnpKSEuh0OkiSZO9QANgvHlssd8qUKRg6dCjCw8OtNk9rkSQJOp0OJSUl9g7FYVhzzHJzc7F8+XL07t0bderUQUhICHr27ImNGzca9V2wYIHZOkWr1WLhwoVGcS5ZsgTNmzeHj48PmjZtinfeeQfFxcUG/e677z60aNECM2bMqNQ6OFzBp9Pp0LBhQ9y8edPo37Vr1yo93+TkZHz66adWjNQ+7FW4OqrqkHdb54zbhLLcd999yM/PR9euXe0dil1Zexx27NiBPXv24LnnnrPK/EhZXn/9dTz33HO47777sH//fvz999+Ijo7GgAEDMH/+fIO+06ZNM1mjdO3aFTqdDn379jXo/9JLL2HWrFl4/fXXkZycjEWLFmH+/PmYOHGiURyTJk3CDz/8gLNnz1q8Dg5X8AGASqUyWTVrNJpKz1Oj0cDZ2dmKUZIjYN7J0ajVami1WqjVDvn1bTXWHodPP/0UTZo0Qfv27a0yP1KWsLAwxMbGYsaMGQgJCUFoaCjeeust9OvXD/PmzUNeXp6+r5OTk1F9kpGRgW3btqFTp05o3ry5vm9SUhI++OADTJs2DQ899BB8fX3Rv39/zJ07F1988QUOHz5sEMf9998PT09PfP755xavg6K/McrOs9qzZw/uuece+Pr6okWLFvjqq6+M+po6l2v9+vWIiYlB7dq1UadOHfTv3x+7du0y6FNSUoKFCxeiVatW8PHxQWhoKMaMGYMLFy4Y9CssLMTMmTNRr149+Pv7Y8iQIUZ9bvXjjz+iS5cuqFGjBgICAjB48GAcOXLEbP/MzExotVpkZmbi//7v//QbWe/evY3GY9++fYiJiYGvr69+13J0dLTBofGGDRti/PjxuHr1qtGyfvrpJ8TExMDf3x8hISEYPny40TkvcuKfO3cutFot9u7da3a9Khq/288ju3btGrRaLZYsWWI0j+joaAwePNigzdw5fHLW8XYffPABPDw8MG/ePH1beduQnJzJzYup3L7xxhsVzl8OW2y7ZfHu3bsXnTt3Ro0aNdClSxccPXoUALB792506dIFfn5+aNOmjdHnDpD/2ZOropyX9/lJTU3FmDFjEBoaCh8fH7Rq1QoLFy40OJSk0+kwZ84cREZGws/PD02bNsWzzz6Ly5cvW9TH1Llrt55H99FHH6Fx48bw8/NDnz59kJCQYLSup06dwqBBg1CjRg3UrVsX8+bNwz///FPl853effddNGjQADVq1ED//v1x4sQJg/dPnjyp3w7d3Nzg5+eHDh064JNPPoEQosrjAABZWVmYNWsWmjdvDl9fXzRv3hxvvPEG8vPzzcZdUlKCTZs2oUePHkbvlY1tfHw8Fi9ejIiICLi7u+PixYuy18fS/CQkJGDw4MEG+TF36FrOtnfrOixcuBANGjRAYGAgnnnmGeh0On3uGjVqhBo1amDYsGG4ceOG2fEqj5zcAaV5mjlzJpo0aQJvb280aNAAL730EnJzcyvVz5Ixq4zJkyejWbNmRu1NmjRBQUEBLl68WO70K1asgCRJGDdunEH7mjVrIEkSHnzwQYP2stc//fSTQbtWq8U999yDdevWWb4SwsFERESIyMhIWX01Go0YMGCAGDhwoDh69KhITU0Vr732mgAgPvroI4O+gYGBYuzYsfrXe/fuFWq1WsydO1dcuHBBXLlyRWzZskV0795dFBcX6/s99thjQqvVis8//1xcvnxZ7N27VzRv3lwEBQWJtLQ0fb+HH35YeHl5ie+++05cuXJFbNu2TfTt21e0aNFC9OjRwyCWWbNmCRcXF/HOO++I8+fPizNnzogxY8YIDw8PcfToUbPrm5+fL3x8fMRTTz0l8vPzRX5+vtDpdAbjMXDgQDFw4EBx+PBhkZCQINauXSuEEEKn0+mnuX79uti+fbto3ry56Ny5sygpKdHP4+WXXxbOzs7itddeE4mJiSItLU2sWrVKPPnkkxbHP2vWLAFA/PXXXxVkUv74paenCwDivffeM5pHq1atRJ8+fQzabs+73HXUaDTi+eefF0IIUVRUJCZMmCBcXV3FV199pe8jZxuqKGdy82IutxXNXw5bbLsajUYMGjRIPPzww+LkyZMiOTlZ9OnTRwQHB4t9+/aJIUOGiOPHj4uUlBQxYMAA4ePjIzIzMw2WJfezJ4fcnJsa47S0NBEUFCSaN28u9uzZIy5fviy++OILodVqxciRI/XTT548WQQEBIgtW7aI69evi6SkJLFs2TIxZcoUi/ps3bpVABA7duzQt/38888CgBg1apR4++23xYULF8Thw4dF06ZNRdOmTQ22lZSUFFGjRg3RsWNHcfDgQZGWliYWL14sHn30UQHAYBuWo2zZw4YNE2+99ZZ+2ffee6/w8/MT586d0/eVJEm/Hebn54sLFy6Ijz76SLi6uhp8J1d2HG7evCmaNWsmQkNDxZo1a8Tly5fFiRMnxJw5c8Ty5cvNrkNcXJwAIFasWGF2/YYPHy7eeOMNkZKSIlatWiUuXrwoe30syc+FCxeEv7+/iIqKEnFxceLixYvivffeE8OHDzfKj9xtr2z5I0eOFIsWLRJpaWlix44dokaNGmLSpEli3rx54t133xVpaWli165dwt/fXzz++OMV5t4UObnLysoSLVq0EI0aNRIbN24U6enp4q+//hIRERGiS5cu+u9Huf0sGbOMjAyh0Whk/XvppZfKXdeSkhIRGRkp3NzcRG5urtl+kiSJhg0bCh8fH6N+jz76qFCpVCa/l728vMSAAQOM2svqmCtXrpQb3+0csuBTqVQmk9OvXz+DvhqNRnh7e4ubN28atA8ZMkT4+vqKvLw8fdvtf/jffPNNoVarRVFRkdlY9u/fLwCIefPmGbSfPn1aODk5iWeffVYIIcTff/8tAIjFixcb9Nu5c6cAYPBH89SpU0KlUolZs2YZ9C3bsAYPHlzO6Ajh4+MjnnnmGZPvaTQa4eXlZTQe5mzfvl0AEPHx8UIIIY4dOyZUKpWYNm2a2Wksib+oqEjk5+cLSZLKjcOS8atqwSdnHYX4r+DLzMwUvXv3FjVq1BA7d+406CNnGxKi/JyZcnteyuIxl1tL538rW227Go1G+Pv7i5ycHH3bsWPHBABRr149kZWVZTBfAOKLL77Qt8n97MlhSc5NjfGkSZOEk5OTSExMNGh/4403BADx999/CyGEaNKkiRgxYkS5y5DTp7yCb8yYMQZ916xZY9R34sSJQqPRGBXFEyZMqFLB99hjjxm0X716Vbi7u4vRo0dXOI8xY8aIpk2b6l9XdhxmzJgh1Gq1OHTokEXr8MsvvwgA4vfffzd6r2z9Hn30Udnzu319LMnPs88+K1xdXcXFixcN+j711FNG+ZG77ZUt/6mnnjLo9/LLLwutVivGjRtn0D5r1izh7Oxs8DmUS07uXn31VaFWq8Xx48cN2uPj4wUA8dNPP1nUz5IxK/sbIedf2Y96c959910BQLz44ovl9iv7zp44caLRe7169RIeHh4mpwsLCxPR0dFG7Z9++qkAIGJjY8td7u0c8pBu06ZNTZ4QaWoXZ48ePeDj42PQ9uCDD+LmzZs4cOCA2WVERkZCkiSMGjUKsbGxJq/y2bp1KwDg4YcfNmhv2LAh2rVrhy1btgAA/vjjDwDA0KFDDfp169YNNWvWNGj79ddfIYTAsGHDDNrVajV69OiBHTt2mI1Zju7duxuNB1B6iGfkyJGoV68ePD09odVq9SeWnj59GkDp4UkhBJ544gmz87ckfmdnZ2i1WqhUqnJjtmT8qkrOOpZJTk7GPffcg3PnzuHvv/9Gt27dDN6Xsw1VRE5eypjLbVXYctuNiYmBh4eH/nXTpk2hVqvRunVreHl56dsjIiLg7OxssL5yP3tyWJJzU2P8xx9/oHXr1mjcuLFBe9k4lMUSGRmJdevWYcmSJUhJSTE5fzl9ynP7KQutWrUCAJw5c0bftm3bNkRFRSEoKMig75AhQyxe3q0eeOABg9cBAQHo0qWLfhsq8/333yMmJga1atWCm5sbtFotVq5caZDfyo7Db7/9hhYtWqB169YWxX7z5k0AgLe3t9k+t69fGTnrU0ZOfv744w9ER0cjODjYoO/th/zK+srZ9soMHDjQ4HVkZCQKCgqMTvOIjIxEcXExkpOTTa5zeeTkbt26dWjevDkiIyMN2tu2bYsaNWrovyvk9rNkzPz9/ZGfny/r3+1X095q/fr1mDlzJtq1a4c333yz3DFZvnw5ABgdzi1j7m+gSqUyODWgTNl3kKWH3R2y4DN30YaLi4tR38DAQKO22rVrAwDS09PNLmPIkCFYunQp9u/fj+joaPj6+mLw4MEGf7QyMjIAwOiLs6yt7P2y/5YXS5lLly4BADp16gRPT094eHjA3d0d7u7u+OSTT5CdnV2lW2HUqVPHqC0tLQ2dOnVCWloaVq1ahdTUVNy8eRM7d+4EAP3yrly5AgAICQkxO39bxG/J+JXH1AfndnLWscyuXbtw4sQJPPHEEyZv4yBnGyqP3LyUMZXbqrLltnv7l7OTkxPc3NyM2lUqFTw8PJCZmWkUV0WfPTksybmpMc7IyDAbx62xLlu2DI888gjmzJmDunXron79+njuuef04ya3T3luH7uyAqasoCmLx1Q+TbVZwtw2cuv37GeffYaRI0eie/fu2LNnD9LT03Hz5k1MnDjR4Eryyo7DlStXZOXxdr6+vgCA7Oxss31M5V7u+pSpSn5MfdfJ3fbMLb/sh5W59ls/c3LJyd2lS5dw4sQJeHp6GnxXuLm54caNG/q45fazZMwAlHvLlFv/mbugb9u2bXj44YfRrFkz/P7779BqtWbHIzMzE6tXr0ZUVJS+wL9VjRo1kJeXZ3J7uXnzJmrUqGHUnpWVBeC/7VYuhyz4LGHqooOyNlMDeavJkycjKSkJycnJWLZsGa5cuYKePXvqLzLw8/Mrdxll8y/7b3mxlCnba3Lo0CFkZGTg2rVruH79Oq5fv47s7Gzk5+fD1dW13LjLY2raNWvWIDMzE59//jmio6Ph5+cHrVZr9OXq7+8PAOV+6doifkvGz8vLCyqVCjk5OUZ95fzRlLOOZZ544gnMmjULs2fPNrhQ41YVbUPlkZuXMlXZLsyx5bZb3q9aU24t2OV+9uSwJOemxtjPz0/W90xAQACWL1+Oa9euIT4+HuPGjcM333yDbt266U8ul9OnPHLHztSPXVPrYAk5ufjqq68QFRWFOXPmoHHjxvq91rdfaFPZcfD395ddHN8qNDQUAIwuLLiVqdzLXZ8ycvJTo0YNWZ83QP62V9Hy5cQll5zc1axZEx07dkRGRobBd8WNGzeQl5eH7777zqJ+loxZ2YV9cv6Zurn+X3/9hcGDB6Nhw4bYtm1bhUeZfvjhB+Tn55vdu9eiRQtIkoSkpCSD9suXLyMzMxMtWrQwmqZsGw8LCyt32bdTfMG3a9cug8ulgdJdsR4eHujQoYOseYSFheGxxx7Djz/+CEmS9FcMdu/eHUDpoaxbXbhwAfHx8fr3Y2JiAMDoBo2xsbFGX7xlV5yuX7/e7EZYHnd3d4v3oJUdarz18BoAfPvttwav+/XrB6D0Kkxzqhq/KZaMn0ajQXBwsNHVgXFxceXu0S0jZx1v9eabb+L999/H66+/jilTppj9gjS3DQHmcyY3LxWpzDZR5k5uu5aQ+9mTw9Kcm4rl0KFDRne//9///mcQaxlnZ2e0bdsWM2fOxNSpU5GUlGR0hZ+cPpUVExODAwcOGN23dNOmTVWa7+3byM2bN7Fnzx6D9S8pKTHantPT0/H777+bnKel49CvXz8cOXIEp06dsij2Nm3awN3dHXFxcRZNZ+n6yFGWn9s/X+vXrzfqa+m2dyeVl7v+/fsjPj4eV69eLfdondx+loyZEAI6nU7Wv9v3uu3fvx8DBgxA/fr1sX37dgQEBFQ4Dl9++SW8vb0xfPhwk+/ff//9AIy/y8pyePvpNEDp92+jRo0sOsIFQPlX6fbs2VMMGzZMpKamiuzsbPHBBx8ItVot3nrrLYO+t5+8P3fuXPH222+LhIQEUVRUJDIzM/VXld56cv7AgQOFt7e3WL16tcjPzxenTp0SnTp1En5+fuLs2bP6fr179xY1a9YUmzZtEgUFBeLgwYOif//+omnTpkZXOj733HPCzc1NLF26VFy5ckUUFxeL06dPiw8//NDgSidTevbsKSIjI8X169dNjoepk1BPnDghXFxcxBNPPCFu3rwpMjIyxGuvvSbuv/9+AUB88803+r4TJkwQGo1GLF68WKSnp4vc3FyxZcsWg5Pk5cb/+uuvC41GI/bs2VPuOlk6fq+99ppwdXUVv/76q9DpdCI2NlYMHTpUREREyLpKV8463j6Wy5cvF05OTmLUqFH6K8fkbkPmcmZJXszltrz5y2WLbddcvB4eHiYvuDB14Yncz54clcl5mXPnzgk/Pz/RqVMncerUKZGfny9Wr14tvL29xcCBA/X9+vbtK1avXi0uXbokJEkSp0+fFlFRUaJ+/fr6C3vk9Cnvoo0DBw4YxGbqIqbTp08LLy8v0bt3b3Hu3DmRm5srVq5cKR588MEqXbRx//33i2XLlomcnByRnJws+vfvL9zd3cXJkyf1fefMmSOcnJzEzz//LAoLC8XJkydFTEyM6Nu3r7j1z1FlxyE9PV3Ur19fREREiB07doj8/Hz9VcjffvttuevxwAMPiJYtW5pdv9vH1pL1qUx+evToIc6ePStyc3PF8uXLxQMPPGCUH7nbnrnlr1271uDijjK//fabyTsohIeHi/Dw8HJGUV7uMjIyROPGjUWLFi3E9u3bRW5ursjOzhYHDhwQEyZMEBs2bLConyVjJoQwuLK6vH+3XnB3+PBh4evrKyIjI2VfHXv06FEBQIwfP77cfmPGjBHe3t5i69atoqSkROzZs0f4+/uLYcOGGfXV6XTC19e3wlrAFIcs+MxdpavRaMSZM2f0fcu+oDds2CAiIiKEWq0WderUEQsXLjSa7+1/+C9duiReffVV0aRJE+Hq6iq8vLxEly5dxK+//mowXUFBgZg5c6YICQkRKpVKeHh4iPvvv1/8888/Bv2ys7PFuHHjhLe3t3BxcRFdunQRCQkJol27dkZ/NIUQYsWKFSIqKkq4uroKV1dX0ahRI/HCCy8Y3OLAlEOHDok2bdoIJycnodFoRK9evYzGw5S1a9eKpk2bCicnJxEYGChmz54tjhw5YlRYSJIkPv74YxEZGSmcnJyEr6+v6Nevn8EVo3Ljt+S2LJaMX35+vnjqqaeEh4eHcHV1FX369BGpqamyb8siZx1NjeWaNWuERqMRDzzwgCgoKJC9DZWXM7l5KS+35c1fDltsu9Yo+OR+9uSobM7LnDp1Stx///3Cw8NDqFQqERISImbOnCkKCgr0fXbv3i0eeeQRUbt2beHs7CwCAwPFqFGjDMZFTp+qFnxCCHHgwAHRuXNn/bpOmTJFf2uS7777zqKxK1v2vn37xLRp04Sfn59Qq9WiY8eOYt++fQZ9dTqdmDJlivD39xfOzs6iVatWYsuWLeLll182KJAqOw5CCHHlyhUxbtw4ERgYKNRqtQgJCREvvviiuHHjRrnr8fvvvwsA4siRIybXz1TBJ3d9LM1PXFycuPfee4WTk5Pw8fERzz33nL54uL14kbPtWavgCwgIEFFRUWZGsJSc3AkhxPXr18WUKVNE3bp1hVqtFj4+PiI6Olp8+umnIj8/3+J+loxZZYwaNUoAEM7OziZrD1M7Lp5//nmjOyqYUlhYKGbPni2Cg4OFWq0WgYGBYtq0aQbrV6bsyu7KfM+phKjEQXo7KiwsLPccDo1Goz8fQavVYvz48fqb8EqSZPau7DqdDk5OTiZP0hRCVHglKVC6e9/JyanCfrfGUVhYCJVKZfKCE1P95RJC6Odddu5Jeet463Rl6yr+3fXt6upqcvlyx8Vc/MXFxSguLjbImRy3zq99+/bw9fU1uhLQVF9TY13RmJhbR3PTFRUVoaSkxGjM5IyVqZyZmt5UXuTm1tz85bLWtmsuXkvby8j97Mlhac4rE4vc7cFUH0mSUFhYaJD/sjZTn6WCggK4uLiYjOnW/GzcuBEDBgzAtm3bcN9995Ubm6l4bl22nO+sW9ev7LvA1GF/S8ahvPWriBACUVFRaNOmjcFTDMobW7nrY438lH3uzfUFzG975pZvSfupU6fQrFkzrFu3zuhqYzljUh65eZLTz9Ixk6vsu90cU7ktLCyEEMKip4BVtI69evWCl5cX1qxZI3ueZRzumVJVOTG9vEEsLyFyixG5G9StcchZn8o8OkilUhmtk5yN7tZ1LbsaWk7f8piL39nZuVKPNbNkPCoa64rGxNw6mpvOxcXFZAEkZ6xM5czU9KbyIje3VXn8IGC9bddcHJa2l7FWsQdYnvPKxCJ3ezCl7JFiFbWVKe8zfGt+/ve//8HNzc3iR4uZi6cit65fed8FloyDqT5yqVQqvP/+++jRowdmzJiBBg0ayF7O7XHevj7WyE9F38eA+W3P3PItad+2bRs6duwou9gri1kOuXmS08/SMZPL3Hd7eSpTr5S3jn/++Sf+/PNPnDx50uL5AnfBRRtERGTo+eefx59//on8/HxkZGRg0aJF+Oqrr/DCCy+Uey86pevSpQuys7NRt25de4dS7YwfPx5//fWXvcO4q91zzz3Izs5Gw4YNKzU9Cz6iu9AjjzxS4S0JKnp2cHV3N6xjZT300EOYO3cugoODUatWLXz22WdYsGAB3nrrLQBAbm5uhWPXuXNnO6+FbWg0GqvuMVaKyh6RIetxdnau0lFOhzuHzxJyz7khxyXnPDIyVtH5KIDpc1Icyd2wjtZg7pyhgoKCcqdTq9U2ufcjEdmGogs+IiIiIuIhXSIiIiLFc/hjnZIkIS0tTf9ILSIiIiIlEUIgOzsbwcHBlbpzB6CAgi8tLU3/HEQiIiIipUpNTUVISEilpnX4gs/LywtA6SAo5XYCkiQhPT0dAQEBla7kyT6YO8fF3Dku5s4xMW/yZWVlITQ0VF/zVIbDF3xlh3G9vb0VVfAVFBTA29ubHwIHw9w5LubOcTF3jol5s1xVTl3jCBMREREpHAs+IiIiIoVjwUdERESkcA5/Dh8REd05kiShsLDQ3mEYkCQJRUVFKCgo4LlgDoR5+4+Li4vNH+nHgo+IiGQpLCzEuXPnIEmSvUMxIISAJEnIzs7m/VgdCPNmyNfXF7Vr17bZWLDgIyKiCgkhcOnSJTg5OSE0NLRa7ZERQqC4uBjOzs4sHBwI81ZKCIG8vDxcvXoVABAUFGST5bDgIyKiChUXFyMvLw/BwcFwd3e3dzgGWDg4JubtP25ubgCAq1evolatWjY5vFt9fqIREVG1VVJSAgBwdXW1cyREylT2Q6qoqMgm82fBR0REst3te2KIbMXWny0WfERERBXIzc1FamqqvcOoMqWsB1mOBR8RESlWRkYGzp8/j/Pnz+PixYv6Q9OWWrt2LTp06FDlePLy8pCSklLl+VR2WdZaD3I8LPiIiEixXnrpJTRp0gQxMTGIjo6Gu7s7hg4divT0dLvEs3HjRrRs2VJxy6LqjwVfFRWXSDiUcBWb9p5D/D9XkFdgm5MtiYiocjp27Ijz58/jwoULSExMRHx8PJ5//nmjfiUlJbh06RLy8/PLnZ8kSbhy5QqEECbfNzefgoICpKenQ5Ik/V7HGzduGE1/62FXc8vS6XT6eVy+fNloHnKWJUkSMjIyyl1XUg4WfFWw92gaxs3/A699/jc+WX0Ur3+xD4/N2YwFKw/g2OkMs18GRERkH3Xr1sUjjzyCnTt3GrQvW7YMtWrVQrNmzeDr64snnngCeXl5Bn1KSkrwwgsvoGbNmmjQoAEaN26MuLg42fM5fPgw5syZg5ycHMTExCAmJgaff/65UYxr165F27Zty13WyZMn9fNo1aoVvL298fbbb+vfL29ZJSUlmD59OmrVqoWGDRsiLCwM+/fvr9K4UvXHgq8SSkokfLbmKOavPID0G4a/4IqKJew5moZXlu3Bix/8ibhT5n8FEhHRnZeTkwNn5/9uQ7t7925MnjwZX375JW7cuIFTp07hr7/+wpw5cwymy8jIQGpqKi5duoTMzEzExMTgkUce0d9Go6L5dOzYEZ988gm8vb31e91efvllkzFWtKw2bdro53HlyhXs2rULixYtwsaNGytcVkZGBvLy8nDp0iXcuHED3bt3x/jx4607yFTt8MbLFiopkbDo+4P46/BFfVub8AB0bBGE85ey8PfRS7iZowMAJKXexNz/24fmDWvi6ftboEEdH3uFTURkdVMW78SNbN0dX66flwaLp8TI7l9QUIDz58+juLgY+/fvx9dff41XXnlF//5HH32E/v37Y8iQIQCABg0aYNasWXjuuefwzjvvGDxV5P3334dWqwUALFy4EIGBgdi8eTMGDRpk0XzkKG9ZZUpKSnD16lX4+fkhJiYGmzdvRv/+/cudr5OTE9577z24uLgAAEaPHo0ePXqgqKhI30bKw4LPQl+sO64v9pydVBg/tBV6R4fp758zbkgL7DmShtU7knAuLQsAcPzMNUxZvBODuzbEY/2aQuNi2wckExHdCTeydbiWWWDvMCp0+PBhxMTEQKfT4fLly3jggQcwa9Ys/fuJiYkYMGCAwTStW7dGfn4+Ll68iNDQUACAp6cn6tatq+/j6+uLsLAwJCUlWTQfOSpaVlZWFsaNG4e1a9fCy8sLnp6euH79Onr16lXhvP39/fVPdihbliRJyM3Nha+vr+wYybGw4LPAroMXsGHPOQClxd6s0dFo3zTQoI+zkxrd2oagS+s62HssDV9vPIVLGbmQBPC/XWcQ/89VzHiiPcJqe9tjFYiIrMbPS+MQy+3YsaP+nL29e/eiT58++Pjjj/Hss88CALRaLXQ6wz2VZa/L9rABpU9AEEIY3CC3oKBA30fufOSoaFmvvfYazpw5g+TkZNSuXRsAMGrUKNy8edOi5dDdgwWfTJk5Ony29qj+9bMPtTIq9m6lVqtwb6s6iI6sjf/tOoMftiSgqFhC6pVsvLT0T0x7rD06NKt9J0InIrIJSw6rVhf33HMP5syZg5kzZ+Lhhx9GrVq10Lp1a+zatcug386dOxEUFISAgAB9m06nw4EDBxAVFQUAOHPmDNLS0tCqVSsAkDUfjUaD4uLiCuOsaFnHjx9H37599cVecXEx9uzZg8jISP085C6L7g68aEOmn7YlIjuv9GTZLq3roGdU3QqmKOXi7ISHe4Tjg6kxqBdUulcvX1eCN7+Kxa6DF2wWLxERmTZ58mTUqFED8+bNAwBMnz4dx44dw9SpU3HkyBGsXLkSCxYswNy5cw2mU6vVGDNmDHbu3Im9e/dixIgRuPfee9G5c2fZ8wkPD0dubi7WrVtn9rYscpbVoUMHfPfdd9i1axfi4+Px+OOP4+zZswbzkLssujuw4JMhr6AIv+9LBgC4ujjhqfubWzyP0EAvvPdcF3RuFQwAkCSB9384iEMJV60aKxER/cff31+/F6yMRqPBggULsGXLFly6dAn16tXDX3/9hTNnzuDhhx/G559/jg8++ABPP/20fhpPT0+0bdsW8+bNw1tvvYUxY8agWbNmWL16tb6PnPlERETg/fffx5tvvonu3bubvC0LAAQEBJS7rNmzZ+P+++/HpEmTMHbsWISGhmLq1KmoVatWucvy9PQ0OpdQo9Ggbt26Fl9UQo5FJRz8niFZWVnw8fFBZmYmvL1tc17croMXsPC7eABAv071MPGhVpWelyQJfLL6iL6A9HJ3wQdTuyPAz+2WPhKuXr2KWrVq8QPoYJg7x8Xcla+goADnzp1D/fr1LT4fzdaEECguLoazs7PNH0B/J3z77bd46aWXTN5QWUmUlreqKu8zZo1ah99qMvyTfF3//x1bBFVpXmq1ChMebIUOzUrP/8vOK8LSnw7xXn1ERERkMyz4ZLh87b+7rdcPqvpeRCe1ClMfbQt/n9IK/nBiOnYfSavyfImIyPGZOuxKVFUs+GTIyv3vMnsfT+vchsDT3RUTbjk0/N3mfyBJ3MtHRHS3GzJkCA4cOGDvMEhhWPDJUFaHWfsUgw5NAxHZoCYA4GJ6Do6d5kOsiYiIyPpY8Mng++9ePSGAG9nWu6u8SqXCwHvr61/vPsrDukRERGR9LPhkqFvbS///x89cs+q82zcJhLNTaRq4h4+IiIhsgQWfDG0i/ruv0dbYZKvOW6txhr9v6cUbN3Pu/EPIiYiISPn4aDUZWjT0R1BND1y6losjSRk4nHgVrcNrISUzBdvObkN2YTa8XL3Qo0EPhPmEWTTvrNxCXL2RDwAI8HWroDcRERGR5VjwyaBWqzCsVziW/HgIAPDaT6tQXO93bD6zEQICapUakpCgggoDwwdidtfZ6FCng6x5/7wtUX91buvwgAp6ExE5Nmv8UCYiy7Hgk6l7u1BsjU3BHynrcbB4IXBGQKC0UJOEBAAQENiYtBGbTm/CqodWYWjToWbnJ4TA3mOX8Otfpc8+dHFWY3CXhrZfESIiO4i9GIs3/nwDGxI3VPmHMhFZjufwyaRWq9CtewkOui2EQAkEJJP9SkQJSqQSDPtlGA5cNL6P0o2sAmzaew4vfvAnFqw8oN+7N6xnuMHj1YiIlGLNqTXovLwzNiVtMvtD+Z7l92DNqTVWX3ZxcTE+//xz9OvXD23btsVDDz2En3/+2eDpRhMmTMD8+fOttkxrz4/IGriHzwLLjiyCWg2UVHB/ZAEBIQTe/PNNfNHsHVw8dR7n07Jw+sJNXLyao+9Xtj+vTZNaeMgvBzh4EPD3B0JCbLcSRER3UOzFWAz7ZRhKpBJ9sXe7ElEClVBh2C/DsHfMXqvu6Zs0aRJ+++03vPvuu2jWrBmSk5OxatUqnD17Fi+//DIAIDU1FRqNdW6qb4v5EVmDSjj4Q1yt8UBhOVIyU1BvST2zX1imhN4Ekj50hqakWP6CtFpIp07hqlbLh7g7IEmScPXqVebOATF35Svvwe7lGfzDYGxM2ogSUVJhXyeVEwaED8C64essik0IgeLiYjg7O0N1yx3yi4uL4eXlhaVLl+Lpp582mKawsBCurq6YOXMmPvzwQ7i6uqJWrdI7MmzatAkrV67Ejz/+CACoWbMmOnbsiNmzZ8PX11c/jzFjxiA8PBwFBQXYuHEjmjZtiuDgYJPzq1+/PsiQubzdrcr7jFmj1uEePpm2nd1mUbEHAP55sKzYA4CCAiAjg3v5iMjhpWSmYH3ietnfnSWiBL8l/IaUzBSrXMhRVkScP3/e6D1XV1cAwHPPPYd9+/YhLCwMM2fOBADUqVMHEyZMwPDhwwEAV65cwdtvv43Bgwfjzz//1M8jJSUF33zzDSZNmoRPPvkEtWrVgouLi8n5EdkbCz6Zsguz9ScZExFRxSrzQ1lAYPu57RjVelSVl+/k5ITZs2fj1VdfxdatW9G9e3d07twZ9913Hzw9PQEAQUFB8PDwgJ+fH5o0aaKfNjAwEIGBgQCAJk2aoHXr1vDz88M///xj0K99+/ZYvHixwXJNzY/I3njcQiYvVy8We0REFij7oWwJtUqNLF2W1WJ45ZVXEB8fj759+yI+Ph7Dhw9H3bp1sWHDhnKnu3r1KqZPn46uXbuiWbNmiI6OBgCcO3fOoF9UVJTVYiWyJe7hk6lHgx5QQWXxr1UiortVZX4oS0KCt8a652O3adMGbdq0AVB6LtQjjzyCUaNG4erVq2bPHevXrx9q1aqFWbNmITg4GC4uLmjZsiV0OsMnIrm58e4K5Bi4h0+mMJ8wDAwfCCeVk6z+KqFGzeJmNo6KiKj6KvuhbAkVVLiv/n02igjw9vbGsGHDkJGRgezsbAClh35vvX7x0qVLOHjwID744AP06dMHLVq0gLOzM4qKimQt4/b5EVUHLPgsMLvrbKhUqgq/wFRQQa1Wo1/oo3coMiKi6sfSH8pOKicMihhktSdvFBYW4plnnsHJkyf1benp6VixYgVatWqlv9oxKCjI4FCtr68vNBoNdu3aBQDIycnB5MmTZS/39vkRVQcs+CzQoU4HrHpoFZzUTma/wJxUTnBSO+Hnh3/C1MH973CERETViyU/lFUqFV7t8qrVlu3i4oL27dtj+PDh8Pb2Rt26dRESEgI3NzesXr1a3+/pp59GbGwsQkJC0KRJE1y+fBmffPIJXnjhBYSGhqJ27doICwuTffj29vmx+KPqgPfhq4QDFw/gjT/f0N9u4NZHBA2KGIRXu7xaeuPQgweBdu0snr904ACuhoTwfmAOiPdyc1zMXfkqex8+oPRJG8N+GQYhhMn78TmpnKBSqfDTQz/hgaYPWBybnPu55eTk4Pr166hdu7b+liy3KikpQVpaGnJzc9GgQQO4urpCp9MhLS0NAQEB8PT0RGJiIoKDg/VX+KampkKr1SIgwPg56KbmR4Z4Hz5DvA9fNdShTgf8+uivSMlMwfZz25Gly4K3xhv31b+PDwEnIrrN0KZDsXfMXrM/lAeED/jvh7KNeHp66gs1U5ycnBAaGmrQptFoDG6YHB4ebvD+7f0rmh+RPbHgq4IwnzCr3CuKiEjp+EOZyL5Y8BER0R3DH8pE9mH3gu/o0aP4448/cPPmTXTs2BH9+yvoQgd/f0CrLX1cmlxabel0RERERFZi14Jv8eLFmDVrFp588kn4+/tj0qRJ6NKlC1auXGnPsKwnLAxISCh9Nq5c/v6lz9G9etV2cREREdFdxW4FX2ZmJqZPn44PP/wQ48ePBwBMnDgRDRo0wIgRI9CnTx97hWZdYWGl/ywh8RFuREREZD12u/fAuXPnUFxcbPAcwqCgIISGhhrcH4mIiIiIqsZue/gaNmwIjUaDHTt2oG3btgBKi8Dk5GQkJCSYnU6n0xk8yzArq/Qh25IkQVLInjFJkiCEUMz63E2YO8fF3JWvbHzK/lU3ZTFVx9jIPObtP2WfLVP1jDW+l+xW8Hl5eWHx4sWYMmUK9uzZA39/f2zbtg1NmzZFXl6e2enmz5+PuXPnGrWnp6ejwJKLI6oxSZKQmZkJIQRvAOtgmDvHxdyVr6ioCJIkobi4GMXFxfYOx4AQAiUlpTd05g18HQfzZqi4uBiSJOHatWtwcXExeK/suc9VYfcnbZw5cwa7d+9Gfn4++vXrh0mTJqGwsBC///67yf6m9vCFhobixo0bd+xJG7YmSRLS09MREBDAPzwOhrlzXMxd+QoKCnD+/HnLn7SRkmL5hWuWnveM0oL09j+Stvbtt9/CxcUFw4YNu6PLVRJ75K26KnvSRr169Uw+acPPz8+xn7TRsGFDNGzYEEBp4v/+++9yH1Kt0Wig0WiM2tVqtaK+pFUqleLW6W7B3Dku5s48tVpd+kzcf//JkpICNGli+a2pEhIsKvqEEPqYbo/t+++/R2xsrNE0QUFBePnll+XHZcLvv/8OrVaL4cOHV2k+d6vy8nY3KvtsmfoOssZ3kl2/1Q4ePKjfnQsA77zzDoqKivD000/bMSoiIrKKjAzLij2gtL8lewQrsGXLFqxfvx716tUz+FenTh2rLYPIEdh1D9/Ro0cxduxYdOrUCQkJCTh8+DB++eUXBAcH2zMsIiJSkJCQELzwwgtm31+2bBlCQ0MRGBiIbdu2oaSkBEOHDkXTpk0N+h05cgSrV6+Gl5cXevXqZeOoiazLrnv4Ro0ahVWrVqFVq1YYN24czpw5ww8RERHdUatXr8bkyZMxadIkFBUV4cSJE2jTpg2OHz+u77N582Z06NABycnJyMrKwoMPPohdu3bZMWoiy9j9HL7w8HCEh4fbOwwiIlKo06dPG+3h69Spk8HFFlqtFrt379ZfQNC1a1d8+eWXWLx4MYQQmDp1Kl544QW8++67AIDRo0cjIiLijq0DUVXZveAjIiKyJa1Wi3r16hm01axZ0+B1r169DK4WjYyMRGpqKgDg4sWLOHXqFL7//nv9+w0aNMA999xju6CJrIwFHxERKVpF5/ABgLu7u8FrJycn/f0Gr1y5AgAICAgw6FOrVi3rBUlkY7z3ABERUTnKrui9ePGiQfuFCxfsEQ5RpbDgIyIiKkft2rXRoUMHLFu2TN8WFxeH/fv32zEqIsvwkC4RESmaqYs2NBoN3nnnHdnzWLp0KXr16oWzZ8+ibt262LlzJy84JIfCgo+IiBRrxIgRaN26tVG7q6ur/v8nTpyIwMBAg/cfeughg+eXduzYEQkJCdi0aRO8vLywYMECHDt2DE5OTjaLnciaWPAREZFi9e7dG7179y63z9ChQ43aYmJijNqCg4MxduxYg9dEjoLn8BERkW34+5c+G9cSWm3pdERkVdzDR0REthEWBiQkWPZsXH//0umIyKpY8BERke2EhbGAI6oGeEiXiIiISOFY8BEREREpHAs+IiIiIoVjwUdERESkcCz4iIiIiBSOBR8REZEF8vLysHnzZuh0uju+7OzsbGzevBlFRUV3fNm3u3z5sv55wvaMKyUlBdu2bcPBgwfv+LLlSk9Px99//23XGFjwERHRHSeEuCPLOXbsGDZv3ozNmzdj27ZtSExMrPKy09LS0K9fP6Snp1slxqysLGzevBnFxcUV9j1z5gz69euHzMxMqyy7KsaOHYsDBw4AsH5ccsdkyZIlaNmyJebPn49169ZZZdm24ObmhqFDh+LIkSN2i4H34SMiIpsTQkCXloSsuE3ITYyFKCyAylULj/AoeLfvB01wY6hUKqsvd9GiRfj1118RFRWFoqIiHDlyBCEhIVizZg0aNGhg9eVVRmJiIvr164cbN27A19e33L7e3t7o06ePwbOA7WHnzp2Ii4vD2rVrbTJ/uWOyePFiLF68GKNHj7ZJHNbi6emJiRMnYubMmdi4caNdYmDBR0RENiVKipG+YRlyju0E1GpAkkrbCwuQc2I3co7/Cc+WMQjoPwEqJ+v/WWrZsiU2b94MoPTQY3R0NCZPnowNGzYAKD1Ee+jQIWg0GkRGRsLNzc1oHsnJyUhJSUFERITZ5VQ0n+LiYhw/fhz5+flo0aIFPD09kZ+frz/Ut23bNnh4eCAoKAh169bFvn370Lt3b5w9exbnz59H27ZtERAQgBdeeEE/78LCQmzfvh0A4OLigvr16xsVsjdv3tTP68qVKzhz5gwaNGhg9CxgU/GZs3TpUowcOdJs4SknrluXWVBQUOGYtGrVSj9dTk4Odu/ejcuXLyM1NRWbN29Gq1at4ObmZnLcPD09LRqny5cv4/Tp02jUqJF+nJKSknDp0iU0b94cNWrUMFqXivL/xBNP4PXXX8eZM2fQsGFDs2NrKyz4iIjIZoQQ/xZ7u0ob/i32/utQ+jrnaOn7AQMn2WRPXxkvLy8MHjwYy5cvBwB89913mDx5Mho2bAghBFJSUrBixQr0799fP82cOXPwzjvvoFWrVkhNTUXXrl2N5lvRfE6fPo3evXvDyckJtWvXxrlz57BgwQL06tULP/zwAwBg2bJlcHZ2RkxMDO69917069cPI0eOxN69e9G4cWO89957kCRJfzjZ398fubm5WLJkCYDSIuvo0aNo164d1qxZAw8PDwDA8ePH0a9fPzz++OPYu3cvatWqhfj4eCxevBgTJ04sN77HHnvMaF0LCwvx+++/46effjI7znLiOn36NPr06SN7TG4t+K5du4YlS5aguLgY69atw969ezF9+nS4urqaHLfQ0FDZ4zRo0CAkJCTAx8cHBw8exIcffog//vgDJ0+ehLu7O5KSkrB+/XqD7UDOdlS3bl00bNgQv/32G1544QWzY2czwsFlZmYKACIzM9PeoVhNSUmJuHTpkigpKbF3KGQh5s5xMXfly8/PFydPnhT5+fmWTXchQZx5c6jsf/kXEiyOTZIkUVhYKCRJMnrvySefFN26dTNoe/TRR0WzZs3EoUOHhKenp/j777/17/3www/Cz89PXL9+XQghRGxsrFCr1WLnzp1CCCFyc3NFp06dBACRmpoqhBCy5jN+/HgxePBg/fs5OTli1apVQgghDhw4IACIGzdu6N//66+/BADx1FNPGWyThw4dEgBEenq6ybHIyckR7dq1E2+88YbRvJ5//nn9GH3++efC3d1dFBQUVBjf7cpiOH/+fJXieuaZZ8TAgQP1MVU0JqZoNBrx22+/Ga3r7eMmJ56yaadOnapvmzp1qgAgXnnlFX3buHHjRNeuXQ3WvaL8l3nwwQfFo48+ajKm8j5j1qh1uIePiIhsJituk8Fh3HKp1ciK3wxtnXCrxnD9+nX9BQB79uzBqlWr8PHHH2P58uVo0qQJcnJysHXrVggh4Ofnh/z8fMTGxqJPnz749ttv0bVrV3Tr1g0A4O7ujmnTpmHo0KH6+cuZj0qlQk5ODvLy8uDu7g4PDw888sgjFcY+ffp0qNUVX195/vx5JCcnIz8/H82aNcOePXuM+rz00kv6vad9+/ZFXl4ezp8/j4iICIviK7tYxdRhTUviUqlUyM3NRV5eHjw8PGSPiRzmxk3OOE2ZMkX//927d8f7779v1LZmzRr9azn5L1OzZk2cOXPGKutoKRZ8RERkM7mJsfKKPQCQJOQm7Ld6DBcuXMCSJUvg4uKCkJAQbN68Gb169UL//v1x+fJlLFy40KB/t27d4OTkBAA4d+6c0flWjRo1Mnh9+vTpCuczY8YMjBgxAoGBgejatSv69u2LMWPG6A8nmhMSElLu+1lZWRgyZAji4+MRGRkJb29vnD9/3uR5iP7+/vr/L3s/Pz/f4vjc3d3103p5eVU6rrJl1q5d26IxkeP2cavsOGm1WpNtZeMGyMt/mbKC2h5Y8BERkU0IISAKCyybprAAQgirnsd360Ubt/Lw8EBkZKTJ98r4+fkhKyvLoO3213LmExYWht27d+PChQvYsWMHFi9ejBUrViA+Pr7c2CsahyVLliAjIwOXL1/WFy+zZs3SX5AilyXxlRXAycnJqFWrVqXjCgsLw86dO3H58mXs3LlT9pjIcfu4WWucTJGT/zIpKSlo3759lZdZGbwPHxER2YRKpYLKVWvZNK5am160cauePXti165dOHfunEF7dna2/gbCHTt2xM6dOw326Kxfv97i+Vy/fh1A6Z6nxx9/HEuWLMHBgweRlZWl3+NTWFho8TqkpqYaXBEqSVKlipjy4rtd7dq10bRpU+zdu7dKcdlqTCobT2XJyT9Qui5xcXHo0aOHVZZrKe7hIyIim/EIj0LOyd2yz+HziIi2fVD/Gj16NH788Ud07doV06dPR1BQEI4dO4bvv/8e8fHxcHFxwejRo7Fo0SL0798fzzzzDE6dOoXPPvvM4vlMnjwZzs7O6NGjB7RaLT7++GPce++98Pb2Rv369eHj44N33nkHPXv2NLpdSnn69u2LkSNHYtGiRQgJCcHKlSv1txOxRHnxmTJ27FisWrUKzz//fKXjeu6556BWq9GzZ0+4ublVOCa3XqVrKWuNkyly8g8AGzZsQI0aNdC7d+8qL7MyWPAREZHNeLfvh5zjf8rrLEnwbtfXqstv0aKF2cOOrq6u2LJlC77++mts27YNRUVFaN26Nfbu3asvdLRaLXbv3o13330XP/30E5o0aYLt27djxowZ+vO75Mzn66+/xvfff48//vgDOp0OgwYNwrhx4wCUnk+3YcMGfPnll/jwww/RtWtXDBo0SH/LklvdfuPlBx98ECUlJVi7di3+/vtv9OnTB4899pjBxQh+fn5G83J1dUWfPn1kxWfK008/jffeew/x8fFo165dpeJauXIlvvnmG2zfvl3WmJgq+Hr37m2QX1PrWpVx8vf3N7joAgACAwPRq1cvg7GsKP8A8PHHH2P69OlwdrZP6aUS4g4938ZGsrKy4OPjg8zMTLO/RByNJEm4evUqatWqJevqLKo+mDvHxdyVr6CgAOfOnUP9+vX1hY4cQgik//bRv/fhK+/PjQqeLbtV6j58QggUFxfD2dn5jh0OJuDnn3/GmTNnMGPGjEpNfzfl7ezZs3j11Vfx9ddfmy34yvuMWaPW4R4+IiKyGZVKhYABEwAVkHN0p/EtWv597dmyW+mTNhT+h19JHn74YXuH4DAaNGiA77//3q4xsOAjIiKbUjk5I2DgJHi37YOs+M3ITdj/37N0I6Lh3a6vzZ6lS0SlWPAREZHNqVQqaOuE62+qbO1brxBR+XiiChER3XEs9ojuLBZ8RERERArHgo+IiGRz8Bs7EFVbtv5sseAjIqIKld2bzFpPPiAiQ3l5eQCgv1GztfGiDSIiqpCzszPc3d2Rnp4OFxeXanWvwrvpfm5KwryVEkIgLy8PV69eha+vr9FNo62FBR8REVVIpVIhKCgI586dQ3Jysr3DMSCEgCRJUKvVd3Xh4GiYN0O+vr6oXbu2zebPgo+IiGRxdXVF48aNq91hXUmScO3aNdSsWbNa7Xmk8jFv/3FxcbHZnr0yLPiIiEg2tVpt0aPV7gRJkuDi4gKtVnvXFw6OhHm7szjCRERERArHgo+IiIhI4VjwERERESkcCz4iIiIihasWBV9aWhpOnDiBzMxMe4dCDo5PASAiIjJm16t0T548iREjRiAlJQVBQUE4e/Yshg4diuXLl0Oj0dgzNHIQQgjo0pKQFbcJuYmxEIUFULlq4REeBe/2/aAJbsz7OxER0V3PrgXf+PHjERAQgP3790Oj0eDMmTNo06YNPv74Y0ydOtWeoZEDECXFSN+wDDnHdgJqNSBJpe2FBcg5sRs5x/+EZ8sYBPSfAJUT70BERER3L7se0r106RI6deqk35vXsGFD1K1bF5cuXbJnWOQAhBD/Fnu7Shv+Lfb+61D6OufoLqRvXMZDvUREdFez626P2bNn45VXXkFERATq1q2LLVu2IDMzExMmTLBnWOQAdGlJpXv2KiSQc3QnvNv2gbZOuI2jIiIiqp7sWvANGDAAv/32GyZNmoSgoCCkpqbi9ddfR/369c1Oo9PpoNPp9K+zsrIAlN6xW7p9L4+DkiRJ/4xBMi3zwEaDw7jlUquRGbcJrkGNbB4Xc+e4mDvHxdw5JuZNPmuMkV0Lvv79+6NWrVpIS0uDm5sbzp49i44dO6KoqAgzZswwOc38+fMxd+5co/b09HQUFBTYOuQ7QpIkZGZmQgjBx82YkZcYK6/YAwBJQm7CfojoYbYNCsydI2PuHBdz55iYN/mys7OrPA+VsNPJTRcvXkRISAg2bNiA/v3769vHjRuHw4cPIzY21uR0pvbwhYaG4saNG/D29rZ53HeCJElIT09HQEAAPwQmCCGQvOARi6erO+Mnm1+xy9w5LubOcTF3jol5ky8rKwt+fn7IzMysdK1jtz18fn5+UKvVuHz5skH7pUuXULNmTbPTaTQak7dsUavVitpgVCqV4tbJmlSuWohC+Xt0Va5aODk52TCiW5bF3Dks5s5xMXeOiXmTxxrjY7eCz93dHU8++SReeeUVqNVqNGjQAFu2bMGGDRvwv//9z15hkYPwCI9Czsndss/h84iItn1QRERE1ZRdz+H77LPP8H//93/43//+h2vXrqFu3brYsWMHunXrZs+wyAF4t++HnON/yussSfBu19e2AREREVVjdi34XFxcMGHCBN6GhSymCW4MzxYx/96Hr7zTUFXwbNkNmuDGdyo0IiKiaocHzckhqVQqBAyYAM+W/+4Nvv38hn9fe7bsVvqkDT5ejYiI7mJ83hQ5LJWTMwIGToJ32z7Iit9ceuuVsmfpRkTDu11fPkuXiIgILPjIwalUKmjrhOufoiGEYIFHRER0Gx7SJUVhsUdERGSMBR8RERGRwrHgIyIiIlI4FnxERERECseCj4iIiEjhWPARERERKRwLPiIiIiKFY8FHREREpHAs+IiIiIgUjgUfERERkcKx4CMiIiJSOBZ8RERERArHgo+IiIhI4VjwERERESkcCz4iIiIihWPBR0RERKRwLPiIiIiIFI4FHxEREZHCseAjIiIiUjgWfEREREQKx4KPiIiISOFY8BEREREpHAs+IiIiIoVjwUdERESkcCz4iIiIiBSOBR8RERGRwrHgIyIiIlI4FnxERERECseCj4iIiEjhWPARERERKRwLPiIiIiKFY8FHREREpHAs+IiIiIgUjgUfERERkcKx4CMiIiJSOBZ8RERERArHgo+IiIhI4VjwERERESkcCz4iIiIihWPBR0RERKRwLPiIiIiIFM7ZnguPjIxEbm6uUftjjz2GN9980w4RERERESmPXQu+TZs2QZIk/eu4uDg8/PDD6NSpkx2jIiIiIlIWuxZ8YWFhBq8XLFiAkJAQ9O3b104RERERESlPtTmHLy8vDz/88APGjh0LJycne4dDREREpBh23cN3q59//hk5OTkYM2ZMuf10Oh10Op3+dVZWFgBAkiSDw8OOTJIkCCEUsz53E+bOcTF3jou5c0zMm3zWGKNKFXxCCJw4cQIXLlwAAISGhqJZs2ZQqVSVDuTLL79Enz59jA7z3m7+/PmYO3euUXt6ejoKCgoqvfzqRJIkZGZmQggBtbra7IQlGZg7x8XcOS7mzjExb/JlZ2dXeR4qIYSQ2/mff/7B0qVLsWrVKly/ft3gvZo1a2L48OGYPHkyIiIiLAoiKSkJ4eHhWLNmDR544IFy+5rawxcaGoobN27A29vbouVWV5IkIT09HQEBAfwQOBjmznExd46LuXNMzJt8WVlZ8PPzQ2ZmZqVrHdl7+CZPnowVK1Zg0KBB+PDDD9GhQwcEBgYCAK5cuYLY2FisX78e7du3x+jRo7F06VLZQXz55ZcIDAzEoEGDKuyr0Wig0WiM2tVqtaI2GJVKpbh1ulswd46LuXNczJ1jYt7kscb4yC74XF1dce7cOfj7+xu95+3tjcaNG2PkyJHIyMjA/PnzZQdQXFyMr7/+GqNHj4azc7U5pZCIiIhIMWRXWIsWLZLVz9/fX3ZfANi4cSMuX76MsWPHyp6GiIiIiOSz+y61rl27Ijk5GaGhofYOhYiIiEiRKl3w7du3D3v27MGNGzeM3rPksWi+vr7w9fWtbBhEREREVIFKFXzz58/Hq6++ihYtWrBYIyIiIqrmKlXwLVmyBBs3bkSfPn2sHQ8RERERWVmlrvPNz89H586drR0LEREREdlApQq+fv36YfXq1daOhYiIiIhsoNKHdFu0aIGff/4ZDRs2NHqk2pIlS6wRGxERERFZQaUKvtdffx1ZWVm4efMmzpw5Y+2YiIiIiMiKKlXw/fDDD9i6dSu6detm7XiIiIiIyMoqdQ6fm5sb2rZta+1YiIiIiMgGKlXwdevWDd999521YyEiIiIiG6jUIV1JkjBhwgT8/PPPaNSokdFFG59++qlVgiMiIiKiqqv0o9UefPBBAMC1a9esFgwRERERWV+lCr5ffvnF2nEQERERkY3IPocvISFB9kwt6UtEREREtiW74OvevTtGjx6N/fv3m3xfCIHdu3fjySefRExMjLXiIyIiIqIqkn1I9+TJk3jjjTfQs2dPuLm5oV27dggMDIQQApcvX0ZcXByKiorw9NNP49SpU7aMmYiIiIgsIHsPn6+vLxYtWoSLFy9iyZIlaNCgAa5fv46bN2+iUaNG+Oijj3Dx4kUsWrQIvr6+NgyZiIiIiCxh8UUb3t7eGDFiBEaMGGGLeIiIiIjIyip142UiIiIichws+IiIiIgUjgUfERERkcKx4CMiIiJSuEoVfPfddx++/fZb5OfnWzseIiIiIrKyShV8jRs3xrPPPougoCCMHz8eBw4csHZcRERERGQllSr4PvvsM1y+fBkffvghEhISEB0djRYtWmDx4sVIT0+3doxEREREVAWVPofPzc0Njz/+OHbs2IHTp09j0KBBmDFjBurUqYOHHnoIe/bssWacRERERFRJVb5oIyEhAZ9//jlWrFgBd3d3jBs3Dmq1Gt27d8frr79uhRCJiIiIqCosftIGAOTk5OCnn37C8uXLsXfvXnTp0gXvvvsuHnroIWi1WgBAbGwsevTowaKPiIiIyM4qVfDVrl0bnp6eePLJJ/HVV1+hcePGRn2ioqJQt27dKgdIRERERFVTqYLv66+/xqBBg+Di4lJuv+PHj1cqKCIiIiKynkoVfEOHDrV2HERERERkI3zSBhEREZHCseAjIiIiUjgWfEREREQKx4KPiIiISOFY8BEREREpHAs+IiIiIoVjwUdERESkcCz4iIiIiBSOBR8RERGRwrHgIyIiIlI4FnxERERECseCj4iIiEjhWPARERERKZyzvQMAgP3792PHjh1wd3fHww8/jKCgIHuHRERERKQYdt3DJ4TA008/jX79+uHSpUu4dOkS+vTpg4SEBHuGRURERKQodt3Dt2zZMnz33Xc4dOgQIiIiAAAvv/wyCgoK7BkWERERkaLYteD78MMPMWLECH2xBwC+vr72C4iIiIhIgexW8GVnZ+Off/7BzJkzsX79esTHxyM4OBhDhgxBQECA2el0Oh10Op3+dVZWFgBAkiRIkmTzuO8ESZIghFDM+txNmDvHxdw5LubOMTFv8lljjOxW8GVmZgIAlixZAj8/P3Tu3Bm//PILpk2bhj/++APt27c3Od38+fMxd+5co/b09HTFHAqWJAmZmZkQQkCt5oXUjoS5c1zMneNi7hwT8yZfdnZ2leehEkIIK8RisZs3b8LPzw/dunXDzp079e19+vSBJEnYunWryelM7eELDQ3FjRs34O3tbeuw7whJkpCeno6AgAB+CBwMc+e4mDvHxdw5JuZNvqysLPj5+SEzM7PStY7d9vD5+voiKCgIUVFRBu3R0dH45ptvzE6n0Wig0WiM2tVqtaI2GJVKpbh1ulswd46LuXNczJ1jYt7kscb42HWEhw8fjr/++gtlOxmFENi1axdatGhhz7CIiIiIFMWuV+m+9tpruO+++xAVFYVOnTohNjYWFy9exPbt2+0ZFhEREZGi2LXg8/X1xb59+7BhwwYkJycjJiYGffv2hbu7uz3DIiIiIlIUuz9azdXVFQ888IC9wyAiIiJSLJ4lSURERKRwLPiIiIiIFI4FHxEREZHCseAjIiIiUjgWfEREREQKx4KPiIiISOFY8BEREREpHAs+IiIiIoVjwUdERESkcCz4iIiIiBSOBR8RERGRwrHgIyIiIlI4FnxERERECseCj4iIiEjhWPARERERKRwLPiIiIiKFY8FHREREpHAs+IiIiIgUjgUfERERkcKx4CMiIiJSOBZ8RERERArHgo+IiIhI4VjwERERESkcCz4iIiIihWPBR0RERKRwLPiIiIiIFI4FHxEREZHCseAjIiIiUjgWfEREREQKx4KPiIiISOFY8BEREREpHAs+IiIiIoVjwUdERESkcCz4iIiIiBSOBR8RERGRwrHgIyIiIlI4FnxERERECseCj4iIiEjhWPARERERKRwLPiIiIiKFY8FHREREpHAs+IiIiIgUjgUfERERkcI523PhFy5cQEZGhkGbm5sbIiIi7BQRERERkfLYteB788038eOPP6JevXr6tkaNGuGXX36xX1BERERECmPXgg8AevbsyQKPiIiIyIbsfg5fcXExEhMTceXKFXuHQkRERKRIdi/4fv31V/Tt2xeNGjVCeHg4duzYYe+QiIiIiBTFrod0Y2Ji8MorryAsLAyFhYWYOnUq7r//fhw7dgx169Y1OY1Op4NOp9O/zsrKAgBIkgRJku5I3LYmSRKEEIpZn7sJc+e4mDvHxdw5JuZNPmuMkUoIIawQi1UUFRWhZs2aeOONN/D888+b7PP6669j7ty5Ru2JiYnw8vKydYh3hCRJyMzMhI+PD9Rqu++EJQswd46LuXNczJ1jYt7ky87ORnh4ODIzM+Ht7V2pedj9oo1bubi4oFatWkhNTTXbZ+bMmZg6dar+dVZWFkJDQxEQEFDpQahuJEmCSqVCQEAAPwQOhrlzXMyd42LuHBPzJp9Wq63yPOxW8AkhUFRUBFdXV33b+fPncf78eTRp0sTsdBqNBhqNxqhdrVYraoNRqVSKW6e7BXPnuJg7x8XcOSbmTR5rjI/dCr6ioiK0b98ekyZNQmRkJFJSUjB37lw0bdoUI0eOtFdYRERERIpjt5La1dUV69atw/HjxzFjxgz88MMPGDt2LA4cOAA3Nzd7hUVERESkOHY9h69+/fpYunSpPUMgIiIiUjweNCciIiJSOBZ8RERERArHgo+IiIhI4VjwERERESkcCz4iIiIihWPBR0RERKRwLPiIiIiIFI4FHxEREZHCseAjIiIiUjgWfEREREQKx4KPiIiISOFY8BFVQ0IIe4dAREQK4mzvAIiotMDTpSUhK24TchNjIQoLoHLVwiM8Ct7t+0ET3BgqlcreYRIRkYNiwUdkZ6KkGOkbliHn2E5ArQYkqbS9sAA5J3Yj5/if8GwZg4D+E6By4keWiIgsx0O6RHYkhPi32NtV2vBvsfdfh9LXOUd3IX3jMh7qJSKiSmHBR2RHurSk0j17qKiQE8g5uhO6tCTbB0VERIrDgo/IjrLiNpUexpVDrUZW/GbbBkRERIrEgo/IjnITY40P45ojSchN2G/bgIiISJFY8BHZiRACorDAsmkKC3geHxERWYwFH5GdqFQqqFy1lk3jquXtWYiIyGIs+IjsyCM8yqJz+Dwiom0bEBERKRILPiI78m7fz6Jz+Lzb9bVtQEREpEgs+IjsSBPcGJ4tYgBUdJhWBc+WMdAEN74DURERkdKw4COyI5VKhYABE+DZsltpw+2Hd/997dmyW+mTNnj+HhERVQKf00RkZyonZwQMnATvtn2QFb8ZuQn7/3uWbkQ0vNv15bN0iYioSljwEVUDKpUK2jrh0NYJB1B6yxYWeEREZC08pEtUDbHYIyIia2LBR0RERKRwLPiIiIiIFI4FHxEREZHCseAjIiIiUjgWfEREREQKx4KPiIiISOFY8BEREREpHAs+IiIiIoVjwUdERESkcCz4iIiIiBSOBR8RERGRwrHgIyIiIlI4FnxERERECseCj4iIiKiShBD2DkEWZ3sHQEREROQohBDQpSUhK24TchNjIQoLoHLVwiM8Ct7t+0ET3BgqlcreYRphwUdEREQkgygpRvqGZcg5thNQqwFJKm0vLEDOid3IOf4nPFvGIKD/BKicqleJxUO6RERERBUQQvxb7O0qbfi32PuvQ+nrnKO7kL5xWbU71FttCr6PP/4YjRo1wltvvWXvUIiIiIgM6NKSSvfsoaJCTiDn6E7o0pJsH5QFqkXBd+jQIbz33nsoLi5Genq6vcMhIiIiMpAVt6n0MK4cajWy4jfbNiAL2b3gy8nJwfDhw/Hpp5/C19fX3uEQERERGclNjDU+jGuOJCE3Yb9tA7KQ3Qu+iRMnok+fPujbt6+9QyEiIiIyIoSAKCywbJrCgmp1Hp9dLyFZuXIlDh48iLi4ONnT6HQ66HQ6/eusrCwAgCRJkORW3tWcJEkQQihmfe4mzJ3jYu4cF3PnmBwtbypXrUVFn8pVW1ooWqHos8YY2a3gS0pKwosvvojt27dDq9XKnm7+/PmYO3euUXt6ejoKCiyrvqsrSZKQmZkJIQTUcs8XoGqBuXNczJ3jYu4ck6PlTR3aAiVn4/VX45ZLpYY6rCWuXr1qlWVnZ2dXeR4qYaf9jR999BGmTZuGOnXq6NtSU1Ph5uYGf39/JCQkwMnJyWg6U3v4QkNDcePGDXh7e9+R2G1NkiSkp6cjICDAIT4E9B/mznExd46LuXNMjpa3gouJuPz1LNn9g554G5o6ja2y7KysLPj5+SEzM7PStY7d9vA9/vjjRuftDR48GNHR0Zg1a5bJYg8ANBoNNBqNUbtarXaIDUYulUqluHW6WzB3jou5c1zMnWNypLy5hUTAs0XMv/fhK29fmQqeLbtBGxJutSduWGN87Fbw+fj4wMfHx6DN1dUVPj4+aNSokZ2iIiIiIjKmUqkQMGACoAJyju40eNIGAP1rz5bdSp+0Uc0er1a9nvtBREREVE2pnJwRMHASvNv2QVb8ZuQm7P/vWboR0fBu15fP0pXjt99+g5ubm73DICIiIjJJpVJBWycc2jrhAEpv2VIdC7zbVauCLzQ01N4hEBEREcnmCMUeUA1uvExEREREtsWCj4iIiEjhWPARERERKRwLPiIiIiKFY8FHRERkhp0eRkVkddXqKl0iIiJ7EkJAl5aErLhNyE2M/e8ea+FR8G7fr9reY42oIiz4iIiIAIiSYqRvWIacYzsNnqIgCguQc2I3co7/Cc+WMaVPUXDin09yLDykS0REdz0hxL/F3q7ShlsfmQUAovR1ztFdSN+4jId6yeGw4CMiorueLi2pdM8eKirkBHKO7oQuLcn2QRFZEQs+IiK662XFbSo9jCuHWo2s+M22DYjIyljwERHRXS83Mdb4MK45koTchP22DYjIyljwERHRXU0IAVFYYNk0hQU8j48cCgs+IiK6q6lUKqhctZZN46rl7VnIobDgIyKiu55HeJRF5/B5RETbNiAiK2PBR0REdz3v9v0sOofPu11f2wZEZGUs+IiI6K6nCW4MzxYxACo6TKuCZ8sYaIIb34GoiKyHBR8REd31VCoVAgZMgGfLbqUNtx/e/fe1Z8tupU/a4Pl75GD4bBgiIiIAKidnBAycBO+2fZAVvxm5Cfv/e5ZuRDS82/Xls3TJYbHgIyIi+pdKpYK2Tji0dcIBlN6yhQUeKQEP6RIREZnBYo+UggUfERERkcKx4CMiIiJSOBZ8RERERArHgo+IiIhI4VjwERERESkcCz4iIiIihXP4+/AJIQAAWVlZdo7EeiRJQnZ2NrRaLdRyH+ZN1QJz57iYO8fF3Dkm5k2+shqnrOapDIcv+LKzswEAoaGhdo6EiIiIyHays7Ph4+NTqWlVoirlYjUgSRLS0tLg5eWlmBtkZmVlITQ0FKmpqfD29rZ3OGQB5s5xMXeOi7lzTMybfEIIZGdnIzg4uNJ7Qx1+D59arUZISIi9w7AJb29vfggcFHPnuJg7x8XcOSbmTZ7K7tkrw4PmRERERArHgo+IiIhI4VjwVUMajQZz5syBRqOxdyhkIebOcTF3jou5c0zM253l8BdtEBEREVH5uIePiIiISOFY8BEREREpHAs+IiIiIoVjwVdN5eXlYffu3UhMTLR3KGSB3NxcHDx4EOnp6fYOhSxw48YNHDp0CImJiSguLrZ3OFSOw4cPIz4+3uz7xcXFOHLkCE6cOFGlx1CRdRUUFGDv3r04f/682T4XL17E0aNHkZOTc+cCu4uw4Kumxo8fj27dumHevHn2DoVkmjdvHgIDAzF69GhERUVh0qRJ9g6JKiBJEiZMmIA6depgzJgx6NmzJxo0aIBt27bZOzS6zccff4zIyEh0794dw4YNM9knNjYW9evXx6BBg9CjRw80adIE//zzzx2OlG6VkZGBF198EQ0aNEDPnj3x0UcfGfXZsGEDWrVqhejoaDz22GMIDAzEq6++aodolY0FXzX0zTffIDExEV26dLF3KCTTO++8g0WLFmHHjh04cuQIzp07h+bNm6OkpMTeoVE5Vq9ejc8//xx///03Dh06hOTkZPTq1QtPPPGEvUOj25w9exarVq3C888/b/J9nU6HBx98EP3790dKSgrS0tLQpEkTs8Uh3RnJyckIDg7GsWPHEB4ebrLPuXPn8N133+HChQs4evQotmzZgvfeew/ff//9HY5W2VjwVTNJSUmYPn06vv32Wzg7O/yT7+4K+fn5mD9/Pl566SV06NBB3z5+/Hg4OTnZMTKqSHp6Ojw8PNCyZUsAgEqlQqdOnXD9+nVIkmTn6OhWixYtQvPmzc2+v2XLFly4cAGzZ88GUPrYzVdeeQVHjx5FXFzcnQqTbtOuXTu8+OKLqFmzptk+kyZNMsht586d0bJlS+zevftOhHjXYMFXjRQWFmLYsGF466230KhRI3uHQzLFxcUhMzMTgwYNwuXLl3Hw4EHcvHnT3mGRDI8++igaNGiAp556Clu2bMH333+PBQsWYP78+ZV+QDnZx6FDhxAYGGjwbPX27dtDpVLh0KFDdoyMLJWZmYmkpCT+HbQy7kKqRqZNm4b69etjzJgx9g6FLJCWlgYAWLlyJX788UcEBgYiISEBTz31FJYuXQqVSmXnCMkcPz8/TJ48GS+//DLi4uJw7do1NG7cGIMGDbJ3aGSh69evG+1FcnJygq+vL65fv26nqKgyxo8fD09PT4wePdreoSgKC75qYs+ePfjiiy/w448/6ndjZ2ZmwsnJCbt370Z0dDRcXFzsHCWZUpaXM2fOIDk5Ga6urjh06BA6deqE1q1bY+zYsXaOkMxZuXIlnnvuOezduxetWrWCJEl44YUX0L17dyQkJMDNzc3eIZJMLi4uKCgoMGovKCiAq6urHSKiypgyZQo2b96M7du3w8/Pz97hKAqPWVQTBQUFaNu2Ld59913MmDEDM2bMQFJSEg4dOoQZM2YgOzvb3iGSGfXq1QMAjB49Wv+HpU2bNoiOjsZff/1lx8ioIuvXr8e9996LVq1aASg972vChAlITU3lYUAHU7duXVy5csXgQqnr168jPz8fYWFhdoyM5Jo2bRpWrFiBrVu3ok2bNvYOR3G4h6+a6NGjB3r06GHQ1rNnT9SuXRvffvutnaIiOVq1aoXatWvj4sWL+jYhBNLS0hAVFWXHyKgiAQEBOHXqFIQQ+kPvqamp+vfIcfTs2RO5ubnYtm0bevfuDQBYt24dXFxc0K1bNztHRxWZPn06vvjiC2zduhXt27e3dziKxIKPqIqcnJzwzjvvYOrUqXB2dkb9+vXx3Xff4erVq5gwYYK9w6NyPPPMM1i+fDlGjRqFRx99FFevXsWcOXPQt29fnjBezRw7dgyZmZlISUlBQUGB/tSXqKgouLq6okmTJhg9ejTGjh2LBQsWoKCgAC+99BKmTZsGf39/O0d/9youLsa+ffsAlN6Y/uLFi9i9eze8vLz0e9bnzZuHhQsXYtGiRdDpdPrc1qxZE02bNrVb7EqjErwVebU1ZcoU1KhRQ3+bAareNm7ciK+++gpZWVlo0qQJpkyZoj/cS9XXyZMn8cknnyApKQleXl7o0qULnnnmGWi1WnuHRreYOHEijh49atS+du1a/d7Y4uJifPTRR9i8eTOcnZ0xZMgQjB07lhdO2VFmZiYGDBhg1N6kSRP83//9H4DSH14nTpww6tO1a1e8/fbbNo/xbsGCj4iIiEjheNEGERERkcKx4CMiIiJSOBZ8RERERArHgo+IiIhI4VjwERERESkcCz4iIiIihWPBR0RERKRwLPiIiGQ4cuRIlZ+ve+rUKezfv99KERERyceCj4ioArm5uRg0aBCKi4urNB9XV1cMHDgQ6enpVoqMiEgeFnxERBX48MMP0bRpU3To0KFK82nYsCF69eqFBQsWWCkyIiJ5WPAR0V1l3bp1OHjwoEHbgQMH8Ntvv5nsL4TAJ598glGjRunbkpKSsHHjRhQVFSE+Ph6//vor0tLSAABFRUXYtWsXNm7ciOvXrxvN7/HHH8fy5ctRUFBgvZUiIqqAs70DICK6k5KTkzFq1CgcOXIEYWFhOHPmDHr06IGFCxea7H/kyBGkpqaie/fu+rbff/8db775Jvz9/REYGIicnBwcPXoUH330Ed5//30EBwfjxo0bSElJwZ49e9C4cWP9tF27dkVOTg52796Nnj172nx9iYgA7uEjorvM5MmT0bFjRzz++OPQ6XQYOXIk7rvvPowbN85k/4MHD6JGjRqoXbu2QfuVK1fw5ptvYtu2bdi/fz969uyJp556CosWLcLWrVsRFxeHyMhILF682GA6Dw8P1K9fHwcOHLDZOhIR3Y4FHxHdVVQqFVasWIF//vkHHTp0QEpKCv7v//7PbP+MjAz4+fkZtdeqVQtDhgzRv+7YsSPCwsLQt29fg7bExESjaf38/JCRkVG1FSEisgALPiK66wQGBmLSpEk4duwYZs+eDX9/f7N9PT09kZuba9R+exGo0WhMtpk6Vy83NxdeXl6VjJ6IyHIs+IjornPhwgUsXrwYzZo1w/vvv4+cnByzfcPDw5Genm6y6KsMSZKQkpKCiIgIq8yPiEgOFnxEdFeRJAlPPPEEoqKiEBsbC2dnZzz//PNm+99zzz1wdXXFvn37rLL8o0ePIjc31+AiECIiW2PBR0R3lYULF+LYsWP46quv4OHhge+//x7ffvst1qxZY7K/u7s7RowYgR9++MEqy1+1ahUGDhxodBEIEZEtseAjortGVlYWTpw4gW+++QZBQUEAgDZt2uDTTz/F9u3bUVJSYnK6GTNmYM2aNbh69SqA0sO8AwYMMOjTpEkTgws2AKB58+YGt17Jzc3FihUrMGvWLGuuFhFRhVRCCGHvIIiIqrtPPvkEwcHBBlfmWmrHjh3Yt28fZs6cab3AiIhkYMFHREREpHA8pEtERESkcCz4iIiIiBSOBR8RERGRwrHgIyIiIlI4FnxERERECseCj4iIiEjhWPARERERKRwLPiIiIiKFY8FHREREpHAs+IiIiIgUjgUfERERkcL9P8etkZdwjootAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 640x640 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "id": "6de52c67",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from robot_sf.render.jsonl_playback import JSONLPlaybackLoader\n",
     "\n",
@@ -297,7 +215,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d3f0bec",
+   "id": "c97a0f5b",
    "metadata": {},
    "source": [
     "## 3. Render a top-down map thumbnail\n",
@@ -307,25 +225,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "2e2c7033",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-15T23:25:20.211835Z",
-     "iopub.status.busy": "2026-07-15T23:25:20.211757Z",
-     "iopub.status.idle": "2026-07-15T23:25:20.253701Z",
-     "shell.execute_reply": "2026-07-15T23:25:20.253152Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Saved: output/notebooks/03_visualize_trace/map_thumbnail.png\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "e87bb0b2",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from robot_sf.maps.map_visualizer import visualize_map_definition\n",
     "\n",
@@ -336,7 +239,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8dda16f2",
+   "id": "2b7192a3",
    "metadata": {},
    "source": [
     "## 4. Export the interactive browser viewer\n",
@@ -348,27 +251,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "025f8860",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-15T23:25:20.255034Z",
-     "iopub.status.busy": "2026-07-15T23:25:20.254966Z",
-     "iopub.status.idle": "2026-07-15T23:25:20.567231Z",
-     "shell.execute_reply": "2026-07-15T23:25:20.566776Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Open this file in a browser to watch the recording:\n",
-      "   output/notebooks/03_visualize_trace/viewer/index.html\n",
-      "Viewer files: ['index.html', 'scene.json', 'viewer.js']\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "20983498",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from robot_sf.render.threejs_viewer import export_threejs_viewer\n",
     "\n",
@@ -385,7 +271,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "749bbcbf",
+   "id": "cd5f2e3b",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -412,16 +298,7 @@
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/robot_sf/gym_env/base_env.py
+++ b/robot_sf/gym_env/base_env.py
@@ -26,6 +26,8 @@ from robot_sf.sim.registry import get_backend
 from robot_sf.sim.simulator import init_simulators
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from robot_sf.render.jsonl_recording import JSONLRecorder
     from robot_sf.render.sim_view import SimulationView
 
@@ -115,6 +117,7 @@ class BaseEnv(Env):
         # New JSONL recording system
         self.use_jsonl_recording = use_jsonl_recording
         self.jsonl_recorder: JSONLRecorder | None = None
+        self.last_recorded_jsonl: Path | None = None
 
         if use_jsonl_recording and recording_enabled:
             # Use provided seed or generate from environment config
@@ -244,6 +247,7 @@ class BaseEnv(Env):
     ) -> None:
         """Start recording a new episode with JSONL recorder."""
         if self.jsonl_recorder is not None:
+            self.last_recorded_jsonl = None
             self.jsonl_recorder.start_episode(
                 config_hash=config_hash,
                 telemetry_path=telemetry_path,
@@ -269,6 +273,7 @@ class BaseEnv(Env):
         """End the current episode recording."""
         if self.jsonl_recorder is not None:
             self.jsonl_recorder.end_episode()
+            self.last_recorded_jsonl = self.jsonl_recorder.last_episode_file
 
     def close_recorder(self) -> None:
         """Close the recorder and clean up resources."""

--- a/robot_sf/render/jsonl_recording.py
+++ b/robot_sf/render/jsonl_recording.py
@@ -106,6 +106,7 @@ class JSONLRecorder:
         self.current_file = None
         self.current_metadata = None
         self.last_simulation_timestep = 0.0
+        self.last_episode_file: Path | None = None
         self.flush_every_n = self._normalize_flush_interval(flush_every_n)
         self.flush_on_episode_end = flush_on_episode_end
         self._records_since_flush = 0
@@ -442,6 +443,7 @@ class JSONLRecorder:
 
         # Close episode file
         self.current_file.close()
+        self.last_episode_file = self._get_episode_filename(self.current_episode_id)
         self.current_file = None
 
         logger.info(f"Ended episode {self.current_episode_id} with {self.current_step_idx} steps")

--- a/scripts/dev/generate_quickstart_notebooks.py
+++ b/scripts/dev/generate_quickstart_notebooks.py
@@ -580,9 +580,19 @@ def build_notebook_03() -> nbf.notebooknode:
         ),
         _code(
             """
-            # Locate the recorded JSONL (the recorder names it with suite/scenario/algorithm/seed).
-            candidates = sorted(recording_dir.glob("*.jsonl"))
-            episode_jsonl = candidates[-1]
+            # Consume the exact path reported by the recorder. Do not glob the directory:
+            # a previous notebook run may have left a newer-looking, stale recording there.
+            env_path = getattr(env, "last_recorded_jsonl", None)
+            if env_path is None:
+                raise FileNotFoundError(
+                    "No JSONL recording was produced; the episode recorder did not report "
+                    "an output path."
+                )
+            episode_jsonl = Path(env_path)
+            if not episode_jsonl.is_file():
+                raise FileNotFoundError(
+                    f"The episode recorder reported a missing JSONL file: {episode_jsonl}"
+                )
             # Promote a stable copy next to the other artifacts.
             stable_jsonl = OUTPUT_DIR / "episode.jsonl"
             stable_jsonl.write_bytes(episode_jsonl.read_bytes())

--- a/tests/test_quickstart_notebooks.py
+++ b/tests/test_quickstart_notebooks.py
@@ -178,3 +178,83 @@ def test_all_notebooks_execute_headless() -> None:
             f"{nb.name} failed to execute headless:\n"
             f"{result.stderr.decode(errors='replace')[-2000:]}"
         )
+
+
+def test_notebook_03_does_not_glob_and_pick_last_recording() -> None:
+    """Notebook 03 must not rely on glob-last JSONL discovery, which silently selects a stale artifact.
+
+    The previous `candidates[-1]` lookup picked the lexicographically-last file in the
+    recordings directory; a higher episode id left by a prior run was selected instead of
+    the freshly recorded episode, producing a cryptic `IndexError`/`ValueError`.
+    """
+    nb = _load("03_visualize_trace.ipynb")
+    joined = "\n".join(c.source for c in nb.cells if c.cell_type == "code")
+    assert "candidates[-1]" not in joined, (
+        "notebook 03 must not use glob-and-pick-last (candidates[-1]) recording discovery"
+    )
+    assert "last_recorded_jsonl" in joined, (
+        "notebook 03 should locate its recording via env.last_recorded_jsonl (deterministic)"
+    )
+    assert "FileNotFoundError" in joined, (
+        "notebook 03 should fail clearly when no recording was produced"
+    )
+
+
+def test_notebook_03_locates_fresh_recording_with_stale_present(tmp_path: Path) -> None:
+    """Reproduces Issue #5827: a stale higher-episode-id recording must NOT be selected.
+
+    We record one deterministic episode, then drop a stale `ep0001` file next to the fresh
+    `ep0000`, and assert the discovery selects the *fresh* file rather than the stale one.
+    """
+    import numpy as np
+
+    from robot_sf.gym_env.environment_factory import make_robot_env
+    from robot_sf.training.scenario_loader import (
+        build_robot_config_from_scenario,
+        load_scenarios,
+    )
+
+    scenario_name = "quickstart_demo_crossing_basic"
+    scenario_path = REPO_ROOT / "configs/scenarios/single/quickstart_demo.yaml"
+    scenario = next(s for s in load_scenarios(scenario_path) if s["name"] == scenario_name)
+    config = build_robot_config_from_scenario(scenario, scenario_path=scenario_path)
+
+    recording_dir = tmp_path / "recordings"
+    recording_dir.mkdir(parents=True, exist_ok=True)
+    # Arm a stale higher episode id, simulating a prior run's leftover artifact.
+    stale = recording_dir / "notebook_quickstart_demo_crossing_basic_random_270_ep0001.jsonl"
+    stale.write_text('{"event": "step", "state": {}}\n')
+
+    env = make_robot_env(
+        config=config,
+        seed=270,
+        debug=False,
+        recording_enabled=True,
+        use_jsonl_recording=True,
+        recording_dir=str(recording_dir),
+        suite_name="notebook",
+        scenario_name=scenario_name,
+        algorithm_name="random",
+        recording_seed=270,
+    )
+    try:
+        env.reset(seed=270)
+        for _ in range(5):
+            _obs, _rew, terminated, truncated, _info = env.step(np.zeros(2, dtype=np.float32))
+            if terminated or truncated:
+                break
+        env.end_episode_recording()
+        assert env.last_recorded_jsonl is not None, (
+            "env.last_recorded_jsonl must point at the recorded file after a recording"
+        )
+        recorded = env.last_recorded_jsonl
+        assert Path(recorded).exists(), f"recorded file missing: {recorded}"
+        assert "ep0000" in Path(recorded).name, (
+            f"fresh recording should be ep0000, got {Path(recorded).name}"
+        )
+        assert Path(recorded).name != stale.name, (
+            "discovery must not select the stale higher episode id"
+        )
+    finally:
+        env.close_recorder()
+        env.exit()


### PR DESCRIPTION
## What / Why

Issue #5827: beginner notebook 03 (`notebooks/03_visualize_trace.ipynb`) could fail
headless while locating its recorded JSONL. Root cause: it discovered the recording via
`sorted(recordings.glob("*.jsonl"))[-1]` — glob-and-pick-last. In the presence of a stale
higher episode id left by a prior run, that lexicographically-last file was selected
instead of the freshly recorded episode, producing a cryptic `IndexError`/`ValueError`
("No valid states found").

### Fix

- `robot_sf/render/jsonl_recording.py`: record the exact completed file in
  `last_episode_file`.
- `robot_sf/gym_env/base_env.py`: expose that exact path as `env.last_recorded_jsonl`, and
  clear it when a new recording starts so callers cannot observe a previous episode's path.
- `scripts/dev/generate_quickstart_notebooks.py`: notebook 03 consumes only the exact path
  reported by the recorder and fails clearly if the path is absent or does not exist. It
  never falls back to scanning a directory that may contain stale artifacts.
- `tests/test_quickstart_notebooks.py`: regression coverage uses an isolated temporary
  recording directory containing a stale higher episode id and verifies the fresh file is
  reported.

This is a distinct bug from PR #5825 (notebook 01 determinism); it does not duplicate it.

## Validation

- `SDL_VIDEODRIVER=dummy uv run python scripts/validation/run_notebooks_smoke.py`
  → all 3 notebooks executed cleanly.
- `uv run pytest tests/test_quickstart_notebooks.py -q`
  → 16 passed, including both stale-recording regressions and the headless notebook test.
- `uv run ruff check robot_sf/gym_env/base_env.py robot_sf/render/jsonl_recording.py scripts/dev/generate_quickstart_notebooks.py tests/test_quickstart_notebooks.py`
  → passed.
- `uv run ruff format --check robot_sf/gym_env/base_env.py robot_sf/render/jsonl_recording.py scripts/dev/generate_quickstart_notebooks.py tests/test_quickstart_notebooks.py`
  → passed.

## Evidence tier

Smoke (CPU-only, headless notebook execution plus focused pytest). No benchmark or paper claims.

## Successor statement

This slice fully resolves #5827 (exact fresh-recording discovery plus regression coverage).
No remaining scope.

Closes #5827

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.
