### PR TITLE
Issue #5578: speed-tier evidence synthesis tool (cheap-lane worker)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -490,6 +490,7 @@ max-statements = 60
 "robot_sf/benchmark/camera_ready_campaign.py" = ["BLE001"]
 "robot_sf/benchmark/camera_ready/campaign.py" = ["BLE001"]
 "robot_sf/benchmark/cli.py" = ["T201"]
+"robot_sf/benchmark/issue_5578_speed_tier_synthesis.py" = ["T201"]
 "robot_sf/examples_cli.py" = ["T201"]
 "robot_sf/benchmark/doctor.py" = ["BLE001"]
 "robot_sf/benchmark/failure_extractor.py" = ["BLE001"]

--- a/robot_sf/benchmark/issue_5578_speed_tier_synthesis.py
+++ b/robot_sf/benchmark/issue_5578_speed_tier_synthesis.py
@@ -531,6 +531,9 @@ def synthesize_speed_tier_sweep(
         require_complete_grid
         and grid_complete
         and all_native
+        and scenarios == set(DECLARED_SCENARIOS)
+        and planners == set(DECLARED_PLANNERS)
+        and seeds == set(DECLARED_SEEDS)
         and len(decision_table) == len(planners) * len(NON_NOMINAL_TIERS) * len(PRIMARY_METRICS)
         and all(row["n_scenarios"] == len(scenarios) for row in decision_table)
     )
