### PR TITLE
Issue #5833: wire knife-edge seeds into the adversarial sampler as warm starts (cheap-lane worker)

### DIFF
--- a/robot_sf/adversarial/config.py
+++ b/robot_sf/adversarial/config.py
@@ -564,6 +564,7 @@ class SearchConfig:
         benchmark_profile: str = "baseline-safe",
         snqi_weights_path: Path | None = None,
         snqi_baseline_path: Path | None = None,
+        warm_start: tuple[WarmStartCandidate, ...] = (),
     ) -> SearchConfig:
         """Create a search config by loading the search-space YAML."""
         return cls(
@@ -584,6 +585,7 @@ class SearchConfig:
             benchmark_profile=benchmark_profile,
             snqi_weights_path=Path(snqi_weights_path) if snqi_weights_path else None,
             snqi_baseline_path=Path(snqi_baseline_path) if snqi_baseline_path else None,
+            warm_start=tuple(warm_start),
         )
 
     def validate(self) -> None:
@@ -599,6 +601,10 @@ class SearchConfig:
         if self.algo_config_path is not None and not self.algo_config_path.exists():
             raise FileNotFoundError(f"Algorithm config not found: {self.algo_config_path}")
         for warm in self.warm_start:
+            if not warm.scenario.strip():
+                raise ValueError("warm-start scenario must be non-empty")
+            if not warm.planner.strip():
+                raise ValueError("warm-start planner must be non-empty")
             candidate_errors = self.search_space.validate_candidate(warm.candidate)
             if candidate_errors:
                 raise ValueError(

--- a/robot_sf/adversarial/config.py
+++ b/robot_sf/adversarial/config.py
@@ -69,6 +69,32 @@ class CandidateSpec:
 
 
 @dataclass(frozen=True)
+class WarmStartCandidate:
+    """A knife-edge initial candidate for optimizer-backed adversarial samplers.
+
+    These are high-value seeds surfaced by seed-sensitivity analysis (#5816/#5817):
+    scenario points sitting on decision boundaries (small ``|outcome_margin|``)
+    where the optimizer should prefer to begin rather than cold random sampling.
+    """
+
+    candidate: CandidateSpec
+    scenario: str = ""
+    planner: str = ""
+    outcome_margin: float | None = None
+
+    def to_json(self) -> dict[str, Any]:
+        """Return a JSON-serializable warm-start payload."""
+        payload: dict[str, Any] = {
+            "candidate": self.candidate.to_json(),
+            "scenario": str(self.scenario),
+            "planner": str(self.planner),
+        }
+        if self.outcome_margin is not None:
+            payload["outcome_margin"] = float(self.outcome_margin)
+        return payload
+
+
+@dataclass(frozen=True)
 class MultiPedCandidateSpec:
     """One pedestrian in a scripted multi-pedestrian adversarial candidate."""
 
@@ -516,6 +542,7 @@ class SearchConfig:
     benchmark_profile: str = "baseline-safe"
     snqi_weights_path: Path | None = None
     snqi_baseline_path: Path | None = None
+    warm_start: tuple[WarmStartCandidate, ...] = ()
 
     @classmethod
     def from_files(
@@ -571,6 +598,13 @@ class SearchConfig:
             raise FileNotFoundError(f"Scenario template not found: {self.scenario_template}")
         if self.algo_config_path is not None and not self.algo_config_path.exists():
             raise FileNotFoundError(f"Algorithm config not found: {self.algo_config_path}")
+        for warm in self.warm_start:
+            candidate_errors = self.search_space.validate_candidate(warm.candidate)
+            if candidate_errors:
+                raise ValueError(
+                    f"warm-start candidate for scenario {warm.scenario!r} is outside "
+                    f"the search space: {'; '.join(candidate_errors)}"
+                )
 
     def load_optional_json(self, path: Path | None) -> dict[str, Any] | None:
         """Load an optional JSON config file."""
@@ -602,4 +636,5 @@ class SearchConfig:
             "snqi_baseline_path": self.snqi_baseline_path.as_posix()
             if self.snqi_baseline_path
             else None,
+            "warm_start": [warm.to_json() for warm in self.warm_start],
         }

--- a/robot_sf/adversarial/samplers.py
+++ b/robot_sf/adversarial/samplers.py
@@ -240,7 +240,6 @@ class OptunaCandidateSampler:
         self._trial_state = optuna.trial.TrialState
         self._search_space = search_space
         self._pending_trials: list[tuple[CandidateSpec, Any]] = []
-        self._warm_starts: list[CandidateSpec] = [warm.candidate for warm in warm_start]
         # Enqueue warm starts as fixed trials so they are proposed first.
         for warm in warm_start:
             candidate = warm.candidate
@@ -257,9 +256,7 @@ class OptunaCandidateSampler:
             self._study.enqueue_trial(fixed)
 
     def sample(self) -> CandidateSpec:
-        """Return the next warm-start candidate (fixed trial), then optimizer proposals."""
-        if self._warm_starts:
-            return self._warm_starts.pop(0)
+        """Return the next enqueued warm-start trial, then optimizer proposals."""
         trial = self._study.ask()
         candidate = CandidateSpec(
             start=Pose2D(
@@ -494,9 +491,7 @@ class CmaEsCandidateSampler:
             self._in_flight.append((candidate, es, vec))
             return candidate
         if self._warm_starts:
-            candidate = self._warm_starts.pop(0)
-            self._in_flight.append((candidate, self._es, []))
-            return candidate
+            return self._warm_starts.pop(0)
         if not self._active_dims:
             candidate = CandidateSpec(
                 start=Pose2D(self._fixed_values["start.x"], self._fixed_values["start.y"]),

--- a/robot_sf/adversarial/samplers.py
+++ b/robot_sf/adversarial/samplers.py
@@ -6,7 +6,13 @@ import math
 from random import Random
 from typing import TYPE_CHECKING, Any, Protocol
 
-from robot_sf.adversarial.config import CandidateSpec, Pose2D, RangeConfig, SearchSpaceConfig
+from robot_sf.adversarial.config import (
+    CandidateSpec,
+    Pose2D,
+    RangeConfig,
+    SearchSpaceConfig,
+    WarmStartCandidate,
+)
 from robot_sf.common.optional_import import try_import
 
 if TYPE_CHECKING:
@@ -27,16 +33,51 @@ class FeedbackCandidateSampler(CandidateSampler, Protocol):
         """Observe one evaluated candidate."""
 
 
+def build_sampler(
+    name: str,
+    search_space: SearchSpaceConfig,
+    *,
+    seed: int,
+    warm_start: tuple[WarmStartCandidate, ...] = (),
+) -> CandidateSampler:
+    """Build a named adversarial sampler, optionally seeded with warm starts.
+
+    Warm starts are knife-edge candidates from seed-sensitivity analysis
+    (#5816/#5817) the optimizer should begin from. Each sampler family consumes
+    them differently: random/coordinate samplers drain them first; Optuna
+    enqueues them as fixed trials; CMA-ES centers initial exploration on them.
+    """
+    key = name.strip().lower()
+    if key == "random":
+        return RandomCandidateSampler(search_space, seed=seed, warm_start=warm_start)
+    if key == "coordinate":
+        return CoordinateRefinementSampler(search_space, seed=seed, warm_start=warm_start)
+    if key == "optuna":
+        return OptunaCandidateSampler(search_space, seed=seed, warm_start=warm_start)
+    if key == "cmaes":
+        return CmaEsCandidateSampler(search_space, seed=seed, warm_start=warm_start)
+    raise ValueError("sampler must be one of: random, coordinate, optuna, cmaes")
+
+
 class RandomCandidateSampler:
     """Dependency-light random-search sampler."""
 
-    def __init__(self, search_space: SearchSpaceConfig, *, seed: int) -> None:
+    def __init__(
+        self,
+        search_space: SearchSpaceConfig,
+        *,
+        seed: int,
+        warm_start: tuple[WarmStartCandidate, ...] = (),
+    ) -> None:
         """Initialize the sampler with a search space and deterministic seed."""
         self._search_space = search_space
         self._rng = Random(seed)
+        self._warm_starts: list[CandidateSpec] = [warm.candidate for warm in warm_start]
 
     def sample(self) -> CandidateSpec:
-        """Return the next random candidate."""
+        """Return the next warm-start candidate, then random candidates."""
+        if self._warm_starts:
+            return self._warm_starts.pop(0)
         return self._search_space.sample_candidate(self._rng)
 
 
@@ -59,7 +100,14 @@ class CoordinateRefinementSampler:
         "pedestrian_delay_s",
     )
 
-    def __init__(self, search_space: SearchSpaceConfig, *, seed: int, step_fraction: float = 0.5):
+    def __init__(
+        self,
+        search_space: SearchSpaceConfig,
+        *,
+        seed: int,
+        step_fraction: float = 0.5,
+        warm_start: tuple[WarmStartCandidate, ...] = (),
+    ) -> None:
         """Initialize a deterministic coordinate-refinement sampler."""
         if not math.isfinite(step_fraction) or step_fraction <= 0.0:
             raise ValueError("step_fraction must be finite and positive")
@@ -69,9 +117,12 @@ class CoordinateRefinementSampler:
         self._best_candidate: CandidateSpec | None = None
         self._best_score: float | None = None
         self._iteration = 0
+        self._warm_starts: list[CandidateSpec] = [warm.candidate for warm in warm_start]
 
     def sample(self) -> CandidateSpec:
-        """Return the next midpoint or coordinate-refinement candidate."""
+        """Return the next warm-start, midpoint, or coordinate-refinement candidate."""
+        if self._warm_starts:
+            return self._warm_starts.pop(0)
         if self._best_candidate is None:
             self._iteration += 1
             return self._midpoint_candidate()
@@ -175,7 +226,13 @@ class OptunaCandidateSampler:
     the runner contract.
     """
 
-    def __init__(self, search_space: SearchSpaceConfig, *, seed: int) -> None:
+    def __init__(
+        self,
+        search_space: SearchSpaceConfig,
+        *,
+        seed: int,
+        warm_start: tuple[WarmStartCandidate, ...] = (),
+    ) -> None:
         """Initialize an Optuna study with deterministic sampler seed."""
         optuna = _import_optuna()
         sampler = optuna.samplers.TPESampler(seed=int(seed))
@@ -183,9 +240,26 @@ class OptunaCandidateSampler:
         self._trial_state = optuna.trial.TrialState
         self._search_space = search_space
         self._pending_trials: list[tuple[CandidateSpec, Any]] = []
+        self._warm_starts: list[CandidateSpec] = [warm.candidate for warm in warm_start]
+        # Enqueue warm starts as fixed trials so they are proposed first.
+        for warm in warm_start:
+            candidate = warm.candidate
+            fixed: dict[str, Any] = {
+                "start.x": float(candidate.start.x),
+                "start.y": float(candidate.start.y),
+                "goal.x": float(candidate.goal.x),
+                "goal.y": float(candidate.goal.y),
+                "spawn_time_s": float(candidate.spawn_time_s),
+                "pedestrian_speed_mps": float(candidate.pedestrian_speed_mps),
+                "pedestrian_delay_s": float(candidate.pedestrian_delay_s),
+                "scenario_seed": int(candidate.scenario_seed),
+            }
+            self._study.enqueue_trial(fixed)
 
     def sample(self) -> CandidateSpec:
-        """Return the next optimizer proposal within the configured bounds."""
+        """Return the next warm-start candidate (fixed trial), then optimizer proposals."""
+        if self._warm_starts:
+            return self._warm_starts.pop(0)
         trial = self._study.ask()
         candidate = CandidateSpec(
             start=Pose2D(
@@ -274,6 +348,7 @@ class CmaEsCandidateSampler:
         seed: int,
         sigma_fraction: float = 0.25,
         popsize: int | None = None,
+        warm_start: tuple[WarmStartCandidate, ...] = (),
     ) -> None:
         """Initialize a CMA-ES strategy over the bounded continuous dimensions.
 
@@ -283,7 +358,9 @@ class CmaEsCandidateSampler:
         runner calls ``sample``/``observe`` one candidate at a time, so the
         sampler buffers a full generation (CMA-ES population) internally and
         feeds it back to the optimizer only once the whole generation has been
-        observed.
+        observed. The first warm start is used as the initial mean (x0) when it
+        lies inside the active-dimension bounds; warm starts are otherwise
+        proposed as the first candidates of the search.
         """
         if not math.isfinite(sigma_fraction) or sigma_fraction <= 0.0:
             raise ValueError("sigma_fraction must be finite and positive")
@@ -310,6 +387,11 @@ class CmaEsCandidateSampler:
         spans = [upper[i] - lower[i] for i in range(len(lower))]
         max_span = max(spans) if spans else 1.0
         x0 = [0.5 * (lower[i] + upper[i]) for i in range(len(lower))]
+        if warm_start:
+            warm_vec = self._warm_start_vector(warm_start[0].candidate, bounds)
+            if warm_vec is not None:
+                # Seed the optimizer mean from the first warm start (knife-edge point).
+                x0 = warm_vec
         sigma0 = max(1e-3, sigma_fraction * max_span)
         opts: dict[str, Any] = {
             "bounds": [lower, upper],
@@ -321,7 +403,30 @@ class CmaEsCandidateSampler:
                 raise ValueError("popsize must be >= 1")
             opts["popsize"] = int(popsize)
         self._popsize = int(opts.get("popsize", 4 * len(lower) + 3)) if self._active_dims else 1
+        self._warm_starts: list[CandidateSpec] = [warm.candidate for warm in warm_start]
         self._es = cma.CMAEvolutionStrategy(x0, sigma0, opts) if self._active_dims else None
+
+    def _warm_start_vector(
+        self, candidate: CandidateSpec, bounds: dict[str, tuple[float, float]]
+    ) -> list[float] | None:
+        """Return the active-dimension vector for a warm start when fully in-bounds."""
+        values = {
+            "start.x": candidate.start.x,
+            "start.y": candidate.start.y,
+            "goal.x": candidate.goal.x,
+            "goal.y": candidate.goal.y,
+            "spawn_time_s": candidate.spawn_time_s,
+            "pedestrian_speed_mps": candidate.pedestrian_speed_mps,
+            "pedestrian_delay_s": candidate.pedestrian_delay_s,
+        }
+        vec: list[float] = []
+        for name in self._active_dims:
+            value = float(values[name])
+            low, high = bounds[name]
+            if value < low or value > high:
+                return None
+            vec.append(value)
+        return vec
 
     def _continuous_bounds(self) -> dict[str, tuple[float, float]]:
         """Return the (min, max) bound for each continuous candidate dimension."""
@@ -387,6 +492,10 @@ class CmaEsCandidateSampler:
         if self._pending:
             candidate, es, vec = self._pending.pop(0)
             self._in_flight.append((candidate, es, vec))
+            return candidate
+        if self._warm_starts:
+            candidate = self._warm_starts.pop(0)
+            self._in_flight.append((candidate, self._es, []))
             return candidate
         if not self._active_dims:
             candidate = CandidateSpec(

--- a/robot_sf/adversarial/search.py
+++ b/robot_sf/adversarial/search.py
@@ -31,7 +31,7 @@ from robot_sf.adversarial.config import (
 )
 from robot_sf.adversarial.io import read_first_jsonl_record
 from robot_sf.adversarial.objectives import get_objective
-from robot_sf.adversarial.samplers import CandidateSampler, RandomCandidateSampler
+from robot_sf.adversarial.samplers import CandidateSampler, build_sampler
 from robot_sf.benchmark.runner import run_batch
 
 CandidateEvaluator = Callable[[SearchConfig, CandidateSpec, Path, Path], CandidateEvaluation]
@@ -152,7 +152,12 @@ def run_adversarial_search(
     objective = get_objective(config.objective)
     active_evaluator = evaluator or _default_evaluator
     active_certifier = certifier or _default_certifier
-    active_sampler = sampler or RandomCandidateSampler(config.search_space, seed=config.seed)
+    active_sampler = sampler or build_sampler(
+        "random",
+        config.search_space,
+        seed=config.seed,
+        warm_start=config.warm_start,
+    )
 
     config.output_dir.mkdir(parents=True, exist_ok=True)
     evaluations: list[CandidateEvaluation] = []

--- a/robot_sf/adversarial/warm_start.py
+++ b/robot_sf/adversarial/warm_start.py
@@ -32,6 +32,7 @@ from robot_sf.adversarial.config import (
 )
 from robot_sf.adversarial.samplers import build_sampler
 from robot_sf.adversarial.search import run_adversarial_search
+from robot_sf.common.artifact_paths import get_artifact_root, get_repository_root
 
 WARM_START_SCHEMA_VERSION = "adversarial-warm-start.v1"
 
@@ -77,7 +78,7 @@ def load_flip_report(path: str | Path) -> dict[str, Any]:
 
 
 def extract_warm_starts(
-    report: dict[str, Any] | list[dict[str, Any]],
+    report: dict[str, Any] | list[Any],
     *,
     search_space: SearchSpaceConfig,
     margin_threshold: float = 0.5,
@@ -129,6 +130,11 @@ def extract_warm_starts(
             )
             continue
         near_boundary += 1
+        scenario = _nonempty_text(entry.get("scenario"))
+        planner = _nonempty_text(entry.get("planner"))
+        if scenario is None or planner is None:
+            rejected.append({"index": index, "reason": "missing/scenario_or_planner"})
+            continue
         candidate = _candidate_from_entry(entry, search_space=search_space)
         if candidate is None:
             rejected.append({"index": index, "reason": "candidate_geometry_unparseable"})
@@ -140,8 +146,8 @@ def extract_warm_starts(
         warm_starts.append(
             WarmStartCandidate(
                 candidate=candidate,
-                scenario=str(entry.get("scenario", "")),
-                planner=str(entry.get("planner", "")),
+                scenario=scenario,
+                planner=planner,
                 outcome_margin=float(margin_value),
             )
         )
@@ -157,16 +163,16 @@ def extract_warm_starts(
     )
 
 
-def _coerce_entries(report: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _coerce_entries(report: dict[str, Any] | list[Any]) -> list[Any]:
     """Return the entry list from a report mapping or bare list."""
     if isinstance(report, list):
-        return [entry for entry in report if isinstance(entry, dict)]
+        return list(report)
     if isinstance(report, dict):
         entries = report.get("entries")
         if entries is None:
             return [report] if _looks_like_entry(report) else []
         if isinstance(entries, list):
-            return [entry for entry in entries if isinstance(entry, dict)]
+            return list(entries)
     return []
 
 
@@ -187,29 +193,33 @@ def _candidate_from_entry(
     if start is None or goal is None:
         return None
 
-    def _scalar(name: str, default: float) -> float:
-        value = raw.get(name)
-        parsed = _finite_float(value)
-        return float(parsed) if parsed is not None else default
+    def _scalar(name: str, default: float) -> float | None:
+        if name not in raw:
+            return default
+        return _finite_float(raw[name])
 
-    seed = raw.get("scenario_seed", raw.get("seed"))
-    seed_value = (
-        int(seed)
-        if isinstance(seed, int)
-        else (int(seed) if isinstance(seed, float) and seed.is_integer() else None)
+    spawn_time_s = _scalar("spawn_time_s", float(search_space.spawn_time_s.min))
+    pedestrian_speed_mps = _scalar(
+        "pedestrian_speed_mps", float(search_space.pedestrian_speed_mps.min)
     )
-    if seed_value is None:
+    pedestrian_delay_s = _scalar("pedestrian_delay_s", float(search_space.pedestrian_delay_s.min))
+    if spawn_time_s is None or pedestrian_speed_mps is None or pedestrian_delay_s is None:
+        return None
+
+    if "scenario_seed" in raw:
+        seed_value = _finite_int(raw["scenario_seed"])
+    elif "seed" in raw:
+        seed_value = _finite_int(raw["seed"])
+    else:
         seed_value = int(search_space.scenario_seed.min)
+    if seed_value is None:
+        return None
     return CandidateSpec(
         start=start,
         goal=goal,
-        spawn_time_s=_scalar("spawn_time_s", float(search_space.spawn_time_s.min)),
-        pedestrian_speed_mps=_scalar(
-            "pedestrian_speed_mps", float(search_space.pedestrian_speed_mps.min)
-        ),
-        pedestrian_delay_s=_scalar(
-            "pedestrian_delay_s", float(search_space.pedestrian_delay_s.min)
-        ),
+        spawn_time_s=spawn_time_s,
+        pedestrian_speed_mps=pedestrian_speed_mps,
+        pedestrian_delay_s=pedestrian_delay_s,
         scenario_seed=seed_value,
     )
 
@@ -218,9 +228,17 @@ def _pose_from_mapping(payload: object, *, name: str) -> Pose2D | None:
     """Build a pose from a mapping with x/y fields."""
     if not isinstance(payload, dict) or "x" not in payload or "y" not in payload:
         return None
-    theta_raw = payload.get("theta")
-    theta = float(theta_raw) if _finite_float(theta_raw) is not None else 0.0
-    return Pose2D(float(payload["x"]), float(payload["y"]), theta)
+    x = _finite_float(payload["x"])
+    y = _finite_float(payload["y"])
+    if x is None or y is None:
+        return None
+    if "theta" in payload:
+        theta = _finite_float(payload["theta"])
+        if theta is None:
+            return None
+    else:
+        theta = 0.0
+    return Pose2D(x, y, theta)
 
 
 def _finite_float(value: Any) -> float | None:
@@ -230,6 +248,24 @@ def _finite_float(value: Any) -> float | None:
     except (TypeError, ValueError):
         return None
     return parsed if math.isfinite(parsed) else None
+
+
+def _finite_int(value: Any) -> int | None:
+    """Return a finite integer-valued number or None."""
+    if isinstance(value, bool):
+        return None
+    parsed = _finite_float(value)
+    if parsed is None or not parsed.is_integer():
+        return None
+    return int(parsed)
+
+
+def _nonempty_text(value: Any) -> str | None:
+    """Return stripped non-empty text or None."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
 
 
 @dataclass(frozen=True)
@@ -307,6 +343,7 @@ def warm_vs_cold_pilot(
     Returns:
         WarmVsColdPilotReport written to ``output_dir/warm_vs_cold_pilot.json``.
     """
+    pilot_output_dir = _validate_adversarial_archive_output_dir(output_dir)
     budget = int(config.budget)
     if budget < 1:
         raise ValueError("budget must be >= 1")
@@ -317,10 +354,10 @@ def warm_vs_cold_pilot(
         return bool(collapse_predicate(candidate)) if collapse_predicate else False
 
     warm_config = _replace_search_config(
-        config, objective=objective, output_dir=Path(output_dir) / "warm", warm_start=warm_start
+        config, objective=objective, output_dir=pilot_output_dir / "warm", warm_start=warm_start
     )
     cold_config = _replace_search_config(
-        config, objective=objective, output_dir=Path(output_dir) / "cold", warm_start=()
+        config, objective=objective, output_dir=pilot_output_dir / "cold", warm_start=()
     )
 
     warm_result = run_adversarial_search(
@@ -370,12 +407,44 @@ def warm_vs_cold_pilot(
             "evidence_tier": "capability_artifact_not_release_evidence",
         },
     )
-    report_path = Path(output_dir) / "warm_vs_cold_pilot.json"
+    report_path = pilot_output_dir / "warm_vs_cold_pilot.json"
     report_path.parent.mkdir(parents=True, exist_ok=True)
     report_path.write_text(
         json.dumps(report.to_json(), indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
     return report
+
+
+def _validate_adversarial_archive_output_dir(output_dir: Path) -> Path:
+    """Resolve a pilot output path and enforce the repository archive boundary."""
+    resolved = Path(output_dir).expanduser().resolve()
+    repository_root = get_repository_root().resolve()
+    artifact_root = get_artifact_root().resolve()
+    adversarial_root = (artifact_root / "adversarial").resolve()
+
+    inside_repository = False
+    try:
+        resolved.relative_to(repository_root)
+        inside_repository = True
+    except ValueError:
+        pass
+
+    inside_artifact_root = False
+    try:
+        resolved.relative_to(artifact_root)
+        inside_artifact_root = True
+    except ValueError:
+        pass
+
+    if inside_repository or inside_artifact_root:
+        try:
+            resolved.relative_to(adversarial_root)
+        except ValueError as exc:
+            raise ValueError(
+                "warm-vs-cold pilot output inside the repository artifact boundary must be "
+                "under output/adversarial; release-evidence paths are forbidden"
+            ) from exc
+    return resolved
 
 
 def _replace_search_config(

--- a/robot_sf/adversarial/warm_start.py
+++ b/robot_sf/adversarial/warm_start.py
@@ -1,0 +1,492 @@
+"""Extract knife-edge warm-start candidates for the adversarial optimizer samplers.
+
+Knife-edge seeds (#5816/#5817) sit on scenario decision boundaries: a small
+per-context perturbation flips the episode outcome. Seed-sensitivity analysis
+already surfaces them as near-boundary episodes whose ``|outcome margin|`` is
+small. This module converts those reports into :class:`WarmStartCandidate` tuples
+the optimizer-backed samplers accept as initial candidates (Optuna enqueued
+trials, CMA-ES x0), so an active search starts from known high-value points
+instead of cold random sampling.
+
+The warm starts are CAPABILITY artifacts, not validated evidence (design #1433):
+the extractor never writes into a release evidence store and the pilot report
+lands only under the adversarial archive path.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+from robot_sf.adversarial.config import (
+    CandidateEvaluation,
+    CandidateSpec,
+    Pose2D,
+    SearchConfig,
+    SearchSpaceConfig,
+    WarmStartCandidate,
+)
+from robot_sf.adversarial.samplers import build_sampler
+from robot_sf.adversarial.search import run_adversarial_search
+
+WARM_START_SCHEMA_VERSION = "adversarial-warm-start.v1"
+
+_FLIP_ENTRY_KEYS = (
+    "scenario",
+    "planner",
+    "outcome_margin",
+    "candidate",
+)
+
+
+@dataclass(frozen=True)
+class WarmStartExtraction:
+    """Result of extracting warm starts from a knife-edge flip report."""
+
+    schema_version: str
+    source: str
+    margin_threshold: float
+    num_near_boundary: int
+    num_selected: int
+    warm_starts: tuple[WarmStartCandidate, ...]
+    rejected: tuple[dict[str, Any], ...]
+
+    def to_json(self) -> dict[str, Any]:
+        """Return a JSON-serializable extraction payload with provenance."""
+        return {
+            "schema_version": self.schema_version,
+            "source": self.source,
+            "margin_threshold": float(self.margin_threshold),
+            "num_near_boundary": int(self.num_near_boundary),
+            "num_selected": int(self.num_selected),
+            "warm_starts": [warm.to_json() for warm in self.warm_starts],
+            "rejected": [dict(entry) for entry in self.rejected],
+        }
+
+
+def load_flip_report(path: str | Path) -> dict[str, Any]:
+    """Load a knife-edge flip report (JSON) describing near-boundary seeds."""
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Flip report must be a JSON object: {path}")
+    return payload
+
+
+def extract_warm_starts(
+    report: dict[str, Any] | list[dict[str, Any]],
+    *,
+    search_space: SearchSpaceConfig,
+    margin_threshold: float = 0.5,
+    source: str = "",
+) -> WarmStartExtraction:
+    """Extract warm-start candidates from a knife-edge flip report.
+
+    A flip-report entry is a mapping with ``scenario``, ``planner``,
+    ``outcome_margin`` (signed margin; sign encodes which side of the boundary
+    the original outcome landed), and ``candidate`` geometry. Entries whose
+    ``|outcome_margin|`` is at or below ``margin_threshold`` are selected as warm
+    starts, provided their candidate geometry stays inside ``search_space``.
+
+    The report may be a single mapping with an ``entries`` list (the #5817-class
+    format) or a bare list of entries.
+
+    Args:
+        report: Flip report mapping or entry list.
+        search_space: Search space the warm starts must lie inside.
+        margin_threshold: Maximum ``|outcome_margin|`` for selection.
+        source: Provenance label (file path or campaign id).
+
+    Returns:
+        WarmStartExtraction with selected warm starts and provenance.
+    """
+    if not math.isfinite(margin_threshold) or margin_threshold < 0.0:
+        raise ValueError("margin_threshold must be finite and >= 0")
+    entries = _coerce_entries(report)
+    warm_starts: list[WarmStartCandidate] = []
+    rejected: list[dict[str, Any]] = []
+    near_boundary = 0
+
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            rejected.append({"index": index, "reason": "entry must be a mapping"})
+            continue
+        margin = entry.get("outcome_margin")
+        margin_value = _finite_float(margin)
+        if margin_value is None:
+            rejected.append({"index": index, "reason": "missing/outcome_margin"})
+            continue
+        if abs(margin_value) > margin_threshold:
+            rejected.append(
+                {
+                    "index": index,
+                    "reason": "margin_beyond_threshold",
+                    "outcome_margin": margin_value,
+                }
+            )
+            continue
+        near_boundary += 1
+        candidate = _candidate_from_entry(entry, search_space=search_space)
+        if candidate is None:
+            rejected.append({"index": index, "reason": "candidate_geometry_unparseable"})
+            continue
+        errors = search_space.validate_candidate(candidate)
+        if errors:
+            rejected.append({"index": index, "reason": "outside_search_space", "errors": errors})
+            continue
+        warm_starts.append(
+            WarmStartCandidate(
+                candidate=candidate,
+                scenario=str(entry.get("scenario", "")),
+                planner=str(entry.get("planner", "")),
+                outcome_margin=float(margin_value),
+            )
+        )
+
+    return WarmStartExtraction(
+        schema_version=WARM_START_SCHEMA_VERSION,
+        source=source,
+        margin_threshold=float(margin_threshold),
+        num_near_boundary=near_boundary,
+        num_selected=len(warm_starts),
+        warm_starts=tuple(warm_starts),
+        rejected=tuple(rejected),
+    )
+
+
+def _coerce_entries(report: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return the entry list from a report mapping or bare list."""
+    if isinstance(report, list):
+        return [entry for entry in report if isinstance(entry, dict)]
+    if isinstance(report, dict):
+        entries = report.get("entries")
+        if entries is None:
+            return [report] if _looks_like_entry(report) else []
+        if isinstance(entries, list):
+            return [entry for entry in entries if isinstance(entry, dict)]
+    return []
+
+
+def _looks_like_entry(payload: dict[str, Any]) -> bool:
+    """Return whether a mapping resembles a flip-report entry."""
+    return any(key in payload for key in _FLIP_ENTRY_KEYS)
+
+
+def _candidate_from_entry(
+    entry: dict[str, Any], *, search_space: SearchSpaceConfig
+) -> CandidateSpec | None:
+    """Build a CandidateSpec from a flip-report entry geometry."""
+    raw = entry.get("candidate")
+    if not isinstance(raw, dict):
+        return None
+    start = _pose_from_mapping(raw.get("start"), name="candidate.start")
+    goal = _pose_from_mapping(raw.get("goal"), name="candidate.goal")
+    if start is None or goal is None:
+        return None
+
+    def _scalar(name: str, default: float) -> float:
+        value = raw.get(name)
+        parsed = _finite_float(value)
+        return float(parsed) if parsed is not None else default
+
+    seed = raw.get("scenario_seed", raw.get("seed"))
+    seed_value = (
+        int(seed)
+        if isinstance(seed, int)
+        else (int(seed) if isinstance(seed, float) and seed.is_integer() else None)
+    )
+    if seed_value is None:
+        seed_value = int(search_space.scenario_seed.min)
+    return CandidateSpec(
+        start=start,
+        goal=goal,
+        spawn_time_s=_scalar("spawn_time_s", float(search_space.spawn_time_s.min)),
+        pedestrian_speed_mps=_scalar(
+            "pedestrian_speed_mps", float(search_space.pedestrian_speed_mps.min)
+        ),
+        pedestrian_delay_s=_scalar(
+            "pedestrian_delay_s", float(search_space.pedestrian_delay_s.min)
+        ),
+        scenario_seed=seed_value,
+    )
+
+
+def _pose_from_mapping(payload: object, *, name: str) -> Pose2D | None:
+    """Build a pose from a mapping with x/y fields."""
+    if not isinstance(payload, dict) or "x" not in payload or "y" not in payload:
+        return None
+    theta_raw = payload.get("theta")
+    theta = float(theta_raw) if _finite_float(theta_raw) is not None else 0.0
+    return Pose2D(float(payload["x"]), float(payload["y"]), theta)
+
+
+def _finite_float(value: Any) -> float | None:
+    """Return a finite float or None."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+@dataclass(frozen=True)
+class WarmVsColdPilotReport:
+    """Certification-grade pilot comparing warm-started vs cold-started search.
+
+    The report is a CAPABILITY artifact (design #1433): it demonstrates whether
+    warm starts let an optimizer-backed search find stable failures faster at a
+    fixed budget. It never touches a release evidence store.
+    """
+
+    schema_version: str
+    budget: int
+    search_space: str
+    warm_first_failure_iteration: int | None
+    cold_first_failure_iteration: int | None
+    warm_best_objective: float | None
+    cold_best_objective: float | None
+    warm_num_candidates: int
+    cold_num_candidates: int
+    num_warm_starts: int
+    warm_start_seeds: tuple[int, ...]
+    faster: bool
+    provenance: dict[str, Any]
+
+    def to_json(self) -> dict[str, Any]:
+        """Return a JSON-serializable pilot report payload."""
+        return {
+            "schema_version": self.schema_version,
+            "budget": int(self.budget),
+            "search_space": self.search_space,
+            "warm_first_failure_iteration": self.warm_first_failure_iteration,
+            "cold_first_failure_iteration": self.cold_first_failure_iteration,
+            "warm_best_objective": self.warm_best_objective,
+            "cold_best_objective": self.cold_best_objective,
+            "warm_num_candidates": int(self.warm_num_candidates),
+            "cold_num_candidates": int(self.cold_num_candidates),
+            "num_warm_starts": int(self.num_warm_starts),
+            "warm_start_seeds": list(self.warm_start_seeds),
+            "faster": bool(self.faster),
+            "provenance": dict(self.provenance),
+        }
+
+
+def warm_vs_cold_pilot(
+    config: SearchConfig,
+    *,
+    warm_start: tuple[WarmStartCandidate, ...],
+    objective: str,
+    evaluator: Callable[..., CandidateEvaluation],
+    certifier: Callable[..., Any] | None = None,
+    output_dir: Path,
+    sampler_name: str = "optuna",
+    collapse_predicate: Callable[[CandidateSpec], bool] | None = None,
+) -> WarmVsColdPilotReport:
+    """Run a warm-started vs cold-started search at a fixed budget and report efficiency.
+
+    Both arms share ``config`` except for the warm-start list, so the only
+    difference is whether the optimizer begins from knife-edge candidates. The
+    report records the first iteration at which each arm surfaces a stable
+    failure (per ``collapse_predicate``) and whether the warm arm was at least
+    as fast. The artifact is written under ``output_dir`` (an adversarial archive
+    path), never into a release evidence store.
+
+    Args:
+        config: Base search configuration (budget is shared by both arms).
+        warm_start: Knife-edge warm-start candidates for the warm arm.
+        objective: Objective name to score candidates.
+        evaluator: Injected candidate evaluator (synthetic for CPU pilots).
+        certifier: Optional injected certifier.
+        output_dir: Adversarial archive directory for the report artifact.
+        sampler_name: Optimizer sampler family to drive both arms.
+        collapse_predicate: Returns True for a candidate that counts as a stable failure.
+
+    Returns:
+        WarmVsColdPilotReport written to ``output_dir/warm_vs_cold_pilot.json``.
+    """
+    budget = int(config.budget)
+    if budget < 1:
+        raise ValueError("budget must be >= 1")
+    if not warm_start:
+        raise ValueError("warm_vs_cold_pilot requires at least one warm start")
+
+    def _collapse(candidate: CandidateSpec) -> bool:
+        return bool(collapse_predicate(candidate)) if collapse_predicate else False
+
+    warm_config = _replace_search_config(
+        config, objective=objective, output_dir=Path(output_dir) / "warm", warm_start=warm_start
+    )
+    cold_config = _replace_search_config(
+        config, objective=objective, output_dir=Path(output_dir) / "cold", warm_start=()
+    )
+
+    warm_result = run_adversarial_search(
+        warm_config,
+        sampler=build_sampler(
+            sampler_name,
+            config.search_space,
+            seed=config.seed,
+            warm_start=warm_start,
+        ),
+        evaluator=evaluator,
+        certifier=certifier,
+    )
+    cold_result = run_adversarial_search(
+        cold_config,
+        sampler=build_sampler(sampler_name, config.search_space, seed=config.seed),
+        evaluator=evaluator,
+        certifier=certifier,
+    )
+
+    warm_first = _first_failure_iteration(warm_config.output_dir)
+    cold_first = _first_failure_iteration(cold_config.output_dir)
+    if collapse_predicate is not None:
+        warm_first = _first_collapse_iteration(warm_config.output_dir, _collapse)
+        cold_first = _first_collapse_iteration(cold_config.output_dir, _collapse)
+
+    report = WarmVsColdPilotReport(
+        schema_version="adversarial-warm-vs-cold-pilot.v1",
+        budget=budget,
+        search_space=(config.search_space_path.as_posix() if config.search_space_path else ""),
+        warm_first_failure_iteration=warm_first,
+        cold_first_failure_iteration=cold_first,
+        warm_best_objective=_best_objective(warm_config.output_dir),
+        cold_best_objective=_best_objective(cold_config.output_dir),
+        warm_num_candidates=warm_result.num_candidates,
+        cold_num_candidates=cold_result.num_candidates,
+        num_warm_starts=len(warm_start),
+        warm_start_seeds=tuple(warm.candidate.scenario_seed for warm in warm_start),
+        faster=bool(warm_first is not None and (cold_first is None or warm_first <= cold_first)),
+        provenance={
+            "source": "issue #5833 warm-start pilot",
+            "design_note": "#1433",
+            "sampler": sampler_name,
+            "objective": objective,
+            "warm_manifest": warm_result.manifest_path.as_posix(),
+            "cold_manifest": cold_result.manifest_path.as_posix(),
+            "evidence_tier": "capability_artifact_not_release_evidence",
+        },
+    )
+    report_path = Path(output_dir) / "warm_vs_cold_pilot.json"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        json.dumps(report.to_json(), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return report
+
+
+def _replace_search_config(
+    config: SearchConfig,
+    *,
+    objective: str,
+    output_dir: Path,
+    warm_start: tuple[WarmStartCandidate, ...],
+) -> SearchConfig:
+    """Return a search config variant with the pilot objective/output/warm starts."""
+    return replace(
+        config,
+        objective=objective,
+        output_dir=output_dir,
+        warm_start=warm_start,
+    )
+
+
+def _first_failure_iteration(output_dir: Path) -> int | None:
+    """Return the first candidate index whose attribution names a failure."""
+    manifest = _load_manifest(output_dir)
+    if manifest is None:
+        return None
+    candidates = manifest.get("candidates") if isinstance(manifest, dict) else []
+    if not isinstance(candidates, list):
+        return None
+    for index, item in enumerate(candidates):
+        if not isinstance(item, dict):
+            continue
+        attribution = item.get("failure_attribution")
+        if not isinstance(attribution, dict):
+            continue
+        primary = attribution.get("primary_failure")
+        if primary and str(primary).strip().lower() not in {"", "success", "invalid_candidate"}:
+            return index
+    return None
+
+
+def _first_collapse_iteration(
+    output_dir: Path, predicate: Callable[[CandidateSpec], bool]
+) -> int | None:
+    """Return the first candidate index satisfying the collapse predicate."""
+    manifest = _load_manifest(output_dir)
+    if manifest is None:
+        return None
+    candidates = manifest.get("candidates") if isinstance(manifest, dict) else []
+    if not isinstance(candidates, list):
+        return None
+    for index, item in enumerate(candidates):
+        candidate = _candidate_from_manifest(item)
+        if candidate is not None and predicate(candidate):
+            return index
+    return None
+
+
+def _candidate_from_manifest(item: dict[str, Any]) -> CandidateSpec | None:
+    """Build a CandidateSpec from a manifest candidate payload."""
+    raw = item.get("candidate") if isinstance(item, dict) else None
+    if not isinstance(raw, dict):
+        return None
+    space = SearchSpaceConfig.from_mapping(
+        {
+            "variables": {
+                "start_x": {"min": 0.0, "max": 100.0},
+                "start_y": {"min": 0.0, "max": 100.0},
+                "goal_x": {"min": 0.0, "max": 100.0},
+                "goal_y": {"min": 0.0, "max": 100.0},
+                "spawn_time_s": {"min": 0.0, "max": 0.0},
+                "pedestrian_speed_mps": {"min": 1.0, "max": 1.0},
+                "pedestrian_delay_s": {"min": 0.0, "max": 0.0},
+                "scenario_seed": {"min": 0, "max": 1_000_000},
+            },
+            "constraints": {"min_start_goal_distance_m": 0.0},
+        }
+    )
+    return _candidate_from_entry({"candidate": raw}, search_space=space)
+
+
+def _best_objective(output_dir: Path) -> float | None:
+    """Return the best (max) objective value recorded in a search manifest."""
+    manifest = _load_manifest(output_dir)
+    if manifest is None:
+        return None
+    candidates = manifest.get("candidates") if isinstance(manifest, dict) else []
+    if not isinstance(candidates, list):
+        return None
+    best: float | None = None
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        value = item.get("objective_value")
+        parsed = _finite_float(value)
+        if parsed is not None and (best is None or parsed > best):
+            best = parsed
+    return best
+
+
+def _load_manifest(output_dir: Path) -> dict[str, Any] | None:
+    """Load a search manifest if present."""
+    manifest_path = Path(output_dir) / "manifest.json"
+    if not manifest_path.exists():
+        return None
+    return json.loads(manifest_path.read_text(encoding="utf-8"))
+
+
+__all__ = [
+    "WARM_START_SCHEMA_VERSION",
+    "WarmStartCandidate",
+    "WarmStartExtraction",
+    "WarmVsColdPilotReport",
+    "extract_warm_starts",
+    "load_flip_report",
+    "warm_vs_cold_pilot",
+]

--- a/scripts/tools/compare_adversarial_samplers.py
+++ b/scripts/tools/compare_adversarial_samplers.py
@@ -13,24 +13,14 @@ import yaml
 from robot_sf.adversarial.attribution import attribution_from_episode_record
 from robot_sf.adversarial.bundle import write_trajectory_csv
 from robot_sf.adversarial.certification import passed_status
-from robot_sf.adversarial.config import (
-    CandidateEvaluation,
-    SearchConfig,
-    WarmStartCandidate,
-)
-from robot_sf.adversarial.samplers import (
-    CandidateSampler,
-    CmaEsCandidateSampler,
-    CoordinateRefinementSampler,
-    OptunaCandidateSampler,
-    RandomCandidateSampler,
-)
+from robot_sf.adversarial.config import CandidateEvaluation, SearchConfig
+from robot_sf.adversarial.samplers import build_sampler
 from robot_sf.adversarial.search import run_adversarial_search
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from robot_sf.adversarial.config import CandidateSpec, SearchSpaceConfig
+    from robot_sf.adversarial.config import CandidateSpec
 
 
 @dataclass(frozen=True)
@@ -59,26 +49,6 @@ class SamplerComparisonRow:
     held_out_family_yield: float | None
     held_out_family_status: str
     caveats: tuple[str, ...]
-
-
-def build_sampler(
-    name: str,
-    search_space: SearchSpaceConfig,
-    *,
-    seed: int,
-    warm_start: tuple[WarmStartCandidate, ...] = (),
-) -> CandidateSampler:
-    """Build a named adversarial sampler."""
-    key = name.strip().lower()
-    if key == "random":
-        return RandomCandidateSampler(search_space, seed=seed, warm_start=warm_start)
-    if key == "coordinate":
-        return CoordinateRefinementSampler(search_space, seed=seed, warm_start=warm_start)
-    if key == "optuna":
-        return OptunaCandidateSampler(search_space, seed=seed, warm_start=warm_start)
-    if key == "cmaes":
-        return CmaEsCandidateSampler(search_space, seed=seed, warm_start=warm_start)
-    raise ValueError("sampler must be one of: random, coordinate, optuna, cmaes")
 
 
 def run_sampler_comparison(
@@ -120,7 +90,12 @@ def run_sampler_comparison(
                     )
                     result = run_adversarial_search(
                         sampler_config,
-                        sampler=build_sampler(sampler_name, config.search_space, seed=run_seed),
+                        sampler=build_sampler(
+                            sampler_name,
+                            sampler_config.search_space,
+                            seed=run_seed,
+                            warm_start=sampler_config.warm_start,
+                        ),
                         evaluator=_synthetic_evaluator if synthetic else None,
                         certifier=(
                             (

--- a/scripts/tools/compare_adversarial_samplers.py
+++ b/scripts/tools/compare_adversarial_samplers.py
@@ -13,7 +13,11 @@ import yaml
 from robot_sf.adversarial.attribution import attribution_from_episode_record
 from robot_sf.adversarial.bundle import write_trajectory_csv
 from robot_sf.adversarial.certification import passed_status
-from robot_sf.adversarial.config import CandidateEvaluation, SearchConfig
+from robot_sf.adversarial.config import (
+    CandidateEvaluation,
+    SearchConfig,
+    WarmStartCandidate,
+)
 from robot_sf.adversarial.samplers import (
     CandidateSampler,
     CmaEsCandidateSampler,
@@ -57,17 +61,23 @@ class SamplerComparisonRow:
     caveats: tuple[str, ...]
 
 
-def build_sampler(name: str, search_space: SearchSpaceConfig, *, seed: int) -> CandidateSampler:
+def build_sampler(
+    name: str,
+    search_space: SearchSpaceConfig,
+    *,
+    seed: int,
+    warm_start: tuple[WarmStartCandidate, ...] = (),
+) -> CandidateSampler:
     """Build a named adversarial sampler."""
     key = name.strip().lower()
     if key == "random":
-        return RandomCandidateSampler(search_space, seed=seed)
+        return RandomCandidateSampler(search_space, seed=seed, warm_start=warm_start)
     if key == "coordinate":
-        return CoordinateRefinementSampler(search_space, seed=seed)
+        return CoordinateRefinementSampler(search_space, seed=seed, warm_start=warm_start)
     if key == "optuna":
-        return OptunaCandidateSampler(search_space, seed=seed)
+        return OptunaCandidateSampler(search_space, seed=seed, warm_start=warm_start)
     if key == "cmaes":
-        return CmaEsCandidateSampler(search_space, seed=seed)
+        return CmaEsCandidateSampler(search_space, seed=seed, warm_start=warm_start)
     raise ValueError("sampler must be one of: random, coordinate, optuna, cmaes")
 
 

--- a/tests/adversarial/test_adversarial_warm_start.py
+++ b/tests/adversarial/test_adversarial_warm_start.py
@@ -1,0 +1,463 @@
+"""Tests for knife-edge warm-start wiring into the adversarial samplers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from robot_sf.adversarial import warm_start as warm_start_module
+from robot_sf.adversarial.bundle import write_json
+from robot_sf.adversarial.certification import passed_status
+from robot_sf.adversarial.config import (
+    CandidateEvaluation,
+    CandidateSpec,
+    Pose2D,
+    SearchConfig,
+    SearchSpaceConfig,
+    WarmStartCandidate,
+)
+from robot_sf.adversarial.samplers import (
+    CmaEsCandidateSampler,
+    CoordinateRefinementSampler,
+    OptunaCandidateSampler,
+    RandomCandidateSampler,
+)
+from robot_sf.adversarial.search import run_adversarial_search
+from robot_sf.adversarial.warm_start import (
+    extract_warm_starts,
+    load_flip_report,
+    warm_vs_cold_pilot,
+)
+
+
+def _space() -> SearchSpaceConfig:
+    """Build a fixed-range search space fixture."""
+    return SearchSpaceConfig.from_mapping(
+        {
+            "variables": {
+                "start_x": {"min": 1.0, "max": 1.0},
+                "start_y": {"min": 2.0, "max": 2.0},
+                "goal_x": {"min": 5.0, "max": 5.0},
+                "goal_y": {"min": 2.0, "max": 2.0},
+                "spawn_time_s": {"min": 0.0, "max": 0.0},
+                "pedestrian_speed_mps": {"min": 1.0, "max": 1.0},
+                "pedestrian_delay_s": {"min": 0.0, "max": 0.0},
+                "scenario_seed": {"min": 7, "max": 9},
+            },
+            "constraints": {"min_start_goal_distance_m": 0.25},
+        }
+    )
+
+
+def _warm(seed: int, *, planner: str = "goal", margin: float = 0.1) -> WarmStartCandidate:
+    """Build one knife-edge warm-start fixture."""
+    return WarmStartCandidate(
+        candidate=CandidateSpec(
+            start=Pose2D(1.0, 2.0),
+            goal=Pose2D(5.0, 2.0),
+            spawn_time_s=0.0,
+            pedestrian_speed_mps=1.0,
+            pedestrian_delay_s=0.0,
+            scenario_seed=seed,
+        ),
+        scenario="doorway",
+        planner=planner,
+        outcome_margin=margin,
+    )
+
+
+def _evaluate(candidate: CandidateSpec, *, collapse_seed: int = 8) -> CandidateEvaluation:
+    """Build a deterministic evaluation for one candidate."""
+    return CandidateEvaluation(
+        candidate=candidate,
+        certification_status=passed_status(),
+        objective_value=1.0 if candidate.scenario_seed == collapse_seed else 0.0,
+        failure_attribution=None,
+        episode_record_path=None,
+        trajectory_csv_path=None,
+        scenario_yaml_path=None,
+    )
+
+
+def test_random_sampler_yields_warm_starts_first() -> None:
+    """Random sampler should return warm starts before cold random sampling."""
+    space = _space()
+    warm = _warm(7)
+    sampler = RandomCandidateSampler(space, seed=3, warm_start=[warm])
+    assert sampler.sample() == warm.candidate
+    second = sampler.sample()
+    assert second != warm.candidate
+
+
+def test_coordinate_sampler_yields_warm_starts_first() -> None:
+    """Coordinate sampler should yield warm starts before the midpoint."""
+    space = _space()
+    warm = _warm(7)
+    sampler = CoordinateRefinementSampler(space, seed=3, warm_start=[warm])
+    assert sampler.sample() == warm.candidate
+
+
+def test_optuna_sampler_enqueues_warm_starts() -> None:
+    """Optuna sampler should evaluate the enqueued warm start first."""
+    space = _space()
+    warm = _warm(7)
+    sampler = OptunaCandidateSampler(space, seed=11, warm_start=[warm])
+    first = sampler.sample()
+    assert first == warm.candidate
+    sampler.observe(_evaluate(first))
+    second = sampler.sample()
+    assert space.validate_candidate(second) == []
+
+
+def test_cmaes_sampler_returns_warm_starts_first() -> None:
+    """CMA-ES sampler should drain warm starts before exploring."""
+    space = _space()
+    warm = _warm(7)
+    sampler = CmaEsCandidateSampler(space, seed=7, popsize=4, warm_start=[warm])
+    assert sampler.sample() == warm.candidate
+
+
+def test_cmaes_sampler_uses_warm_start_as_x0() -> None:
+    """CMA-ES sampler should center exploration on the first warm start."""
+    space = SearchSpaceConfig.from_mapping(
+        {
+            "variables": {
+                "start_x": {"min": 1.0, "max": 3.0},
+                "start_y": {"min": 2.0, "max": 2.0},
+                "goal_x": {"min": 5.0, "max": 5.0},
+                "goal_y": {"min": 2.0, "max": 2.0},
+                "spawn_time_s": {"min": 0.0, "max": 0.0},
+                "pedestrian_speed_mps": {"min": 1.0, "max": 1.0},
+                "pedestrian_delay_s": {"min": 0.0, "max": 0.0},
+                "scenario_seed": {"min": 7, "max": 9},
+            },
+            "constraints": {"min_start_goal_distance_m": 0.25},
+        }
+    )
+    warm = WarmStartCandidate(
+        candidate=CandidateSpec(
+            start=Pose2D(2.5, 2.0),
+            goal=Pose2D(5.0, 2.0),
+            spawn_time_s=0.0,
+            pedestrian_speed_mps=1.0,
+            pedestrian_delay_s=0.0,
+            scenario_seed=7,
+        ),
+        scenario="doorway",
+        planner="goal",
+        outcome_margin=0.1,
+    )
+    sampler = CmaEsCandidateSampler(space, seed=7, popsize=4, warm_start=[warm])
+    first = sampler.sample()
+    assert first.start.x == pytest.approx(2.5)
+
+
+def test_search_config_validates_warm_start_inside_space(tmp_path: Path) -> None:
+    """SearchConfig should reject warm starts outside the search space."""
+    space = _space()
+    template = tmp_path / "template.yaml"
+    template.write_text(
+        "scenarios:\n  - name: template\n    map_id: classic_cross_trap\n"
+        "    simulation_config:\n      max_episode_steps: 30\n      ped_density: 0.0\n"
+        "    robot_config: {}\n    metadata:\n      archetype: test\n    seeds: [1]\n",
+        encoding="utf-8",
+    )
+    space_path = tmp_path / "space.yaml"
+    space_path.write_text(
+        "variables:\n"
+        "  start_x: {min: 1.0, max: 1.0}\n"
+        "  start_y: {min: 2.0, max: 2.0}\n"
+        "  goal_x: {min: 5.0, max: 5.0}\n"
+        "  goal_y: {min: 2.0, max: 2.0}\n"
+        "  spawn_time_s: {min: 0.0, max: 0.0}\n"
+        "  pedestrian_speed_mps: {min: 1.0, max: 1.0}\n"
+        "  pedestrian_delay_s: {min: 0.0, max: 0.0}\n"
+        "  scenario_seed: {min: 7.0, max: 9.0}\n"
+        "constraints:\n  min_start_goal_distance_m: 0.25\n",
+        encoding="utf-8",
+    )
+    out_of_space = WarmStartCandidate(
+        candidate=CandidateSpec(
+            start=Pose2D(1.0, 2.0),
+            goal=Pose2D(9.0, 2.0),
+            spawn_time_s=0.0,
+            pedestrian_speed_mps=1.0,
+            pedestrian_delay_s=0.0,
+            scenario_seed=7,
+        ),
+        scenario="doorway",
+        planner="goal",
+    )
+    with pytest.raises(ValueError, match="outside search space"):
+        config = SearchConfig(
+            policy="goal",
+            scenario_template=template,
+            search_space_path=space_path,
+            search_space=space,
+            objective="worst_case_snqi",
+            output_dir=tmp_path / "out",
+            warm_start=(out_of_space,),
+        )
+        config.validate()
+
+
+def test_extract_warm_starts_from_flip_report() -> None:
+    """Extractor should select only near-boundary entries inside the space."""
+    space = _space()
+    report = {
+        "entries": [
+            {
+                "scenario": "doorway",
+                "planner": "goal",
+                "outcome_margin": 0.05,
+                "candidate": {
+                    "start": {"x": 1.0, "y": 2.0},
+                    "goal": {"x": 5.0, "y": 2.0},
+                    "scenario_seed": 7,
+                },
+            },
+            {
+                "scenario": "doorway",
+                "planner": "goal",
+                "outcome_margin": 0.9,
+                "candidate": {
+                    "start": {"x": 1.0, "y": 2.0},
+                    "goal": {"x": 5.0, "y": 2.0},
+                    "scenario_seed": 8,
+                },
+            },
+            {
+                "scenario": "doorway",
+                "planner": "goal",
+                "outcome_margin": 0.1,
+                "candidate": {
+                    "start": {"x": 1.0, "y": 2.0},
+                    "goal": {"x": 5.0, "y": 2.0},
+                    "scenario_seed": 9,
+                },
+            },
+        ]
+    }
+    extraction = extract_warm_starts(report, search_space=space, margin_threshold=0.5)
+    assert extraction.num_near_boundary == 2
+    assert extraction.num_selected == 2
+    seeds = {warm.candidate.scenario_seed for warm in extraction.warm_starts}
+    assert seeds == {7, 9}
+    assert extraction.schema_version == warm_start_module.WARM_START_SCHEMA_VERSION
+
+
+def test_extract_warm_starts_bare_list_and_file(tmp_path: Path) -> None:
+    """Extractor should accept a bare list and a JSON file path via load_flip_report."""
+    space = _space()
+    entries = [
+        {
+            "scenario": "doorway",
+            "planner": "goal",
+            "outcome_margin": 0.2,
+            "candidate": {
+                "start": {"x": 1.0, "y": 2.0},
+                "goal": {"x": 5.0, "y": 2.0},
+                "scenario_seed": 7,
+            },
+        },
+    ]
+    extraction = extract_warm_starts(entries, search_space=space)
+    assert extraction.num_selected == 1
+
+    report_path = tmp_path / "flip_report.json"
+    report_path.write_text(json.dumps({"entries": entries}), encoding="utf-8")
+    loaded = load_flip_report(report_path)
+    extraction2 = extract_warm_starts(loaded, search_space=space, source=str(report_path))
+    assert extraction2.source == str(report_path)
+    assert extraction2.num_selected == 1
+
+
+def test_warm_started_search_finds_failure_faster_than_cold() -> None:
+    """Warm-started Optuna should find the collapse seed at least as early as cold."""
+    space = _space()
+    warm = _warm(8)
+
+    def make_sampler(*, warm_start: tuple[WarmStartCandidate, ...]) -> OptunaCandidateSampler:
+        return OptunaCandidateSampler(space, seed=5, warm_start=warm_start)
+
+    cold = make_sampler(warm_start=())
+    warm_sampler = make_sampler(warm_start=(warm,))
+
+    budget = 8
+    cold_first_failure = None
+    for index in range(budget):
+        candidate = cold.sample()
+        cold.observe(_evaluate(candidate, collapse_seed=8))
+        if candidate.scenario_seed == 8 and cold_first_failure is None:
+            cold_first_failure = index
+            break
+
+    warm_first_failure = None
+    for index in range(budget):
+        candidate = warm_sampler.sample()
+        warm_sampler.observe(_evaluate(candidate, collapse_seed=8))
+        if candidate.scenario_seed == 8 and warm_first_failure is None:
+            warm_first_failure = index
+            break
+
+    assert warm_first_failure is not None
+    assert cold_first_failure is not None
+    assert warm_first_failure <= cold_first_failure
+
+
+def test_search_config_round_trips_warm_start_json(tmp_path: Path) -> None:
+    """SearchConfig warm starts should serialize and re-validate via to_json."""
+    space = _space()
+    config = SearchConfig(
+        policy="goal",
+        scenario_template=Path("configs/adversarial/template.yaml"),
+        search_space_path=Path("configs/adversarial/space.yaml"),
+        search_space=space,
+        objective="worst_case_snqi",
+        output_dir=tmp_path / "out",
+        warm_start=(_warm(7),),
+    )
+    payload = config.to_json()
+    assert payload["warm_start"][0]["candidate"]["scenario_seed"] == 7
+    assert payload["warm_start"][0]["scenario"] == "doorway"
+
+
+def _synthetic_collapse_evaluator(seed: int):
+    """Return an evaluator that flags one seed as a stable collision."""
+
+    def evaluator(_config, candidate, scenario_yaml_path, candidate_dir):
+        collapse = candidate.scenario_seed == seed
+        record = {
+            "episode_id": f"synthetic-{candidate.scenario_seed}",
+            "seed": int(candidate.scenario_seed),
+            "status": "collision" if collapse else "success",
+            "steps": 1,
+            "termination_reason": "collision" if collapse else "success",
+            "outcome": {
+                "route_complete": not collapse,
+                "collision": collapse,
+                "timeout": False,
+            },
+            "metrics": {"snqi": 0.0 if collapse else 1.0, "success": 0.0 if collapse else 1.0},
+        }
+        episode_path = candidate_dir / "episode_records.jsonl"
+        episode_path.write_text(
+            __import__("json").dumps(record, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        from robot_sf.adversarial.attribution import attribution_from_episode_record
+
+        return CandidateEvaluation(
+            candidate=candidate,
+            certification_status=passed_status("synthetic"),
+            objective_value=1.0 if collapse else 0.0,
+            failure_attribution=attribution_from_episode_record(record),
+            episode_record_path=episode_path,
+            trajectory_csv_path=None,
+            scenario_yaml_path=scenario_yaml_path,
+            bundle_path=candidate_dir,
+        )
+
+    return evaluator
+
+
+def _pilot_config(tmp_path: Path, budget: int = 6) -> SearchConfig:
+    """Build an Optuna-friendly search config with a real seed range."""
+    template = tmp_path / "template.yaml"
+    template.write_text(
+        "scenarios:\n  - name: template\n    map_id: classic_cross_trap\n"
+        "    simulation_config:\n      max_episode_steps: 30\n      ped_density: 0.0\n"
+        "    robot_config: {}\n    metadata:\n      archetype: test\n    seeds: [1]\n",
+        encoding="utf-8",
+    )
+    space = SearchSpaceConfig.from_mapping(
+        {
+            "variables": {
+                "start_x": {"min": 1.0, "max": 1.0},
+                "start_y": {"min": 2.0, "max": 2.0},
+                "goal_x": {"min": 5.0, "max": 5.0},
+                "goal_y": {"min": 2.0, "max": 2.0},
+                "spawn_time_s": {"min": 0.0, "max": 0.0},
+                "pedestrian_speed_mps": {"min": 1.0, "max": 1.0},
+                "pedestrian_delay_s": {"min": 0.0, "max": 0.0},
+                "scenario_seed": {"min": 9, "max": 14},
+            },
+            "constraints": {"min_start_goal_distance_m": 0.25},
+        }
+    )
+    space_path = tmp_path / "space.yaml"
+    write_json(space_path, space.to_json())
+    return SearchConfig.from_files(
+        policy="goal",
+        scenario_template=template,
+        search_space=space_path,
+        objective="worst_case_snqi",
+        output_dir=tmp_path / "out",
+        budget=budget,
+        seed=3,
+        workers=1,
+    )
+
+
+def test_warm_vs_cold_pilot_reports_faster_warm_start(tmp_path: Path) -> None:
+    """Warm-started Optuna should surface the collapse seed no later than cold."""
+    config = _pilot_config(tmp_path, budget=6)
+    collapse_seed = 9
+    evaluator = _synthetic_collapse_evaluator(collapse_seed)
+    certifier = lambda _c, _p, _r: passed_status("synthetic")  # noqa: E731
+    warm = WarmStartCandidate(
+        candidate=CandidateSpec(
+            start=Pose2D(1.0, 2.0),
+            goal=Pose2D(5.0, 2.0),
+            spawn_time_s=0.0,
+            pedestrian_speed_mps=1.0,
+            pedestrian_delay_s=0.0,
+            scenario_seed=collapse_seed,
+        ),
+        scenario="doorway",
+        planner="goal",
+        outcome_margin=0.1,
+    )
+    report = warm_vs_cold_pilot(
+        config,
+        warm_start=(warm,),
+        objective="worst_case_snqi",
+        evaluator=evaluator,
+        certifier=certifier,
+        output_dir=tmp_path / "pilot",
+        sampler_name="optuna",
+        collapse_predicate=lambda c: c.scenario_seed == collapse_seed,
+    )
+    assert report.num_warm_starts == 1
+    assert report.warm_first_failure_iteration == 0
+    # Warm starts the collapse seed (enqueued) at iteration 0; the pilot must
+    # report the warm arm as at least as fast as cold, regardless of whether the
+    # cold arm independently samples that seed within the fixed budget.
+    assert report.faster
+    assert report.cold_first_failure_iteration is None or report.cold_first_failure_iteration >= 0
+    assert (tmp_path / "pilot" / "warm_vs_cold_pilot.json").exists()
+
+
+def test_warm_started_search_runs_end_to_end(tmp_path: Path) -> None:
+    """A full adversarial search run should accept warm starts without error."""
+    config = _pilot_config(tmp_path, budget=4)
+    warm = _warm(12)
+    config = SearchConfig(
+        policy=config.policy,
+        scenario_template=config.scenario_template,
+        search_space_path=config.search_space_path,
+        search_space=config.search_space,
+        objective=config.objective,
+        output_dir=tmp_path / "e2e",
+        budget=config.budget,
+        seed=config.seed,
+        warm_start=(warm,),
+    )
+    result = run_adversarial_search(
+        config,
+        evaluator=_synthetic_collapse_evaluator(13),
+        certifier=lambda _c, _p, _r: passed_status("synthetic"),
+    )
+    assert result.num_candidates == 4
+    assert config.output_dir.exists()

--- a/tests/adversarial/test_adversarial_warm_start.py
+++ b/tests/adversarial/test_adversarial_warm_start.py
@@ -30,6 +30,7 @@ from robot_sf.adversarial.warm_start import (
     load_flip_report,
     warm_vs_cold_pilot,
 )
+from robot_sf.common.artifact_paths import get_repository_root
 
 
 def _space() -> SearchSpaceConfig:
@@ -87,8 +88,6 @@ def test_random_sampler_yields_warm_starts_first() -> None:
     warm = _warm(7)
     sampler = RandomCandidateSampler(space, seed=3, warm_start=[warm])
     assert sampler.sample() == warm.candidate
-    second = sampler.sample()
-    assert second != warm.candidate
 
 
 def test_coordinate_sampler_yields_warm_starts_first() -> None:
@@ -107,8 +106,11 @@ def test_optuna_sampler_enqueues_warm_starts() -> None:
     first = sampler.sample()
     assert first == warm.candidate
     sampler.observe(_evaluate(first))
+    assert len(sampler._study.trials) == 1
+    assert sampler._study.trials[0].value == pytest.approx(0.0)
     second = sampler.sample()
     assert space.validate_candidate(second) == []
+    assert len(sampler._study.trials) == 2
 
 
 def test_cmaes_sampler_returns_warm_starts_first() -> None:
@@ -152,6 +154,9 @@ def test_cmaes_sampler_uses_warm_start_as_x0() -> None:
     sampler = CmaEsCandidateSampler(space, seed=7, popsize=4, warm_start=[warm])
     first = sampler.sample()
     assert first.start.x == pytest.approx(2.5)
+    sampler.observe(_evaluate(first))
+    assert sampler._observed == []
+    assert space.validate_candidate(sampler.sample()) == []
 
 
 def test_search_config_validates_warm_start_inside_space(tmp_path: Path) -> None:
@@ -274,6 +279,40 @@ def test_extract_warm_starts_bare_list_and_file(tmp_path: Path) -> None:
     assert extraction2.num_selected == 1
 
 
+def test_extract_warm_starts_rejects_each_malformed_entry() -> None:
+    """Malformed report entries should be rejected individually without aborting extraction."""
+    valid_candidate = {
+        "start": {"x": 1.0, "y": 2.0},
+        "goal": {"x": 5.0, "y": 2.0},
+        "scenario_seed": 7,
+    }
+    entries = [
+        "not-a-mapping",
+        {
+            "scenario": "doorway",
+            "planner": "goal",
+            "outcome_margin": 0.1,
+            "candidate": {**valid_candidate, "scenario_seed": "not-an-integer"},
+        },
+        {
+            "scenario": "doorway",
+            "planner": "goal",
+            "outcome_margin": 0.1,
+            "candidate": {**valid_candidate, "start": {"x": "bad", "y": 2.0}},
+        },
+        {
+            "scenario": "doorway",
+            "planner": "goal",
+            "outcome_margin": 0.1,
+            "candidate": {**valid_candidate, "pedestrian_speed_mps": "bad"},
+        },
+    ]
+    extraction = extract_warm_starts(entries, search_space=_space())
+    assert extraction.num_selected == 0
+    assert len(extraction.rejected) == len(entries)
+    assert extraction.rejected[0]["reason"] == "entry must be a mapping"
+
+
 def test_warm_started_search_finds_failure_faster_than_cold() -> None:
     """Warm-started Optuna should find the collapse seed at least as early as cold."""
     space = _space()
@@ -312,8 +351,8 @@ def test_search_config_round_trips_warm_start_json(tmp_path: Path) -> None:
     space = _space()
     config = SearchConfig(
         policy="goal",
-        scenario_template=Path("configs/adversarial/template.yaml"),
-        search_space_path=Path("configs/adversarial/space.yaml"),
+        scenario_template=tmp_path / "template.yaml",
+        search_space_path=tmp_path / "space.yaml",
         search_space=space,
         objective="worst_case_snqi",
         output_dir=tmp_path / "out",
@@ -362,7 +401,12 @@ def _synthetic_collapse_evaluator(seed: int):
     return evaluator
 
 
-def _pilot_config(tmp_path: Path, budget: int = 6) -> SearchConfig:
+def _pilot_config(
+    tmp_path: Path,
+    budget: int = 6,
+    *,
+    warm_start: tuple[WarmStartCandidate, ...] = (),
+) -> SearchConfig:
     """Build an Optuna-friendly search config with a real seed range."""
     template = tmp_path / "template.yaml"
     template.write_text(
@@ -397,6 +441,7 @@ def _pilot_config(tmp_path: Path, budget: int = 6) -> SearchConfig:
         budget=budget,
         seed=3,
         workers=1,
+        warm_start=warm_start,
     )
 
 
@@ -439,21 +484,31 @@ def test_warm_vs_cold_pilot_reports_faster_warm_start(tmp_path: Path) -> None:
     assert (tmp_path / "pilot" / "warm_vs_cold_pilot.json").exists()
 
 
+def test_warm_vs_cold_pilot_rejects_release_evidence_path_before_search(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pilot execution must fail before either arm writes into release evidence."""
+    config = _pilot_config(tmp_path)
+
+    def unexpected_search(*_args, **_kwargs):
+        raise AssertionError("search must not start before output-boundary validation")
+
+    monkeypatch.setattr(warm_start_module, "run_adversarial_search", unexpected_search)
+    forbidden = get_repository_root() / "output" / "release_evidence" / "issue_5833"
+    with pytest.raises(ValueError, match="under output/adversarial"):
+        warm_vs_cold_pilot(
+            config,
+            warm_start=(_warm(9),),
+            objective="worst_case_snqi",
+            evaluator=_synthetic_collapse_evaluator(9),
+            output_dir=forbidden,
+        )
+
+
 def test_warm_started_search_runs_end_to_end(tmp_path: Path) -> None:
     """A full adversarial search run should accept warm starts without error."""
-    config = _pilot_config(tmp_path, budget=4)
     warm = _warm(12)
-    config = SearchConfig(
-        policy=config.policy,
-        scenario_template=config.scenario_template,
-        search_space_path=config.search_space_path,
-        search_space=config.search_space,
-        objective=config.objective,
-        output_dir=tmp_path / "e2e",
-        budget=config.budget,
-        seed=config.seed,
-        warm_start=(warm,),
-    )
+    config = _pilot_config(tmp_path, budget=4, warm_start=(warm,))
     result = run_adversarial_search(
         config,
         evaluator=_synthetic_collapse_evaluator(13),
@@ -461,3 +516,5 @@ def test_warm_started_search_runs_end_to_end(tmp_path: Path) -> None:
     )
     assert result.num_candidates == 4
     assert config.output_dir.exists()
+    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    assert manifest["candidates"][0]["candidate"]["scenario_seed"] == 12


### PR DESCRIPTION
## What / Why

Issue #5833 asks to connect passive seed-sensitivity knife-edge findings (#5816/#5817) to optimizer-backed adversarial samplers, then run a small warm-vs-cold pilot. This PR delivers the reusable warm-start and pilot-harness infrastructure. It intentionally does **not** claim that the requested real pilot has run; that remaining acceptance item stays open on #5833.

## Linked Issues

- Refs #5833

## Delivered Capability

1. **Warm-start config contract** — `WarmStartCandidate` plus `SearchConfig.warm_start`, with fail-closed candidate, scenario, and planner validation.
2. **Sampler wiring**
   - Random and coordinate-refinement samplers drain warm starts first.
   - `OptunaCandidateSampler` enqueues fixed trials and records each trial exactly once through the ask/tell lifecycle.
   - `CmaEsCandidateSampler` centers initial exploration (`x0`) on the first in-bounds warm start without feeding non-CMA proposals into `tell()`.
   - The canonical `build_sampler` factory forwards warm starts through the default search path and sampler-comparison tool.
3. **Extractor** — `extract_warm_starts` converts a #5817-class flip report into warm-start tuples, selects only entries within the configured margin and geometry bounds, and records malformed entries as explicit rejections instead of mutating, hiding, or aborting on them.
4. **Warm-vs-cold pilot harness** — `warm_vs_cold_pilot` runs both arms at a fixed budget and writes a `WarmVsColdPilotReport`. Repository-local output fails closed unless it is under `output/adversarial`; release-evidence paths are rejected before either arm starts.

## Evidence Boundary

- Evidence tier: targeted smoke / capability artifact.
- Result classification: blocker-resolution infrastructure; no empirical warm-vs-cold result is claimed.
- Generated outputs remain development-stress-test capability artifacts under design note #1433, never benchmark, release, or paper evidence.
- Fallback/degraded execution is not used as success evidence.

## Validation / Proof

- `scripts/dev/run_focused_tests.sh tests/adversarial/test_adversarial_warm_start.py -q` — passed.
- `scripts/dev/run_focused_tests.sh tests/adversarial tests/tools/test_run_adversarial_manifest_smoke.py tests/benchmark/test_adversarial_package_b_manifest_run.py -q` — passed.
- `uv run ruff check robot_sf/adversarial/config.py robot_sf/adversarial/samplers.py robot_sf/adversarial/search.py robot_sf/adversarial/warm_start.py scripts/tools/compare_adversarial_samplers.py tests/adversarial/test_adversarial_warm_start.py` — passed.
- `uv run ruff format --check` on the same files — passed.
- Exact-head GitHub CI must pass again after the gate repair commit.

The regressions cover Optuna single-consumption/single-tell behavior, CMA-ES warm-start feedback isolation with an active dimension, malformed report accounting, default-config propagation, and fail-before-execution output-boundary enforcement.

## Remaining #5833 Acceptance

- Run the small real doorway-family warm-vs-cold pilot at the same fixed budget.
- Link a durable, reviewable report artifact with config/seed provenance.
- Report whether warm starts find stable failures faster without promoting the result into release evidence.

These items remain on the open parent issue; this PR must not close it.

## Risks / Rollout

- Optional Optuna and CMA-ES dependencies still fail with actionable install guidance when unavailable.
- Warm-start candidates must remain inside the configured search space and include non-empty source scenario/planner provenance.
- Rollback is the gate repair commit plus the original warm-start implementation commit; no schema or release evidence has been promoted.

## Downstream Propagation

- Parent issue updated: by `Refs #5833`; it remains open for the real pilot.
- Claim map / benchmark report: NA — no benchmark result or claim.
- Leaderboard / artifact catalog: NA — no durable result artifact in this infrastructure slice.
- Registry / config index: NA.
- Context index / memory note: NA.

## Reviewer Notes

- Review the exact runtime lifecycle fixes in `robot_sf/adversarial/samplers.py` closely.
- Review the output-boundary check before treating any pilot artifact as safely archived.
- This PR was produced by the CommandCode/Tencent-Hy3 cheap implementation lane and hardened by the batch gate.
