### PR TITLE
P0: unbreak main — notebooks headless + examples-smoke CI contract (UX-wave integration drift)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,16 @@ jobs:
       - name: Example smoke tests
         run: scripts/dev/ci_driver.sh examples-smoke
 
+  notebooks-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up CI Python environment
+        uses: ./.github/actions/setup-ci-python
+
       - name: Notebook smoke tests
         run: scripts/dev/ci_driver.sh notebooks-smoke
 
@@ -326,6 +336,7 @@ jobs:
       - xdist-scratch-isolation
       - wheel-smoke-install
       - examples-smoke
+      - notebooks-smoke
     if: always()
     steps:
       - name: Check split job results
@@ -356,5 +367,9 @@ jobs:
           fi
           if [[ "${{ needs.examples-smoke.result }}" != "success" ]]; then
             echo "examples-smoke finished with ${{ needs.examples-smoke.result }}" >&2
+            exit 1
+          fi
+          if [[ "${{ needs.notebooks-smoke.result }}" != "success" ]]; then
+            echo "notebooks-smoke finished with ${{ needs.notebooks-smoke.result }}" >&2
             exit 1
           fi

--- a/notebooks/03_visualize_trace.ipynb
+++ b/notebooks/03_visualize_trace.ipynb
@@ -140,6 +140,7 @@
    "source": [
     "from robot_sf.gym_env.environment_factory import make_robot_env\n",
     "from robot_sf.gym_env.robot_env import RobotEnv\n",
+    "from robot_sf.common.artifact_paths import resolve_artifact_path\n",
     "from robot_sf.training.scenario_loader import load_scenarios, build_robot_config_from_scenario\n",
     "from robot_sf.baselines.random_policy import RandomPlanner\n",
     "\n",
@@ -151,6 +152,7 @@
     "    s for s in load_scenarios(SCENARIO_PATH) if s[\"name\"] == SCENARIO_NAME\n",
     ")\n",
     "config = build_robot_config_from_scenario(scenario, scenario_path=SCENARIO_PATH)\n",
+    "recording_dir = resolve_artifact_path(OUTPUT_DIR / \"recordings\")\n",
     "\n",
     "env: RobotEnv = make_robot_env(\n",
     "    config=config,\n",
@@ -158,7 +160,7 @@
     "    debug=False,\n",
     "    recording_enabled=True,\n",
     "    use_jsonl_recording=True,\n",
-    "    recording_dir=str(OUTPUT_DIR / \"recordings\"),\n",
+    "    recording_dir=str(recording_dir),\n",
     "    suite_name=\"notebook\",\n",
     "    scenario_name=SCENARIO_NAME,\n",
     "    algorithm_name=\"random\",\n",
@@ -209,7 +211,7 @@
    ],
    "source": [
     "# Locate the recorded JSONL (the recorder names it with suite/scenario/algorithm/seed).\n",
-    "candidates = sorted((OUTPUT_DIR / \"recordings\").glob(\"*.jsonl\"))\n",
+    "candidates = sorted(recording_dir.glob(\"*.jsonl\"))\n",
     "episode_jsonl = candidates[-1]\n",
     "# Promote a stable copy next to the other artifacts.\n",
     "stable_jsonl = OUTPUT_DIR / \"episode.jsonl\"\n",

--- a/scripts/dev/generate_quickstart_notebooks.py
+++ b/scripts/dev/generate_quickstart_notebooks.py
@@ -531,6 +531,7 @@ def build_notebook_03() -> nbf.notebooknode:
             """
             from robot_sf.gym_env.environment_factory import make_robot_env
             from robot_sf.gym_env.robot_env import RobotEnv
+            from robot_sf.common.artifact_paths import resolve_artifact_path
             from robot_sf.training.scenario_loader import load_scenarios, build_robot_config_from_scenario
             from robot_sf.baselines.random_policy import RandomPlanner
 
@@ -542,6 +543,7 @@ def build_notebook_03() -> nbf.notebooknode:
                 s for s in load_scenarios(SCENARIO_PATH) if s["name"] == SCENARIO_NAME
             )
             config = build_robot_config_from_scenario(scenario, scenario_path=SCENARIO_PATH)
+            recording_dir = resolve_artifact_path(OUTPUT_DIR / "recordings")
 
             env: RobotEnv = make_robot_env(
                 config=config,
@@ -549,7 +551,7 @@ def build_notebook_03() -> nbf.notebooknode:
                 debug=False,
                 recording_enabled=True,
                 use_jsonl_recording=True,
-                recording_dir=str(OUTPUT_DIR / "recordings"),
+                recording_dir=str(recording_dir),
                 suite_name="notebook",
                 scenario_name=SCENARIO_NAME,
                 algorithm_name="random",
@@ -579,7 +581,7 @@ def build_notebook_03() -> nbf.notebooknode:
         _code(
             """
             # Locate the recorded JSONL (the recorder names it with suite/scenario/algorithm/seed).
-            candidates = sorted((OUTPUT_DIR / "recordings").glob("*.jsonl"))
+            candidates = sorted(recording_dir.glob("*.jsonl"))
             episode_jsonl = candidates[-1]
             # Promote a stable copy next to the other artifacts.
             stable_jsonl = OUTPUT_DIR / "episode.jsonl"

--- a/tests/test_ci_driver_contract.py
+++ b/tests/test_ci_driver_contract.py
@@ -28,6 +28,7 @@ CI_JOB_TIMEOUTS = {
     "xdist-scratch-isolation": 15,
     "wheel-smoke-install": 20,
     "examples-smoke": 30,
+    "notebooks-smoke": 30,
     "ci": 5,
 }
 PHASE_PATTERN = re.compile(
@@ -346,6 +347,16 @@ def test_ci_workflow_examples_smoke_is_independent_and_required_by_aggregate() -
     assert _workflow_job_phases("examples-smoke") == {"examples-smoke"}
     assert "needs" not in workflow["jobs"]["examples-smoke"]
     assert "examples-smoke" in workflow["jobs"]["ci"]["needs"]
+
+
+def test_ci_workflow_notebooks_smoke_is_independent_and_required_by_aggregate() -> None:
+    """Keep notebook execution in a separately timed job required by aggregate CI."""
+    workflow = yaml.safe_load(_workflow_text())
+
+    assert "notebooks-smoke" in workflow["jobs"]
+    assert _workflow_job_phases("notebooks-smoke") == {"notebooks-smoke"}
+    assert "needs" not in workflow["jobs"]["notebooks-smoke"]
+    assert "notebooks-smoke" in workflow["jobs"]["ci"]["needs"]
 
 
 def test_ci_workflow_wheel_smoke_is_independent_and_required_by_aggregate() -> None:


### PR DESCRIPTION
## Summary
Restore green integrated CI after the UX-wave merges by making notebook recording honor the test artifact-root override and by separating examples and notebook smoke phases into independently required jobs.

## Linked Issues
- No linked issue: this is a direct P0 repair requested for red `main` at `a69482416`.

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: none

## What Changed
- Resolve notebook 03's JSONL recording directory through the canonical artifact-path helper, and keep the generated notebook source synchronized.
- Move `notebooks-smoke` into its own 30-minute CI job while keeping `examples-smoke` independent.
- Require both jobs from the aggregate `ci` job and add an explicit notebook-job contract test.

## Why It Matters
- Added value: restores the beginner notebooks' real headless execution path and preserves independent smoke diagnostics.
- Expected impact: the two integrated `main` failures become green without skipping or weakening either test.
- Why this is worth merging now: `main` is red on these contracts.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - CI and UX integration repair only.
- Comparator or baseline, if applicable: NA
- Evidence tier: NA
- Result classification: NA
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support workflow only.

## Domain-Aware Approval
- Required for this PR: no - no research evidence or benchmark semantics change.
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: repository support-work exemption
- Validity checklist:
  - Target claim/hypothesis: NA
  - Comparator or split/evidence validity: NA
  - Fallback/degraded exclusions: NA
  - Claim boundary: CI and notebook execution only
  - Implementation integrity vs experimental validity: implementation integrity only

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - no research mechanism.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: stop after CI review
- Proposed child issue or existing follow-up: NA

## Validation / Proof
- Commands run:
  - Baseline: `uv run python -m pytest tests/test_quickstart_notebooks.py tests/test_ci_driver_contract.py -q` -> `2 failed, 33 passed` at `a69482416`.
  - Fixed: same command -> `36 passed in 72.35s`.
  - `PYTEST_NUM_WORKERS=16 scripts/dev/run_tests_parallel.sh --no-fast-fail -m "not slow"` -> exit 0.
  - `PR_READY_PR_BODY_FILE=/tmp/robot_sf_p0_pr_body.md PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=16 scripts/dev/pr_ready_check.sh` -> exit 0; clean-HEAD freshness stamp recorded for `a78442bdf` against `a69482416`.
  - `uv run ruff check scripts/dev/generate_quickstart_notebooks.py tests/test_ci_driver_contract.py` -> clean.
  - `uv run ruff format --check scripts/dev/generate_quickstart_notebooks.py tests/test_ci_driver_contract.py` -> clean.
- Evidence that the change works here: notebook 03 executes under pytest's `ROBOT_SF_ARTIFACT_ROOT` override, and CI contract parsing sees independent aggregate-required jobs for both smoke phases.
- Benchmarks or smoke tests, if applicable: headless notebook execution is smoke evidence only; no benchmark claim.

## Risks / Rollout
- Compatibility risks: one additional independent GitHub Actions job uses the existing shared setup action and existing `notebooks-smoke` driver phase.
- Failure modes: notebook failures now identify the notebook job directly instead of being folded into examples smoke.
- Rollback or fallback plan: revert this PR; no fallback or degraded path is introduced.

## Docs / Provenance
- Updated docs: none; no user-facing behavior or command changed.
- Relevant design or provenance notes: based on current `origin/main` SHA `a69482416`.
- Any assumptions that need to be preserved: artifact producers may redirect repository-local paths through `ROBOT_SF_ARTIFACT_ROOT`, so consumers must inspect the resolved path.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this repair changes no research claim, benchmark, metric, schema, model provenance, registry, or durable evidence surface.

## Follow-Up Issues
- Deferred work: none; reviewer/CI verification only.
- Issues opened for follow-up: NA - no deferred implementation scope.

## Reviewer Notes
- Verify that `examples-smoke` invokes only `examples-smoke`, `notebooks-smoke` invokes only `notebooks-smoke`, and aggregate `ci` checks both results.
- Known limitation: the three-notebook execution is intentionally marked slow; it completed locally without reaching the 600-second per-notebook timeout.
- Shared-helper migration: inapplicable; this uses the existing artifact-path helper at one notebook recording call site and changes no helper contract.

## Artifact Handling
- Test and notebook outputs under ignored `output/` are disposable, worktree-local validation artifacts and are not dependencies of this PR. No generated artifact is committed or promoted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated smoke checks for quickstart notebooks as part of continuous integration.
  * Improved trace visualization notebooks to locate recorded artifacts reliably.

* **Bug Fixes**
  * Fixed notebook recording and artifact discovery when outputs are stored in resolved locations.

* **Tests**
  * Added coverage verifying the notebook smoke checks run independently and are required for CI completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->