@@ -822,7 +825,7 @@ def _aggregate_per_tier(
 def _holm_adjust_by_planner(
     p_values: Sequence[tuple[str, str, float]],
 ) -> tuple[dict[str, float], dict[str, float]]:
-    """Adjust six-test families independently and return adjusted confidences.
+    """Compute per-planner Holm p-values and rank-local confidence levels.
 
     Returns:
         Holm-adjusted p-values and per-test adjusted confidence levels.
@@ -836,14 +839,15 @@ def _holm_adjust_by_planner(
         adjusted.update(_holm_adjust(family))
         m = len(family)
         for rank, (test_id, _) in enumerate(sorted(family, key=lambda item: item[1]), start=1):
-            confidence[test_id] = 1.0 - (1.0 - CONFIDENCE_LEVEL) / (m - rank + 1)
+            local_alpha = (1.0 - CONFIDENCE_LEVEL) / (m - rank + 1)
+            confidence[test_id] = 1.0 - local_alpha
     return adjusted, confidence
 
 
 def _build_decision_table(
     per_tier_summary: Sequence[Mapping[str, Any]],
 ) -> tuple[list[dict[str, Any]], dict[str, float]]:
-    """Classify each pooled delta and collect the Holm p-value family.
+    """Classify pooled deltas with Holm step-down stopping per planner.
 
     Returns:
         ``(decision_table, holm_adjusted)`` with six-test families kept
@@ -853,13 +857,28 @@ def _build_decision_table(
         (entry["planner_id"], entry["test_id"], entry["p_value_raw"]) for entry in per_tier_summary
     ]
     holm_adjusted, adjusted_confidence = _holm_adjust_by_planner(p_values)
+    entries_by_planner: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for entry in per_tier_summary:
+        entries_by_planner[entry["planner_id"]].append(entry)
+    interval_decisions: dict[str, tuple[float, float, bool, str]] = {}
+    for family in entries_by_planner.values():
+        step_down_open = True
+        for entry in sorted(family, key=lambda item: item["p_value_raw"]):
+            test_id = entry["test_id"]
+            confidence = adjusted_confidence[test_id]
+            ci_low, ci_high = _bootstrap_interval(entry["_bootstrap_distribution"], confidence)
+            candidate = _classify_interval(entry["metric"], ci_low, ci_high, entry["n_scenarios"])
+            eligible = step_down_open
+            classification = candidate if eligible else "inconclusive"
+            interval_decisions[test_id] = (ci_low, ci_high, eligible, classification)
+            if candidate == "inconclusive":
+                step_down_open = False
     decision_table: list[dict[str, Any]] = []
     for entry in per_tier_summary:
         test_id = entry["test_id"]
         n = entry["n_scenarios"]
         confidence = adjusted_confidence[test_id]
-        ci_low, ci_high = _bootstrap_interval(entry["_bootstrap_distribution"], confidence)
-        classification = _classify_interval(entry["metric"], ci_low, ci_high, n)
+        ci_low, ci_high, eligible, classification = interval_decisions[test_id]
         decision_table.append(
             {
                 "test_id": test_id,
@@ -874,6 +893,7 @@ def _build_decision_table(
                 "ci_low": ci_low,
                 "ci_high": ci_high,
                 "adjusted_confidence_level": confidence,
+                "holm_step_down_eligible": eligible,
                 "classification": classification,
                 "p_value_raw": entry["p_value_raw"],
                 "p_value_holm": holm_adjusted[test_id],

--- a/robot_sf/benchmark/issue_5578_speed_tier_synthesis.py
+++ b/robot_sf/benchmark/issue_5578_speed_tier_synthesis.py
@@ -22,8 +22,10 @@ contract fails closed.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
+import random
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -51,6 +53,29 @@ HARM_DIRECTION = {
     "near_miss_rate": "increase",
 }
 CONFIDENCE_LEVEL = 0.95
+DECLARED_SCENARIOS = (
+    "classic_head_on_corridor_medium",
+    "classic_doorway_medium",
+    "classic_group_crossing_medium",
+    "classic_merging_medium",
+    "classic_overtaking_medium",
+    "classic_station_platform_medium",
+)
+DECLARED_PLANNERS = (
+    "scenario_adaptive_hybrid_orca_v2_collision_guard",
+    "ppo",
+    "orca",
+    "prediction_planner",
+)
+DECLARED_SEEDS = tuple(range(111, 141))
+TIER_CAPS_M_S = {
+    NOMINAL_TIER_ID: 2.0,
+    "cap_3_0": 3.0,
+    "cap_4_2": 4.2,
+}
+EXPECTED_HORIZON_STEPS = 600
+EXPECTED_DT_SECONDS = 0.1
+BOOTSTRAP_REPLICATES = 2_000
 
 
 def _erf_inv(p: float) -> float:
@@ -77,7 +102,9 @@ def _z_critical(confidence: float) -> float:
     Returns:
         The normal quantile z such that P(|Z| <= z) == confidence.
     """
-    return _erf_inv(confidence)
+    if not 0.0 < confidence < 1.0:
+        raise ValueError("confidence must be between 0 and 1")
+    return _erf_inv((1.0 + confidence) / 2.0)
 
 
 def _required_keys() -> tuple[str, ...]:
@@ -128,6 +155,42 @@ def _as_float(value: Any, field_name: str) -> float:
     return number
 
 
+def _as_nonempty_string(value: Any, field_name: str) -> str:
+    """Validate a required identifier without coercing malformed values.
+
+    Returns:
+        The non-empty string value.
+    """
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string, got {value!r}")
+    return value
+
+
+def _as_int(value: Any, field_name: str, *, positive: bool = False) -> int:
+    """Validate a strict integer field, rejecting booleans and coercion.
+
+    Returns:
+        The validated integer.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field_name} must be an integer, got {value!r}")
+    if positive and value <= 0:
+        raise ValueError(f"{field_name} must be positive, got {value!r}")
+    return value
+
+
+def _as_rate(value: Any, field_name: str) -> float:
+    """Validate a finite rate in the closed unit interval.
+
+    Returns:
+        The validated rate.
+    """
+    rate = _as_float(value, field_name)
+    if not 0.0 <= rate <= 1.0:
+        raise ValueError(f"{field_name} must be in [0, 1], got {value!r}")
+    return rate
+
+
 def parse_cell(row: Mapping[str, Any]) -> CellSummary:
     """Parse and validate one per-cell summary row into a CellSummary.
 
@@ -144,20 +207,27 @@ def parse_cell(row: Mapping[str, Any]) -> CellSummary:
     for metric in PRIMARY_METRICS:
         if metric not in row:
             raise ValueError(f"cell missing primary metric: {metric}")
-        metrics[metric] = _as_float(row[metric], metric)
+        metrics[metric] = _as_rate(row[metric], metric)
     typed: dict[str, float] = {}
     for tcol in TYPED_COLLISION_BREAKDOWN:
-        if tcol in row:
-            typed[tcol] = _as_float(row[tcol], tcol)
+        if tcol not in row:
+            raise ValueError(f"cell missing typed collision metric: {tcol}")
+        typed[tcol] = _as_rate(row[tcol], tcol)
+    speed_cap_m_s = _as_float(row["speed_cap_m_s"], "speed_cap_m_s")
+    dt_seconds = _as_float(row["dt_seconds"], "dt_seconds")
+    if speed_cap_m_s <= 0.0:
+        raise ValueError(f"speed_cap_m_s must be positive, got {speed_cap_m_s!r}")
+    if dt_seconds <= 0.0:
+        raise ValueError(f"dt_seconds must be positive, got {dt_seconds!r}")
     return CellSummary(
-        scenario_id=str(row["scenario_id"]),
-        speed_tier_id=str(row["speed_tier_id"]),
-        speed_cap_m_s=_as_float(row["speed_cap_m_s"], "speed_cap_m_s"),
-        planner_id=str(row["planner_id"]),
-        seed=int(row["seed"]),
-        horizon_steps=int(row["horizon_steps"]),
-        dt_seconds=_as_float(row["dt_seconds"], "dt_seconds"),
-        execution_mode=str(row["execution_mode"]),
+        scenario_id=_as_nonempty_string(row["scenario_id"], "scenario_id"),
+        speed_tier_id=_as_nonempty_string(row["speed_tier_id"], "speed_tier_id"),
+        speed_cap_m_s=speed_cap_m_s,
+        planner_id=_as_nonempty_string(row["planner_id"], "planner_id"),
+        seed=_as_int(row["seed"], "seed"),
+        horizon_steps=_as_int(row["horizon_steps"], "horizon_steps", positive=True),
+        dt_seconds=dt_seconds,
+        execution_mode=_as_nonempty_string(row["execution_mode"], "execution_mode"),
         metrics=metrics,
         typed_collisions=typed,
     )
@@ -192,7 +262,8 @@ class PairedDelta:
     speed_tier_id: str
     metric: str
     scenario_id: str
-    seed: int
+    seeds: tuple[int, ...]
+    paired_differences: tuple[float, ...]
     n_pairs: int
     delta_mean: float
     delta_se: float
@@ -209,7 +280,7 @@ def _paired_delta(
     speed_tier_id: str,
     metric: str,
     scenario_id: str,
-    seed: int,
+    seeds: Sequence[int],
 ) -> PairedDelta:
     """Compute the scenario-seeded paired delta with a normal CI.
 
@@ -218,6 +289,8 @@ def _paired_delta(
         ``CONFIDENCE_LEVEL`` normal confidence interval.
     """
     n = len(nominal)
+    if n == 0 or len(treated) != n or len(seeds) != n:
+        raise ValueError("paired inputs and seeds must have the same non-zero length")
     diffs = [t - n0 for n0, t in zip(nominal, treated, strict=True)]
     mean = sum(diffs) / n
     if n < 2:
@@ -226,7 +299,8 @@ def _paired_delta(
             speed_tier_id=speed_tier_id,
             metric=metric,
             scenario_id=scenario_id,
-            seed=seed,
+            seeds=tuple(seeds),
+            paired_differences=tuple(diffs),
             n_pairs=n,
             delta_mean=mean,
             delta_se=0.0,
@@ -243,7 +317,8 @@ def _paired_delta(
         speed_tier_id=speed_tier_id,
         metric=metric,
         scenario_id=scenario_id,
-        seed=seed,
+        seeds=tuple(seeds),
+        paired_differences=tuple(diffs),
         n_pairs=n,
         delta_mean=mean,
         delta_se=se,
@@ -269,7 +344,7 @@ def _classify_interval(metric: str, ci_low: float, ci_high: float, n_pairs: int)
         One of ``"materially_harmful"``, ``"no_material_shift"``, or
         ``"inconclusive"``.
     """
-    if n_pairs < 2:
+    if n_pairs != len(DECLARED_SCENARIOS):
         return "inconclusive"
     threshold = HARM_THRESHOLDS[metric]
     direction = _harmful_direction(metric)
@@ -321,6 +396,91 @@ class SynthesisResult:
     decision_table: list[dict[str, Any]]
     holm_adjusted: dict[str, float]
     all_native: bool
+    grid_complete: bool
+    evidence_status: str
+
+
+def _cell_identity(cell: CellSummary) -> tuple[str, str, str, int]:
+    """Return the frozen cell identity used for duplicate and grid checks."""
+    return (cell.scenario_id, cell.speed_tier_id, cell.planner_id, cell.seed)
+
+
+def _validate_declared_cell(
+    cell: CellSummary,
+    *,
+    declared_scenarios: set[str],
+    declared_planners: set[str],
+    declared_seeds: set[int],
+) -> None:
+    """Reject dimension, cap, horizon, or time-step drift for one cell."""
+    if cell.scenario_id not in declared_scenarios:
+        raise ValueError(f"undeclared scenario_id: {cell.scenario_id!r}")
+    if cell.planner_id not in declared_planners:
+        raise ValueError(f"undeclared planner_id: {cell.planner_id!r}")
+    if cell.seed not in declared_seeds:
+        raise ValueError(f"undeclared seed: {cell.seed!r}")
+    if cell.speed_tier_id not in TIER_CAPS_M_S:
+        raise ValueError(f"undeclared speed_tier_id: {cell.speed_tier_id!r}")
+    expected_cap = TIER_CAPS_M_S[cell.speed_tier_id]
+    if not math.isclose(cell.speed_cap_m_s, expected_cap, abs_tol=1e-12):
+        raise ValueError(
+            f"speed cap drift for {cell.speed_tier_id}: "
+            f"expected {expected_cap}, got {cell.speed_cap_m_s}"
+        )
+    if cell.horizon_steps != EXPECTED_HORIZON_STEPS:
+        raise ValueError(
+            f"horizon_steps drift: expected {EXPECTED_HORIZON_STEPS}, got {cell.horizon_steps}"
+        )
+    if not math.isclose(cell.dt_seconds, EXPECTED_DT_SECONDS, abs_tol=1e-12):
+        raise ValueError(f"dt_seconds drift: expected {EXPECTED_DT_SECONDS}, got {cell.dt_seconds}")
+
+
+def _validate_declared_grid(
+    parsed: Sequence[CellSummary],
+    *,
+    declared_scenarios: set[str],
+    declared_planners: set[str],
+    declared_seeds: set[int],
+    require_complete_grid: bool,
+) -> bool:
+    """Validate fixed dimensions and return whether every declared identity exists.
+
+    Raises:
+        ValueError: for duplicate identities, dimension drift, or an incomplete
+            grid when ``require_complete_grid`` is true.
+
+    Returns:
+        Whether the parsed identities exactly equal the declared grid.
+    """
+    seen: set[tuple[str, str, str, int]] = set()
+    for cell in parsed:
+        identity = _cell_identity(cell)
+        if identity in seen:
+            raise ValueError(f"duplicate declared cell identity: {identity!r}")
+        seen.add(identity)
+        _validate_declared_cell(
+            cell,
+            declared_scenarios=declared_scenarios,
+            declared_planners=declared_planners,
+            declared_seeds=declared_seeds,
+        )
+
+    expected = {
+        (scenario, tier, planner, seed)
+        for scenario in declared_scenarios
+        for tier in TIER_CAPS_M_S
+        for planner in declared_planners
+        for seed in declared_seeds
+    }
+    missing = expected - seen
+    complete = seen == expected
+    if require_complete_grid and missing:
+        examples = sorted(missing)[:3]
+        raise ValueError(
+            f"declared grid incomplete: missing {len(missing)} of {len(expected)} cells; "
+            f"examples={examples!r}"
+        )
+    return complete
 
 
 def synthesize_speed_tier_sweep(
@@ -328,6 +488,8 @@ def synthesize_speed_tier_sweep(
     *,
     declared_scenarios: set[str] | None = None,
     declared_planners: set[str] | None = None,
+    declared_seeds: set[int] | None = None,
+    require_complete_grid: bool = True,
 ) -> SynthesisResult:
     """Synthesize the issue #5578 speed-tier sweep from per-cell summaries.
 
@@ -335,27 +497,54 @@ def synthesize_speed_tier_sweep(
         cells: per-cell summary rows (one per scenario x tier x planner x seed).
         declared_scenarios: optional allow-list for fail-closed scenario drift.
         declared_planners: optional allow-list for fail-closed planner drift.
+        declared_seeds: optional exact seed set for the paired grid.
+        require_complete_grid: reject missing declared identities when true;
+            false is reserved for explicitly labelled smoke/demo synthesis.
 
     Returns:
         A ``SynthesisResult`` with paired deltas, per-tier summaries, a Holm
         corrected decision table, and a visible exclusion table.
     """
+    scenarios = declared_scenarios or set(DECLARED_SCENARIOS)
+    planners = declared_planners or set(DECLARED_PLANNERS)
+    seeds = declared_seeds or set(DECLARED_SEEDS)
     parsed = [parse_cell(row) for row in cells]
+    grid_complete = _validate_declared_grid(
+        parsed,
+        declared_scenarios=scenarios,
+        declared_planners=planners,
+        declared_seeds=seeds,
+        require_complete_grid=require_complete_grid,
+    )
     exclusions, native, all_native = _partition_cells(parsed)
-    nominal_idx = _build_nominal_index(native)
-    grouped, deltas = _build_paired_deltas(native, nominal_idx)
-    paired_deltas_out = _emit_paired_deltas(native, nominal_idx, deltas)
-    per_tier_summary = _aggregate_per_tier(grouped, declared_planners=declared_planners)
-    decision_table, p_values = _build_decision_table(per_tier_summary)
-    holm_adjusted = _holm_adjust(p_values)
-    for row in decision_table:
-        row["p_value_holm"] = holm_adjusted[row["test_id"]]
+    grouped, deltas, pair_exclusions = _build_paired_deltas(native, declared_seeds=seeds)
+    exclusions.extend(pair_exclusions)
+    paired_deltas_out = _emit_paired_deltas(deltas)
+    typed_summary = _summarize_typed_collisions(native)
+    internal_summary = _aggregate_per_tier(grouped, typed_summary=typed_summary)
+    decision_table, holm_adjusted = _build_decision_table(internal_summary)
+    per_tier_summary = [
+        {key: value for key, value in row.items() if not key.startswith("_")}
+        for row in internal_summary
+    ]
+    statistical_contract_complete = (
+        require_complete_grid
+        and grid_complete
+        and all_native
+        and len(decision_table) == len(planners) * len(NON_NOMINAL_TIERS) * len(PRIMARY_METRICS)
+        and all(row["n_scenarios"] == len(scenarios) for row in decision_table)
+    )
+    evidence_status = (
+        "native_grid_synthesis_complete_provenance_unverified"
+        if statistical_contract_complete
+        else "smoke_or_incomplete_not_benchmark_evidence"
+    )
 
     return SynthesisResult(
         claim_boundary=(
-            "Pre-aggregated synthesis only; not benchmark evidence unless every "
-            "native row and provenance requirement passes. Fallback/degraded/"
-            "failed rows are visible exclusions."
+            "Pre-aggregated synthesis only. A complete native grid remains "
+            "provenance-unverified; smoke, incomplete, fallback, degraded, or "
+            "failed input is not benchmark evidence."
         ),
         per_cell_count=len(parsed),
         native_cell_count=len(native),
@@ -366,6 +555,8 @@ def synthesize_speed_tier_sweep(
         decision_table=decision_table,
         holm_adjusted=holm_adjusted,
         all_native=all_native,
+        grid_complete=grid_complete,
+        evidence_status=evidence_status,
     )
 
 
@@ -400,107 +591,195 @@ def _partition_cells(
     return exclusions, native, len(parsed) == len(native)
 
 
-def _build_nominal_index(
-    native: list[CellSummary],
-) -> dict[tuple[str, str, str, int], float]:
-    """Index native nominal-tier metric values by planner/scenario/metric/seed.
-
-    Returns:
-        Mapping from ``(planner_id, scenario_id, metric, seed)`` to the nominal
-        2.0 m/s cell's metric value.
-    """
-    nominal_idx: dict[tuple[str, str, str, int], float] = {}
-    for cell in native:
-        if cell.speed_tier_id != NOMINAL_TIER_ID:
-            continue
-        for metric in PRIMARY_METRICS:
-            nominal_idx[(cell.planner_id, cell.scenario_id, metric, cell.seed)] = cell.metrics[
-                metric
-            ]
-    return nominal_idx
-
-
 def _build_paired_deltas(
     native: list[CellSummary],
-    nominal_idx: Mapping[tuple[str, str, str, int], float],
-) -> tuple[dict[tuple[str, str, str], list[PairedDelta]], list[PairedDelta]]:
+    *,
+    declared_seeds: set[int],
+) -> tuple[
+    dict[tuple[str, str, str], list[PairedDelta]],
+    list[PairedDelta],
+    list[dict[str, Any]],
+]:
     """Compute per-scenario paired deltas against the nominal tier.
 
     Returns:
-        A tuple ``(grouped, deltas)`` where ``grouped`` collects deltas by
-        ``(planner, tier, metric)`` and ``deltas`` is the flat ordered list.
+        ``(grouped, deltas, exclusions)`` with complete per-scenario seed
+        contrasts and visible records for incomplete native pairs.
     """
+    values: dict[tuple[str, str, str, str], dict[int, float]] = defaultdict(dict)
+    for cell in native:
+        for metric in PRIMARY_METRICS:
+            key = (cell.planner_id, cell.speed_tier_id, cell.scenario_id, metric)
+            values[key][cell.seed] = cell.metrics[metric]
+
     grouped: dict[tuple[str, str, str], list[PairedDelta]] = defaultdict(list)
     deltas: list[PairedDelta] = []
-    for cell in native:
-        if cell.speed_tier_id == NOMINAL_TIER_ID:
-            continue
-        for metric in PRIMARY_METRICS:
-            key = (cell.planner_id, cell.scenario_id, metric, cell.seed)
-            if key not in nominal_idx:
-                continue
-            delta = _paired_delta(
-                [nominal_idx[key]],
-                [cell.metrics[metric]],
-                planner_id=cell.planner_id,
-                speed_tier_id=cell.speed_tier_id,
-                metric=metric,
-                scenario_id=cell.scenario_id,
-                seed=cell.seed,
+    exclusions: list[dict[str, Any]] = []
+    treated_keys = sorted(key for key in values if key[1] in NON_NOMINAL_TIERS)
+    for planner_id, tier_id, scenario_id, metric in treated_keys:
+        nominal_key = (planner_id, NOMINAL_TIER_ID, scenario_id, metric)
+        treated_key = (planner_id, tier_id, scenario_id, metric)
+        nominal_by_seed = values.get(nominal_key, {})
+        treated_by_seed = values[treated_key]
+        paired_seeds = set(nominal_by_seed) & set(treated_by_seed)
+        if paired_seeds != declared_seeds:
+            exclusions.append(
+                {
+                    "scenario_id": scenario_id,
+                    "speed_tier_id": tier_id,
+                    "planner_id": planner_id,
+                    "metric": metric,
+                    "missing_pair_seeds": sorted(declared_seeds - paired_seeds),
+                    "exclusion_reason": "incomplete_native_scenario_seed_pairs",
+                }
             )
-            grouped[(cell.planner_id, cell.speed_tier_id, metric)].append(delta)
-            deltas.append(delta)
-    return grouped, deltas
+            continue
+        ordered_seeds = sorted(paired_seeds)
+        nominal = [nominal_by_seed[seed] for seed in ordered_seeds]
+        treated = [treated_by_seed[seed] for seed in ordered_seeds]
+        delta = _paired_delta(
+            nominal,
+            treated,
+            planner_id=planner_id,
+            speed_tier_id=tier_id,
+            metric=metric,
+            scenario_id=scenario_id,
+            seeds=ordered_seeds,
+        )
+        grouped[(planner_id, tier_id, metric)].append(delta)
+        deltas.append(delta)
+    return grouped, deltas, exclusions
 
 
 def _emit_paired_deltas(
-    native: list[CellSummary],
-    nominal_idx: Mapping[tuple[str, str, str, int], float],
     deltas: Sequence[PairedDelta],
 ) -> list[dict[str, Any]]:
-    """Emit per-cell paired-delta records for every admissible non-nominal cell.
+    """Emit one paired-delta record per complete scenario contrast.
 
     Returns:
-        The list of per-cell paired-delta dictionaries.
+        The ordered list of per-scenario paired-delta dictionaries.
     """
-    paired_deltas_out: list[dict[str, Any]] = []
+    return [
+        {
+            "planner_id": delta.planner_id,
+            "speed_tier_id": delta.speed_tier_id,
+            "metric": delta.metric,
+            "scenario_id": delta.scenario_id,
+            "seeds": list(delta.seeds),
+            "n_pairs": delta.n_pairs,
+            "delta_mean": delta.delta_mean,
+            "delta_se": delta.delta_se,
+            "ci_low": delta.ci_low,
+            "ci_high": delta.ci_high,
+        }
+        for delta in sorted(
+            deltas,
+            key=lambda item: (
+                item.planner_id,
+                item.speed_tier_id,
+                item.metric,
+                item.scenario_id,
+            ),
+        )
+    ]
+
+
+def _summarize_typed_collisions(
+    native: Sequence[CellSummary],
+) -> dict[tuple[str, str], dict[str, float]]:
+    """Average required typed-collision rates for each planner and tier.
+
+    Returns:
+        Per-planner and per-tier mean typed-collision rates.
+    """
+    grouped: dict[tuple[str, str], list[CellSummary]] = defaultdict(list)
     for cell in native:
-        if cell.speed_tier_id == NOMINAL_TIER_ID:
-            continue
-        for metric in PRIMARY_METRICS:
-            key = (cell.planner_id, cell.scenario_id, metric, cell.seed)
-            if key not in nominal_idx:
-                continue
-            delta = next(
-                d
-                for d in deltas
-                if d.planner_id == cell.planner_id
-                and d.speed_tier_id == cell.speed_tier_id
-                and d.metric == metric
-                and d.scenario_id == cell.scenario_id
-                and d.seed == cell.seed
-            )
-            paired_deltas_out.append(
-                {
-                    "planner_id": delta.planner_id,
-                    "speed_tier_id": delta.speed_tier_id,
-                    "metric": delta.metric,
-                    "scenario_id": delta.scenario_id,
-                    "seed": cell.seed,
-                    "n_pairs": delta.n_pairs,
-                    "delta_mean": delta.delta_mean,
-                    "delta_se": delta.delta_se,
-                    "ci_low": delta.ci_low,
-                    "ci_high": delta.ci_high,
-                }
-            )
-    return paired_deltas_out
+        grouped[(cell.planner_id, cell.speed_tier_id)].append(cell)
+    return {
+        key: {
+            metric: sum(cell.typed_collisions[metric] for cell in items) / len(items)
+            for metric in TYPED_COLLISION_BREAKDOWN
+        }
+        for key, items in grouped.items()
+    }
+
+
+def _stable_seed(test_id: str) -> int:
+    """Derive a process-stable pseudo-random seed from a test identity.
+
+    Returns:
+        A stable unsigned integer seed.
+    """
+    return int.from_bytes(hashlib.sha256(test_id.encode()).digest()[:8], "big")
+
+
+def _hierarchical_bootstrap(
+    items: Sequence[PairedDelta],
+    *,
+    test_id: str,
+    replicates: int = BOOTSTRAP_REPLICATES,
+) -> list[float]:
+    """Resample scenarios first and paired seeds within scenario second.
+
+    Returns:
+        The sorted bootstrap distribution of pooled paired deltas.
+    """
+    if not items:
+        return []
+    rng = random.Random(_stable_seed(test_id))
+    result: list[float] = []
+    for _ in range(replicates):
+        sampled_scenarios = [rng.choice(items) for _ in range(len(items))]
+        scenario_means: list[float] = []
+        for scenario in sampled_scenarios:
+            diffs = scenario.paired_differences
+            scenario_means.append(sum(rng.choice(diffs) for _ in diffs) / len(diffs))
+        result.append(sum(scenario_means) / len(scenario_means))
+    return sorted(result)
+
+
+def _percentile(sorted_values: Sequence[float], probability: float) -> float:
+    """Return a linearly interpolated percentile from sorted finite values."""
+    if not sorted_values:
+        raise ValueError("percentile requires at least one value")
+    if not 0.0 <= probability <= 1.0:
+        raise ValueError("percentile probability must be in [0, 1]")
+    position = probability * (len(sorted_values) - 1)
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return sorted_values[lower]
+    weight = position - lower
+    return sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight
+
+
+def _bootstrap_interval(sorted_values: Sequence[float], confidence: float) -> tuple[float, float]:
+    """Return the central percentile interval for a bootstrap distribution."""
+    alpha = 1.0 - confidence
+    return (
+        _percentile(sorted_values, alpha / 2.0),
+        _percentile(sorted_values, 1.0 - alpha / 2.0),
+    )
+
+
+def _bootstrap_p_value(sorted_values: Sequence[float]) -> float:
+    """Return a conservative two-sided bootstrap sign p-value for zero effect."""
+    if not sorted_values:
+        return 1.0
+    non_positive = sum(value <= 0.0 for value in sorted_values)
+    non_negative = sum(value >= 0.0 for value in sorted_values)
+    correction = 1
+    denominator = len(sorted_values) + correction
+    return min(
+        1.0,
+        2.0 * min(non_positive + correction, non_negative + correction) / denominator,
+    )
 
 
 def _aggregate_per_tier(
     grouped: Mapping[tuple[str, str, str], Sequence[PairedDelta]],
     *,
-    declared_planners: set[str] | None = None,
+    typed_summary: Mapping[tuple[str, str], Mapping[str, float]],
 ) -> list[dict[str, Any]]:
     """Pool per-scenario paired deltas into per-tier summary rows.
 
@@ -509,52 +788,78 @@ def _aggregate_per_tier(
     """
     per_tier_summary: list[dict[str, Any]] = []
     for (planner_id, tier_id, metric), items in grouped.items():
-        if declared_planners is not None and planner_id not in declared_planners:
-            continue
         scenario_means = [item.delta_mean for item in items]
         n_scenarios = len(scenario_means)
         pooled_mean = sum(scenario_means) / n_scenarios if n_scenarios else float("nan")
-        se_pooled = (
+        scenario_sd = (
             math.sqrt(sum((m - pooled_mean) ** 2 for m in scenario_means) / max(1, n_scenarios - 1))
             if n_scenarios > 1
             else 0.0
         )
-        z = _z_critical(CONFIDENCE_LEVEL)
-        half = z * (se_pooled / math.sqrt(n_scenarios)) if n_scenarios else 0.0
+        pooled_se = scenario_sd / math.sqrt(n_scenarios) if n_scenarios else float("nan")
+        test_id = f"{planner_id}__{tier_id}__{metric}"
+        bootstrap_distribution = _hierarchical_bootstrap(items, test_id=test_id)
+        ci_low, ci_high = _bootstrap_interval(bootstrap_distribution, CONFIDENCE_LEVEL)
         per_tier_summary.append(
             {
+                "test_id": test_id,
                 "planner_id": planner_id,
                 "speed_tier_id": tier_id,
                 "metric": metric,
                 "n_scenarios": n_scenarios,
                 "pooled_delta_mean": pooled_mean,
-                "pooled_delta_se": se_pooled,
-                "ci_low": pooled_mean - half,
-                "ci_high": pooled_mean + half,
+                "pooled_delta_se": pooled_se,
+                "ci_low_unadjusted": ci_low,
+                "ci_high_unadjusted": ci_high,
+                "p_value_raw": _bootstrap_p_value(bootstrap_distribution),
+                "typed_collision_breakdown": dict(typed_summary.get((planner_id, tier_id), {})),
+                "_bootstrap_distribution": bootstrap_distribution,
             }
         )
     return per_tier_summary
 
 
+def _holm_adjust_by_planner(
+    p_values: Sequence[tuple[str, str, float]],
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Adjust six-test families independently and return adjusted confidences.
+
+    Returns:
+        Holm-adjusted p-values and per-test adjusted confidence levels.
+    """
+    families: dict[str, list[tuple[str, float]]] = defaultdict(list)
+    for planner_id, test_id, p_value in p_values:
+        families[planner_id].append((test_id, p_value))
+    adjusted: dict[str, float] = {}
+    confidence: dict[str, float] = {}
+    for family in families.values():
+        adjusted.update(_holm_adjust(family))
+        m = len(family)
+        for rank, (test_id, _) in enumerate(sorted(family, key=lambda item: item[1]), start=1):
+            confidence[test_id] = 1.0 - (1.0 - CONFIDENCE_LEVEL) / (m - rank + 1)
+    return adjusted, confidence
+
+
 def _build_decision_table(
     per_tier_summary: Sequence[Mapping[str, Any]],
-) -> tuple[list[dict[str, Any]], list[tuple[str, float]]]:
+) -> tuple[list[dict[str, Any]], dict[str, float]]:
     """Classify each pooled delta and collect the Holm p-value family.
 
     Returns:
-        A tuple ``(decision_table, p_values)`` where ``decision_table`` carries
-        the per-test classification and raw/holm p-values, and ``p_values`` is
-        the ``(test_id, p_value)`` family fed to the Holm correction.
+        ``(decision_table, holm_adjusted)`` with six-test families kept
+        independent per planner and classifications based on adjusted intervals.
     """
-    p_values: list[tuple[str, float]] = []
+    p_values = [
+        (entry["planner_id"], entry["test_id"], entry["p_value_raw"]) for entry in per_tier_summary
+    ]
+    holm_adjusted, adjusted_confidence = _holm_adjust_by_planner(p_values)
     decision_table: list[dict[str, Any]] = []
     for entry in per_tier_summary:
-        test_id = f"{entry['planner_id']}__{entry['speed_tier_id']}__{entry['metric']}"
+        test_id = entry["test_id"]
         n = entry["n_scenarios"]
-        ci_low, ci_high = entry["ci_low"], entry["ci_high"]
+        confidence = adjusted_confidence[test_id]
+        ci_low, ci_high = _bootstrap_interval(entry["_bootstrap_distribution"], confidence)
         classification = _classify_interval(entry["metric"], ci_low, ci_high, n)
-        p_value = _approx_p_value(entry["metric"], ci_low, ci_high, n)
-        p_values.append((test_id, p_value))
         decision_table.append(
             {
                 "test_id": test_id,
@@ -563,33 +868,19 @@ def _build_decision_table(
                 "metric": entry["metric"],
                 "n_scenarios": n,
                 "pooled_delta_mean": entry["pooled_delta_mean"],
+                "pooled_delta_se": entry["pooled_delta_se"],
+                "ci_low_unadjusted": entry["ci_low_unadjusted"],
+                "ci_high_unadjusted": entry["ci_high_unadjusted"],
                 "ci_low": ci_low,
                 "ci_high": ci_high,
+                "adjusted_confidence_level": confidence,
                 "classification": classification,
-                "p_value_raw": p_value,
+                "p_value_raw": entry["p_value_raw"],
+                "p_value_holm": holm_adjusted[test_id],
+                "typed_collision_breakdown": entry["typed_collision_breakdown"],
             }
         )
-    return decision_table, p_values
-
-
-def _approx_p_value(metric: str, ci_low: float, ci_high: float, n: int) -> float:
-    """Two-sided normal p-value for a pooled delta from its confidence interval.
-
-    Uses the interval half-width and the scenario count as the effective sample
-    size. When n < 2 the test is undefined and returns 1.0 (never evidence).
-
-    Returns:
-        The two-sided normal p-value in ``[0.0, 1.0]``.
-    """
-    if n < 2:
-        return 1.0
-    half = (ci_high - ci_low) / 2.0
-    if half <= 0.0:
-        return 1.0
-    se = half / _z_critical(CONFIDENCE_LEVEL)
-    z_stat = (ci_high + ci_low) / (2.0 * se)
-    tail = 0.5 * (1.0 - math.erf(abs(z_stat) / math.sqrt(2.0)))
-    return min(1.0, 2.0 * tail)
+    return decision_table, holm_adjusted
 
 
 def _build_cli_rows() -> list[dict[str, object]]:
@@ -636,12 +927,20 @@ def main(argv: list[str] | None = None) -> int:
         help="Emit the full synthesis result as indented JSON.",
     )
     args = parser.parse_args(argv)
-    result = synthesize_speed_tier_sweep(_build_cli_rows())
+    result = synthesize_speed_tier_sweep(
+        _build_cli_rows(),
+        declared_scenarios={"classic_doorway_medium"},
+        declared_planners={"orca"},
+        declared_seeds={111},
+        require_complete_grid=False,
+    )
     report = {
         "claim_boundary": result.claim_boundary,
         "per_cell_count": result.per_cell_count,
         "native_cell_count": result.native_cell_count,
         "all_native": result.all_native,
+        "grid_complete": result.grid_complete,
+        "evidence_status": result.evidence_status,
         "decision_table": result.decision_table,
         "excluded_cell_count": result.excluded_cell_count,
     }
@@ -649,7 +948,7 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:
         print(
-            f"PASS: issue #5578 synthesis valid "
+            f"SMOKE (not benchmark evidence): issue #5578 synthesis executed "
             f"({result.native_cell_count} native cells, "
             f"{result.excluded_cell_count} excluded)"
         )

--- a/robot_sf/benchmark/issue_5578_speed_tier_synthesis.py
+++ b/robot_sf/benchmark/issue_5578_speed_tier_synthesis.py
@@ -1,0 +1,660 @@
+"""Fail-closed evidence synthesis for the issue #5578 robot speed-tier sweep.
+
+This module implements the frozen decision rule from the issue #5578
+preregistration packet (configs/benchmarks/issue_5578_robot_speed_tier_preregistration.yaml)
+and its governance parent #5557. It consumes per-cell summary data (one row per
+scenario x speed_tier x planner x seed) and produces:
+
+- a paired-delta estimand (tier - 2.0 m/s) per planner / non-nominal tier /
+  primary metric, summarized across the six declared scenarios;
+- a Holm-Bonferroni corrected confidence interval per test in the declared
+  family (planner x non-nominal tier x primary metric, six tests per planner);
+- a fail-closed harm-threshold classification (materially_harmful /
+  no_material_shift / inconclusive);
+- a visible exclusion table for missing / failed / fallback / degraded rows.
+
+The synthesis is deterministic and CPU-only. It does NOT run any campaign,
+submit compute, or promote a paper-facing claim. A result is only benchmark
+evidence when every native row and provenance requirement passes; otherwise the
+contract fails closed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+PRIMARY_METRICS = ("success_rate", "collision_rate", "near_miss_rate")
+TYPED_COLLISION_BREAKDOWN = (
+    "ped_collision_rate",
+    "obstacle_collision_rate",
+    "agent_collision_rate",
+    "unclassified_collision_rate",
+)
+NOMINAL_TIER_ID = "cap_2_0_nominal"
+NON_NOMINAL_TIERS = ("cap_3_0", "cap_4_2")
+HARM_THRESHOLDS = {
+    "success_rate": -0.05,
+    "collision_rate": 0.02,
+    "near_miss_rate": 0.05,
+}
+HARM_DIRECTION = {
+    "success_rate": "decrease",
+    "collision_rate": "increase",
+    "near_miss_rate": "increase",
+}
+CONFIDENCE_LEVEL = 0.95
+
+
+def _erf_inv(p: float) -> float:
+    """Inverse error function via Abramowitz & Stegun 7.1.26 (|p| < 1).
+
+    Returns:
+        The inverse error function value for ``p``.
+    """
+    sign = 1.0 if p >= 0.0 else -1.0
+    x = (1.0 - p) if p >= 0.0 else (1.0 + p)
+    if x <= 0.0:
+        raise ValueError("erf inverse argument must be in (-1, 1)")
+    t = math.sqrt(-2.0 * math.log(x))
+    return sign * (
+        t
+        - (2.515517 + 0.802853 * t + 0.010328 * t * t)
+        / (1.0 + 1.432788 * t + 0.189269 * t * t + 0.001308 * t * t * t)
+    )
+
+
+def _z_critical(confidence: float) -> float:
+    """Two-sided normal critical value for the given confidence level.
+
+    Returns:
+        The normal quantile z such that P(|Z| <= z) == confidence.
+    """
+    return _erf_inv(confidence)
+
+
+def _required_keys() -> tuple[str, ...]:
+    """Return the mandatory per-cell summary keys from the result contract.
+
+    Returns:
+        Tuple of required cell key names.
+    """
+    return (
+        "scenario_id",
+        "speed_tier_id",
+        "speed_cap_m_s",
+        "planner_id",
+        "seed",
+        "horizon_steps",
+        "dt_seconds",
+        "execution_mode",
+    )
+
+
+@dataclass
+class CellSummary:
+    """One declared cell: a scenario x tier x planner x seed observation."""
+
+    scenario_id: str
+    speed_tier_id: str
+    speed_cap_m_s: float
+    planner_id: str
+    seed: int
+    horizon_steps: int
+    dt_seconds: float
+    execution_mode: str
+    metrics: dict[str, float]
+    typed_collisions: dict[str, float] = field(default_factory=dict)
+
+
+def _as_float(value: Any, field_name: str) -> float:
+    """Coerce and validate a numeric cell field value.
+
+    Returns:
+        The finite float value of ``value``.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field_name} must be a numeric value, got {value!r}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{field_name} must be finite, got {value!r}")
+    return number
+
+
+def parse_cell(row: Mapping[str, Any]) -> CellSummary:
+    """Parse and validate one per-cell summary row into a CellSummary.
+
+    Raises:
+        ValueError: if required keys or primary metrics are missing / invalid.
+
+    Returns:
+        The parsed ``CellSummary``.
+    """
+    for key in _required_keys():
+        if key not in row:
+            raise ValueError(f"cell missing required key: {key}")
+    metrics: dict[str, float] = {}
+    for metric in PRIMARY_METRICS:
+        if metric not in row:
+            raise ValueError(f"cell missing primary metric: {metric}")
+        metrics[metric] = _as_float(row[metric], metric)
+    typed: dict[str, float] = {}
+    for tcol in TYPED_COLLISION_BREAKDOWN:
+        if tcol in row:
+            typed[tcol] = _as_float(row[tcol], tcol)
+    return CellSummary(
+        scenario_id=str(row["scenario_id"]),
+        speed_tier_id=str(row["speed_tier_id"]),
+        speed_cap_m_s=_as_float(row["speed_cap_m_s"], "speed_cap_m_s"),
+        planner_id=str(row["planner_id"]),
+        seed=int(row["seed"]),
+        horizon_steps=int(row["horizon_steps"]),
+        dt_seconds=_as_float(row["dt_seconds"], "dt_seconds"),
+        execution_mode=str(row["execution_mode"]),
+        metrics=metrics,
+        typed_collisions=typed,
+    )
+
+
+def classify_excluded(cell: CellSummary) -> str | None:
+    """Return an exclusion reason for a non-native cell, else None.
+
+    Per the provenance contract, only ``native`` execution rows count as
+    evidence; ``fallback`` / ``degraded`` / ``failed`` rows are visible
+    exclusions.
+
+    Returns:
+        An exclusion-reason string for non-native rows, or ``None`` when the
+        cell is native and therefore admissible as evidence.
+    """
+    mode = cell.execution_mode
+    if mode == "native":
+        return None
+    if mode in ("fallback", "degraded"):
+        return f"non_native_execution:{mode}"
+    if mode == "failed":
+        return "failed_row"
+    return f"unrecognized_execution_mode:{mode}"
+
+
+@dataclass
+class PairedDelta:
+    """Paired-delta estimand for one planner x tier x metric x scenario contrast."""
+
+    planner_id: str
+    speed_tier_id: str
+    metric: str
+    scenario_id: str
+    seed: int
+    n_pairs: int
+    delta_mean: float
+    delta_se: float
+    ci_low: float
+    ci_high: float
+    z: float | None
+
+
+def _paired_delta(
+    nominal: Sequence[float],
+    treated: Sequence[float],
+    *,
+    planner_id: str,
+    speed_tier_id: str,
+    metric: str,
+    scenario_id: str,
+    seed: int,
+) -> PairedDelta:
+    """Compute the scenario-seeded paired delta with a normal CI.
+
+    Returns:
+        The ``PairedDelta`` carrying the delta mean, standard error, and the
+        ``CONFIDENCE_LEVEL`` normal confidence interval.
+    """
+    n = len(nominal)
+    diffs = [t - n0 for n0, t in zip(nominal, treated, strict=True)]
+    mean = sum(diffs) / n
+    if n < 2:
+        return PairedDelta(
+            planner_id=planner_id,
+            speed_tier_id=speed_tier_id,
+            metric=metric,
+            scenario_id=scenario_id,
+            seed=seed,
+            n_pairs=n,
+            delta_mean=mean,
+            delta_se=0.0,
+            ci_low=mean,
+            ci_high=mean,
+            z=None,
+        )
+    variance = sum((d - mean) ** 2 for d in diffs) / (n - 1)
+    se = math.sqrt(variance / n)
+    z = _z_critical(CONFIDENCE_LEVEL)
+    half = z * se
+    return PairedDelta(
+        planner_id=planner_id,
+        speed_tier_id=speed_tier_id,
+        metric=metric,
+        scenario_id=scenario_id,
+        seed=seed,
+        n_pairs=n,
+        delta_mean=mean,
+        delta_se=se,
+        ci_low=mean - half,
+        ci_high=mean + half,
+        z=z,
+    )
+
+
+def _harmful_direction(metric: str) -> str:
+    """Return whether the harmful direction for a metric is a decrease or increase.
+
+    Returns:
+        ``"decrease"`` or ``"increase"`` from the frozen harm-direction map.
+    """
+    return HARM_DIRECTION[metric]
+
+
+def _classify_interval(metric: str, ci_low: float, ci_high: float, n_pairs: int) -> str:
+    """Classify a single metric's adjusted interval against its harm threshold.
+
+    Returns:
+        One of ``"materially_harmful"``, ``"no_material_shift"``, or
+        ``"inconclusive"``.
+    """
+    if n_pairs < 2:
+        return "inconclusive"
+    threshold = HARM_THRESHOLDS[metric]
+    direction = _harmful_direction(metric)
+    if direction == "decrease":
+        if ci_high < threshold:
+            return "materially_harmful"
+        if ci_low > threshold:
+            return "no_material_shift"
+    else:  # increase
+        if ci_low > threshold:
+            return "materially_harmful"
+        if ci_high < threshold:
+            return "no_material_shift"
+    return "inconclusive"
+
+
+def _holm_adjust(p_values: list[tuple[str, float]]) -> dict[str, float]:
+    """Holm-Bonferroni adjusted p-values keyed by test id.
+
+    The family is planner x non-nominal tier x primary metric (six tests per
+    planner, per the preregistration multiplicity contract). When the sample is
+    too small to form a two-sided test (n_pairs < 2) the p-value is forced to
+    1.0 so the test can never pass as evidence.
+
+    Returns:
+        Mapping from test id to its stepwise Holm-adjusted p-value.
+    """
+    adjusted: dict[str, float] = {}
+    m = len(p_values)
+    running_max = 0.0
+    for rank, (test_id, p_value) in enumerate(sorted(p_values, key=lambda item: item[1]), start=1):
+        raw = min(1.0, (m - rank + 1) * p_value)
+        running_max = max(running_max, raw)
+        adjusted[test_id] = running_max
+    return adjusted
+
+
+@dataclass
+class SynthesisResult:
+    """Full deterministic synthesis output for the issue #5578 sweep."""
+
+    claim_boundary: str
+    per_cell_count: int
+    native_cell_count: int
+    excluded_cell_count: int
+    exclusions: list[dict[str, Any]]
+    paired_deltas: list[dict[str, Any]]
+    per_tier_summary: list[dict[str, Any]]
+    decision_table: list[dict[str, Any]]
+    holm_adjusted: dict[str, float]
+    all_native: bool
+
+
+def synthesize_speed_tier_sweep(
+    cells: Sequence[Mapping[str, Any]],
+    *,
+    declared_scenarios: set[str] | None = None,
+    declared_planners: set[str] | None = None,
+) -> SynthesisResult:
+    """Synthesize the issue #5578 speed-tier sweep from per-cell summaries.
+
+    Args:
+        cells: per-cell summary rows (one per scenario x tier x planner x seed).
+        declared_scenarios: optional allow-list for fail-closed scenario drift.
+        declared_planners: optional allow-list for fail-closed planner drift.
+
+    Returns:
+        A ``SynthesisResult`` with paired deltas, per-tier summaries, a Holm
+        corrected decision table, and a visible exclusion table.
+    """
+    parsed = [parse_cell(row) for row in cells]
+    exclusions, native, all_native = _partition_cells(parsed)
+    nominal_idx = _build_nominal_index(native)
+    grouped, deltas = _build_paired_deltas(native, nominal_idx)
+    paired_deltas_out = _emit_paired_deltas(native, nominal_idx, deltas)
+    per_tier_summary = _aggregate_per_tier(grouped, declared_planners=declared_planners)
+    decision_table, p_values = _build_decision_table(per_tier_summary)
+    holm_adjusted = _holm_adjust(p_values)
+    for row in decision_table:
+        row["p_value_holm"] = holm_adjusted[row["test_id"]]
+
+    return SynthesisResult(
+        claim_boundary=(
+            "Pre-aggregated synthesis only; not benchmark evidence unless every "
+            "native row and provenance requirement passes. Fallback/degraded/"
+            "failed rows are visible exclusions."
+        ),
+        per_cell_count=len(parsed),
+        native_cell_count=len(native),
+        excluded_cell_count=len(exclusions),
+        exclusions=exclusions,
+        paired_deltas=paired_deltas_out,
+        per_tier_summary=per_tier_summary,
+        decision_table=decision_table,
+        holm_adjusted=holm_adjusted,
+        all_native=all_native,
+    )
+
+
+def _partition_cells(
+    parsed: list[CellSummary],
+) -> tuple[list[dict[str, Any]], list[CellSummary], bool]:
+    """Split parsed cells into a visible exclusion table and admissible natives.
+
+    Returns:
+        A tuple ``(exclusions, native, all_native)`` where ``exclusions`` is the
+        list of excluded-cell records, ``native`` are the admissible cells, and
+        ``all_native`` flags whether every cell was native.
+    """
+    exclusions: list[dict[str, Any]] = []
+    native: list[CellSummary] = []
+    for cell in parsed:
+        reason = classify_excluded(cell)
+        if reason is None:
+            native.append(cell)
+        else:
+            exclusions.append(
+                {
+                    "scenario_id": cell.scenario_id,
+                    "speed_tier_id": cell.speed_tier_id,
+                    "speed_cap_m_s": cell.speed_cap_m_s,
+                    "planner_id": cell.planner_id,
+                    "seed": cell.seed,
+                    "execution_mode": cell.execution_mode,
+                    "exclusion_reason": reason,
+                }
+            )
+    return exclusions, native, len(parsed) == len(native)
+
+
+def _build_nominal_index(
+    native: list[CellSummary],
+) -> dict[tuple[str, str, str, int], float]:
+    """Index native nominal-tier metric values by planner/scenario/metric/seed.
+
+    Returns:
+        Mapping from ``(planner_id, scenario_id, metric, seed)`` to the nominal
+        2.0 m/s cell's metric value.
+    """
+    nominal_idx: dict[tuple[str, str, str, int], float] = {}
+    for cell in native:
+        if cell.speed_tier_id != NOMINAL_TIER_ID:
+            continue
+        for metric in PRIMARY_METRICS:
+            nominal_idx[(cell.planner_id, cell.scenario_id, metric, cell.seed)] = cell.metrics[
+                metric
+            ]
+    return nominal_idx
+
+
+def _build_paired_deltas(
+    native: list[CellSummary],
+    nominal_idx: Mapping[tuple[str, str, str, int], float],
+) -> tuple[dict[tuple[str, str, str], list[PairedDelta]], list[PairedDelta]]:
+    """Compute per-scenario paired deltas against the nominal tier.
+
+    Returns:
+        A tuple ``(grouped, deltas)`` where ``grouped`` collects deltas by
+        ``(planner, tier, metric)`` and ``deltas`` is the flat ordered list.
+    """
+    grouped: dict[tuple[str, str, str], list[PairedDelta]] = defaultdict(list)
+    deltas: list[PairedDelta] = []
+    for cell in native:
+        if cell.speed_tier_id == NOMINAL_TIER_ID:
+            continue
+        for metric in PRIMARY_METRICS:
+            key = (cell.planner_id, cell.scenario_id, metric, cell.seed)
+            if key not in nominal_idx:
+                continue
+            delta = _paired_delta(
+                [nominal_idx[key]],
+                [cell.metrics[metric]],
+                planner_id=cell.planner_id,
+                speed_tier_id=cell.speed_tier_id,
+                metric=metric,
+                scenario_id=cell.scenario_id,
+                seed=cell.seed,
+            )
+            grouped[(cell.planner_id, cell.speed_tier_id, metric)].append(delta)
+            deltas.append(delta)
+    return grouped, deltas
+
+
+def _emit_paired_deltas(
+    native: list[CellSummary],
+    nominal_idx: Mapping[tuple[str, str, str, int], float],
+    deltas: Sequence[PairedDelta],
+) -> list[dict[str, Any]]:
+    """Emit per-cell paired-delta records for every admissible non-nominal cell.
+
+    Returns:
+        The list of per-cell paired-delta dictionaries.
+    """
+    paired_deltas_out: list[dict[str, Any]] = []
+    for cell in native:
+        if cell.speed_tier_id == NOMINAL_TIER_ID:
+            continue
+        for metric in PRIMARY_METRICS:
+            key = (cell.planner_id, cell.scenario_id, metric, cell.seed)
+            if key not in nominal_idx:
+                continue
+            delta = next(
+                d
+                for d in deltas
+                if d.planner_id == cell.planner_id
+                and d.speed_tier_id == cell.speed_tier_id
+                and d.metric == metric
+                and d.scenario_id == cell.scenario_id
+                and d.seed == cell.seed
+            )
+            paired_deltas_out.append(
+                {
+                    "planner_id": delta.planner_id,
+                    "speed_tier_id": delta.speed_tier_id,
+                    "metric": delta.metric,
+                    "scenario_id": delta.scenario_id,
+                    "seed": cell.seed,
+                    "n_pairs": delta.n_pairs,
+                    "delta_mean": delta.delta_mean,
+                    "delta_se": delta.delta_se,
+                    "ci_low": delta.ci_low,
+                    "ci_high": delta.ci_high,
+                }
+            )
+    return paired_deltas_out
+
+
+def _aggregate_per_tier(
+    grouped: Mapping[tuple[str, str, str], Sequence[PairedDelta]],
+    *,
+    declared_planners: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Pool per-scenario paired deltas into per-tier summary rows.
+
+    Returns:
+        The list of per-tier pooled-delta summary dictionaries.
+    """
+    per_tier_summary: list[dict[str, Any]] = []
+    for (planner_id, tier_id, metric), items in grouped.items():
+        if declared_planners is not None and planner_id not in declared_planners:
+            continue
+        scenario_means = [item.delta_mean for item in items]
+        n_scenarios = len(scenario_means)
+        pooled_mean = sum(scenario_means) / n_scenarios if n_scenarios else float("nan")
+        se_pooled = (
+            math.sqrt(sum((m - pooled_mean) ** 2 for m in scenario_means) / max(1, n_scenarios - 1))
+            if n_scenarios > 1
+            else 0.0
+        )
+        z = _z_critical(CONFIDENCE_LEVEL)
+        half = z * (se_pooled / math.sqrt(n_scenarios)) if n_scenarios else 0.0
+        per_tier_summary.append(
+            {
+                "planner_id": planner_id,
+                "speed_tier_id": tier_id,
+                "metric": metric,
+                "n_scenarios": n_scenarios,
+                "pooled_delta_mean": pooled_mean,
+                "pooled_delta_se": se_pooled,
+                "ci_low": pooled_mean - half,
+                "ci_high": pooled_mean + half,
+            }
+        )
+    return per_tier_summary
+
+
+def _build_decision_table(
+    per_tier_summary: Sequence[Mapping[str, Any]],
+) -> tuple[list[dict[str, Any]], list[tuple[str, float]]]:
+    """Classify each pooled delta and collect the Holm p-value family.
+
+    Returns:
+        A tuple ``(decision_table, p_values)`` where ``decision_table`` carries
+        the per-test classification and raw/holm p-values, and ``p_values`` is
+        the ``(test_id, p_value)`` family fed to the Holm correction.
+    """
+    p_values: list[tuple[str, float]] = []
+    decision_table: list[dict[str, Any]] = []
+    for entry in per_tier_summary:
+        test_id = f"{entry['planner_id']}__{entry['speed_tier_id']}__{entry['metric']}"
+        n = entry["n_scenarios"]
+        ci_low, ci_high = entry["ci_low"], entry["ci_high"]
+        classification = _classify_interval(entry["metric"], ci_low, ci_high, n)
+        p_value = _approx_p_value(entry["metric"], ci_low, ci_high, n)
+        p_values.append((test_id, p_value))
+        decision_table.append(
+            {
+                "test_id": test_id,
+                "planner_id": entry["planner_id"],
+                "speed_tier_id": entry["speed_tier_id"],
+                "metric": entry["metric"],
+                "n_scenarios": n,
+                "pooled_delta_mean": entry["pooled_delta_mean"],
+                "ci_low": ci_low,
+                "ci_high": ci_high,
+                "classification": classification,
+                "p_value_raw": p_value,
+            }
+        )
+    return decision_table, p_values
+
+
+def _approx_p_value(metric: str, ci_low: float, ci_high: float, n: int) -> float:
+    """Two-sided normal p-value for a pooled delta from its confidence interval.
+
+    Uses the interval half-width and the scenario count as the effective sample
+    size. When n < 2 the test is undefined and returns 1.0 (never evidence).
+
+    Returns:
+        The two-sided normal p-value in ``[0.0, 1.0]``.
+    """
+    if n < 2:
+        return 1.0
+    half = (ci_high - ci_low) / 2.0
+    if half <= 0.0:
+        return 1.0
+    se = half / _z_critical(CONFIDENCE_LEVEL)
+    z_stat = (ci_high + ci_low) / (2.0 * se)
+    tail = 0.5 * (1.0 - math.erf(abs(z_stat) / math.sqrt(2.0)))
+    return min(1.0, 2.0 * tail)
+
+
+def _build_cli_rows() -> list[dict[str, object]]:
+    """Build a fail-closed demo grid so the CLI runs without a campaign.
+
+    Returns:
+        A minimal per-cell summary grid (one planner, one scenario, one seed,
+        all native) for smoke-testing the synthesis path end to end.
+    """
+    demo: list[dict[str, object]] = []
+    for tier_id, cap in (("cap_2_0_nominal", 2.0), ("cap_3_0", 3.0), ("cap_4_2", 4.2)):
+        demo.append(
+            {
+                "scenario_id": "classic_doorway_medium",
+                "speed_tier_id": tier_id,
+                "speed_cap_m_s": cap,
+                "planner_id": "orca",
+                "seed": 111,
+                "horizon_steps": 600,
+                "dt_seconds": 0.1,
+                "execution_mode": "native",
+                "success_rate": 0.8,
+                "collision_rate": 0.1,
+                "near_miss_rate": 0.2,
+                "ped_collision_rate": 0.0,
+                "obstacle_collision_rate": 0.0,
+                "agent_collision_rate": 0.0,
+                "unclassified_collision_rate": 0.0,
+            }
+        )
+    return demo
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI smoke entry point: synthesize the demo grid and print the report.
+
+    Returns:
+        Process exit code (0 on success).
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the full synthesis result as indented JSON.",
+    )
+    args = parser.parse_args(argv)
+    result = synthesize_speed_tier_sweep(_build_cli_rows())
+    report = {
+        "claim_boundary": result.claim_boundary,
+        "per_cell_count": result.per_cell_count,
+        "native_cell_count": result.native_cell_count,
+        "all_native": result.all_native,
+        "decision_table": result.decision_table,
+        "excluded_cell_count": result.excluded_cell_count,
+    }
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            f"PASS: issue #5578 synthesis valid "
+            f"({result.native_cell_count} native cells, "
+            f"{result.excluded_cell_count} excluded)"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_issue_5578_speed_tier_synthesis.py
+++ b/tests/benchmark/test_issue_5578_speed_tier_synthesis.py
@@ -9,6 +9,7 @@ failed rows. No campaign is run; synthetic per-cell summaries drive the checks.
 from __future__ import annotations
 
 import math
+import statistics
 
 import pytest
 
@@ -20,7 +21,10 @@ from robot_sf.benchmark.issue_5578_speed_tier_synthesis import (
     PRIMARY_METRICS,
     _classify_interval,
     _holm_adjust,
+    _holm_adjust_by_planner,
+    _z_critical,
     classify_excluded,
+    main,
     parse_cell,
     synthesize_speed_tier_sweep,
 )
@@ -126,6 +130,43 @@ def test_parse_cell_validates_required_keys() -> None:
         parse_cell(bad)
 
 
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("scenario_id", None, "non-empty string"),
+        ("seed", True, "must be an integer"),
+        ("seed", 111.5, "must be an integer"),
+        ("horizon_steps", "600", "must be an integer"),
+        ("dt_seconds", 0.0, "must be positive"),
+        ("speed_cap_m_s", -1.0, "must be positive"),
+        ("success_rate", 1.1, "must be in.*0, 1"),
+    ],
+)
+def test_parse_cell_rejects_coercive_or_out_of_range_values(
+    field: str, value: object, message: str
+) -> None:
+    """Malformed identifiers, integral fields, durations, and rates fail closed."""
+    row = _cell(
+        "classic_doorway_medium",
+        NOMINAL_TIER_ID,
+        2.0,
+        "orca",
+        111,
+        metrics={"success_rate": 0.9},
+    )
+    row[field] = value
+    with pytest.raises(ValueError, match=message):
+        parse_cell(row)
+
+
+def test_parse_cell_requires_typed_collision_breakdown() -> None:
+    """Typed collision rates are mandatory rather than silently omitted."""
+    row = _cell("classic_doorway_medium", NOMINAL_TIER_ID, 2.0, "orca", 111, metrics={})
+    row.pop("ped_collision_rate")
+    with pytest.raises(ValueError, match="typed collision metric"):
+        parse_cell(row)
+
+
 def test_classify_excluded_marks_non_native_rows() -> None:
     """Only native rows pass; fallback/degraded/failed are visible exclusions."""
     native = parse_cell(_cell("s", "t", 2.0, "orca", 1, metrics={}, execution_mode="native"))
@@ -153,6 +194,13 @@ def test_holm_adjust_is_monotone_and_stepwise() -> None:
     assert adjusted["a"] <= adjusted["c"]
 
 
+def test_two_sided_critical_value_matches_declared_confidence() -> None:
+    """The 95% two-sided normal critical value is approximately 1.96."""
+    assert _z_critical(0.95) == pytest.approx(1.96, abs=0.005)
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        _z_critical(1.0)
+
+
 def test_classify_interval_detects_harmful_collision_increase() -> None:
     """A collision-rate CI entirely above the +0.02 harm threshold is harmful."""
     ci_low, ci_high = 0.05, 0.10
@@ -177,6 +225,10 @@ def test_synthesis_full_native_grid_reports_all_cells() -> None:
         nominal_metrics={"success_rate": 0.8, "collision_rate": 0.1, "near_miss_rate": 0.2},
         tier_metrics={"success_rate": 0.8, "collision_rate": 0.1, "near_miss_rate": 0.2},
     )
+    scenario_effects = {scenario: 0.01 * (index + 1) for index, scenario in enumerate(SCENARIOS)}
+    for cell in cells:
+        if cell["speed_tier_id"] != NOMINAL_TIER_ID:
+            cell["success_rate"] = 0.8 + scenario_effects[str(cell["scenario_id"])]
     result = synthesize_speed_tier_sweep(cells)
     assert result.native_cell_count == len(cells)
     assert result.excluded_cell_count == 0
@@ -187,9 +239,25 @@ def test_synthesis_full_native_grid_reports_all_cells() -> None:
     )
     for row in result.decision_table:
         assert row["p_value_holm"] <= 1.0
-        # Identical metrics -> zero pooled delta -> no material shift.
+        assert row["n_scenarios"] == len(SCENARIOS)
         assert row["classification"] == "no_material_shift"
-        assert row["pooled_delta_mean"] == pytest.approx(0.0)
+        assert row["adjusted_confidence_level"] >= CONFIDENCE_LEVEL
+        assert set(row["typed_collision_breakdown"]) == {
+            "ped_collision_rate",
+            "obstacle_collision_rate",
+            "agent_collision_rate",
+            "unclassified_collision_rate",
+        }
+    success_row = next(
+        row
+        for row in result.decision_table
+        if row["planner_id"] == "orca"
+        and row["speed_tier_id"] == "cap_3_0"
+        and row["metric"] == "success_rate"
+    )
+    expected_se = statistics.stdev(scenario_effects.values()) / math.sqrt(len(SCENARIOS))
+    assert success_row["pooled_delta_mean"] == pytest.approx(0.035)
+    assert success_row["pooled_delta_se"] == pytest.approx(expected_se)
 
 
 def test_synthesis_flags_fallback_rows_as_exclusions() -> None:
@@ -252,8 +320,49 @@ def test_synthesis_holm_family_is_six_tests_per_planner() -> None:
     for planner in PLANNERS:
         planner_rows = [r for r in result.decision_table if r["planner_id"] == planner]
         assert len(planner_rows) == 6
+        expected = _holm_adjust([(row["test_id"], row["p_value_raw"]) for row in planner_rows])
+        assert {row["test_id"]: row["p_value_holm"] for row in planner_rows} == expected
     # Harm thresholds and confidence are the frozen preregistration values.
     assert HARM_THRESHOLDS["success_rate"] == -0.05
     assert HARM_THRESHOLDS["collision_rate"] == 0.02
     assert HARM_THRESHOLDS["near_miss_rate"] == 0.05
     assert math.isclose(CONFIDENCE_LEVEL, 0.95)
+
+
+def test_holm_families_are_independent_per_planner() -> None:
+    """Distinct planner inputs receive independent six-test Holm adjustments."""
+    values = [
+        *(("a", f"a{i}", p) for i, p in enumerate((0.01, 0.02, 0.03, 0.04, 0.05, 0.06))),
+        *(("b", f"b{i}", p) for i, p in enumerate((0.001, 0.2, 0.3, 0.4, 0.5, 0.6))),
+    ]
+    adjusted, confidence = _holm_adjust_by_planner(values)
+    assert {key: adjusted[key] for key in adjusted if key.startswith("a")} == _holm_adjust(
+        [(test_id, p_value) for planner, test_id, p_value in values if planner == "a"]
+    )
+    assert {key: adjusted[key] for key in adjusted if key.startswith("b")} == _holm_adjust(
+        [(test_id, p_value) for planner, test_id, p_value in values if planner == "b"]
+    )
+    assert confidence["a0"] == pytest.approx(1.0 - 0.05 / 6.0)
+    assert confidence["b0"] == pytest.approx(1.0 - 0.05 / 6.0)
+
+
+def test_synthesis_rejects_incomplete_duplicate_and_drifted_grids() -> None:
+    """Incomplete, duplicate, and dimension-drifted inputs cannot become evidence."""
+    cells = _full_native_grid(nominal_metrics={}, tier_metrics={})
+    with pytest.raises(ValueError, match="grid incomplete"):
+        synthesize_speed_tier_sweep(cells[:-1])
+    with pytest.raises(ValueError, match="duplicate declared cell identity"):
+        synthesize_speed_tier_sweep([*cells, dict(cells[0])])
+    drifted = [dict(cell) for cell in cells]
+    drifted[0]["speed_cap_m_s"] = 2.1
+    with pytest.raises(ValueError, match="speed cap drift"):
+        synthesize_speed_tier_sweep(drifted)
+
+
+def test_cli_demo_is_explicit_smoke_not_benchmark_evidence(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The built-in partial demo never prints a benchmark-success PASS label."""
+    assert main([]) == 0
+    output = capsys.readouterr().out
+    assert output.startswith("SMOKE (not benchmark evidence):")

--- a/tests/benchmark/test_issue_5578_speed_tier_synthesis.py
+++ b/tests/benchmark/test_issue_5578_speed_tier_synthesis.py
@@ -1,0 +1,259 @@
+"""Tests for the issue #5578 robot speed-tier evidence synthesis.
+
+These tests prove the frozen #5557 decision rule is implemented correctly and
+fails closed: paired-delta estimand, Holm-Bonferroni correction, harm-threshold
+classification, and visible exclusion of non-native / fallback / degraded /
+failed rows. No campaign is run; synthetic per-cell summaries drive the checks.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from robot_sf.benchmark.issue_5578_speed_tier_synthesis import (
+    CONFIDENCE_LEVEL,
+    HARM_THRESHOLDS,
+    NOMINAL_TIER_ID,
+    NON_NOMINAL_TIERS,
+    PRIMARY_METRICS,
+    _classify_interval,
+    _holm_adjust,
+    classify_excluded,
+    parse_cell,
+    synthesize_speed_tier_sweep,
+)
+
+SCENARIOS = (
+    "classic_head_on_corridor_medium",
+    "classic_doorway_medium",
+    "classic_group_crossing_medium",
+    "classic_merging_medium",
+    "classic_overtaking_medium",
+    "classic_station_platform_medium",
+)
+PLANNERS = (
+    "scenario_adaptive_hybrid_orca_v2_collision_guard",
+    "ppo",
+    "orca",
+    "prediction_planner",
+)
+SEEDS = list(range(111, 141))
+
+
+def _cell(
+    scenario_id: str,
+    tier_id: str,
+    cap: float,
+    planner_id: str,
+    seed: int,
+    *,
+    metrics: dict[str, float],
+    execution_mode: str = "native",
+) -> dict[str, object]:
+    return {
+        "scenario_id": scenario_id,
+        "speed_tier_id": tier_id,
+        "speed_cap_m_s": cap,
+        "planner_id": planner_id,
+        "seed": seed,
+        "horizon_steps": 600,
+        "dt_seconds": 0.1,
+        "execution_mode": execution_mode,
+        "success_rate": metrics.get("success_rate", 0.0),
+        "collision_rate": metrics.get("collision_rate", 0.0),
+        "near_miss_rate": metrics.get("near_miss_rate", 0.0),
+        "ped_collision_rate": 0.0,
+        "obstacle_collision_rate": 0.0,
+        "agent_collision_rate": 0.0,
+        "unclassified_collision_rate": 0.0,
+    }
+
+
+def _full_native_grid(
+    *,
+    nominal_metrics: dict[str, float],
+    tier_metrics: dict[str, float],
+    tier_id: str = "cap_3_0",
+    cap: float = 3.0,
+) -> list[dict[str, object]]:
+    cells: list[dict[str, object]] = []
+    for planner in PLANNERS:
+        for scenario in SCENARIOS:
+            for seed in SEEDS:
+                cells.append(
+                    _cell(
+                        scenario,
+                        NOMINAL_TIER_ID,
+                        2.0,
+                        planner,
+                        seed,
+                        metrics=nominal_metrics,
+                    )
+                )
+                for t_id, t_cap in (("cap_3_0", 3.0), ("cap_4_2", 4.2)):
+                    cells.append(
+                        _cell(
+                            scenario,
+                            t_id,
+                            t_cap,
+                            planner,
+                            seed,
+                            metrics=tier_metrics,
+                        )
+                    )
+    return cells
+
+
+def test_parse_cell_validates_required_keys() -> None:
+    """A well-formed cell parses; a missing key fails closed."""
+    cell = parse_cell(
+        _cell(
+            "classic_doorway_medium",
+            NOMINAL_TIER_ID,
+            2.0,
+            "orca",
+            111,
+            metrics={"success_rate": 0.9},
+        )
+    )
+    assert cell.planner_id == "orca"
+    assert cell.speed_cap_m_s == pytest.approx(2.0)
+    bad = dict(_cell("classic_doorway_medium", NOMINAL_TIER_ID, 2.0, "orca", 111, metrics={}))
+    bad.pop("scenario_id")
+    with pytest.raises(ValueError, match="scenario_id"):
+        parse_cell(bad)
+
+
+def test_classify_excluded_marks_non_native_rows() -> None:
+    """Only native rows pass; fallback/degraded/failed are visible exclusions."""
+    native = parse_cell(_cell("s", "t", 2.0, "orca", 1, metrics={}, execution_mode="native"))
+    assert classify_excluded(native) is None
+    for mode in ("fallback", "degraded", "failed"):
+        cell = parse_cell(_cell("s", "t", 2.0, "orca", 1, metrics={}, execution_mode=mode))
+        assert classify_excluded(cell) is not None
+        assert (
+            "fallback" in classify_excluded(cell)
+            or "degraded" in classify_excluded(cell)
+            or "failed" in classify_excluded(cell)
+        )
+
+
+def test_holm_adjust_is_monotone_and_stepwise() -> None:
+    """Holm adjustment must be monotone non-decreasing in the sorted order."""
+    p_values = [("a", 0.01), ("b", 0.02), ("c", 0.04)]
+    adjusted = _holm_adjust(p_values)
+    vals = [adjusted[k] for k, _ in p_values]
+    assert vals == sorted(vals)
+    assert all(0.0 <= v <= 1.0 for v in vals)
+    # Smallest raw p gets the largest multiplier (m - rank + 1 = 3), but the
+    # stepwise max keeps larger adjusted values non-decreasing; the first raw p
+    # yields 0.01*3=0.03 which is <= 0.04*1=0.04 for the largest raw p.
+    assert adjusted["a"] <= adjusted["c"]
+
+
+def test_classify_interval_detects_harmful_collision_increase() -> None:
+    """A collision-rate CI entirely above the +0.02 harm threshold is harmful."""
+    ci_low, ci_high = 0.05, 0.10
+    assert _classify_interval("collision_rate", ci_low, ci_high, n_pairs=6) == "materially_harmful"
+    # A CI entirely below the threshold is a no-material-shift.
+    assert _classify_interval("collision_rate", 0.0, 0.01, n_pairs=6) == "no_material_shift"
+    # Overlapping the threshold is inconclusive.
+    assert _classify_interval("collision_rate", -0.01, 0.05, n_pairs=6) == "inconclusive"
+    # Too few pairs is inconclusive (never evidence).
+    assert _classify_interval("collision_rate", 0.05, 0.10, n_pairs=1) == "inconclusive"
+
+
+def test_classify_interval_detects_harmful_success_decrease() -> None:
+    """A success-rate CI entirely below the -0.05 harm threshold is harmful."""
+    assert _classify_interval("success_rate", -0.20, -0.08, n_pairs=6) == "materially_harmful"
+    assert _classify_interval("success_rate", 0.0, 0.10, n_pairs=6) == "no_material_shift"
+
+
+def test_synthesis_full_native_grid_reports_all_cells() -> None:
+    """A complete native grid synthesizes paired deltas and a decision table."""
+    cells = _full_native_grid(
+        nominal_metrics={"success_rate": 0.8, "collision_rate": 0.1, "near_miss_rate": 0.2},
+        tier_metrics={"success_rate": 0.8, "collision_rate": 0.1, "near_miss_rate": 0.2},
+    )
+    result = synthesize_speed_tier_sweep(cells)
+    assert result.native_cell_count == len(cells)
+    assert result.excluded_cell_count == 0
+    assert result.all_native is True
+    # 4 planners x 2 non-nominal tiers x 3 metrics = 24 decision rows.
+    assert len(result.decision_table) == len(PLANNERS) * len(NON_NOMINAL_TIERS) * len(
+        PRIMARY_METRICS
+    )
+    for row in result.decision_table:
+        assert row["p_value_holm"] <= 1.0
+        # Identical metrics -> zero pooled delta -> no material shift.
+        assert row["classification"] == "no_material_shift"
+        assert row["pooled_delta_mean"] == pytest.approx(0.0)
+
+
+def test_synthesis_flags_fallback_rows_as_exclusions() -> None:
+    """Fallback/degraded rows must appear in the exclusion table and shrink native."""
+    cells = _full_native_grid(
+        nominal_metrics={"success_rate": 0.8},
+        tier_metrics={"success_rate": 0.8},
+    )
+    # Corrupt one planner's tier cells with fallback execution.
+    for c in cells:
+        if c["planner_id"] == "orca" and c["speed_tier_id"] != NOMINAL_TIER_ID:
+            c["execution_mode"] = "fallback"
+    result = synthesize_speed_tier_sweep(cells)
+    assert result.all_native is False
+    assert result.excluded_cell_count == len(SCENARIOS) * len(SEEDS) * len(NON_NOMINAL_TIERS)
+    reasons = {e["exclusion_reason"] for e in result.exclusions}
+    assert {"non_native_execution:fallback"} <= reasons
+    # The orca decision rows must be absent when its tier rows are excluded.
+    orca_tier_rows = [
+        r
+        for r in result.decision_table
+        if r["planner_id"] == "orca" and r["speed_tier_id"] == "cap_3_0"
+    ]
+    assert orca_tier_rows == []
+
+
+def test_synthesis_paired_delta_is_tier_minus_nominal() -> None:
+    """The pooled delta must equal tier minus nominal mean across scenarios."""
+    cells = _full_native_grid(
+        nominal_metrics={"collision_rate": 0.10},
+        tier_metrics={"collision_rate": 0.18},
+    )
+    result = synthesize_speed_tier_sweep(cells)
+    row = next(
+        r
+        for r in result.decision_table
+        if r["planner_id"] == "orca"
+        and r["speed_tier_id"] == "cap_3_0"
+        and r["metric"] == "collision_rate"
+    )
+    assert row["pooled_delta_mean"] == pytest.approx(0.08)
+    assert row["classification"] == "materially_harmful"
+
+
+def test_synthesis_fails_closed_on_missing_metric() -> None:
+    """A cell missing a primary metric fails closed rather than guessing."""
+    bad = _cell("classic_doorway_medium", NOMINAL_TIER_ID, 2.0, "orca", 111, metrics={})
+    bad.pop("success_rate")
+    with pytest.raises(ValueError, match="success_rate"):
+        synthesize_speed_tier_sweep([bad])
+
+
+def test_synthesis_holm_family_is_six_tests_per_planner() -> None:
+    """The multiplicity family must be six tests per planner (2 tiers x 3 metrics)."""
+    cells = _full_native_grid(
+        nominal_metrics={"success_rate": 0.8, "collision_rate": 0.1, "near_miss_rate": 0.2},
+        tier_metrics={"success_rate": 0.8, "collision_rate": 0.1, "near_miss_rate": 0.2},
+    )
+    result = synthesize_speed_tier_sweep(cells)
+    for planner in PLANNERS:
+        planner_rows = [r for r in result.decision_table if r["planner_id"] == planner]
+        assert len(planner_rows) == 6
+    # Harm thresholds and confidence are the frozen preregistration values.
+    assert HARM_THRESHOLDS["success_rate"] == -0.05
+    assert HARM_THRESHOLDS["collision_rate"] == 0.02
+    assert HARM_THRESHOLDS["near_miss_rate"] == 0.05
+    assert math.isclose(CONFIDENCE_LEVEL, 0.95)

--- a/tests/benchmark/test_issue_5578_speed_tier_synthesis.py
+++ b/tests/benchmark/test_issue_5578_speed_tier_synthesis.py
@@ -19,6 +19,7 @@ from robot_sf.benchmark.issue_5578_speed_tier_synthesis import (
     NOMINAL_TIER_ID,
     NON_NOMINAL_TIERS,
     PRIMARY_METRICS,
+    _build_decision_table,
     _classify_interval,
     _holm_adjust,
     _holm_adjust_by_planner,
@@ -346,6 +347,40 @@ def test_holm_families_are_independent_per_planner() -> None:
     assert confidence["b0"] == pytest.approx(1.0 - 0.05 / 6.0)
 
 
+def test_holm_step_down_blocks_decisive_later_classifications() -> None:
+    """A failed ordered comparison makes every later family row inconclusive."""
+    raw_p_values = (0.001, 0.011, 0.012, 0.5, 0.6, 0.7)
+    bootstrap_distributions = (
+        [0.1] * 100,
+        [-0.01] * 50 + [0.05] * 50,
+        *([0.1] * 100 for _ in range(4)),
+    )
+    summaries = [
+        {
+            "test_id": f"orca__test_{index}",
+            "planner_id": "orca",
+            "speed_tier_id": "cap_3_0",
+            "metric": "collision_rate",
+            "n_scenarios": len(SCENARIOS),
+            "pooled_delta_mean": 0.1,
+            "pooled_delta_se": 0.01,
+            "ci_low_unadjusted": 0.08,
+            "ci_high_unadjusted": 0.12,
+            "p_value_raw": p_value,
+            "typed_collision_breakdown": {},
+            "_bootstrap_distribution": bootstrap_distributions[index],
+        }
+        for index, p_value in enumerate(raw_p_values)
+    ]
+    decision_table, _ = _build_decision_table(summaries)
+    assert decision_table[0]["holm_step_down_eligible"] is True
+    assert decision_table[0]["classification"] == "materially_harmful"
+    assert decision_table[1]["holm_step_down_eligible"] is True
+    assert decision_table[1]["classification"] == "inconclusive"
+    assert all(row["holm_step_down_eligible"] is False for row in decision_table[2:])
+    assert all(row["classification"] == "inconclusive" for row in decision_table[2:])
+
+
 def test_synthesis_rejects_incomplete_duplicate_and_drifted_grids() -> None:
     """Incomplete, duplicate, and dimension-drifted inputs cannot become evidence."""
     cells = _full_native_grid(nominal_metrics={}, tier_metrics={})
@@ -357,6 +392,29 @@ def test_synthesis_rejects_incomplete_duplicate_and_drifted_grids() -> None:
     drifted[0]["speed_cap_m_s"] = 2.1
     with pytest.raises(ValueError, match="speed cap drift"):
         synthesize_speed_tier_sweep(drifted)
+
+
+def test_custom_declared_dimensions_remain_smoke_not_benchmark_evidence() -> None:
+    """A complete caller-defined mini-grid cannot impersonate the frozen suite."""
+    cells = [
+        _cell(
+            "classic_doorway_medium",
+            tier_id,
+            cap,
+            "orca",
+            111,
+            metrics={"success_rate": 0.8, "collision_rate": 0.1, "near_miss_rate": 0.2},
+        )
+        for tier_id, cap in ((NOMINAL_TIER_ID, 2.0), ("cap_3_0", 3.0), ("cap_4_2", 4.2))
+    ]
+    result = synthesize_speed_tier_sweep(
+        cells,
+        declared_scenarios={"classic_doorway_medium"},
+        declared_planners={"orca"},
+        declared_seeds={111},
+    )
+    assert result.grid_complete is True
+    assert result.evidence_status == "smoke_or_incomplete_not_benchmark_evidence"
 
 
 def test_cli_demo_is_explicit_smoke_not_benchmark_evidence(


### PR DESCRIPTION
## Summary

Issue #5578's preregistration (PR #5583) froze the robot speed-tier sweep protocol but left native campaign execution and evidence synthesis outstanding. This partial successor slice adds the deterministic, CPU-only synthesis engine; it does not run the campaign or make a speed-effect claim.

## Linked Issues

- Refs #5578 — partial slice; native campaign execution and durable evidence remain open.

## Stack / Dependency

- Base dependency: PR #5583 (merged preregistration)
- Required prior PRs: #5583
- Stack follow-up issues: #5578
- Safe to review independently: yes
- Review dependency reason: the implementation is checked against the frozen preregistration landed by #5583.

## What Changed

- Added `robot_sf/benchmark/issue_5578_speed_tier_synthesis.py`.
- Enforced the exact scenario/planner/tier/seed grid, cap/horizon/time-step values, strict identifier and rate types, native/fallback exclusions, and typed-collision output.
- Implemented paired seed contrasts within scenario, deterministic scenario-first/seed-second hierarchical resampling, and six-test Holm-Bonferroni families per planner whose adjusted intervals drive classification.
- Added adversarial contract tests for malformed, incomplete, duplicate, drifted, fallback, and pseudoreplicated inputs.
- Kept the built-in CLI explicitly labelled `SMOKE (not benchmark evidence)`.

## Why It Matters

- Added value: turns future native per-cell summaries into a reproducible, fail-closed decision table.
- Expected impact: prevents malformed, incomplete, fallback, degraded, or statistically pseudoreplicated rows from becoming speed-effect evidence.
- Why this is worth merging now: the native campaign needs a reviewed consumer for its outputs before execution.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: whether raising the robot speed cap above 2.0 m/s materially harms success, collision, or near-miss rates.
- Comparator or baseline: each non-nominal tier minus the paired 2.0 m/s tier for the same planner/scenario/seed.
- Evidence tier: implementation-integrity smoke; no campaign evidence.
- Result classification: blocker-resolution for the synthesis path only.
- Decision or stop rule: frozen harm thresholds and per-planner Holm-adjusted intervals in `configs/benchmarks/issue_5578_robot_speed_tier_preregistration.yaml`.
- Parent/synthesis surface to update: #5578 and `docs/context/evidence/issue_5578_robot_speed_tier_sweep` after native rows exist.
- New analysis tool representative use: synthetic declared-grid tests and the explicit smoke CLI; the real native campaign remains in #5578.

## Domain-Aware Approval

- Required for this PR: yes — it implements evidence classification and benchmark interpretation logic.
- Domains reviewed: evidence classification, benchmark interpretation, and paper-facing claim boundary.
- Status: approved for implementation integrity only; no experimental-validity or result claim approved.
- Approver/review source: batch gate review at the repaired head, checked against #5578, PR #5583, and the frozen preregistration.
- Validity checklist:
  - Target claim/hypothesis: speed-tier harm relative to 2.0 m/s.
  - Comparator or split/evidence validity: paired seeds within each declared scenario; six declared scenarios; independent six-test Holm family per planner.
  - Fallback/degraded exclusions: visible and never benchmark-success evidence.
  - Claim boundary: synthesis implementation only; complete native grid remains provenance-unverified.
  - Implementation integrity vs experimental validity: tests establish implementation integrity; only the future native campaign can establish experimental validity.

## Falsification / Non-Transfer Check

- Did the mechanism activate? NA — no campaign ran.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario contain the targeted failure mode? NA.
- Result route: continue to the pre-registered native campaign under #5578.
- Follow-up question: whether complete native rows cross the frozen harm thresholds.

## Next Empirical Action

- Rerun needed: no for this code slice; yes for the outstanding native campaign.
- Extractor or analysis tool needed: no; this PR supplies the synthesizer.
- Artifact missing or unavailable: all native 2,160-cell summaries and provenance bundle.
- Stop / revise / continue decision: continue via #5578 after this implementation is accepted.
- Proposed child issue or existing follow-up: #5578.

## Validation / Proof

- `uv run pytest tests/benchmark/test_issue_5578_speed_tier_synthesis.py -q`
- `uv run ruff check robot_sf/benchmark/issue_5578_speed_tier_synthesis.py tests/benchmark/test_issue_5578_speed_tier_synthesis.py`
- `uv run ruff format --check robot_sf/benchmark/issue_5578_speed_tier_synthesis.py tests/benchmark/test_issue_5578_speed_tier_synthesis.py`
- `uv run python -m robot_sf.benchmark.issue_5578_speed_tier_synthesis`
- `uv run python scripts/validation/check_issue_5578_robot_speed_tier_preregistration.py --json`
- `uv run pytest -q tests/validation/test_check_issue_5578_robot_speed_tier_preregistration.py`
- Evidence: focused synthesis and preregistration tests pass; CLI reports smoke/non-evidence explicitly.

## Risks / Rollout

- Compatibility risks: this is a new module with no existing callers.
- Failure modes: malformed or incomplete inputs raise; non-native inputs are excluded and cannot produce a complete statistical contract.
- Rollback or fallback plan: revert this isolated module/test addition; fallback/degraded execution is not an accepted evidence path.

## Docs / Provenance

- Updated docs: PR contract only; frozen protocol remains in `configs/benchmarks/issue_5578_robot_speed_tier_preregistration.yaml`.
- Relevant provenance: #5578, #5557, and PR #5583.
- Assumption: future campaign rows use the exact frozen 2,160-cell identity and native execution/provenance contract.

## Downstream Propagation

- Parent issue updated: pending dispatcher merge; #5578 remains open.
- Claim map / benchmark report updated: NA — no result.
- Leaderboard / artifact catalog updated: NA — no result.
- Registry or config index updated: NA — isolated synthesis helper.
- Context index / memory note updated: NA — no result.
- Follow-up issue opened for deferred propagation: no; #5578 already owns campaign execution and evidence promotion.
- Not applicable because: this PR produces implementation-integrity proof, not benchmark evidence.

## Follow-Up Issues

- Deferred work: native 2,160-cell campaign execution and durable evidence promotion.
- Issues opened for follow-up: none; #5578 remains the active owner.

## Reviewer Notes

- Verify statistical hierarchy, per-planner Holm families, exact-grid rejection, and smoke/non-evidence wording closely.
- Known limitation: the tool does not accept or verify the external provenance bundle; a complete native grid is labelled provenance-unverified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fail-closed evidence synthesis for robot speed-tier benchmark results, including strict validation and non-native execution exclusions.
  * Computes paired deltas (nominal vs non-nominal), pooled tier summaries with confidence intervals, and harm-based classifications.
  * Produces a decision table with Holm–Bonferroni–adjusted p-values.
  * Includes a CLI demo that outputs either a short report or JSON.

* **Tests**
  * Added regression coverage for validation rules, exclusion logic, statistical calculations, multiple-testing behavior, grid completeness, and CLI smoke output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->