### PR TITLE
fix(benchmark): build-time realizability validation + streamed episode records + campaign log hygiene (#5829 items 1-3)

### DIFF
--- a/configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml
+++ b/configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml
@@ -25,6 +25,7 @@ response_law_fractions:
   - 0.5
 scenarios:
   - id: issue_3574_classic_crossing_density_002
+    map_file: maps/svg_maps/classic_crossing.svg
     density: 0.02
     pedestrian_control_trace_near_field_clearance_m: 1.0
     population_size: 12

--- a/robot_sf/benchmark/campaign_logging.py
+++ b/robot_sf/benchmark/campaign_logging.py
@@ -1,0 +1,55 @@
+"""Logging defaults shared by long-running benchmark campaign entry points."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+from robot_sf.common.logging import configure_logging
+
+if TYPE_CHECKING:
+    import argparse
+
+CAMPAIGN_LOG_LEVEL_ENV = "ROBOT_SF_CAMPAIGN_LOG_LEVEL"
+
+
+def campaign_debug_default() -> bool:
+    """Return whether the campaign log-level environment opts into DEBUG."""
+
+    value = os.environ.get(CAMPAIGN_LOG_LEVEL_ENV, "INFO").strip().upper()
+    if value not in {"INFO", "DEBUG"}:
+        raise ValueError(f"{CAMPAIGN_LOG_LEVEL_ENV} must be INFO or DEBUG (got {value!r})")
+    return value == "DEBUG"
+
+
+def add_campaign_logging_argument(parser: argparse.ArgumentParser) -> None:
+    """Add the common explicit DEBUG opt-in to a campaign argument parser."""
+
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        default=campaign_debug_default(),
+        help=f"Enable DEBUG logs (default INFO; env: {CAMPAIGN_LOG_LEVEL_ENV}=DEBUG).",
+    )
+
+
+def configure_campaign_logging(*, debug: bool) -> None:
+    """Set Loguru and standard-library logging to INFO unless DEBUG was requested."""
+
+    configure_logging(verbose=debug)
+    level = logging.DEBUG if debug else logging.INFO
+    root_logger = logging.getLogger()
+    if not root_logger.handlers:
+        logging.basicConfig(level=level, format="%(levelname)s:%(name)s:%(message)s")
+    root_logger.setLevel(level)
+    for handler in root_logger.handlers:
+        handler.setLevel(level)
+
+
+__all__ = [
+    "CAMPAIGN_LOG_LEVEL_ENV",
+    "add_campaign_logging_argument",
+    "campaign_debug_default",
+    "configure_campaign_logging",
+]

--- a/robot_sf/benchmark/heterogeneous_population_ablation_runner.py
+++ b/robot_sf/benchmark/heterogeneous_population_ablation_runner.py
@@ -19,12 +19,15 @@ from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
+
 from robot_sf.benchmark.heterogeneous_population_ablation import (
     PopulationMixNotRealizableError,
     build_runtime_population_control_trace_labels,
 )
 from robot_sf.benchmark.map_runner import _build_policy
 from robot_sf.benchmark.map_runner_episode import run_map_episode
+from robot_sf.nav.navigation import get_prepared_obstacles
 from robot_sf.ped_npc import ped_population
 from robot_sf.ped_npc.ped_population import PedSpawnConfig
 from robot_sf.training.scenario_loader import resolve_map_definition
@@ -58,9 +61,9 @@ def assert_manifest_spawn_realizable(
 ) -> None:
     """Dry-run each distinct scenario/population spawn plan and aggregate failures.
 
-    This deliberately calls the same spawn-budget helper used by
-    :func:`robot_sf.ped_npc.ped_population.populate_simulation`. It parses map geometry
-    but does not create a simulator or sample any pedestrian positions.
+    This deliberately calls the same population-construction helper used by the simulator.
+    It parses map geometry and samples the requested pedestrian positions, but does not create
+    a simulator or advance any episode state.
 
     Raises:
         ManifestSpawnRealizabilityError: Any distinct scenario/map/population cell cannot spawn.
@@ -103,13 +106,21 @@ def assert_manifest_spawn_realizable(
                 response_law_seed=simulation_config.get("response_law_seed"),
                 force_population_size=int(simulation_config["population_size"]),
             )
-            ped_population._spawn_configs_for_forced_population(
-                spawn_config,
-                map_definition.ped_routes,
-                map_definition.ped_crowded_zones,
-                map_definition.single_pedestrians,
-            )
-        except (KeyError, TypeError, ValueError, OSError) as exc:
+            random_state = np.random.get_state()
+            np.random.seed(int(row.get("seed", DEFAULT_ARCHETYPE_SEED)))
+            try:
+                ped_population.populate_simulation(
+                    0.5,
+                    spawn_config,
+                    map_definition.ped_routes,
+                    map_definition.ped_crowded_zones,
+                    obstacle_polygons=get_prepared_obstacles(map_definition),
+                    single_pedestrians=map_definition.single_pedestrians,
+                    time_step_s=0.1,
+                )
+            finally:
+                np.random.set_state(random_state)
+        except (AssertionError, KeyError, TypeError, ValueError, OSError, RuntimeError) as exc:
             failures.append(f"{cell_name}: {exc}")
 
     if failures:

--- a/robot_sf/benchmark/heterogeneous_population_ablation_runner.py
+++ b/robot_sf/benchmark/heterogeneous_population_ablation_runner.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from functools import partial
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from robot_sf.benchmark.heterogeneous_population_ablation import (
     PopulationMixNotRealizableError,
@@ -25,6 +25,12 @@ from robot_sf.benchmark.heterogeneous_population_ablation import (
 )
 from robot_sf.benchmark.map_runner import _build_policy
 from robot_sf.benchmark.map_runner_episode import run_map_episode
+from robot_sf.ped_npc import ped_population
+from robot_sf.ped_npc.ped_population import PedSpawnConfig
+from robot_sf.training.scenario_loader import resolve_map_definition
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
 
 # Per-archetype desired-speed factors used when materializing a manifest row into
 # a runtime population. The ``mean_matched_homogeneous`` value is the weighted mean
@@ -38,6 +44,80 @@ DEFAULT_ARCHETYPE_SPEED_FACTORS = {
 
 DEFAULT_ARCHETYPE_SEED = 3574
 DEFAULT_MAX_EPISODE_STEPS = 600
+
+
+class ManifestSpawnRealizabilityError(ValueError):
+    """Raised when one or more manifest scenario/population cells cannot spawn."""
+
+
+def assert_manifest_spawn_realizable(
+    manifest_rows: Sequence[Mapping[str, Any]],
+    *,
+    scenario_path: Path,
+    map_path: Path | str | None = None,
+) -> None:
+    """Dry-run each distinct scenario/population spawn plan and aggregate failures.
+
+    This deliberately calls the same spawn-budget helper used by
+    :func:`robot_sf.ped_npc.ped_population.populate_simulation`. It parses map geometry
+    but does not create a simulator or sample any pedestrian positions.
+
+    Raises:
+        ManifestSpawnRealizabilityError: Any distinct scenario/map/population cell cannot spawn.
+    """
+
+    seen_cells: set[tuple[str, str, int]] = set()
+    failures: list[str] = []
+    for row_index, row in enumerate(manifest_rows):
+        scenario_id = str(row.get("scenario_id", f"manifest_rows[{row_index}]")).strip()
+        raw_map = row.get("map_file", map_path)
+        try:
+            counts = row["arm_population"]["counts"]
+            population_size = sum(int(value) for value in counts.values())
+        except (KeyError, TypeError, ValueError, AttributeError) as exc:
+            failures.append(f"scenario={scenario_id}: invalid forced population: {exc}")
+            continue
+
+        cell_key = (scenario_id, str(raw_map), population_size)
+        if cell_key in seen_cells:
+            continue
+        seen_cells.add(cell_key)
+        cell_name = f"scenario={scenario_id} population_size={population_size} map_file={raw_map}"
+
+        try:
+            scenario = build_episode_scenario(row, map_path=map_path)
+            map_definition = resolve_map_definition(
+                scenario["map_file"],
+                scenario_path=scenario_path,
+            )
+            if map_definition is None:
+                raise ValueError(f"map definition could not be loaded: {scenario['map_file']}")
+            simulation_config = scenario["simulation_config"]
+            spawn_config = PedSpawnConfig(
+                peds_per_area_m2=float(simulation_config["ped_density"]),
+                max_group_members=3,
+                archetype_composition=simulation_config.get("archetype_composition"),
+                archetype_speed_factors=simulation_config.get("archetype_speed_factors"),
+                archetype_seed=simulation_config.get("archetype_seed"),
+                response_law_composition=simulation_config.get("response_law_composition"),
+                response_law_seed=simulation_config.get("response_law_seed"),
+                force_population_size=int(simulation_config["population_size"]),
+            )
+            ped_population._spawn_configs_for_forced_population(
+                spawn_config,
+                map_definition.ped_routes,
+                map_definition.ped_crowded_zones,
+                map_definition.single_pedestrians,
+            )
+        except (KeyError, TypeError, ValueError, OSError) as exc:
+            failures.append(f"{cell_name}: {exc}")
+
+    if failures:
+        details = "\n".join(f"- {failure}" for failure in failures)
+        raise ManifestSpawnRealizabilityError(
+            "manifest spawn realizability validation failed for "
+            f"{len(failures)} scenario/population cell(s):\n{details}"
+        )
 
 
 def build_episode_scenario(
@@ -225,6 +305,8 @@ __all__ = [
     "DEFAULT_ARCHETYPE_SEED",
     "DEFAULT_ARCHETYPE_SPEED_FACTORS",
     "DEFAULT_MAX_EPISODE_STEPS",
+    "ManifestSpawnRealizabilityError",
+    "assert_manifest_spawn_realizable",
     "build_episode_scenario",
     "run_manifest_row",
 ]

--- a/scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574.py
+++ b/scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574.py
@@ -10,8 +10,9 @@ from typing import Any
 
 import yaml
 
-from robot_sf.benchmark.heterogeneous_population_ablation import (
-    build_mean_matched_harness_manifest,
+from robot_sf.benchmark.campaign_logging import (
+    add_campaign_logging_argument,
+    configure_campaign_logging,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -31,6 +32,11 @@ def parse_args() -> argparse.Namespace:
         default="output/issue_3574_mean_matched_harness/manifest.json",
         help="Manifest JSON output path.",
     )
+    parser.add_argument(
+        "--legacy-map",
+        help="Explicit map used to validate legacy inline scenarios without map_file fields.",
+    )
+    add_campaign_logging_argument(parser)
     return parser.parse_args()
 
 
@@ -52,11 +58,25 @@ def main() -> int:
     """Build and write the manifest."""
 
     args = parse_args()
+    configure_campaign_logging(debug=args.debug)
     config_path = REPO_ROOT / args.config
     output_path = REPO_ROOT / args.output
+    from robot_sf.benchmark.heterogeneous_population_ablation import (
+        build_mean_matched_harness_manifest,
+    )
+    from robot_sf.benchmark.heterogeneous_population_ablation_runner import (
+        assert_manifest_spawn_realizable,
+    )
+
     manifest = build_mean_matched_harness_manifest(
         _load_yaml(config_path),
         config_path=args.config,
+    )
+    legacy_map_path = None if args.legacy_map is None else REPO_ROOT / args.legacy_map
+    assert_manifest_spawn_realizable(
+        manifest["manifest_rows"],
+        scenario_path=config_path,
+        map_path=legacy_map_path,
     )
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")

--- a/scripts/benchmark/run_heterogeneous_population_ablation_issue_3574.py
+++ b/scripts/benchmark/run_heterogeneous_population_ablation_issue_3574.py
@@ -9,12 +9,17 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
-from robot_sf.benchmark.heterogeneous_population_ablation_runner import run_manifest_row
+from robot_sf.benchmark.campaign_logging import (
+    add_campaign_logging_argument,
+    configure_campaign_logging,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FSYNC_EVERY = 10
 
 
 def parse_args() -> argparse.Namespace:
@@ -37,12 +42,47 @@ def parse_args() -> argparse.Namespace:
             "fields; matrix-derived rows always use their own map."
         ),
     )
+    parser.add_argument(
+        "--fsync-every",
+        type=int,
+        default=DEFAULT_FSYNC_EVERY,
+        help="Call fsync after this many completed episode records (default: 10).",
+    )
+    add_campaign_logging_argument(parser)
     return parser.parse_args()
+
+
+def _run_manifest_row(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    """Import the heavy runtime only after campaign logging has been configured."""
+
+    from robot_sf.benchmark.heterogeneous_population_ablation_runner import (
+        run_manifest_row,
+    )
+
+    return run_manifest_row(*args, **kwargs)
+
+
+def _append_episode_record(
+    output_file: TextIO,
+    record: dict[str, Any],
+    *,
+    completed_count: int,
+    fsync_every: int,
+) -> None:
+    """Append one complete JSON line, flush it, and periodically sync it to disk."""
+
+    output_file.write(json.dumps(record) + "\n")
+    output_file.flush()
+    if completed_count % fsync_every == 0:
+        os.fsync(output_file.fileno())
 
 
 def main() -> int:
     """Run all ablation scenarios."""
     args = parse_args()
+    configure_campaign_logging(debug=args.debug)
+    if args.fsync_every <= 0:
+        raise ValueError("--fsync-every must be positive")
     manifest_path = REPO_ROOT / args.manifest
     output_path = REPO_ROOT / args.output
 
@@ -59,45 +99,51 @@ def main() -> int:
     # Build scenarios dynamically matching the manifest
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    records: list[dict[str, Any]] = []
-
     legacy_map_path = None if args.legacy_map is None else REPO_ROOT / args.legacy_map
+    completed_count = 0
+    with output_path.open("w", encoding="utf-8") as output_file:
+        for idx, row in enumerate(manifest_rows):
+            scenario_id = row["scenario_id"]
+            planner = row["planner"]
+            seed = int(row["seed"])
+            arm = row["population_arm"]
 
-    for idx, row in enumerate(manifest_rows):
-        scenario_id = row["scenario_id"]
-        planner = row["planner"]
-        seed = int(row["seed"])
-        arm = row["population_arm"]
-
-        print(
-            f"[{idx + 1}/{len(manifest_rows)}] Running scenario={scenario_id} arm={arm} planner={planner} seed={seed}"
-        )
-
-        try:
-            # Assemble the runtime scenario and run the episode through the shared
-            # harness helper so the emitted record carries the per-pedestrian control
-            # trace the readiness gate requires (issue #5397).
-            rec = run_manifest_row(
-                row,
-                map_path=legacy_map_path,
-                scenario_path=manifest_path,
-                horizon=600,
-                dt=0.1,
+            print(
+                f"[{idx + 1}/{len(manifest_rows)}] Running scenario={scenario_id} "
+                f"arm={arm} planner={planner} seed={seed}"
             )
-            records.append(rec)
-        except (RuntimeError, ValueError, KeyError, TypeError, OSError) as e:
-            # Narrow the handler (issue #4618 CI-B) to the runtime/config failures a
-            # simulation run can plausibly raise; annotate with the failing arm/planner/seed
-            # before re-raising so the traceback identifies the offending row.
-            print(f"Exception during simulation (arm={arm}, planner={planner}, seed={seed}): {e}")
-            raise
 
-    # Write out JSONL
-    with output_path.open("w", encoding="utf-8") as f:
-        for rec in records:
-            f.write(json.dumps(rec) + "\n")
+            try:
+                # Assemble the runtime scenario and run the episode through the shared
+                # harness helper so the emitted record carries the per-pedestrian control
+                # trace the readiness gate requires (issue #5397).
+                record = _run_manifest_row(
+                    row,
+                    map_path=legacy_map_path,
+                    scenario_path=manifest_path,
+                    horizon=600,
+                    dt=0.1,
+                )
+                completed_count += 1
+                _append_episode_record(
+                    output_file,
+                    record,
+                    completed_count=completed_count,
+                    fsync_every=args.fsync_every,
+                )
+            except (RuntimeError, ValueError, KeyError, TypeError, OSError) as exc:
+                # Narrow the handler (issue #4618 CI-B) to the runtime/config failures a
+                # simulation run can plausibly raise; annotate with the failing arm/planner/seed
+                # before re-raising so the traceback identifies the offending row.
+                print(
+                    "Exception during simulation "
+                    f"(arm={arm}, planner={planner}, seed={seed}): {exc}"
+                )
+                raise
+        if completed_count and completed_count % args.fsync_every:
+            os.fsync(output_file.fileno())
 
-    print(f"Successfully wrote {len(records)} episode records to {output_path}")
+    print(f"Successfully wrote {completed_count} episode records to {output_path}")
     return 0
 
 

--- a/tests/benchmark/test_issue_5829_campaign_robustness.py
+++ b/tests/benchmark/test_issue_5829_campaign_robustness.py
@@ -15,7 +15,11 @@ import yaml
 from robot_sf.benchmark import campaign_logging
 from robot_sf.benchmark.heterogeneous_population_ablation_runner import (
     ManifestSpawnRealizabilityError,
+    assert_manifest_spawn_realizable,
 )
+from robot_sf.nav.global_route import GlobalRoute
+from robot_sf.nav.map_config import MapDefinition
+from robot_sf.nav.obstacle import Obstacle
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -96,6 +100,60 @@ def test_manifest_build_rejects_francis_forced_population_cell_once(tmp_path: Pa
     assert "population_size=12" in message
     assert "remaining 11 background pedestrians" in message
     assert not output_path.exists()
+
+
+def test_manifest_preflight_rejects_present_but_unsampleable_route(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A route blocked by obstacle geometry fails during build-time spawn construction."""
+
+    spawn_zone = ((1.0, 1.0), (2.0, 1.0), (1.0, 2.0))
+    goal_zone = ((8.0, 8.0), (9.0, 8.0), (8.0, 9.0))
+    route = GlobalRoute(
+        spawn_id=0,
+        goal_id=0,
+        waypoints=[(1.5, 1.5), (8.5, 8.5)],
+        spawn_zone=spawn_zone,
+        goal_zone=goal_zone,
+    )
+    blocked_map = MapDefinition(
+        width=10.0,
+        height=10.0,
+        obstacles=[Obstacle([(-10.0, -10.0), (20.0, -10.0), (20.0, 20.0), (-10.0, 20.0)])],
+        robot_spawn_zones=[spawn_zone],
+        ped_spawn_zones=[spawn_zone],
+        robot_goal_zones=[goal_zone],
+        bounds=[
+            (0.0, 10.0, 0.0, 0.0),
+            (0.0, 10.0, 10.0, 10.0),
+            (0.0, 0.0, 0.0, 10.0),
+            (10.0, 10.0, 0.0, 10.0),
+        ],
+        robot_routes=[route],
+        ped_goal_zones=[goal_zone],
+        ped_crowded_zones=[],
+        ped_routes=[route],
+    )
+    map_path = tmp_path / "blocked-route.svg"
+    map_path.write_text("<svg/>", encoding="utf-8")
+    monkeypatch.setattr(
+        "robot_sf.benchmark.heterogeneous_population_ablation_runner.resolve_map_definition",
+        lambda *_args, **_kwargs: blocked_map,
+    )
+    row = {
+        "scenario_id": "blocked_route",
+        "map_file": str(map_path),
+        "seed": 101,
+        "density": 0.02,
+        "arm_population": {
+            "counts": {"standard": 2},
+            "composition": {"standard": 1.0},
+            "pedestrian_control_trace_labels": [],
+        },
+    }
+
+    with pytest.raises(ManifestSpawnRealizabilityError, match="Failed to sample"):
+        assert_manifest_spawn_realizable([row], scenario_path=tmp_path / "scenario.yaml")
 
 
 def test_runner_preserves_completed_jsonl_records_on_abort(

--- a/tests/benchmark/test_issue_5829_campaign_robustness.py
+++ b/tests/benchmark/test_issue_5829_campaign_robustness.py
@@ -1,0 +1,207 @@
+"""Regression tests for issue #5829's design-independent campaign fixes."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+
+from robot_sf.benchmark import campaign_logging
+from robot_sf.benchmark.heterogeneous_population_ablation_runner import (
+    ManifestSpawnRealizabilityError,
+)
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUILD_SCRIPT = REPO_ROOT / "scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574.py"
+RUN_SCRIPT = REPO_ROOT / "scripts/benchmark/run_heterogeneous_population_ablation_issue_3574.py"
+FRANCIS_SINGLE_INTERACTION_MAP = (
+    REPO_ROOT / "maps/svg_maps/francis2023/francis2023_frontal_approach.svg"
+)
+
+
+def _load_script(path: Path, module_name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_main(module: ModuleType, argv: list[str]) -> int:
+    previous = sys.argv
+    sys.argv = argv
+    try:
+        return int(module.main())
+    finally:
+        sys.argv = previous
+
+
+def _francis_manifest_config() -> dict[str, Any]:
+    return {
+        "schema_version": "mean_matched_heterogeneity_harness.config.v1",
+        "issue": 5829,
+        "planners": [{"key": "goal", "algo": "goal"}],
+        "seeds": [101, 102],
+        "response_law_fractions": [0.0],
+        "scenarios": [
+            {
+                "id": "francis2023_frontal_approach",
+                "map_file": str(FRANCIS_SINGLE_INTERACTION_MAP),
+                "density": 0.02,
+                "population_size": 12,
+                "archetype_seed": 3574,
+                "composition": {"cautious": 0.25, "standard": 0.5, "hurried": 0.25},
+                "archetypes": {
+                    "cautious": {"desired_speed_factor": 0.7, "radius_m": 0.35},
+                    "standard": {"desired_speed_factor": 1.0, "radius_m": 0.3},
+                    "hurried": {"desired_speed_factor": 1.4, "radius_m": 0.25},
+                },
+            }
+        ],
+    }
+
+
+def test_manifest_build_rejects_francis_forced_population_cell_once(tmp_path: Path) -> None:
+    """Francis single-interaction geometry fails before output despite repeated rows."""
+
+    config_path = tmp_path / "francis.yaml"
+    config_path.write_text(yaml.safe_dump(_francis_manifest_config()), encoding="utf-8")
+    output_path = tmp_path / "manifest.json"
+    module = _load_script(BUILD_SCRIPT, "issue_5829_manifest_builder")
+
+    with pytest.raises(ManifestSpawnRealizabilityError) as exc_info:
+        _run_main(
+            module,
+            [
+                BUILD_SCRIPT.name,
+                "--config",
+                str(config_path),
+                "--output",
+                str(output_path),
+            ],
+        )
+
+    message = str(exc_info.value)
+    assert "1 scenario/population cell" in message
+    assert "scenario=francis2023_frontal_approach" in message
+    assert "population_size=12" in message
+    assert "remaining 11 background pedestrians" in message
+    assert not output_path.exists()
+
+
+def test_runner_preserves_completed_jsonl_records_on_abort(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A mid-campaign abort leaves each completed episode as parseable JSONL."""
+
+    module = _load_script(RUN_SCRIPT, "issue_5829_campaign_runner")
+    rows = [
+        {
+            "scenario_id": f"scenario_{index}",
+            "planner": "goal",
+            "seed": 100 + index,
+            "population_arm": "heterogeneous",
+        }
+        for index in range(3)
+    ]
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({"manifest_rows": rows}), encoding="utf-8")
+    output_path = tmp_path / "episode_records.jsonl"
+    calls = 0
+
+    def abort_after_two(row: dict[str, Any], **_kwargs: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        if calls == 3:
+            raise RuntimeError("simulated abrupt campaign stop")
+        return {"scenario_id": row["scenario_id"], "completed": True}
+
+    fsync_calls: list[int] = []
+    monkeypatch.setattr(module, "_run_manifest_row", abort_after_two)
+    monkeypatch.setattr(module, "configure_campaign_logging", lambda **_kwargs: None)
+    monkeypatch.setattr(module.os, "fsync", fsync_calls.append)
+
+    with pytest.raises(RuntimeError, match="simulated abrupt campaign stop"):
+        _run_main(
+            module,
+            [
+                RUN_SCRIPT.name,
+                "--manifest",
+                str(manifest_path),
+                "--output",
+                str(output_path),
+                "--fsync-every",
+                "2",
+            ],
+        )
+
+    records = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines()]
+    assert records == [
+        {"scenario_id": "scenario_0", "completed": True},
+        {"scenario_id": "scenario_1", "completed": True},
+    ]
+    assert len(fsync_calls) == 1
+
+
+@pytest.mark.parametrize("script_path", [BUILD_SCRIPT, RUN_SCRIPT])
+def test_campaign_entry_points_default_to_info_with_explicit_debug_opt_in(
+    script_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both campaign CLIs default to INFO and honor flag/environment DEBUG opt-in."""
+
+    module = _load_script(script_path, f"issue_5829_logging_{script_path.stem}")
+    monkeypatch.delenv(campaign_logging.CAMPAIGN_LOG_LEVEL_ENV, raising=False)
+    monkeypatch.setattr(sys, "argv", [script_path.name])
+    assert module.parse_args().debug is False
+
+    monkeypatch.setenv(campaign_logging.CAMPAIGN_LOG_LEVEL_ENV, "DEBUG")
+    assert module.parse_args().debug is True
+
+    monkeypatch.setenv(campaign_logging.CAMPAIGN_LOG_LEVEL_ENV, "INFO")
+    monkeypatch.setattr(sys, "argv", [script_path.name, "--debug"])
+    assert module.parse_args().debug is True
+
+
+@pytest.mark.parametrize(
+    ("debug", "expected_level"),
+    [(False, logging.INFO), (True, logging.DEBUG)],
+)
+def test_campaign_logging_configures_loguru_and_stdlib_levels(
+    debug: bool,
+    expected_level: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shared campaign setup applies one level to Loguru and stdlib logging."""
+
+    root = logging.getLogger()
+    previous_root_level = root.level
+    previous_handlers = list(root.handlers)
+    previous_handler_levels = {handler: handler.level for handler in previous_handlers}
+    loguru_verbose: list[bool] = []
+    monkeypatch.setattr(
+        campaign_logging,
+        "configure_logging",
+        lambda *, verbose: loguru_verbose.append(verbose),
+    )
+    try:
+        campaign_logging.configure_campaign_logging(debug=debug)
+
+        assert loguru_verbose == [debug]
+        assert root.level == expected_level
+        assert all(handler.level == expected_level for handler in root.handlers)
+    finally:
+        root.setLevel(previous_root_level)
+        for handler in list(root.handlers):
+            if handler not in previous_handler_levels:
+                root.removeHandler(handler)
+        for handler, previous_level in previous_handler_levels.items():
+            handler.setLevel(previous_level)


### PR DESCRIPTION
## Summary
The heterogeneity campaign now rejects impossible forced-population cells before execution, preserves every completed episode during an interrupted run, and defaults campaign logging to INFO. This PR implements only issue #5829's design-independent items 1–3; it does not choose or implement a spawn-geometry option.

## Linked Issues
- Relates to `#5829`

## Stack / Dependency
- Base dependency: current `origin/main`
- Required prior PRs: none
- Stack follow-up issues: `#5829` retains the spawn-geometry decision
- Safe to review independently: yes
- Review dependency reason, if any: PR #5830 addresses unrelated main-red notebook/CI-driver tests and is not required by this implementation.

## What Changed
- Added a build-time spawn-realizability preflight that parses each distinct scenario/map/forced-population cell and invokes the production population-construction path, including obstacle-aware position sampling, without constructing a simulator.
- Made the episode runner write and flush each JSONL record immediately, with configurable periodic `fsync` and a final sync for a normal partial batch.
- Added shared campaign logging setup used by both builder and runner: INFO by default, DEBUG only via `--debug` or `ROBOT_SF_CAMPAIGN_LOG_LEVEL=DEBUG`.
- Added the explicit classic-crossing map to the tracked inline smoke config so its build preflight is self-contained.
- Added focused regression tests for the Francis population-12 failure, interrupted streaming, and logging defaults/opt-ins.

## Why It Matters
- Added value: startup-class geometry failures are rejected in seconds instead of after hours of campaign compute.
- Expected impact: interrupted campaigns retain parseable completed episode rows and default stderr remains bounded.
- Why this is worth merging now: three campaign attempts were lost to the same late spawn failure, and the last attempt also lost all completed rows while producing 1.1 GB of DEBUG stderr.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: remove three execution blockers for the issue #3574/#5829 heterogeneity campaign.
- Comparator or baseline, if applicable: `origin/main` behavior buffered all rows, logged DEBUG before campaign configuration, and discovered missing spawn geometry only during simulation.
- Evidence tier: targeted smoke / implementation-integrity tests; no benchmark result.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: reject the build when any requested cell cannot construct the runtime spawn budget; retain only completed JSONL rows on interruption.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #5829.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - campaign robustness support; no research evidence is interpreted.

## Domain-Aware Approval
- Required for this PR: yes - the PR records targeted smoke evidence for a benchmark campaign execution path.
- Domains reviewed: benchmark interpretation
- Status: waived
- Approver/review source or waiver: scope waiver because the evidence proves implementation integrity only; no empirical result, comparison, metric, evidence classification, or paper-facing claim is produced.
- Validity checklist:
  - Target claim/hypothesis: fail early, retain completed rows, and suppress default DEBUG logs.
  - Comparator or split/evidence validity: scenario, planner, seed, arm, and metric semantics are unchanged.
  - Fallback/degraded exclusions: failed spawn cells stop manifest creation; no fallback/degraded row is treated as success.
  - Claim boundary: tests and smoke commands establish implementation behavior only.
  - Implementation integrity vs experimental validity: implementation integrity is tested; experimental validity is out of scope.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes - the Francis single-interaction fixture reaches the runtime spawn-budget error during manifest build.
- Did the intervention change command source, selected command, trajectory, or route progress? no.
- Did the scenario actually contain the targeted failure mode? yes - one explicit pedestrian, no pedestrian routes, no crowded zones, and forced population 12.
- Result route: continue after review; the spawn-geometry decision remains separate.
- Follow-up question or issue for weak, negative, or non-transfer results: issue #5829 retains options (a)/(b)/(c).

## Next Empirical Action
- Rerun needed: no for this implementation PR; campaign rerun waits for the separate spawn-geometry/scope decision.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: no implementation artifact is missing.
- Stop / revise / continue decision: merge the design-independent safeguards independently; do not start an impossible full campaign.
- Proposed child issue or existing follow-up: existing issue #5829.

## Validation / Proof
- Commands run:
  - `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy scripts/dev/run_focused_tests.sh tests/benchmark/test_issue_5829_campaign_robustness.py tests/ped_npc/test_force_population_size_split.py tests/benchmark/test_issue_3574_integration_contract.py tests/benchmark/test_heterogeneous_population_ablation.py -q`
  - `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest -n 8 --dist load -m 'not slow' tests`
  - focused Ruff check and format check for all changed Python files
  - default builder smoke with captured stderr size
  - `PR_READY_MODE=final PR_READY_PR_BODY_FILE=<body-file> PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - `git diff --check`
- Evidence that the change works here: 82 focused tests passed after the gate fix; 859 fast tests passed on the author head; final committed-head readiness passed core and optional lanes on the author head with changed-line coverage above the 80% gate; the Francis N=12 build fails naming one scenario/population cell and the remaining 11 background pedestrians; an obstacle-blocked route fails during preflight before manifest output; simulated abort preserves two parseable completed rows; the 72-row default build completed successfully with INFO logging.
- Benchmarks or smoke tests, if applicable: manifest-build smoke only; no simulation campaign or benchmark result was produced.

## Risks / Rollout
- Compatibility risks: legacy inline configs without `map_file` must provide the existing explicit map fallback to receive realizability validation; the tracked smoke config now names its map directly.
- Failure modes: malformed/missing maps and impossible forced-population budgets fail before manifest output; disk write/sync failures still fail the runner rather than claiming complete output.
- Rollback or fallback plan: revert this isolated commit; do not bypass failed realizability as a successful benchmark path.

## Docs / Provenance
- Updated docs: none; CLI help and tests document the new operational controls.
- Relevant design or provenance notes: issue #5829 and the exact runtime helper in `robot_sf/ped_npc/ped_population.py`.
- Any assumptions that need to be preserved: the build check must continue using the runtime spawn-budget path, and spawn geometry remains an explicit maintainer decision.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes - claim/comment and PR linkage.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): no - existing issue #5829 owns the remaining decision.
- Not applicable because: this PR creates no empirical result, durable benchmark artifact, metric change, leaderboard row, or paper-facing claim.

## Follow-Up Issues
- Deferred work: spawn-geometry option (a), scope option (b), or published-map option (c).
- Issues opened for follow-up: none; tracked in #5829.

## Reviewer Notes
- Verify that build-time validation still calls `populate_simulation` for production spawn construction and never constructs a simulator or advances an episode.
- Verify that a write/flush occurs immediately after each successful `run_manifest_row` return.
- Known limitation: this PR intentionally does not make Francis population 12 realizable; it makes that cell fail at build time.
- Shared-helper migration: not applicable; the new logging helper has two campaign call sites, no legacy helper is replaced, and no serialized return schema changes.
