### PR TITLE
Issue #5832: layered-risk ablation harness (cheap-lane worker)

### DIFF
--- a/configs/benchmark/risk_layer_ablation.yaml
+++ b/configs/benchmark/risk_layer_ablation.yaml
@@ -56,5 +56,5 @@ layers:
       w_force_exceed: 1.0
       w_near: 1.5
       w_comfort: 1.0
-      w_time: 0.5
+      w_time: 0.0
       w_semantic_risk: 1.5

--- a/configs/benchmark/risk_layer_ablation.yaml
+++ b/configs/benchmark/risk_layer_ablation.yaml
@@ -1,0 +1,60 @@
+# Risk-layer ablation configuration (issue #5832)
+#
+# Progressive hazard-model scoring for planner evaluation. Each layer adds a
+# hazard dimension and maps to an SNQI weight configuration consumed by
+# robot_sf.benchmark.risk_layer_ablation.
+#
+# Layer contract:
+#   L0_geometry_only     - static obstacles / hard contact geometry (baseline).
+#   L1_plus_dynamics     - L0 + moving-pedestrian near-field and motion comfort.
+#   L2_plus_semantic_risk- L1 + zone/context (semantic) risk weighting.
+#
+# When a scenario family carries no zone metadata, the L2 semantic-risk term
+# (metrics.semantic_risk_exposure) is unavailable and L2 is scored on its
+# remaining active terms only. This is by design, not an error.
+
+schema_version: "risk_layer_ablation.v1"
+risk_layer_version: "risk-layers.v1"
+group_by: "scenario_params.algo"
+fallback_group_by: "algo"
+bootstrap:
+  seed: 20260716
+  samples: 200
+
+layers:
+  - name: "L0_geometry_only"
+    level: 0
+    description: "Static obstacles and hard contact geometry only."
+    adds: ["geometry"]
+    weights:
+      w_success: 2.0
+      w_collisions: 2.0
+      w_force_exceed: 1.0
+      w_near: 0.0
+      w_comfort: 0.0
+      w_time: 0.0
+      w_semantic_risk: 0.0
+  - name: "L1_plus_dynamics"
+    level: 1
+    description: "L0 plus moving-pedestrian dynamics: near-field exposure and motion comfort."
+    adds: ["dynamics"]
+    weights:
+      w_success: 2.0
+      w_collisions: 2.0
+      w_force_exceed: 1.0
+      w_near: 1.5
+      w_comfort: 1.0
+      w_time: 0.0
+      w_semantic_risk: 0.0
+  - name: "L2_plus_semantic_risk"
+    level: 2
+    description: "L1 plus semantic/zone risk weighting from scenario zone metadata."
+    adds: ["semantic_risk"]
+    weights:
+      w_success: 2.0
+      w_collisions: 2.0
+      w_force_exceed: 1.0
+      w_near: 1.5
+      w_comfort: 1.0
+      w_time: 0.5
+      w_semantic_risk: 1.5

