### PR TITLE
feat(ped-npc): deterministic background scatter-spawn for forced populations on geometry-less maps (#5829 option a)

### DIFF
--- a/robot_sf/ped_npc/ped_behavior.py
+++ b/robot_sf/ped_npc/ped_behavior.py
@@ -14,6 +14,7 @@ from robot_sf.ped_npc.ped_grouping import PedestrianGroupings, PedestrianStates
 from robot_sf.ped_npc.ped_zone import sample_zone
 
 if TYPE_CHECKING:
+    import numpy as np
     from shapely.prepared import PreparedGeometry
 
 #: Fail-open release time (seconds) for a proximity hold when no ``hold_timeout_s`` is configured.
@@ -63,6 +64,25 @@ class CrowdedZoneBehavior:
     zone_assignments: dict[int, int]
     crowded_zones: list[Zone]
     goal_proximity_threshold: float = 1
+    obstacle_polygons: list["PreparedGeometry"] | None = None
+    rng: "np.random.Generator | None" = None
+    goal_sample_max_attempts_per_point: int = 20
+
+    def _sample_goal(self, zone: Zone) -> Vec2D:
+        """Sample a zone goal, preserving the legacy call when unconstrained.
+
+        Returns:
+            A sampled goal inside ``zone``.
+        """
+        if self.obstacle_polygons is None and self.rng is None:
+            return sample_zone(zone, 1)[0]
+        return sample_zone(
+            zone,
+            1,
+            obstacle_polygons=self.obstacle_polygons,
+            max_attempts_per_point=self.goal_sample_max_attempts_per_point,
+            rng=self.rng,
+        )[0]
 
     def step(self):
         """
@@ -79,7 +99,7 @@ class CrowdedZoneBehavior:
             if dist_to_goal < self.goal_proximity_threshold:
                 any_pid = next(iter(self.groups.groups[gid]))
                 zone = self.crowded_zones[self.zone_assignments[any_pid]]
-                new_goal = sample_zone(zone, 1)[0]
+                new_goal = self._sample_goal(zone)
                 self.groups.redirect_group(gid, new_goal)
 
     def reset(self):
@@ -92,7 +112,7 @@ class CrowdedZoneBehavior:
         for gid in self.groups.group_ids:
             any_pid = next(iter(self.groups.groups[gid]))
             zone = self.crowded_zones[self.zone_assignments[any_pid]]
-            new_goal = sample_zone(zone, 1)[0]
+            new_goal = self._sample_goal(zone)
             self.groups.redirect_group(gid, new_goal)
 
 

--- a/robot_sf/ped_npc/ped_population.py
+++ b/robot_sf/ped_npc/ped_population.py
@@ -887,11 +887,17 @@ def _populate_scattered_background(
         groups.append(set(ped_ids))
         zone_id = int(rng.integers(len(zones)))
         zone = zones[zone_id]
-        spawn_points = [
-            _sample_scatter_point(zone, rng, exclusions, accepted_positions, ped_radius)
-            for _ in ped_ids
-        ]
-        accepted_positions.extend(spawn_points)
+        spawn_points = []
+        for _ped_id in ped_ids:
+            spawn_point = _sample_scatter_point(
+                zone,
+                rng,
+                exclusions,
+                accepted_positions,
+                ped_radius,
+            )
+            spawn_points.append(spawn_point)
+            accepted_positions.append(spawn_point)
         group_goal = _sample_scatter_point(zone, rng, exclusions, [], ped_radius)
         centroid = np.mean(spawn_points, axis=0)
         heading = atan2(group_goal[1] - centroid[1], group_goal[0] - centroid[0])

--- a/robot_sf/ped_npc/ped_population.py
+++ b/robot_sf/ped_npc/ped_population.py
@@ -35,7 +35,8 @@ from math import atan2, ceil, cos, dist, sin
 
 import numpy as np
 from shapely.geometry import Point as _ShapelyPoint
-from shapely.prepared import PreparedGeometry
+from shapely.geometry import Polygon as _ShapelyPolygon
+from shapely.prepared import PreparedGeometry, prep
 
 from robot_sf.common.types import PedGrouping, PedState, Vec2D, Zone, ZoneAssignments
 from robot_sf.nav.map_config import GlobalRoute
@@ -728,12 +729,6 @@ def _spawn_configs_for_forced_population(
             f"single pedestrians ({forced_population_size} < {single_pedestrian_count})"
         )
     background_population_size = forced_population_size - single_pedestrian_count
-    if background_population_size > 0 and not (ped_crowded_zones or ped_routes):
-        raise ValueError(
-            "force_population_size requires a pedestrian route or crowded zone for the "
-            f"remaining {background_population_size} background pedestrians"
-        )
-
     apply_archetypes_to_forced_population = spawn_config.archetype_composition is not None
     # Direct callers of ``populate_ped_routes`` retain their existing archetype behavior.
     # Here the final merged population owns the composition, so defer factor assignment
@@ -743,7 +738,12 @@ def _spawn_configs_for_forced_population(
         if apply_archetypes_to_forced_population
         else spawn_config
     )
-    if ped_crowded_zones and ped_routes:
+    if background_population_size > 0 and not (ped_crowded_zones or ped_routes):
+        # ``populate_simulation`` realizes this share in an in-memory crowded zone spanning
+        # free map space. Treat it as the crowd share so build-time dry runs see the same budget.
+        zone_share = background_population_size
+        route_share = 0
+    elif ped_crowded_zones and ped_routes:
         zone_share = background_population_size // 2
         route_share = background_population_size - zone_share
     elif ped_crowded_zones:
@@ -758,6 +758,152 @@ def _spawn_configs_for_forced_population(
         replace(background_spawn_config, force_population_size=route_share),
         apply_archetypes_to_forced_population,
     )
+
+
+def _zone_polygon(zone: Zone) -> _ShapelyPolygon:
+    """Expand a three-corner map rectangle into its four-corner Shapely polygon.
+
+    Returns:
+        The rectangular zone polygon.
+    """
+    a, b, c = zone
+    d = (a[0] + c[0] - b[0], a[1] + c[1] - b[1])
+    return _ShapelyPolygon((a, b, c, d))
+
+
+def _scatter_exclusions(
+    obstacle_polygons: list[PreparedGeometry],
+    reserved_zones: list[Zone],
+    single_pedestrians: list,
+    ped_radius: float,
+    reserved_zone_radius: float,
+) -> list[PreparedGeometry]:
+    """Build radius-inflated exclusions for obstacles, robot zones, and scripted actors.
+
+    Returns:
+        Prepared exclusion geometries with pedestrian-radius clearance applied.
+    """
+    exclusions = [prep(obstacle.context.buffer(ped_radius)) for obstacle in obstacle_polygons]
+    zone_clearance = ped_radius + reserved_zone_radius
+    exclusions.extend(prep(_zone_polygon(zone).buffer(zone_clearance)) for zone in reserved_zones)
+    exclusions.extend(
+        prep(_ShapelyPoint(ped.start).buffer(2 * ped_radius)) for ped in single_pedestrians
+    )
+    return exclusions
+
+
+def _synthetic_crowd_zones(
+    map_bounds: tuple[float, float, float, float],
+    ped_radius: float,
+) -> list[Zone]:
+    """Split radius-inset rectangular map bounds into two crowd-behavior triangles.
+
+    Returns:
+        Two triangles covering the collision-radius-inset map rectangle.
+    """
+    x_min, x_max, y_min, y_max = map_bounds
+    x_min += ped_radius
+    x_max -= ped_radius
+    y_min += ped_radius
+    y_max -= ped_radius
+    if x_min >= x_max or y_min >= y_max:
+        raise ValueError(
+            "force_population_size cannot synthesize background pedestrians: map bounds "
+            f"{map_bounds!r} have no interior after applying ped_radius={ped_radius}"
+        )
+    return [
+        ((x_min, y_min), (x_max, y_min), (x_max, y_max)),
+        ((x_min, y_min), (x_max, y_max), (x_min, y_max)),
+    ]
+
+
+def _sample_scatter_point(
+    zone: Zone,
+    rng: np.random.Generator,
+    exclusions: list[PreparedGeometry],
+    accepted_positions: list[Vec2D],
+    ped_radius: float,
+    *,
+    max_attempts: int = 1000,
+) -> Vec2D:
+    """Sample one seeded free-space point clear of all occupied geometry.
+
+    Returns:
+        A collision-free point inside ``zone``.
+    """
+    a, b, c = (np.asarray(vertex, dtype=float) for vertex in zone)
+    for _attempt in range(max_attempts):
+        rel_width, rel_height = rng.uniform(0.0, 1.0, 2)
+        if rel_width + rel_height > 1.0:
+            rel_width = 1.0 - rel_width
+            rel_height = 1.0 - rel_height
+        candidate_array = b + rel_width * (a - b) + rel_height * (c - b)
+        candidate = (float(candidate_array[0]), float(candidate_array[1]))
+        point = _ShapelyPoint(candidate)
+        if any(exclusion.intersects(point) for exclusion in exclusions):
+            continue
+        if any(dist(candidate, occupied) < 2 * ped_radius for occupied in accepted_positions):
+            continue
+        return candidate
+    raise RuntimeError(
+        "Failed to scatter-spawn a forced background pedestrian after "
+        f"{max_attempts} attempts with ped_radius={ped_radius}. The map may not have "
+        "enough collision-free walkable space for the requested population."
+    )
+
+
+def _populate_scattered_background(
+    config: PedSpawnConfig,
+    num_pedestrians: int,
+    map_bounds: tuple[float, float, float, float],
+    exclusions: list[PreparedGeometry],
+    ped_radius: float,
+) -> tuple[PedState, list[PedGrouping], ZoneAssignments, list[Zone], np.random.Generator]:
+    """Create seeded collision-free background groups using standard crowded-zone behavior.
+
+    Returns:
+        Pedestrian states, group memberships, zone assignments, synthetic zones, and RNG.
+    """
+    zones = _synthetic_crowd_zones(map_bounds, ped_radius)
+    scatter_seed = config.route_spawn_seed
+    if scatter_seed is None:
+        scatter_seed = config.archetype_seed
+    if scatter_seed is None:
+        scatter_seed = config.response_law_seed
+    rng = np.random.default_rng(0 if scatter_seed is None else scatter_seed)
+    ped_states = np.zeros((num_pedestrians, 6))
+    groups: list[PedGrouping] = []
+    zone_assignments: ZoneAssignments = {}
+    accepted_positions: list[Vec2D] = []
+    num_unassigned = num_pedestrians
+
+    while num_unassigned > 0:
+        group_size = int(
+            rng.choice(len(config.group_member_probs), p=config.group_member_probs) + 1
+        )
+        group_size = min(group_size, num_unassigned)
+        first_id = num_pedestrians - num_unassigned
+        ped_ids = list(range(first_id, first_id + group_size))
+        groups.append(set(ped_ids))
+        zone_id = int(rng.integers(len(zones)))
+        zone = zones[zone_id]
+        spawn_points = [
+            _sample_scatter_point(zone, rng, exclusions, accepted_positions, ped_radius)
+            for _ in ped_ids
+        ]
+        accepted_positions.extend(spawn_points)
+        group_goal = _sample_scatter_point(zone, rng, exclusions, [], ped_radius)
+        centroid = np.mean(spawn_points, axis=0)
+        heading = atan2(group_goal[1] - centroid[1], group_goal[0] - centroid[0])
+        velocity = np.asarray([cos(heading), sin(heading)]) * config.initial_speed
+        ped_states[ped_ids, 0:2] = spawn_points
+        ped_states[ped_ids, 2:4] = velocity
+        ped_states[ped_ids, 4:6] = group_goal
+        for ped_id in ped_ids:
+            zone_assignments[ped_id] = zone_id
+        num_unassigned -= group_size
+
+    return ped_states, groups, zone_assignments, zones, rng
 
 
 def _apply_forced_population_contract(
@@ -783,7 +929,7 @@ def _apply_forced_population_contract(
     ped_states[:, 2:4] *= speed_factors[:, np.newaxis]
 
 
-def populate_simulation(  # noqa: PLR0913
+def populate_simulation(  # noqa: C901,PLR0913
     tau: float,
     spawn_config: PedSpawnConfig,
     ped_routes: list[GlobalRoute],
@@ -793,6 +939,10 @@ def populate_simulation(  # noqa: PLR0913
     time_step_s: float = 0.1,
     single_ped_goal_threshold: float | None = None,
     add_ego_state: bool = False,
+    map_bounds: tuple[float, float, float, float] | None = None,
+    reserved_zones: list[Zone] | None = None,
+    ped_radius: float = 0.4,
+    reserved_zone_radius: float = 0.0,
 ) -> tuple[PedestrianStates, PedestrianGroupings, list[PedestrianBehavior]]:
     """Orchestrate complete pedestrian population initialization for simulation.
 
@@ -817,6 +967,10 @@ def populate_simulation(  # noqa: PLR0913
         time_step_s: Simulation step time in seconds (used for wait behavior).
         single_ped_goal_threshold: Optional distance threshold for single-ped waypoint arrival.
         add_ego_state: If True, adds a pedestrian state for the ego agent at the end of the array.
+        map_bounds: Optional free-space bounds used only for geometry-less forced backgrounds.
+        reserved_zones: Robot spawn/goal zones excluded from synthesized background placement.
+        ped_radius: Pedestrian collision radius used by synthesized placement.
+        reserved_zone_radius: Additional agent radius applied around reserved zones.
 
     Returns:
         Tuple of (pysf_state, groups, ped_behaviors):
@@ -835,6 +989,7 @@ def populate_simulation(  # noqa: PLR0913
         >>> # Use pysf_state and behaviors in physics simulation
     """
     prepared_obstacles = prepare_obstacle_polygons(obstacle_polygons or [])
+    single_pedestrians = single_pedestrians or []
 
     # ``force_population_size`` sets the exact total across every spawn channel. Reserve
     # map-defined single pedestrians first, then split the remaining background budget
@@ -849,16 +1004,63 @@ def populate_simulation(  # noqa: PLR0913
         )
     )
 
-    crowd_ped_states_np, crowd_groups, zone_assignments = populate_crowded_zones(
-        crowd_spawn_config,
-        ped_crowded_zones,
-        obstacle_polygons=prepared_obstacles,
+    forced_size = spawn_config.force_population_size
+    background_size = None if forced_size is None else forced_size - len(single_pedestrians)
+    synthesize_background = bool(
+        background_size is not None
+        and background_size > 0
+        and not ped_crowded_zones
+        and not ped_routes
     )
-    route_ped_states_np, route_groups, route_assignments, initial_sections = populate_ped_routes(
-        route_spawn_config,
-        ped_routes,
-        obstacle_polygons=prepared_obstacles,
-    )
+    synthetic_behavior_exclusions: list[PreparedGeometry] | None = None
+    synthetic_rng: np.random.Generator | None = None
+    behavior_crowded_zones = ped_crowded_zones
+    if synthesize_background:
+        if map_bounds is None:
+            raise ValueError(
+                "force_population_size requires map_bounds to synthesize the remaining "
+                f"{background_size} background pedestrians"
+            )
+        if ped_radius <= 0 or reserved_zone_radius < 0:
+            raise ValueError(
+                "geometry-less forced population synthesis requires ped_radius > 0 and "
+                "reserved_zone_radius >= 0"
+            )
+        synthetic_behavior_exclusions = _scatter_exclusions(
+            prepared_obstacles,
+            reserved_zones or [],
+            single_pedestrians,
+            ped_radius,
+            reserved_zone_radius,
+        )
+        (
+            crowd_ped_states_np,
+            crowd_groups,
+            zone_assignments,
+            behavior_crowded_zones,
+            synthetic_rng,
+        ) = _populate_scattered_background(
+            crowd_spawn_config,
+            int(background_size),
+            map_bounds,
+            synthetic_behavior_exclusions,
+            ped_radius,
+        )
+        route_ped_states_np = np.zeros((0, 6))
+        route_groups, route_assignments, initial_sections = [], {}, []
+    else:
+        crowd_ped_states_np, crowd_groups, zone_assignments = populate_crowded_zones(
+            crowd_spawn_config,
+            ped_crowded_zones,
+            obstacle_polygons=prepared_obstacles,
+        )
+        route_ped_states_np, route_groups, route_assignments, initial_sections = (
+            populate_ped_routes(
+                route_spawn_config,
+                ped_routes,
+                obstacle_polygons=prepared_obstacles,
+            )
+        )
 
     # Populate single pedestrians if provided
     if single_pedestrians:
@@ -925,7 +1127,14 @@ def populate_simulation(  # noqa: PLR0913
     for ped_ids in route_groups:
         route_groupings.new_group(ped_ids)
 
-    crowd_behavior = CrowdedZoneBehavior(crowd_groupings, zone_assignments, ped_crowded_zones)
+    crowd_behavior = CrowdedZoneBehavior(
+        crowd_groupings,
+        zone_assignments,
+        behavior_crowded_zones,
+        obstacle_polygons=synthetic_behavior_exclusions,
+        rng=synthetic_rng,
+        goal_sample_max_attempts_per_point=1000 if synthesize_background else 20,
+    )
     route_behavior = FollowRouteBehavior(
         route_groupings,
         route_assignments,

--- a/robot_sf/ped_npc/ped_population.py
+++ b/robot_sf/ped_npc/ped_population.py
@@ -884,21 +884,45 @@ def _populate_scattered_background(
         group_size = min(group_size, num_unassigned)
         first_id = num_pedestrians - num_unassigned
         ped_ids = list(range(first_id, first_id + group_size))
+        zone_id: int | None = None
+        spawn_points: list[Vec2D] | None = None
+        group_goal: Vec2D | None = None
+        last_capacity_error: RuntimeError | None = None
+        for candidate_zone_id in rng.permutation(len(zones)):
+            candidate_zone = zones[int(candidate_zone_id)]
+            candidate_points: list[Vec2D] = []
+            try:
+                for _ped_id in ped_ids:
+                    candidate_points.append(
+                        _sample_scatter_point(
+                            candidate_zone,
+                            rng,
+                            exclusions,
+                            [*accepted_positions, *candidate_points],
+                            ped_radius,
+                        )
+                    )
+                candidate_goal = _sample_scatter_point(
+                    candidate_zone,
+                    rng,
+                    exclusions,
+                    [],
+                    ped_radius,
+                )
+            except RuntimeError as error:
+                last_capacity_error = error
+                continue
+            zone_id = int(candidate_zone_id)
+            spawn_points = candidate_points
+            group_goal = candidate_goal
+            break
+        if zone_id is None or spawn_points is None or group_goal is None:
+            raise RuntimeError(
+                f"No synthetic crowd zone can fit forced background group of size {group_size}."
+            ) from last_capacity_error
+
         groups.append(set(ped_ids))
-        zone_id = int(rng.integers(len(zones)))
-        zone = zones[zone_id]
-        spawn_points = []
-        for _ped_id in ped_ids:
-            spawn_point = _sample_scatter_point(
-                zone,
-                rng,
-                exclusions,
-                accepted_positions,
-                ped_radius,
-            )
-            spawn_points.append(spawn_point)
-            accepted_positions.append(spawn_point)
-        group_goal = _sample_scatter_point(zone, rng, exclusions, [], ped_radius)
+        accepted_positions.extend(spawn_points)
         centroid = np.mean(spawn_points, axis=0)
         heading = atan2(group_goal[1] - centroid[1], group_goal[0] - centroid[0])
         velocity = np.asarray([cos(heading), sin(heading)]) * config.initial_speed

--- a/robot_sf/ped_npc/ped_zone.py
+++ b/robot_sf/ped_npc/ped_zone.py
@@ -18,6 +18,8 @@ def sample_zone(
     num_samples: int,
     obstacle_polygons: list[list[Vec2D]] | list[PreparedGeometry] | None = None,
     max_attempts_per_point: int = 20,
+    *,
+    rng: np.random.Generator | None = None,
 ) -> list[Vec2D]:
     """
     Generate random sample points within a triangular zone, avoiding obstacles when provided.
@@ -27,11 +29,14 @@ def sample_zone(
         num_samples: Number of points to sample.
         obstacle_polygons: Optional list of polygon vertex lists to reject points inside.
         max_attempts_per_point: Attempts before giving up per requested sample.
+        rng: Optional deterministic random generator. The legacy global NumPy RNG is used
+            when omitted.
 
     Returns:
         list[Vec2D]: Sampled points that do not intersect obstacles.
     """
     prepared_polygons = prepare_obstacle_polygons(obstacle_polygons or [])
+    rng_local = np.random if rng is None else rng
     a, b, c = zone
     a, b, c = np.array(a), np.array(b), np.array(c)
     vec_ba, vec_bc = a - b, c - b
@@ -44,8 +49,8 @@ def sample_zone(
     while len(samples) < num_samples and attempts < max_attempts:
         remaining = num_samples - len(samples)
         current_batch = max(batch_size, remaining)
-        rel_width = np.random.uniform(0, 1, current_batch)
-        rel_height = np.random.uniform(0, 1, current_batch)
+        rel_width = rng_local.uniform(0, 1, current_batch)
+        rel_height = rng_local.uniform(0, 1, current_batch)
         fold_mask = rel_width + rel_height > 1.0
         rel_width[fold_mask] = 1.0 - rel_width[fold_mask]
         rel_height[fold_mask] = 1.0 - rel_height[fold_mask]

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -761,6 +761,13 @@ class PedSimulator(Simulator):
             time_step_s=self.config.time_per_step_in_secs,
             single_ped_goal_threshold=pysf_config.desired_force_config.goal_threshold,
             add_ego_state=True,  # Add Ego pedestrian state to pysf_state
+            map_bounds=self.map_def.get_map_bounds(),
+            reserved_zones=[*self.map_def.robot_spawn_zones, *self.map_def.robot_goal_zones],
+            ped_radius=self.config.ped_radius,
+            reserved_zone_radius=max(
+                (float(robot.config.radius) for robot in self.robots),
+                default=0.0,
+            ),
         )
         for behavior in self.peds_behaviors:
             if isinstance(behavior, SinglePedestrianBehavior):

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -276,6 +276,13 @@ class Simulator:
             single_pedestrians=self.map_def.single_pedestrians,
             time_step_s=self.config.time_per_step_in_secs,
             single_ped_goal_threshold=pysf_config.desired_force_config.goal_threshold,
+            map_bounds=self.map_def.get_map_bounds(),
+            reserved_zones=[*self.map_def.robot_spawn_zones, *self.map_def.robot_goal_zones],
+            ped_radius=self.config.ped_radius,
+            reserved_zone_radius=max(
+                (float(robot.config.radius) for robot in self.robots),
+                default=0.0,
+            ),
         )
         for behavior in self.peds_behaviors:
             if isinstance(behavior, SinglePedestrianBehavior):

--- a/tests/ped_npc/test_force_population_size_split.py
+++ b/tests/ped_npc/test_force_population_size_split.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from shapely.geometry import Point, Polygon
+from shapely.prepared import prep
 
 from robot_sf.nav.navigation import get_prepared_obstacles
 from robot_sf.nav.svg_map_parser import SvgMapConverter
@@ -331,3 +332,32 @@ def test_force_population_scatter_spawn_has_radius_clearance(
     for left_index, left in enumerate(positions):
         for right in positions[left_index + 1 :]:
             assert np.linalg.norm(left - right) >= 2 * ped_radius - 1e-9
+
+
+def test_force_population_scatter_retries_another_synthetic_zone() -> None:
+    """A blocked first synthetic triangle does not hide capacity in the second."""
+    map_bounds = (0.0, 10.0, 0.0, 10.0)
+    ped_radius = 0.4
+    zones = ped_population._synthetic_crowd_zones(map_bounds, ped_radius)
+    blocked_zone = prep(Polygon(zones[0]).buffer(1e-6))
+    spawn_config = PedSpawnConfig(
+        peds_per_area_m2=0.0,
+        max_group_members=1,
+        force_population_size=1,
+        route_spawn_seed=0,
+    )
+
+    ped_states, groups, assignments, returned_zones, _rng = (
+        ped_population._populate_scattered_background(
+            spawn_config,
+            1,
+            map_bounds,
+            [blocked_zone],
+            ped_radius,
+        )
+    )
+
+    assert returned_zones == zones
+    assert groups == [{0}]
+    assert assignments == {0: 1}
+    assert not blocked_zone.intersects(Point(ped_states[0, 0:2]))

--- a/tests/ped_npc/test_force_population_size_split.py
+++ b/tests/ped_npc/test_force_population_size_split.py
@@ -13,21 +13,69 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from shapely.geometry import Point, Polygon
 
 from robot_sf.nav.navigation import get_prepared_obstacles
 from robot_sf.nav.svg_map_parser import SvgMapConverter
-from robot_sf.ped_npc import ped_population
+from robot_sf.ped_npc import ped_behavior, ped_population
 from robot_sf.ped_npc.ped_archetypes import assign_archetype_labels
+from robot_sf.ped_npc.ped_behavior import CrowdedZoneBehavior
 from robot_sf.ped_npc.ped_population import PedSpawnConfig, populate_simulation
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _CLASSIC_BOTTLENECK_MEDIUM_SVG = _REPO_ROOT / "maps" / "svg_maps" / "classic_bottleneck_medium.svg"
+_FRANCIS2023_BLIND_CORNER_SVG = (
+    _REPO_ROOT / "maps" / "svg_maps" / "francis2023" / "francis2023_blind_corner.svg"
+)
 
 
 @pytest.fixture(scope="module")
 def _route_map_with_explicit_pedestrian():
     """Load a real map containing both a route and one explicit pedestrian."""
     return SvgMapConverter(str(_CLASSIC_BOTTLENECK_MEDIUM_SVG)).get_map_definition()
+
+
+@pytest.fixture(scope="module")
+def _geometryless_francis_map():
+    """Load a real single-interaction map with no background spawn geometry."""
+    map_def = SvgMapConverter(str(_FRANCIS2023_BLIND_CORNER_SVG)).get_map_definition()
+    assert not map_def.ped_routes
+    assert not map_def.ped_crowded_zones
+    assert len(map_def.single_pedestrians) == 1
+    return map_def
+
+
+def _forced_francis_population(map_def, seed: int):
+    """Instantiate the issue #5829 regression population with production geometry inputs."""
+    spawn_config = PedSpawnConfig(
+        peds_per_area_m2=0.0,
+        max_group_members=3,
+        initial_speed=0.5,
+        force_population_size=12,
+        route_spawn_seed=seed,
+        archetype_composition={"cautious": 0.25, "standard": 0.5, "hurried": 0.25},
+        archetype_speed_factors={"cautious": 0.7, "standard": 1.0, "hurried": 1.4},
+        archetype_seed=3574,
+    )
+    return spawn_config, populate_simulation(
+        tau=0.5,
+        spawn_config=spawn_config,
+        ped_routes=map_def.ped_routes,
+        ped_crowded_zones=map_def.ped_crowded_zones,
+        obstacle_polygons=get_prepared_obstacles(map_def),
+        single_pedestrians=map_def.single_pedestrians,
+        map_bounds=map_def.get_map_bounds(),
+        reserved_zones=[*map_def.robot_spawn_zones, *map_def.robot_goal_zones],
+        ped_radius=0.4,
+        reserved_zone_radius=0.3,
+    )
+
+
+def _zone_polygon(zone) -> Polygon:
+    """Expand the map's three-corner rectangle encoding into a polygon."""
+    a, b, c = zone
+    d = (a[0] + c[0] - b[0], a[1] + c[1] - b[1])
+    return Polygon((a, b, c, d))
 
 
 @pytest.fixture
@@ -180,3 +228,105 @@ def test_force_population_size_preserves_full_population_archetype_mix(
     )
     assert np.allclose(speeds, expected_speeds)
     assert Counter(np.round(speeds, 6).tolist()) == {0.35: 3, 0.5: 6, 0.7: 3}
+
+
+def test_force_population_scatter_spawns_geometryless_francis_map(
+    _geometryless_francis_map,
+) -> None:
+    """A Francis-style forced population is exact, composed, and uses crowd wandering."""
+    spawn_config, (ped_states, _groups, behaviors) = _forced_francis_population(
+        _geometryless_francis_map,
+        seed=219,
+    )
+
+    assert ped_states.num_peds == 12
+    speeds = np.linalg.norm(ped_states.ped_velocities, axis=1)
+    labels = assign_archetype_labels(
+        12,
+        spawn_config.archetype_composition,
+        seed=spawn_config.archetype_seed,
+    )
+    expected_speeds = np.asarray(
+        [0.5 * spawn_config.archetype_speed_factors[label] for label in labels],
+    )
+    assert np.allclose(speeds, expected_speeds)
+    assert Counter(np.round(speeds, 6).tolist()) == {0.35: 3, 0.5: 6, 0.7: 3}
+    assert isinstance(behaviors[0], CrowdedZoneBehavior)
+    assert behaviors[0].groups.states.num_peds == 11
+
+
+def test_force_population_scatter_spawn_is_seed_deterministic(
+    _geometryless_francis_map,
+) -> None:
+    """Identical population seeds reproduce positions while another seed changes them."""
+    _, (same_a, _groups_a, behaviors_a) = _forced_francis_population(
+        _geometryless_francis_map,
+        seed=219,
+    )
+    _, (same_b, _groups_b, behaviors_b) = _forced_francis_population(
+        _geometryless_francis_map,
+        seed=219,
+    )
+    _, (different, _groups_c, _behaviors_c) = _forced_francis_population(
+        _geometryless_francis_map,
+        seed=220,
+    )
+
+    assert np.array_equal(same_a.ped_positions, same_b.ped_positions)
+    assert not np.array_equal(same_a.ped_positions[:11], different.ped_positions[:11])
+
+    behaviors_a[0].reset()
+    behaviors_b[0].reset()
+    assert np.array_equal(same_a.pysf_states()[:11, 4:6], same_b.pysf_states()[:11, 4:6])
+    for goal in same_a.pysf_states()[:11, 4:6]:
+        assert all(
+            not exclusion.intersects(Point(goal)) for exclusion in behaviors_a[0].obstacle_polygons
+        )
+
+
+def test_native_crowded_zone_goal_sampling_keeps_legacy_call(monkeypatch) -> None:
+    """Native crowd zones keep the pre-existing unconstrained sampler invocation."""
+    zone = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)]
+    calls = []
+
+    def _record_sample(sampled_zone, num_samples):
+        calls.append((sampled_zone, num_samples))
+        return [(0.25, 0.75)]
+
+    monkeypatch.setattr(ped_behavior, "sample_zone", _record_sample)
+    behavior = CrowdedZoneBehavior(groups=None, zone_assignments={}, crowded_zones=[])
+
+    assert behavior._sample_goal(zone) == (0.25, 0.75)
+    assert calls == [(zone, 1)]
+
+
+def test_force_population_scatter_spawn_has_radius_clearance(
+    _geometryless_francis_map,
+) -> None:
+    """Synthesized backgrounds start clear of static geometry and every t=0 agent."""
+    ped_radius = 0.4
+    _, (ped_states, _groups, _behaviors) = _forced_francis_population(
+        _geometryless_francis_map,
+        seed=219,
+    )
+    positions = ped_states.ped_positions
+    background_positions = positions[:11]
+    prepared_obstacles = get_prepared_obstacles(_geometryless_francis_map)
+    reserved_polygons = [
+        _zone_polygon(zone)
+        for zone in [
+            *_geometryless_francis_map.robot_spawn_zones,
+            *_geometryless_francis_map.robot_goal_zones,
+        ]
+    ]
+
+    for position in background_positions:
+        point = Point(position)
+        assert all(
+            obstacle.context.distance(point) >= ped_radius - 1e-9 for obstacle in prepared_obstacles
+        )
+        assert all(zone.distance(point) >= ped_radius + 0.3 - 1e-9 for zone in reserved_polygons)
+
+    for left_index, left in enumerate(positions):
+        for right in positions[left_index + 1 :]:
+            assert np.linalg.norm(left - right) >= 2 * ped_radius - 1e-9

--- a/tests/ped_npc/test_force_population_size_split.py
+++ b/tests/ped_npc/test_force_population_size_split.py
@@ -305,7 +305,7 @@ def test_force_population_scatter_spawn_has_radius_clearance(
 ) -> None:
     """Synthesized backgrounds start clear of static geometry and every t=0 agent."""
     ped_radius = 0.4
-    _, (ped_states, _groups, _behaviors) = _forced_francis_population(
+    _, (ped_states, groups, _behaviors) = _forced_francis_population(
         _geometryless_francis_map,
         seed=219,
     )
@@ -319,6 +319,7 @@ def test_force_population_scatter_spawn_has_radius_clearance(
             *_geometryless_francis_map.robot_goal_zones,
         ]
     ]
+    assert any(len(group) > 1 for group in groups.groups.values())
 
     for position in background_positions:
         point = Point(position)


### PR DESCRIPTION
## Summary

Synthesizes deterministic, radius-aware background pedestrian spawns when an exact forced
population has a remainder but the map declares neither pedestrian routes nor crowded zones.
Published map/scenario files stay unchanged, and native route/crowd-zone behavior retains its
legacy sampling path.

## Linked Issues

- Relates to `#5829` (maintainer-approved option a only; do not close the parent issue)
- Relates to `issue 5836 (resolved)` (unrelated full-suite timing-test friction observed during validation)

## Stack / Dependency

- Base dependency: none (`#5830` is already merged and included)
- Required prior PRs: none
- Stack follow-up issues: none (`#5831` merged the campaign robustness items 1-3).
- Safe to review independently: yes
- Review dependency reason, if any: this PR changes only runtime population construction; it keeps
  `_spawn_configs_for_forced_population` callable with its existing signature for `#5831`.

## What Changed

- Assigns a geometry-less forced remainder to an in-memory synthetic crowd share instead of
  raising the old `ValueError`.
- Samples starts from radius-inset map bounds using the existing population seed and rejection
  checks against radius-buffered obstacles, robot spawn/goal zones, scripted pedestrians, prior
  groups, and members of the current group.
- Reuses `CrowdedZoneBehavior` for wandering and seeded free-space goal resampling; native
  route/crowd maps continue through the existing spawners and exact legacy `sample_zone(zone, 1)`
  call.
- Passes map bounds and actual simulator pedestrian/robot radii into population construction.
- Adds real Francis blind-corner regression coverage for exact count, archetype mix, determinism,
  different-seed variation, goal determinism, initial clearance, and unchanged native crowd
  sampling.

## Why It Matters

- Added value: forced S30 population cells can instantiate on single-interaction maps without
  editing published scenario geometry.
- Expected impact: the three Francis-style full-S30 shards no longer die during population
  construction after hours of prior work.
- Why this is worth merging now: it removes the confirmed #5829 campaign blocker while preserving
  exact-population and comparability contracts.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: #5829 population-construction blocker
  for exact forced populations on geometry-less single-interaction maps.
- Comparator or baseline, if applicable: prior behavior raised before episode construction.
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: merge only if exact count, composition, deterministic
  placement, clearance, and a real one-cell episode record are all demonstrated.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #5829; no
  benchmark-result claim map update because this is implementation-integrity evidence only.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no analysis tool added.

## Domain-Aware Approval

- Required for this PR: yes - the implementation enables benchmark execution while deliberately
  preserving published maps and excluding degraded/fallback evidence.
- Domains reviewed: benchmark interpretation, evidence classification
- Status: approved
- Approver/review source or waiver: maintainer approval of option (a), 2026-07-16, in #5829 task
  direction.
- Validity checklist:
  - Target claim/hypothesis: population construction is realizable without changing published maps.
  - Comparator or split/evidence validity: native geometry maps remain on their legacy code path.
  - Fallback/degraded exclusions: synthesis is native population construction, not a fallback
    planner; the smoke record reports no degraded execution.
  - Claim boundary: one targeted smoke proves blocker removal, not full-S30 benchmark outcomes.
  - Implementation integrity vs experimental validity: tests/smoke establish implementation
    integrity; no experimental conclusion is claimed.

## Falsification / Non-Transfer Check

- Did the mechanism activate? yes
- Did the intervention change command source, selected command, trajectory, or route progress?
  It only creates the missing background population; planner/controller selection is unchanged.
- Did the scenario actually contain the targeted failure mode? yes -
  `francis2023_blind_corner` has one scripted pedestrian and no crowd zones/routes, with forced N=12.
- Result route: continue
- Follow-up question if weak, negative, or non-transfer results: full campaign execution remains outside this PR; open parent #5829 owns the resulting campaign rerun.

## Next Empirical Action

- Rerun needed: yes - rerun full S30 under open parent #5829 after this PR lands.
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: no durable benchmark result is claimed; local smoke output is
  intentionally disposable.
- Stop / revise / continue decision: continue to review/merge, then rerun the campaign.
- Proposed child issue or existing follow-up: open parent #5829.

## Validation / Proof

- Commands run:
  - `scripts/dev/run_focused_tests.sh tests/ped_npc/test_force_population_size_split.py tests/zone_sampling_test.py tests/test_single_pedestrian.py tests/sim/test_simulator_action_count.py tests/sim/test_pedestrian_desired_speed.py -q`
  - focused changed-line coverage over the population, behavior, zone, and simulator modules;
    minimum gate passed (88.9%, 93.8%, 100%, 100% respectively)
  - `uv run ruff check ...`, `uv run ruff format --check ...`, and `git diff --check origin/main...HEAD`
  - docstring TODO diff/ratchet, broad-exception ratchet, and optional-import freshness checks
  - `scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574.py --config configs/benchmarks/issue_3574_mean_matched_harness_full_s30_goal.yaml`
  - one-row `run_heterogeneous_population_ablation_issue_3574.py` slice for
    `francis2023_blind_corner`, goal planner, heterogeneous arm, seed 111, response-law fraction 0
  - `PYTEST_NUM_WORKERS=8 scripts/dev/run_tests_parallel.sh`
- Evidence that the change works here:
  - unit tests instantiate exactly 12 pedestrians with 3 cautious / 6 standard / 3 hurried;
    same-seed starts and reset goals are byte-equal, different-seed starts differ, and every initial
    actor pair plus obstacle and robot-zone clearance respects configured radii.
  - full S30 manifest build produced 11,520 pending-runtime rows.
  - final one-cell smoke wrote episode
    `francis2023_blind_corner--111--6e83898bea7b9bec` with declared population 12,
    instantiated population 12, and 12 trace labels. It later terminated by a recorded pedestrian
    collision; population construction completed and an episode record was produced.
  - the final full lane reached 13,452 passed / 47 skipped, then stopped on the unrelated
    wall-clock-sensitive reproducibility test. Its immediate isolated rerun passed in 1.64s; tracked
    as issue 5836 (resolved). A clean full run before the final intra-group-clearance tightening exited 0, and all
    changed-path tests/coverage were rerun after that tightening.
- Benchmarks or smoke tests, if applicable: targeted diagnostic smoke only; not benchmark evidence.

## Risks / Rollout

- Compatibility risks: added optional `populate_simulation` geometry/radius inputs; existing direct
  callers retain defaults, and `_spawn_configs_for_forced_population` has no signature change.
- Failure modes: an overfull map fails closed after bounded seeded sampling with an actionable
  collision-free-space error.
- Rollback or fallback plan: revert this PR; no published maps or configs require rollback.

## Docs / Provenance

- Updated docs: none; behavior is covered in API docstrings and regression tests.
- Relevant design or provenance notes: implements maintainer-approved #5829 option (a), 2026-07-16.
- Any assumptions that need to be preserved: route spawn seed is the primary scatter seed; existing
  archetype and response-law assignment remains the final whole-population contract.

## Downstream Propagation

- Parent issue updated (yes/no/NA): yes - PR linkage to #5829
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA - #5831 merged and issue 5836 (resolved) is resolved; open parent #5829 owns the campaign rerun.
- Not applicable because: this PR produces no research result or durable benchmark artifact.

## Follow-Up Issues

- Deferred work: full campaign rerun remains on open parent #5829; no other deferred work.
- Issues opened for follow-up: issue 5836 (resolved).

## Reviewer Notes

- Verify the synthetic path activates only for a positive forced remainder with no native routes or
  crowded zones.
- Verify native maps retain their existing spawners and legacy global-NumPy goal-sampling call.
- Verify same-group members are added to the occupied set immediately, before sampling the next
  member.
- Shared-helper migration: inapplicable; no shared helper or process-boundary contract migrated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating background pedestrians when maps lack pedestrian spawn routes or crowded zones.
  * Added collision-aware pedestrian placement around obstacles, robot areas, and scripted actors.
  * Added configurable and repeatable random sampling for pedestrian goals and placement.
  * Forced population sizes now fill the requested total in geometry-less maps.

* **Bug Fixes**
  * Improved pedestrian spacing and clearance from restricted areas during spawning.

* **Tests**
  * Added coverage for population sizing, deterministic generation, goal sampling, and geometry clearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



