### PR TITLE
ci: add merge_group trigger (prereq for merge queue #95)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  merge_group:
   push:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
Adds the `merge_group` trigger to the definitive CI workflow. **Must merge BEFORE enabling the merge queue** in repo settings, or the required `ci` check never runs on queued groups and the queue stalls. Bare `merge_group:` runs the full `ci` job on every queued group; no change to push/PR behavior. Refs ll7/codex-orchestrator#95.