--- a/docs/benchmark_risk_layer_ablation.md
+++ b/docs/benchmark_risk_layer_ablation.md
@@ -1,0 +1,99 @@
+# Risk-layer ablation for planner evaluation
+
+This page defines the **risk-layer ablation axis** introduced in
+[issue #5832](https://github.com/ll7/robot_sf_ll7/issues/5832) and implemented in
+`robot_sf/benchmark/risk_layer_ablation.py`. It is an *evaluation-config + reporting*
+change built on the existing metric stack (collision ledger, near-field exposure,
+SNQI weights). It runs no simulation and makes no benchmark claim on its own.
+
+## Motivation
+
+Two 2026-07-15 preprints argue that navigation-safety evidence requires
+**heterogeneous hazard fusion**, evaluated layer by layer:
+
+- a powered-wheelchair study fusing slope / static / dynamic / semantic hazards
+  into a probabilistic risk map (paired Monte Carlo eval cut collisions from
+  >73% to <32%);
+- a vehicle-in-the-loop platform showing localization uncertainty dominating
+  weather as the cooperative-perception error source.
+
+Both support the claim that a planner can look safe only because the evaluation
+ignores a hazard layer. The ablation makes that inversion measurable: *a planner
+ranked safe at L0 but unsafe at L2 is exactly the publishable finding class.*
+
+## The three risk layers
+
+| Layer | Hazard dimensions | Active SNQI terms |
+| --- | --- | --- |
+| `L0_geometry_only` | static obstacles, hard contact geometry | `w_success`, `w_collisions`, `w_force_exceed` |
+| `L1_plus_dynamics` | L0 + moving-pedestrian **dynamics** | + `w_near`, `w_comfort` |
+| `L2_plus_semantic_risk` | L1 + **semantic / zone** risk | + `w_time`, `w_semantic_risk` |
+
+Layer definitions and their exact weight mappings live in
+`RISK_LAYERS` / `RISK_LAYER_WEIGHTS` in `robot_sf/benchmark/risk_layer_ablation.py`
+and are mirrored in `configs/benchmark/risk_layer_ablation.yaml`.
+
+- **L0** is the current baseline behaviour: only static obstacles and hard
+  contact geometry matter.
+- **L1** adds moving-pedestrian dynamics — near-field exposure and motion
+  comfort — so planners that "look safe" only because pedestrians are treated
+  as static get penalized.
+- **L2** adds semantic/zone risk weighting. The semantic-risk term is read from
+  `metrics.semantic_risk_exposure`, which scenario families carry when they have
+  zone metadata (crossings, doorways, high-density zones). When that metric is
+  absent, the layer reports it `unavailable` and scores on the remaining active
+  terms only — never imputing a zero risk field.
+
+## Metric mapping
+
+Each layer is a fixed-schema SNQI weight configuration. Activating a higher layer
+enables additional terms; deactivating keeps a `0.0` weight. Because
+`compute_snqi_v0` uses the zero-weight contract, a missing metric under a `0.0`
+weight never collapses the score, and a missing semantic metric under a non-zero
+L2 weight is reported as unavailable rather than imputed.
+
+## Report artifact
+
+`build_risk_layer_report` consumes episode records that already carry `metrics`
+and a planner/group key, then produces:
+
+- per-layer mean SNQI per planner;
+- per-planner **rank** under each layer;
+- **per-planner rank delta from L0** (`rank_delta_from_l0`; positive = worse than at L0);
+- an optional **bootstrap stability** block per layer with rank confidence
+  intervals (`ci95_low` / `ci95_high`) and a normalized Spearman stability score.
+
+`format_risk_layer_markdown` renders the per-planner delta table. A planner whose
+rank changes between L0 and the richest layer has `rank_changed = true`.
+
+### Bounded first slice
+
+The first slice is an **L0-vs-L1 ablation on one released scenario family** with
+the standard seed set, reporting the per-planner delta table with bootstrap CIs.
+L2 is wired and documented but only exercised when the scenario family carries
+zone metadata.
+
+## Usage
+
+```python
+from robot_sf.benchmark.risk_layer_ablation import (
+    build_risk_layer_report,
+    format_risk_layer_markdown,
+)
+
+report = build_risk_layer_report(
+    records,                       # episode dicts with metrics + planner key
+    bootstrap={"seed": 20260716, "samples": 200},
+)
+print(format_risk_layer_markdown(report))
+```
+
+## Acceptance criteria (issue #5832)
+
+- Ablation config producing per-layer metric tables for >=2 planners on >=1
+  scenario family, seeds pinned — `configs/benchmark/risk_layer_ablation.yaml`.
+- A report artifact showing per-layer rank changes (or their absence) with
+  bootstrap CIs — `build_risk_layer_report(bootstrap=...)`.
+- A docs page defining the layers and their metric mapping — this file.
+- Tests: layer configs load, and metrics differ between layers on a fixture
+  where they must — `tests/test_risk_layer_ablation.py`.

--- a/docs/benchmark_risk_layer_ablation.md
+++ b/docs/benchmark_risk_layer_ablation.md
@@ -27,7 +27,7 @@ ranked safe at L0 but unsafe at L2 is exactly the publishable finding class.*
 | --- | --- | --- |
 | `L0_geometry_only` | static obstacles, hard contact geometry | `w_success`, `w_collisions`, `w_force_exceed` |
 | `L1_plus_dynamics` | L0 + moving-pedestrian **dynamics** | + `w_near`, `w_comfort` |
-| `L2_plus_semantic_risk` | L1 + **semantic / zone** risk | + `w_time`, `w_semantic_risk` |
+| `L2_plus_semantic_risk` | L1 + **semantic / zone** risk | + `w_semantic_risk` |
 
 Layer definitions and their exact weight mappings live in
 `RISK_LAYERS` / `RISK_LAYER_WEIGHTS` in `robot_sf/benchmark/risk_layer_ablation.py`
@@ -41,8 +41,8 @@ and are mirrored in `configs/benchmark/risk_layer_ablation.yaml`.
 - **L2** adds semantic/zone risk weighting. The semantic-risk term is read from
   `metrics.semantic_risk_exposure`, which scenario families carry when they have
   zone metadata (crossings, doorways, high-density zones). When that metric is
-  absent, the layer reports it `unavailable` and scores on the remaining active
-  terms only — never imputing a zero risk field.
+  absent from every record, the layer reports it `unavailable` and equals L1.
+  Partial coverage fails closed rather than imputing missing records.
 
 ## Metric mapping
 
@@ -77,13 +77,13 @@ zone metadata.
 
 ```python
 from robot_sf.benchmark.risk_layer_ablation import (
-    build_risk_layer_report,
+    build_risk_layer_report_from_config,
     format_risk_layer_markdown,
 )
 
-report = build_risk_layer_report(
-    records,                       # episode dicts with metrics + planner key
-    bootstrap={"seed": 20260716, "samples": 200},
+report = build_risk_layer_report_from_config(
+    records,  # episode dicts with metrics + planner key
+    baseline_stats=baseline_stats,
 )
 print(format_risk_layer_markdown(report))
 ```

--- a/robot_sf/benchmark/risk_layer_ablation.py
+++ b/robot_sf/benchmark/risk_layer_ablation.py
@@ -33,17 +33,23 @@ under a non-zero L2 weight is reported as unavailable rather than imputed.
 from __future__ import annotations
 
 import math
+from collections import Counter
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 import numpy as np
+import yaml
 
 from robot_sf.benchmark.rank_metrics import rank_by, spearman
-from robot_sf.benchmark.snqi.compute import compute_snqi_v0
+from robot_sf.benchmark.snqi.compute import compute_snqi_v0, normalize_metric_required
 
 RISK_LAYER_ABLATION_SCHEMA = "risk_layer_ablation.v1"
 RISK_LAYER_VERSION = "risk-layers.v1"
+DEFAULT_RISK_LAYER_CONFIG = (
+    Path(__file__).resolve().parents[2] / "configs/benchmark/risk_layer_ablation.yaml"
+)
 
 # Semantic-risk exposure metric produced by zone-aware scenarios. Absent for
 # scenario families without zone metadata; the L2 layer degrades gracefully.
@@ -60,6 +66,13 @@ RISK_WEIGHT_NAMES = (
     "w_time",
     "w_semantic_risk",
 )
+
+_BASELINE_METRIC_BY_WEIGHT = {
+    "w_collisions": "collisions",
+    "w_force_exceed": "force_exceed_events",
+    "w_near": "near_misses",
+    "w_semantic_risk": SEMANTIC_RISK_METRIC_KEY,
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -125,7 +138,7 @@ RISK_LAYER_WEIGHTS: dict[str, dict[str, float]] = {
         "w_force_exceed": 1.0,
         "w_near": 1.5,
         "w_comfort": 1.0,
-        "w_time": 0.5,
+        "w_time": 0.0,
         "w_semantic_risk": 1.5,
     },
 }
@@ -186,16 +199,31 @@ def _score_episode(
     Returns:
         SNQI score for the episode under the supplied weights.
     """
-    return float(compute_snqi_v0(_episode_metrics(record), weights, baseline_stats))
+    metrics = _episode_metrics(record)
+    score = float(compute_snqi_v0(metrics, weights, baseline_stats))
+    semantic_weight = float(weights.get("w_semantic_risk", 0.0))
+    if semantic_weight == 0.0:
+        return score
+    if SEMANTIC_RISK_METRIC_KEY not in metrics:
+        raise ValueError(
+            "semantic-risk scoring requires metrics.semantic_risk_exposure on every record"
+        )
+    semantic_norm = normalize_metric_required(
+        SEMANTIC_RISK_METRIC_KEY,
+        metrics[SEMANTIC_RISK_METRIC_KEY],
+        baseline_stats,
+    )
+    return score - semantic_weight * semantic_norm
 
 
-def _semantic_risk_available(records: Iterable[Mapping[str, Any]]) -> bool:
-    """Return whether any episode carries a finite semantic-risk metric."""
+def _semantic_risk_coverage(records: Sequence[Mapping[str, Any]]) -> tuple[int, int]:
+    """Return finite semantic-risk metric count and total record count."""
+    present = 0
     for record in records:
         value = _episode_metrics(record).get(SEMANTIC_RISK_METRIC_KEY)
         if isinstance(value, bool | int | float) and math.isfinite(float(value)):
-            return True
-    return False
+            present += 1
+    return present, len(records)
 
 
 def compute_layer_scores(
@@ -214,18 +242,124 @@ def compute_layer_scores(
     groups: dict[str, list[float]] = {}
     for record in records:
         key = _resolve_group_key(record, group_by, fallback_group_by)
-        try:
-            score = _score_episode(record, layer_weights, baseline_stats)
-        except (ValueError, TypeError, KeyError):
-            continue
+        if key == "unknown":
+            raise ValueError(
+                f"record is missing both group keys {group_by!r} and {fallback_group_by!r}"
+            )
+        score = _score_episode(record, layer_weights, baseline_stats)
         if not math.isfinite(score):
-            continue
+            raise ValueError(f"non-finite risk-layer score for planner {key!r}")
         groups.setdefault(key, []).append(score)
     return {
         planner: {"mean": sum(vals) / len(vals), "support": len(vals)}
         for planner, vals in groups.items()
         if vals
     }
+
+
+def _validate_layer_weights(
+    weights_by_layer: Mapping[str, Mapping[str, float]],
+    layer_names: Sequence[str],
+) -> None:
+    """Validate exact, finite, non-negative risk-layer weight mappings."""
+    expected = set(RISK_WEIGHT_NAMES)
+    for name in layer_names:
+        if name not in weights_by_layer:
+            raise ValueError(f"missing weights for risk layer {name!r}")
+        weights = weights_by_layer[name]
+        if set(weights) != expected:
+            missing = sorted(expected - set(weights))
+            extra = sorted(set(weights) - expected)
+            raise ValueError(f"invalid weights for {name!r}: missing={missing}, extra={extra}")
+        for weight_name, value in weights.items():
+            numeric = float(value)
+            if not math.isfinite(numeric) or numeric < 0.0:
+                raise ValueError(
+                    f"weight {weight_name!r} for {name!r} must be finite and non-negative"
+                )
+
+
+def _validate_baseline_coverage(
+    weights_by_layer: Mapping[str, Mapping[str, float]],
+    baseline_stats: Mapping[str, Mapping[str, float]],
+) -> None:
+    """Fail closed when an active normalized term lacks baseline statistics."""
+    required = {
+        metric_name
+        for weights in weights_by_layer.values()
+        for weight_name, metric_name in _BASELINE_METRIC_BY_WEIGHT.items()
+        if float(weights[weight_name]) > 0.0
+    }
+    missing = sorted(required - set(baseline_stats))
+    if missing:
+        raise ValueError(f"baseline_stats missing active normalized metrics: {missing}")
+
+
+def _validate_comparable_records(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    group_by: str,
+    fallback_group_by: str,
+) -> None:
+    """Require identical scenario/seed multisets for every compared planner."""
+    coverage: dict[str, Counter[tuple[str, str]]] = {}
+    for index, record in enumerate(records):
+        planner = _resolve_group_key(record, group_by, fallback_group_by)
+        if planner == "unknown":
+            raise ValueError(
+                f"record {index} is missing both group keys {group_by!r} and {fallback_group_by!r}"
+            )
+        scenario_id = record.get("scenario_id")
+        seed = record.get("seed")
+        if scenario_id is None or seed is None:
+            raise ValueError(f"record {index} must carry scenario_id and seed provenance")
+        key = (str(scenario_id), str(seed))
+        coverage.setdefault(planner, Counter())[key] += 1
+    if len(coverage) < 2:
+        raise ValueError("risk-layer ablation requires at least two planners")
+    reference_planner = sorted(coverage)[0]
+    reference = coverage[reference_planner]
+    for planner, planner_coverage in coverage.items():
+        if planner_coverage != reference:
+            raise ValueError(
+                "planner scenario/seed coverage differs: "
+                f"{planner!r} does not match {reference_planner!r}"
+            )
+
+
+def _effective_layer_weights(
+    records: Sequence[Mapping[str, Any]],
+    weights_by_layer: Mapping[str, Mapping[str, float]],
+) -> tuple[dict[str, dict[str, float]], bool]:
+    """Return scoreable weights and all-or-none semantic-risk availability."""
+    present, total = _semantic_risk_coverage(records)
+    if 0 < present < total:
+        raise ValueError(
+            "partial semantic-risk coverage is not comparable: "
+            f"{present} of {total} records provide {SEMANTIC_RISK_METRIC_KEY}"
+        )
+    semantic_available = total > 0 and present == total
+    effective = {name: dict(weights) for name, weights in weights_by_layer.items()}
+    if not semantic_available:
+        for weights in effective.values():
+            weights["w_semantic_risk"] = 0.0
+    return effective, semantic_available
+
+
+def _resolve_layer_weights(
+    layer_names: Sequence[str],
+    weights_override: Mapping[str, Mapping[str, float]] | None,
+) -> dict[str, dict[str, float]]:
+    """Return requested layer weights, rejecting unknown layer names."""
+    resolved: dict[str, dict[str, float]] = {}
+    for name in layer_names:
+        if weights_override is not None and name in weights_override:
+            resolved[name] = dict(weights_override[name])
+        elif name in RISK_LAYER_WEIGHTS:
+            resolved[name] = dict(RISK_LAYER_WEIGHTS[name])
+        else:
+            raise ValueError(f"unknown risk layer: {name!r}")
+    return resolved
 
 
 def compute_risk_layer_ablation(
@@ -241,8 +375,8 @@ def compute_risk_layer_ablation(
 
     Args:
         records: Episode records carrying ``metrics`` and a planner/group key.
-        baseline_stats: Optional SNQI baseline normalization stats. When absent,
-            the v0 zero-baseline fallback is used (all terms normalized to 0).
+        baseline_stats: SNQI baseline normalization stats. Missing coverage for
+            an active normalized metric fails closed.
         group_by: Dotted key used to group episodes by planner.
         fallback_group_by: Fallback grouping key when ``group_by`` is absent.
         layer_names: Ordered subset of risk-layer names to evaluate. Defaults to
@@ -254,17 +388,24 @@ def compute_risk_layer_ablation(
         List of per-planner rows ordered by L0 rank (best first).
     """
     record_list = [dict(record) for record in records]
+    if not record_list:
+        return []
     baseline: Mapping[str, Mapping[str, float]] = baseline_stats or {}
     names = list(layer_names) if layer_names is not None else [layer.name for layer in RISK_LAYERS]
 
-    weights_by_layer: dict[str, dict[str, float]] = {}
-    for name in names:
-        if weights_override is not None and name in weights_override:
-            weights_by_layer[name] = dict(weights_override[name])
-        elif name in RISK_LAYER_WEIGHTS:
-            weights_by_layer[name] = dict(RISK_LAYER_WEIGHTS[name])
-        else:
-            raise ValueError(f"unknown risk layer: {name!r}")
+    weights_by_layer = _resolve_layer_weights(names, weights_override)
+
+    _validate_layer_weights(weights_by_layer, names)
+    _validate_comparable_records(
+        record_list,
+        group_by=group_by,
+        fallback_group_by=fallback_group_by,
+    )
+    weights_by_layer, _semantic_available = _effective_layer_weights(
+        record_list,
+        weights_by_layer,
+    )
+    _validate_baseline_coverage(weights_by_layer, baseline)
 
     per_layer_means: dict[str, dict[str, float]] = {}
     per_layer_support: dict[str, dict[str, int]] = {}
@@ -329,6 +470,7 @@ def bootstrap_layer_rank_stability(
     records: Iterable[Mapping[str, Any]],
     *,
     layer_name: str,
+    baseline_stats: Mapping[str, Mapping[str, float]],
     rng: Any | None = None,
     samples: int = 200,
     group_by: str = "scenario_params.algo",
@@ -345,6 +487,7 @@ def bootstrap_layer_rank_stability(
     Args:
         records: Episode records with a planner/group key and metrics.
         layer_name: Risk layer whose ranking stability is estimated.
+        baseline_stats: Baseline normalization statistics for active metrics.
         rng: Random generator exposing ``integers(...)`` (e.g.
             ``numpy.random.default_rng(seed)``).
         samples: Number of bootstrap resamples.
@@ -366,15 +509,27 @@ def bootstrap_layer_rank_stability(
         if weights_override is not None and layer_name in weights_override
         else RISK_LAYER_WEIGHTS[layer_name]
     )
+    record_list = [dict(record) for record in records]
+    _validate_comparable_records(
+        record_list,
+        group_by=group_by,
+        fallback_group_by=fallback_group_by,
+    )
+    effective, _semantic_available = _effective_layer_weights(
+        record_list,
+        {layer_name: weights},
+    )
+    weights = effective[layer_name]
+    _validate_layer_weights({layer_name: weights}, [layer_name])
+    _validate_baseline_coverage({layer_name: weights}, baseline_stats)
     grouped: dict[str, list[float]] = {}
-    for record in records:
+    for record in record_list:
         key = _resolve_group_key(record, group_by, fallback_group_by)
-        try:
-            score = _score_episode(record, weights, {})
-        except (ValueError, TypeError, KeyError):
-            continue
+        score = _score_episode(record, weights, baseline_stats)
         if math.isfinite(score):
             grouped.setdefault(key, []).append(score)
+        else:
+            raise ValueError(f"non-finite bootstrap score for planner {key!r}")
 
     if len(grouped) < 2:
         raise ValueError("bootstrap_layer_rank_stability requires at least two planners")
@@ -441,7 +596,8 @@ def build_risk_layer_report(
 
     Args:
         records: Episode records carrying metrics and a planner/group key.
-        baseline_stats: Optional SNQI baseline normalization stats.
+        baseline_stats: SNQI baseline normalization stats. Missing coverage for
+            an active normalized metric fails closed.
         group_by: Planner grouping key.
         fallback_group_by: Fallback grouping key.
         layer_names: Ordered subset of risk layers to evaluate.
@@ -464,7 +620,8 @@ def build_risk_layer_report(
     )
     names = list(layer_names) if layer_names is not None else [layer.name for layer in RISK_LAYERS]
 
-    semantic_available = _semantic_risk_available(record_list)
+    semantic_present, semantic_total = _semantic_risk_coverage(record_list)
+    semantic_available = semantic_total > 0 and semantic_present == semantic_total
     bootstrap_blocks: dict[str, Any] = {}
     if bootstrap is not None and record_list:
         rng = np.random.default_rng(int(bootstrap.get("seed", 0)))
@@ -473,14 +630,15 @@ def build_risk_layer_report(
                 bootstrap_blocks[name] = bootstrap_layer_rank_stability(
                     record_list,
                     layer_name=name,
+                    baseline_stats=baseline_stats or {},
                     rng=rng,
                     samples=int(bootstrap.get("samples", 200)),
                     group_by=group_by,
                     fallback_group_by=fallback_group_by,
                     weights_override=weights_override,
                 )
-            except ValueError:
-                bootstrap_blocks[name] = {"status": "skipped", "reason": "insufficient_planners"}
+            except ValueError as exc:
+                raise ValueError(f"bootstrap failed for risk layer {name!r}") from exc
 
     return {
         "schema_version": RISK_LAYER_ABLATION_SCHEMA,
@@ -504,6 +662,11 @@ def build_risk_layer_report(
             if layer.name in names
         ],
         "semantic_risk_available": semantic_available,
+        "semantic_risk_coverage": {
+            "present": semantic_present,
+            "total": semantic_total,
+            "status": "complete" if semantic_available else "unavailable",
+        },
         "group_by": group_by,
         "fallback_group_by": fallback_group_by,
         "n_episodes": len(record_list),
@@ -520,6 +683,121 @@ def build_risk_layer_report(
         ],
         "bootstrap": bootstrap_blocks,
     }
+
+
+def _parse_config_layers(
+    payload: Mapping[str, Any],
+) -> tuple[list[str], dict[str, dict[str, float]]]:
+    """Parse and validate ordered risk-layer definitions from config.
+
+    Returns:
+        Ordered layer names and weights keyed by layer.
+    """
+    raw_layers = payload.get("layers")
+    if not isinstance(raw_layers, list) or not all(
+        isinstance(layer, Mapping) for layer in raw_layers
+    ):
+        raise ValueError("risk-layer config layers must be a list of mappings")
+    names = [str(layer.get("name", "")) for layer in raw_layers]
+    expected_names = [layer.name for layer in RISK_LAYERS]
+    if names != expected_names:
+        raise ValueError(f"risk-layer order must be {expected_names}")
+    weights_by_layer: dict[str, dict[str, float]] = {}
+    for raw_layer in raw_layers:
+        raw_weights = raw_layer.get("weights")
+        if not isinstance(raw_weights, Mapping):
+            raise ValueError(f"risk layer {raw_layer.get('name')!r} is missing weights")
+        weights_by_layer[str(raw_layer["name"])] = {
+            str(name): float(value) for name, value in raw_weights.items()
+        }
+    _validate_layer_weights(weights_by_layer, names)
+    return names, weights_by_layer
+
+
+def _parse_config_bootstrap(payload: Mapping[str, Any]) -> dict[str, int]:
+    """Parse and validate deterministic bootstrap controls.
+
+    Returns:
+        Integer seed and positive sample count.
+    """
+    raw_bootstrap = payload.get("bootstrap")
+    if not isinstance(raw_bootstrap, Mapping):
+        raise ValueError("bootstrap must be a mapping")
+    try:
+        seed = int(raw_bootstrap["seed"])
+        samples = int(raw_bootstrap["samples"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("bootstrap requires integer seed and samples") from exc
+    if samples < 1:
+        raise ValueError("bootstrap.samples must be at least 1")
+    return {"seed": seed, "samples": samples}
+
+
+def _validate_config_header(payload: Mapping[str, Any]) -> None:
+    """Validate config schema and risk-layer versions."""
+    if payload.get("schema_version") != RISK_LAYER_ABLATION_SCHEMA:
+        raise ValueError(f"risk-layer config schema_version must be {RISK_LAYER_ABLATION_SCHEMA!r}")
+    if payload.get("risk_layer_version") != RISK_LAYER_VERSION:
+        raise ValueError(f"risk_layer_version must be {RISK_LAYER_VERSION!r}")
+
+
+def load_risk_layer_config(
+    config_path: Path = DEFAULT_RISK_LAYER_CONFIG,
+) -> dict[str, Any]:
+    """Load and validate the canonical risk-layer ablation configuration.
+
+    Returns:
+        Normalized config fields consumed by the config-first report builder.
+    """
+    try:
+        payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise ValueError(f"cannot load risk-layer config {config_path}") from exc
+    if not isinstance(payload, Mapping):
+        raise ValueError("risk-layer config root must be a mapping")
+    _validate_config_header(payload)
+    names, weights_by_layer = _parse_config_layers(payload)
+
+    group_by = payload.get("group_by")
+    fallback_group_by = payload.get("fallback_group_by")
+    if not isinstance(group_by, str) or not group_by:
+        raise ValueError("group_by must be a non-empty dotted-key string")
+    if not isinstance(fallback_group_by, str) or not fallback_group_by:
+        raise ValueError("fallback_group_by must be a non-empty dotted-key string")
+    bootstrap = _parse_config_bootstrap(payload)
+
+    return {
+        "schema_version": RISK_LAYER_ABLATION_SCHEMA,
+        "risk_layer_version": RISK_LAYER_VERSION,
+        "group_by": group_by,
+        "fallback_group_by": fallback_group_by,
+        "layer_names": names,
+        "weights_by_layer": weights_by_layer,
+        "bootstrap": bootstrap,
+    }
+
+
+def build_risk_layer_report_from_config(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    baseline_stats: Mapping[str, Mapping[str, float]],
+    config_path: Path = DEFAULT_RISK_LAYER_CONFIG,
+) -> dict[str, Any]:
+    """Build a report using one validated config as the runtime source of truth.
+
+    Returns:
+        Risk-layer report artifact.
+    """
+    config = load_risk_layer_config(config_path)
+    return build_risk_layer_report(
+        records,
+        baseline_stats=baseline_stats,
+        group_by=config["group_by"],
+        fallback_group_by=config["fallback_group_by"],
+        layer_names=config["layer_names"],
+        weights_override=config["weights_by_layer"],
+        bootstrap=config["bootstrap"],
+    )
 
 
 def format_risk_layer_markdown(report: Mapping[str, Any]) -> str:
@@ -603,6 +881,7 @@ def _clamp01(value: float) -> float:
 
 
 __all__ = [
+    "DEFAULT_RISK_LAYER_CONFIG",
     "RISK_LAYERS",
     "RISK_LAYER_ABLATION_SCHEMA",
     "RISK_LAYER_VERSION",
@@ -613,7 +892,9 @@ __all__ = [
     "RiskLayerDefinition",
     "bootstrap_layer_rank_stability",
     "build_risk_layer_report",
+    "build_risk_layer_report_from_config",
     "compute_layer_scores",
     "compute_risk_layer_ablation",
     "format_risk_layer_markdown",
+    "load_risk_layer_config",
 ]

--- a/robot_sf/benchmark/risk_layer_ablation.py
+++ b/robot_sf/benchmark/risk_layer_ablation.py
@@ -1,0 +1,619 @@
+"""Layered-risk ablation for planner evaluation (issue #5832).
+
+Scores each planner under progressively richer risk models and reports
+per-layer ranking deltas with bootstrap confidence intervals.
+
+The ablation axis mirrors the research motivation in issue #5832:
+
+* **L0 geometry-only** — static obstacles / contact geometry. The current
+  baseline behaviour where only hard collisions and obstacles matter.
+* **L1 +dynamics** — moving pedestrians with velocity / intent exposure.
+  Near-field and motion-comfort terms become active.
+* **L2 +semantic risk** — zone / context weighting (crossings, doorways,
+  high-density zones weighted in the risk field). The semantic-risk term is
+  read from ``metrics.semantic_risk_exposure`` when a scenario carries zone
+  metadata; otherwise the layer reports the term ``unavailable`` and the
+  planner score is computed from the remaining active terms only.
+
+This module is pure analysis / reporting tooling built on top of the existing
+SNQI metric stack. It never runs a benchmark campaign and never promotes a
+benchmark claim: it consumes episode records that already carry metrics and
+produces per-layer tables plus a JSON / Markdown report artifact.
+
+Metric mapping
+--------------
+Each risk layer is a fixed-schema SNQI weight configuration (see
+``RISK_LAYERS``). Activating a higher layer enables additional weight terms;
+deactivating a layer term sets its weight to ``0.0``. Because
+``compute_snqi_v0`` uses the zero-weight contract, a missing metric under a
+``0.0`` weight never collapses the score, and a missing *semantic* metric
+under a non-zero L2 weight is reported as unavailable rather than imputed.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from robot_sf.benchmark.rank_metrics import rank_by, spearman
+from robot_sf.benchmark.snqi.compute import compute_snqi_v0
+
+RISK_LAYER_ABLATION_SCHEMA = "risk_layer_ablation.v1"
+RISK_LAYER_VERSION = "risk-layers.v1"
+
+# Semantic-risk exposure metric produced by zone-aware scenarios. Absent for
+# scenario families without zone metadata; the L2 layer degrades gracefully.
+SEMANTIC_RISK_METRIC_KEY = "semantic_risk_exposure"
+
+# Canonical SNQI components used by the risk layers (subset of WEIGHT_NAMES in
+# robot_sf.benchmark.snqi.compute).
+RISK_WEIGHT_NAMES = (
+    "w_success",
+    "w_collisions",
+    "w_force_exceed",
+    "w_near",
+    "w_comfort",
+    "w_time",
+    "w_semantic_risk",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RiskLayerDefinition:
+    """One risk-model layer in the progressive ablation axis."""
+
+    name: str
+    level: int
+    description: str
+    # Names of the hazard dimensions this layer adds relative to the previous one.
+    adds: tuple[str, ...]
+
+
+# Progressive risk-model definitions. L0 is the current baseline; each higher
+# layer strictly adds hazard dimensions.
+RISK_LAYERS: tuple[RiskLayerDefinition, ...] = (
+    RiskLayerDefinition(
+        name="L0_geometry_only",
+        level=0,
+        description="Static obstacles and hard contact geometry only.",
+        adds=("geometry",),
+    ),
+    RiskLayerDefinition(
+        name="L1_plus_dynamics",
+        level=1,
+        description="L0 plus moving-pedestrian dynamics: near-field exposure and motion comfort.",
+        adds=("dynamics",),
+    ),
+    RiskLayerDefinition(
+        name="L2_plus_semantic_risk",
+        level=2,
+        description="L1 plus semantic/zone risk weighting from scenario zone metadata.",
+        adds=("semantic_risk",),
+    ),
+)
+
+
+# Mapping from layer name to its SNQI weight configuration. Activating a layer
+# enables the cumulative set of weight terms; deactivating keeps a ``0.0``
+# weight so the zero-weight contract keeps the score finite.
+RISK_LAYER_WEIGHTS: dict[str, dict[str, float]] = {
+    "L0_geometry_only": {
+        "w_success": 2.0,
+        "w_collisions": 2.0,
+        "w_force_exceed": 1.0,
+        "w_near": 0.0,
+        "w_comfort": 0.0,
+        "w_time": 0.0,
+        "w_semantic_risk": 0.0,
+    },
+    "L1_plus_dynamics": {
+        "w_success": 2.0,
+        "w_collisions": 2.0,
+        "w_force_exceed": 1.0,
+        "w_near": 1.5,
+        "w_comfort": 1.0,
+        "w_time": 0.0,
+        "w_semantic_risk": 0.0,
+    },
+    "L2_plus_semantic_risk": {
+        "w_success": 2.0,
+        "w_collisions": 2.0,
+        "w_force_exceed": 1.0,
+        "w_near": 1.5,
+        "w_comfort": 1.0,
+        "w_time": 0.5,
+        "w_semantic_risk": 1.5,
+    },
+}
+
+
+@dataclass
+class RiskLayerAblationRow:
+    """Per-planner row across the risk-layer ablation axis."""
+
+    planner: str
+    per_layer_rank: dict[str, int]
+    per_layer_score: dict[str, float]
+    per_layer_support: dict[str, int]
+    # layer_name -> rank delta relative to L0 (positive = worse than at L0).
+    rank_delta_from_l0: dict[str, float]
+    # True when the planner's rank changed between L0 and the richest layer.
+    rank_changed: bool = field(default=False)
+
+
+def _get_nested(record: Mapping[str, Any], dotted: str, default: Any | None = None) -> Any:
+    """Return a dotted-path value from a mapping."""
+    current: Any = record
+    for part in dotted.split("."):
+        if isinstance(current, Mapping) and part in current:
+            current = current[part]
+        else:
+            return default
+    return current
+
+
+def _resolve_group_key(record: Mapping[str, Any], group_by: str, fallback_group_by: str) -> str:
+    """Resolve a planner/group key from an episode record.
+
+    Returns:
+        Planner/group key string, or ``"unknown"`` when both keys are absent.
+    """
+    value = _get_nested(record, group_by)
+    if value is None:
+        value = _get_nested(record, fallback_group_by)
+    return str(value) if value is not None else "unknown"
+
+
+def _episode_metrics(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a normalized metrics view for one episode."""
+    metrics = record.get("metrics")
+    if not isinstance(metrics, Mapping):
+        metrics = {}
+    return dict(metrics)
+
+
+def _score_episode(
+    record: Mapping[str, Any],
+    weights: Mapping[str, float],
+    baseline_stats: Mapping[str, Mapping[str, float]],
+) -> float:
+    """Score one episode under a risk-layer weight configuration.
+
+    Returns:
+        SNQI score for the episode under the supplied weights.
+    """
+    return float(compute_snqi_v0(_episode_metrics(record), weights, baseline_stats))
+
+
+def _semantic_risk_available(records: Iterable[Mapping[str, Any]]) -> bool:
+    """Return whether any episode carries a finite semantic-risk metric."""
+    for record in records:
+        value = _episode_metrics(record).get(SEMANTIC_RISK_METRIC_KEY)
+        if isinstance(value, bool | int | float) and math.isfinite(float(value)):
+            return True
+    return False
+
+
+def compute_layer_scores(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    layer_weights: Mapping[str, float],
+    baseline_stats: Mapping[str, Mapping[str, float]],
+    group_by: str = "scenario_params.algo",
+    fallback_group_by: str = "algo",
+) -> dict[str, dict[str, Any]]:
+    """Compute per-planner mean SNQI scores for one risk layer.
+
+    Returns:
+        Mapping from planner id to ``{"mean": float, "support": int}``.
+    """
+    groups: dict[str, list[float]] = {}
+    for record in records:
+        key = _resolve_group_key(record, group_by, fallback_group_by)
+        try:
+            score = _score_episode(record, layer_weights, baseline_stats)
+        except (ValueError, TypeError, KeyError):
+            continue
+        if not math.isfinite(score):
+            continue
+        groups.setdefault(key, []).append(score)
+    return {
+        planner: {"mean": sum(vals) / len(vals), "support": len(vals)}
+        for planner, vals in groups.items()
+        if vals
+    }
+
+
+def compute_risk_layer_ablation(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    baseline_stats: Mapping[str, Mapping[str, float]] | None = None,
+    group_by: str = "scenario_params.algo",
+    fallback_group_by: str = "algo",
+    layer_names: Sequence[str] | None = None,
+    weights_override: Mapping[str, Mapping[str, float]] | None = None,
+) -> list[RiskLayerAblationRow]:
+    """Score planners under each risk layer and compute per-layer rank deltas.
+
+    Args:
+        records: Episode records carrying ``metrics`` and a planner/group key.
+        baseline_stats: Optional SNQI baseline normalization stats. When absent,
+            the v0 zero-baseline fallback is used (all terms normalized to 0).
+        group_by: Dotted key used to group episodes by planner.
+        fallback_group_by: Fallback grouping key when ``group_by`` is absent.
+        layer_names: Ordered subset of risk-layer names to evaluate. Defaults to
+            all ``RISK_LAYERS`` in level order.
+        weights_override: Optional per-layer weight configurations overriding
+            ``RISK_LAYER_WEIGHTS`` (used by tests and custom configs).
+
+    Returns:
+        List of per-planner rows ordered by L0 rank (best first).
+    """
+    record_list = [dict(record) for record in records]
+    baseline: Mapping[str, Mapping[str, float]] = baseline_stats or {}
+    names = list(layer_names) if layer_names is not None else [layer.name for layer in RISK_LAYERS]
+
+    weights_by_layer: dict[str, dict[str, float]] = {}
+    for name in names:
+        if weights_override is not None and name in weights_override:
+            weights_by_layer[name] = dict(weights_override[name])
+        elif name in RISK_LAYER_WEIGHTS:
+            weights_by_layer[name] = dict(RISK_LAYER_WEIGHTS[name])
+        else:
+            raise ValueError(f"unknown risk layer: {name!r}")
+
+    per_layer_means: dict[str, dict[str, float]] = {}
+    per_layer_support: dict[str, dict[str, int]] = {}
+    for name in names:
+        scored = compute_layer_scores(
+            record_list,
+            layer_weights=weights_by_layer[name],
+            baseline_stats=baseline,
+            group_by=group_by,
+            fallback_group_by=fallback_group_by,
+        )
+        per_layer_means[name] = {planner: info["mean"] for planner, info in scored.items()}
+        per_layer_support[name] = {planner: info["support"] for planner, info in scored.items()}
+
+    if not per_layer_means or not names:
+        return []
+
+    base_layer = names[0]
+    base_ranks = rank_by(
+        per_layer_means[base_layer],
+        higher_is_better=True,
+        tie_abs_tol=1e-12,
+    )
+
+    rows_by_planner: dict[str, RiskLayerAblationRow] = {}
+    for name in names:
+        ranks = rank_by(
+            per_layer_means[name],
+            higher_is_better=True,
+            tie_abs_tol=1e-12,
+        )
+        for planner, rank in ranks.items():
+            row = rows_by_planner.get(planner)
+            if row is None:
+                row = RiskLayerAblationRow(
+                    planner=planner,
+                    per_layer_rank={},
+                    per_layer_score={},
+                    per_layer_support={},
+                    rank_delta_from_l0={},
+                )
+                rows_by_planner[planner] = row
+            row.per_layer_rank[name] = round(rank)
+            row.per_layer_score[name] = float(per_layer_means[name][planner])
+            row.per_layer_support[name] = int(per_layer_support[name].get(planner, 0))
+            row.rank_delta_from_l0[name] = float(rank - base_ranks.get(planner, rank))
+
+    for row in rows_by_planner.values():
+        richest = names[-1]
+        row.rank_changed = int(row.per_layer_rank.get(richest, 0)) != int(
+            row.per_layer_rank.get(base_layer, 0)
+        )
+
+    ordered = sorted(
+        rows_by_planner.values(),
+        key=lambda r: r.per_layer_rank.get(base_layer, len(rows_by_planner) + 1),
+    )
+    return ordered
+
+
+def bootstrap_layer_rank_stability(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    layer_name: str,
+    rng: Any | None = None,
+    samples: int = 200,
+    group_by: str = "scenario_params.algo",
+    fallback_group_by: str = "algo",
+    weights_override: Mapping[str, Mapping[str, float]] | None = None,
+) -> dict[str, Any]:
+    """Estimate bootstrap stability of a layer's planner ranking.
+
+    Stratified resampling preserves each planner's episode count and recomputes
+    the mean SNQI per planner, then measures how often the resampled ranking
+    preserves the baseline ordering (Spearman correlation). Higher values mean
+    the layer's ranking is robust to episode resampling.
+
+    Args:
+        records: Episode records with a planner/group key and metrics.
+        layer_name: Risk layer whose ranking stability is estimated.
+        rng: Random generator exposing ``integers(...)`` (e.g.
+            ``numpy.random.default_rng(seed)``).
+        samples: Number of bootstrap resamples.
+        group_by: Planner grouping key.
+        fallback_group_by: Fallback grouping key.
+        weights_override: Optional per-layer weight overrides.
+
+    Returns:
+        JSON-compatible payload with ``status: "ok"`` and a normalized
+        ``stability`` score in ``[0, 1]`` plus per-layer rank CIs.
+    """
+    if rng is None:
+        raise ValueError("bootstrap_layer_rank_stability requires rng=default_rng(seed)")
+    if samples < 1:
+        raise ValueError("samples must be >= 1")
+
+    weights = (
+        weights_override[layer_name]
+        if weights_override is not None and layer_name in weights_override
+        else RISK_LAYER_WEIGHTS[layer_name]
+    )
+    grouped: dict[str, list[float]] = {}
+    for record in records:
+        key = _resolve_group_key(record, group_by, fallback_group_by)
+        try:
+            score = _score_episode(record, weights, {})
+        except (ValueError, TypeError, KeyError):
+            continue
+        if math.isfinite(score):
+            grouped.setdefault(key, []).append(score)
+
+    if len(grouped) < 2:
+        raise ValueError("bootstrap_layer_rank_stability requires at least two planners")
+
+    baseline_ordering = sorted(
+        grouped,
+        key=lambda g: (-_mean(grouped[g]), g),
+    )
+    baseline_ranks = rank_by(
+        {g: _mean(grouped[g]) for g in grouped},
+        higher_is_better=True,
+        tie_abs_tol=1e-12,
+    )
+    baseline_rank_vec = [baseline_ranks[g] for g in baseline_ordering]
+
+    correlations: list[float] = []
+    rank_samples: dict[str, list[float]] = {g: [] for g in grouped}
+    for _ in range(samples):
+        sample_means = {g: _mean(_resample(grouped[g], rng=rng)) for g in grouped}
+        sample_ranks = rank_by(sample_means, higher_is_better=True, tie_abs_tol=1e-12)
+        for g in grouped:
+            rank_samples[g].append(float(sample_ranks[g]))
+        sample_vec = [sample_ranks[g] for g in baseline_ordering]
+        correlation = spearman(baseline_rank_vec, sample_vec, degenerate=None, tie_abs_tol=1e-12)
+        correlations.append(
+            float(correlation)
+            if correlation is not None
+            else (1.0 if sample_vec == baseline_rank_vec else 0.0)
+        )
+
+    raw_mean = _mean(correlations)
+    stability = (raw_mean + 1.0) / 2.0
+    return {
+        "status": "ok",
+        "layer": layer_name,
+        "stability": _clamp01(stability),
+        "samples": int(samples),
+        "method": "bootstrap_spearman",
+        "baseline_ordering": baseline_ordering,
+        "rank_cis": {
+            g: {
+                "mean_rank": _mean(rank_samples[g]),
+                "min_rank": float(min(rank_samples[g])),
+                "max_rank": float(max(rank_samples[g])),
+                "ci95_low": _percentile(rank_samples[g], 2.5),
+                "ci95_high": _percentile(rank_samples[g], 97.5),
+            }
+            for g in baseline_ordering
+        },
+    }
+
+
+def build_risk_layer_report(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    baseline_stats: Mapping[str, Mapping[str, float]] | None = None,
+    group_by: str = "scenario_params.algo",
+    fallback_group_by: str = "algo",
+    layer_names: Sequence[str] | None = None,
+    weights_override: Mapping[str, Mapping[str, float]] | None = None,
+    bootstrap: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the full risk-layer ablation report artifact.
+
+    Args:
+        records: Episode records carrying metrics and a planner/group key.
+        baseline_stats: Optional SNQI baseline normalization stats.
+        group_by: Planner grouping key.
+        fallback_group_by: Fallback grouping key.
+        layer_names: Ordered subset of risk layers to evaluate.
+        weights_override: Optional per-layer weight overrides.
+        bootstrap: Optional ``{"seed": int, "samples": int}`` enabling bootstrap
+            rank-CI estimation on every evaluated layer.
+
+    Returns:
+        JSON-serializable report with per-layer tables, per-planner deltas, and
+        optional bootstrap stability blocks.
+    """
+    record_list = [dict(record) for record in records]
+    rows = compute_risk_layer_ablation(
+        record_list,
+        baseline_stats=baseline_stats,
+        group_by=group_by,
+        fallback_group_by=fallback_group_by,
+        layer_names=layer_names,
+        weights_override=weights_override,
+    )
+    names = list(layer_names) if layer_names is not None else [layer.name for layer in RISK_LAYERS]
+
+    semantic_available = _semantic_risk_available(record_list)
+    bootstrap_blocks: dict[str, Any] = {}
+    if bootstrap is not None and record_list:
+        rng = np.random.default_rng(int(bootstrap.get("seed", 0)))
+        for name in names:
+            try:
+                bootstrap_blocks[name] = bootstrap_layer_rank_stability(
+                    record_list,
+                    layer_name=name,
+                    rng=rng,
+                    samples=int(bootstrap.get("samples", 200)),
+                    group_by=group_by,
+                    fallback_group_by=fallback_group_by,
+                    weights_override=weights_override,
+                )
+            except ValueError:
+                bootstrap_blocks[name] = {"status": "skipped", "reason": "insufficient_planners"}
+
+    return {
+        "schema_version": RISK_LAYER_ABLATION_SCHEMA,
+        "risk_layer_version": RISK_LAYER_VERSION,
+        "status": "artifact_only",
+        "claim_boundary": (
+            "Computes per-layer planner rankings from supplied episode records "
+            "only; does not run a benchmark campaign or establish a benchmark claim."
+        ),
+        "layers": [
+            {
+                "name": layer.name,
+                "level": layer.level,
+                "description": layer.description,
+                "adds": list(layer.adds),
+                "weights": weights_override[layer.name]
+                if weights_override is not None and layer.name in weights_override
+                else dict(RISK_LAYER_WEIGHTS[layer.name]),
+            }
+            for layer in RISK_LAYERS
+            if layer.name in names
+        ],
+        "semantic_risk_available": semantic_available,
+        "group_by": group_by,
+        "fallback_group_by": fallback_group_by,
+        "n_episodes": len(record_list),
+        "rows": [
+            {
+                "planner": row.planner,
+                "per_layer_rank": dict(row.per_layer_rank),
+                "per_layer_score": dict(row.per_layer_score),
+                "per_layer_support": dict(row.per_layer_support),
+                "rank_delta_from_l0": dict(row.rank_delta_from_l0),
+                "rank_changed": row.rank_changed,
+            }
+            for row in rows
+        ],
+        "bootstrap": bootstrap_blocks,
+    }
+
+
+def format_risk_layer_markdown(report: Mapping[str, Any]) -> str:
+    """Render the risk-layer ablation report as a Markdown table.
+
+    Returns:
+        Markdown string with a per-planner delta table.
+    """
+    rows = report.get("rows", [])
+    if not rows:
+        return "_no planner rows_"
+    layer_names = [layer["name"] for layer in report.get("layers", [])]
+    header_cells = ["Planner", "L0 rank"] + [f"Δrank {name}" for name in layer_names[1:]]
+    lines = [
+        "| " + " | ".join(header_cells) + " |",
+        "|" + "|".join(["---:"] * len(header_cells)) + "|",
+    ]
+    for row in rows:
+        l0 = row["per_layer_rank"].get(layer_names[0], "")
+        deltas = [f"{row['rank_delta_from_l0'].get(name, 0.0):+.0f}" for name in layer_names[1:]]
+        lines.append("| " + " | ".join([str(row["planner"]), str(l0), *deltas]) + " |")
+    semantic = report.get("semantic_risk_available")
+    if semantic is False:
+        lines.append("")
+        lines.append(
+            "_Note: L2 semantic-risk term unavailable on supplied records "
+            "(no zone metadata); L2 scored on remaining active terms._"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _mean(values: Sequence[float]) -> float:
+    """Arithmetic mean of finite values.
+
+    Returns:
+        Mean value of the inputs.
+    """
+    vals = [float(v) for v in values]
+    if not vals:
+        raise ValueError("mean requires at least one value")
+    return float(math.fsum(vals) / len(vals))
+
+
+def _resample(values: list[float], *, rng: Any) -> list[float]:
+    """One with-replacement bootstrap resample.
+
+    Returns:
+        Resampled list with the same length as ``values``.
+    """
+    indexes = rng.integers(0, len(values), size=len(values))
+    return [values[int(index)] for index in indexes]
+
+
+def _percentile(values: Sequence[float], quantile: float) -> float:
+    """Linear-interpolation percentile (0-100) over sorted values.
+
+    Returns:
+        Percentile value at ``quantile`` (0-100 scale).
+    """
+    vals = sorted(float(v) for v in values)
+    if not vals:
+        raise ValueError("percentile requires at least one value")
+    if len(vals) == 1:
+        return vals[0]
+    rank = (quantile / 100.0) * (len(vals) - 1)
+    low = math.floor(rank)
+    high = math.ceil(rank)
+    if low == high:
+        return vals[low]
+    frac = rank - low
+    return vals[low] * (1.0 - frac) + vals[high] * frac
+
+
+def _clamp01(value: float) -> float:
+    """Clamp a floating-point value to ``[0, 1]``.
+
+    Returns:
+        Value bounded to ``[0, 1]``.
+    """
+    return max(0.0, min(1.0, float(value)))
+
+
+__all__ = [
+    "RISK_LAYERS",
+    "RISK_LAYER_ABLATION_SCHEMA",
+    "RISK_LAYER_VERSION",
+    "RISK_LAYER_WEIGHTS",
+    "RISK_WEIGHT_NAMES",
+    "SEMANTIC_RISK_METRIC_KEY",
+    "RiskLayerAblationRow",
+    "RiskLayerDefinition",
+    "bootstrap_layer_rank_stability",
+    "build_risk_layer_report",
+    "compute_layer_scores",
+    "compute_risk_layer_ablation",
+    "format_risk_layer_markdown",
+]

--- a/tests/test_risk_layer_ablation.py
+++ b/tests/test_risk_layer_ablation.py
@@ -16,12 +16,16 @@ import pytest
 
 from robot_sf.benchmark import risk_layer_ablation as rla
 
-CONFIG_PATH = Path("configs/benchmark/risk_layer_ablation.yaml")
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = REPO_ROOT / "configs/benchmark/risk_layer_ablation.yaml"
 
 BASELINE_STATS = {
     "collisions": {"med": 0.0, "p95": 2.0},
+    "force_exceed_events": {"med": 0.0, "p95": 2.0},
+    "near_misses": {"med": 0.0, "p95": 2.0},
     "comfort_exposure": {"med": 0.0, "p95": 2.0},
     "time_to_goal_norm": {"med": 0.5, "p95": 1.0},
+    "semantic_risk_exposure": {"med": 0.0, "p95": 2.0},
 }
 
 
@@ -77,13 +81,10 @@ def _dynamics_flip_records(n: int = 4) -> list[dict]:
 
 def test_risk_layer_config_loads() -> None:
     """The canonical ablation config must load with three progressive layers."""
-    import yaml
-
-    with CONFIG_PATH.open(encoding="utf-8") as f:
-        config = yaml.safe_load(f)
+    config = rla.load_risk_layer_config(CONFIG_PATH)
 
     assert config["schema_version"] == rla.RISK_LAYER_ABLATION_SCHEMA
-    layer_names = [layer["name"] for layer in config["layers"]]
+    layer_names = config["layer_names"]
     assert layer_names == [
         "L0_geometry_only",
         "L1_plus_dynamics",
@@ -91,10 +92,12 @@ def test_risk_layer_config_loads() -> None:
     ]
     # Each higher layer must enable strictly more weight terms than the prior one.
     active_counts = [
-        sum(1 for w in layer["weights"].values() if w > 0.0) for layer in config["layers"]
+        sum(1 for weight in config["weights_by_layer"][name].values() if weight > 0.0)
+        for name in layer_names
     ]
     assert active_counts == sorted(active_counts)
     assert active_counts[-1] > active_counts[0]
+    assert config["weights_by_layer"] == rla.RISK_LAYER_WEIGHTS
 
 
 def test_risk_layer_constants_consistent() -> None:
@@ -165,10 +168,66 @@ def test_l2_degrades_gracefully_without_zone_metadata() -> None:
         bootstrap={"seed": 1, "samples": 50},
     )
     assert report["semantic_risk_available"] is False
+    assert report["semantic_risk_coverage"] == {
+        "present": 0,
+        "total": len(records),
+        "status": "unavailable",
+    }
     # L2 should still produce finite ranks for both planners.
     by_planner = {row["planner"]: row for row in report["rows"]}
     assert by_planner["A"]["per_layer_rank"]["L2_plus_semantic_risk"] in (1, 2)
     assert by_planner["B"]["per_layer_rank"]["L2_plus_semantic_risk"] in (1, 2)
+    assert all(
+        row["per_layer_score"]["L2_plus_semantic_risk"]
+        == row["per_layer_score"]["L1_plus_dynamics"]
+        for row in report["rows"]
+    )
+
+
+def test_semantic_risk_changes_l2_ranking() -> None:
+    """L2 must apply semantic exposure instead of a hidden time penalty."""
+    records = _dynamics_flip_records()
+    for record in records:
+        record["metrics"]["comfort_exposure"] = 0.0
+        record["metrics"]["semantic_risk_exposure"] = (
+            2.0 if record["scenario_params"]["algo"] == "A" else 0.0
+        )
+
+    report = rla.build_risk_layer_report(records, baseline_stats=BASELINE_STATS)
+    rows = {row["planner"]: row for row in report["rows"]}
+
+    assert report["semantic_risk_available"] is True
+    assert rows["A"]["per_layer_rank"]["L0_geometry_only"] == 1
+    assert rows["A"]["per_layer_rank"]["L2_plus_semantic_risk"] == 2
+
+
+def test_partial_semantic_coverage_fails_closed() -> None:
+    """A partial semantic metric cannot be silently imputed as neutral."""
+    records = _dynamics_flip_records()
+    records[0]["metrics"].pop("semantic_risk_exposure")
+
+    with pytest.raises(ValueError, match="partial semantic-risk coverage"):
+        rla.build_risk_layer_report(records, baseline_stats=BASELINE_STATS)
+
+
+def test_mismatched_planner_seed_coverage_fails_closed() -> None:
+    """Planner rankings require the same scenario/seed multiset."""
+    records = _dynamics_flip_records()
+    records.pop()
+
+    with pytest.raises(ValueError, match="scenario/seed coverage differs"):
+        rla.build_risk_layer_report(records, baseline_stats=BASELINE_STATS)
+
+
+def test_config_drives_report_runtime() -> None:
+    """The checked-in YAML is consumed by the public config-first entry point."""
+    report = rla.build_risk_layer_report_from_config(
+        _dynamics_flip_records(),
+        baseline_stats=BASELINE_STATS,
+        config_path=CONFIG_PATH,
+    )
+
+    assert report["bootstrap"]["L0_geometry_only"]["samples"] == 200
 
 
 def test_markdown_report_renders_delta_table() -> None:

--- a/tests/test_risk_layer_ablation.py
+++ b/tests/test_risk_layer_ablation.py
@@ -1,0 +1,189 @@
+"""Tests for the risk-layer ablation harness (issue #5832).
+
+The tests assert the acceptance criteria from the issue:
+- layer configs load (from the canonical YAML and from the module constants);
+- metrics differ between layers on a fixture where they must (the L0-vs-L1
+  dynamics inversion);
+- the report artifact carries per-planner rank deltas and bootstrap CIs;
+- L2 degrades gracefully when no zone metadata is present.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark import risk_layer_ablation as rla
+
+CONFIG_PATH = Path("configs/benchmark/risk_layer_ablation.yaml")
+
+BASELINE_STATS = {
+    "collisions": {"med": 0.0, "p95": 2.0},
+    "comfort_exposure": {"med": 0.0, "p95": 2.0},
+    "time_to_goal_norm": {"med": 0.5, "p95": 1.0},
+}
+
+
+def _dynamics_flip_records(n: int = 4) -> list[dict]:
+    """Two planners designed so L1 (dynamics) inverts the L0 ranking.
+
+    Planner A has clean geometry but high comfort exposure (bad dynamics).
+    Planner B has one collision (worse geometry) but clean dynamics.
+    """
+    records: list[dict] = []
+
+    def add(planner: str, metrics: dict) -> None:
+        for i in range(n):
+            records.append(
+                {
+                    "episode_id": f"{planner}-{i}",
+                    "scenario_id": "fam-1",
+                    "seed": i,
+                    "scenario_params": {"algo": planner},
+                    "algo": planner,
+                    "metrics": metrics,
+                }
+            )
+
+    add(
+        "A",
+        {
+            "success": 1.0,
+            "collisions": 0.0,
+            "near_misses": 0.0,
+            "comfort_exposure": 2.0,
+            "force_exceed_events": 0.0,
+            "jerk_mean": 0.0,
+            "time_to_goal_norm": 0.5,
+            "semantic_risk_exposure": 0.0,
+        },
+    )
+    add(
+        "B",
+        {
+            "success": 1.0,
+            "collisions": 1.0,
+            "near_misses": 0.0,
+            "comfort_exposure": 0.0,
+            "force_exceed_events": 0.0,
+            "jerk_mean": 0.0,
+            "time_to_goal_norm": 0.5,
+            "semantic_risk_exposure": 0.0,
+        },
+    )
+    return records
+
+
+def test_risk_layer_config_loads() -> None:
+    """The canonical ablation config must load with three progressive layers."""
+    import yaml
+
+    with CONFIG_PATH.open(encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    assert config["schema_version"] == rla.RISK_LAYER_ABLATION_SCHEMA
+    layer_names = [layer["name"] for layer in config["layers"]]
+    assert layer_names == [
+        "L0_geometry_only",
+        "L1_plus_dynamics",
+        "L2_plus_semantic_risk",
+    ]
+    # Each higher layer must enable strictly more weight terms than the prior one.
+    active_counts = [
+        sum(1 for w in layer["weights"].values() if w > 0.0) for layer in config["layers"]
+    ]
+    assert active_counts == sorted(active_counts)
+    assert active_counts[-1] > active_counts[0]
+
+
+def test_risk_layer_constants_consistent() -> None:
+    """Module constants expose the documented layer set and weight schema."""
+    assert [layer.name for layer in rla.RISK_LAYERS] == [
+        "L0_geometry_only",
+        "L1_plus_dynamics",
+        "L2_plus_semantic_risk",
+    ]
+    for name in ("L0_geometry_only", "L1_plus_dynamics", "L2_plus_semantic_risk"):
+        assert name in rla.RISK_LAYER_WEIGHTS
+        assert set(rla.RISK_LAYER_WEIGHTS[name]) == set(rla.RISK_WEIGHT_NAMES)
+
+
+def test_metrics_differ_between_layers_on_fixture() -> None:
+    """The dynamics fixture must invert the ranking between L0 and L1."""
+    records = _dynamics_flip_records()
+    rows = rla.compute_risk_layer_ablation(
+        records,
+        baseline_stats=BASELINE_STATS,
+        group_by="scenario_params.algo",
+    )
+    by_planner = {row.planner: row for row in rows}
+
+    # A is best at L0 (geometry-only) but drops at L1; B is the inverse.
+    assert by_planner["A"].per_layer_rank["L0_geometry_only"] == 1
+    assert by_planner["A"].per_layer_rank["L1_plus_dynamics"] == 2
+    assert by_planner["A"].rank_changed is True
+
+    assert by_planner["B"].per_layer_rank["L0_geometry_only"] == 2
+    assert by_planner["B"].per_layer_rank["L1_plus_dynamics"] == 1
+
+    # Per-planner rank delta from L0 must capture the inversion.
+    assert by_planner["A"].rank_delta_from_l0["L1_plus_dynamics"] == 1.0
+    assert by_planner["B"].rank_delta_from_l0["L1_plus_dynamics"] == -1.0
+
+
+def test_report_artifact_carries_bootstrap_cis() -> None:
+    """The report artifact must include per-planner rank CIs and stability."""
+    records = _dynamics_flip_records()
+    report = rla.build_risk_layer_report(
+        records,
+        baseline_stats=BASELINE_STATS,
+        bootstrap={"seed": 7, "samples": 200},
+    )
+    assert report["schema_version"] == rla.RISK_LAYER_ABLATION_SCHEMA
+    assert len(report["rows"]) == 2
+
+    boot = report["bootstrap"]["L0_geometry_only"]
+    assert boot["status"] == "ok"
+    assert 0.0 <= boot["stability"] <= 1.0
+    assert "rank_cis" in boot
+    for planner in ("A", "B"):
+        ci = boot["rank_cis"][planner]
+        assert ci["ci95_low"] <= ci["mean_rank"] <= ci["ci95_high"]
+
+
+def test_l2_degrades_gracefully_without_zone_metadata() -> None:
+    """Without semantic_risk_exposure, L2 scores remaining active terms only."""
+    records = _dynamics_flip_records()
+    # Remove the semantic metric entirely from every record.
+    for record in records:
+        record["metrics"].pop("semantic_risk_exposure", None)
+
+    report = rla.build_risk_layer_report(
+        records,
+        baseline_stats=BASELINE_STATS,
+        bootstrap={"seed": 1, "samples": 50},
+    )
+    assert report["semantic_risk_available"] is False
+    # L2 should still produce finite ranks for both planners.
+    by_planner = {row["planner"]: row for row in report["rows"]}
+    assert by_planner["A"]["per_layer_rank"]["L2_plus_semantic_risk"] in (1, 2)
+    assert by_planner["B"]["per_layer_rank"]["L2_plus_semantic_risk"] in (1, 2)
+
+
+def test_markdown_report_renders_delta_table() -> None:
+    """The Markdown formatter must render a per-planner delta table."""
+    records = _dynamics_flip_records()
+    report = rla.build_risk_layer_report(records, baseline_stats=BASELINE_STATS)
+    md = rla.format_risk_layer_markdown(report)
+    assert "| Planner | L0 rank |" in md
+    assert "Δrank L1_plus_dynamics" in md
+
+
+def test_unknown_layer_rejected() -> None:
+    """Requesting an unknown risk layer must fail closed."""
+    with pytest.raises(ValueError):
+        rla.compute_risk_layer_ablation(
+            _dynamics_flip_records(),
+            layer_names=["L0_geometry_only", "nope"],
+        )


### PR DESCRIPTION
## What / why

Implements the **risk-layer ablation axis** from issue #5832: score planners under progressively richer risk models and report per-layer rank deltas with bootstrap CIs. This is an evaluation-config + reporting change built on the existing metric stack (collision ledger, near-field exposure, SNQI weights) — no new simulator feature, no campaign, no training.

Three layers (each adds a hazard dimension):
- **L0 geometry-only** — static obstacles / hard contact geometry (current baseline behaviour).
- **L1 +dynamics** — adds moving-pedestrian near-field exposure and motion comfort.
- **L2 +semantic risk** — adds zone/context weighting via `metrics.semantic_risk_exposure`; degrades gracefully (scores remaining active terms, reports `unavailable`) when a scenario family carries no zone metadata.

The key publishable finding class — *a planner ranked safe at L0 but unsafe at L2* — is made measurable: each planner carries `rank_delta_from_l0` per layer and `rank_changed`.

## Files

- `robot_sf/benchmark/risk_layer_ablation.py` — `RISK_LAYERS`/`RISK_LAYER_WEIGHTS` constants, `compute_risk_layer_ablation`, `bootstrap_layer_rank_stability` (stratified bootstrap Spearman stability + rank CIs), `build_risk_layer_report` (JSON artifact), `format_risk_layer_markdown`.
- `configs/benchmark/risk_layer_ablation.yaml` — pinned layer weight configs + seed set (`seed: 20260716`, `samples: 200`).
- `docs/benchmark_risk_layer_ablation.md` — defines the layers and their metric mapping (issue acceptance: docs page).
- `tests/test_risk_layer_ablation.py` — acceptance tests.

## Validation

CPU-level only. `pytest tests/test_risk_layer_ablation.py` → **7 passed**. `ruff check` + `ruff format` clean on all changed files.

Fixture demonstrates the target inversion: planner A is rank 1 at L0 (clean geometry) but drops to rank 2 once dynamics are weighted at L1; planner B is the inverse — exactly the L0-vs-L1 dynamics finding the issue calls out.

```
A  L0 rank 1, L1 rank 2, ΔL1 +1, changed True
B  L0 rank 2, L1 rank 1, ΔL1 -1, changed True
```

Bootstrap block per layer returns `status: ok`, stability in [0,1], and `rank_cis` with `ci95_low`/`ci95_high`.

## Scope / successor

Bounded first slice as scoped in the issue: **L0-vs-L1 ablation harness + report artifact + docs + config + tests** are complete and fully resolve the evaluation-axis acceptance (>=2 planners, per-layer tables, bootstrap CIs, docs, tests). L2 is wired, documented, and exercised in the graceful-degradation test; the issue's "one released scenario family" campaign run (actual episode-record production) remains a follow-up because it requires a benchmark campaign, which the cheap lane does not run. Refs #5832.

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

## Batch-gate hardening

- L2 now scores normalized `semantic_risk_exposure`; it no longer attributes a
  time penalty to semantic risk.
- The config-first entry point loads and validates the checked-in YAML,
  including layer order, exact weight schema, deterministic bootstrap controls,
  and finite non-negative weights.
- Planner scenario/seed coverage, active baseline statistics, semantic coverage,
  malformed scores, and bootstrap scoring now fail closed.
- Validation after the gate fix: `uv run ruff check
  robot_sf/benchmark/risk_layer_ablation.py tests/test_risk_layer_ablation.py`
  and `uv run pytest tests/test_risk_layer_ablation.py -q` (`11 passed`).

## Domain-Aware Approval

- Required: yes — this is benchmark-analysis and evidence-classification code.
- Domains reviewed: metric semantics, comparison validity, bootstrap validity,
  fallback/degraded exclusions, and claim boundary.
- Status: approved for this artifact-only harness at
  `37e0439acf5230dcf0c890ff7c6da53d0e7dcc41`.
- Validity boundary: implementation integrity is proven on adversarial fixtures;
  no released-scenario campaign result or planner-ranking claim is established.
- Fallback/degraded exclusion: fully absent semantic evidence is reported
  unavailable and makes L2 equal L1; partial semantic or planner/seed coverage
  fails closed.
- Remaining empirical campaign: retained on open parent issue #5832; this PR
  intentionally uses `Refs #5832`.
