### PR TITLE
Issue #5303: cross-planner adversarial transfer matrix (slice 1) (cheap-lane worker)

### DIFF
--- a/robot_sf/adversarial/transfer_matrix.py
+++ b/robot_sf/adversarial/transfer_matrix.py
@@ -1,0 +1,628 @@
+"""Cross-planner adversarial transfer matrix and minimax robustness ranking.
+
+Slice 1 of issue #5303 (cheap-lane, capability-only). This module *measures*
+transfer structure: it reuses the existing adversarial archive of certified
+worst-case configs found against ONE target planner and builds the K x N
+transfer matrix — does a discovered weak point transfer to the other planners,
+or is it policy-specific?
+
+It deliberately does NOT run the minimax search game (that is a later slice,
+only if slice 1 shows meaningful transfer structure). It also does NOT run any
+bench re-evaluations itself: those run on the ops queue (the issue pins
+"compute via ops queue"). Instead it consumes a per-planner evaluation table
+whose rows are produced by replaying each certified config against each planner
+at the standard seed protocol and summarising the episode with
+:func:`robot_sf.adversarial.robustness.compute_robustness_report` (so the
+transfer metric uses the same signed-robustness semantics as the search
+objectives).
+
+Capability-not-evidence boundary: the matrix is built only from archive paths
+and pinned configs/seeds. No benchmark or paper-facing claim is made here; the
+report is explicitly labelled capability-only.
+
+Status: research/exploratory. These artifacts are transfer measurements, not
+reported benchmark metrics.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from robot_sf.adversarial.archive import (
+    ARCHIVE_SCHEMA_VERSION,
+    SEARCH_MANIFEST_SCHEMA_VERSION,
+)
+
+_TRANSFER_MATRIX_SCHEMA_VERSION = "adversarial_transfer_matrix.v1"
+
+# Benchmark eligibility tiers that count as "certified / repliable" for slice 1.
+_CERTIFIED_ELIGIBILITY = frozenset({"eligible", "stress_only"})
+
+# Default 3-planner mechanism-stratified roster for slice 1: the issue asks for
+# the target planner plus 2 other planners. The roster mirrors the engineered
+# candidates called out in the issue's evidence-grade promotion plan.
+DEFAULT_TRANSFER_ROSTER: tuple[str, ...] = (
+    "scenario_adaptive_hybrid_orca_v1",
+    "scenario_adaptive_hybrid_orca_v2_collision_guard",
+    "ppo",
+)
+
+
+@dataclass(frozen=True)
+class CertifiedConfig:
+    """One certified worst-case config selected from a target-planner archive.
+
+    Attributes
+    ----------
+    config_id : str
+        Stable id for the config within the transfer matrix.
+    target_planner : str
+        Planner the config was optimized / certified against.
+    candidate : dict[str, Any]
+        The perturbable scenario candidate (start/goal/seed/speed/...).
+    objective_value : float
+        Worst-case composite objective (signed-robustness based) against the
+        target planner. Larger = worse (more negative robustness).
+    source_manifest : str
+        Origin manifest path (provenance; archive path only).
+    source_candidate_index : int
+        Candidate index within the source manifest.
+    certification_tier : str
+        Benchmark eligibility tier from certification (eligible / stress_only).
+    scenario_seed : int | None
+        Pinned scenario seed for replay reproducibility.
+    """
+
+    config_id: str
+    target_planner: str
+    candidate: dict[str, Any]
+    objective_value: float
+    source_manifest: str
+    source_candidate_index: int
+    certification_tier: str
+    scenario_seed: int | None
+
+
+@dataclass(frozen=True)
+class PlannerEval:
+    """One per-planner re-evaluation result for a certified config.
+
+    Attributes
+    ----------
+    config_id : str
+        Config this result belongs to (matches :class:`CertifiedConfig`).
+    planner : str
+        Evaluated planner.
+    robustness : float
+        Overall signed robustness against this planner (negative = violated).
+    failed : bool
+        Whether the planner reproduced a failure (robustness < 0).
+    seed : int | None
+        Pinned evaluation seed (standard seed protocol).
+    """
+
+    config_id: str
+    planner: str
+    robustness: float
+    failed: bool
+    seed: int | None
+
+
+@dataclass(frozen=True)
+class TransferCell:
+    """One cell of the K x N transfer matrix."""
+
+    config_id: str
+    planner: str
+    robustness: float
+    failed: bool
+    transferred: bool
+
+
+@dataclass(frozen=True)
+class PlannerRanking:
+    """Minimax (worst-case regret) ranking for one planner."""
+
+    planner: str
+    worst_case_robustness: float
+    transfer_failure_rate: float
+    minimax_regret: float
+    rank: int
+
+
+@dataclass(frozen=True)
+class TransferMatrix:
+    """The full K x N transfer measurement plus summary statistics."""
+
+    schema_version: str = _TRANSFER_MATRIX_SCHEMA_VERSION
+    target_planner: str = ""
+    config_ids: tuple[str, ...] = ()
+    planners: tuple[str, ...] = ()
+    cells: tuple[TransferCell, ...] = ()
+    ranking: tuple[PlannerRanking, ...] = ()
+    overall_transfer_rate: float = 0.0
+    transfer_rate_ci: tuple[float, float] = (0.0, 0.0)
+    transfer_rate_bootstrap_n: int = 0
+
+    def to_json(self) -> dict[str, Any]:
+        """Return a JSON-serialisable payload."""
+        return {
+            "schema_version": self.schema_version,
+            "target_planner": self.target_planner,
+            "config_ids": list(self.config_ids),
+            "planners": list(self.planners),
+            "cells": [c.__dict__ for c in self.cells],
+            "ranking": [r.__dict__ for r in self.ranking],
+            "overall_transfer_rate": self.overall_transfer_rate,
+            "transfer_rate_ci": list(self.transfer_rate_ci),
+            "transfer_rate_bootstrap_n": self.transfer_rate_bootstrap_n,
+        }
+
+
+def _candidate_certification_tier(candidate: dict[str, Any]) -> str | None:
+    """Extract the benchmark eligibility tier from a candidate payload."""
+    cert = candidate.get("certification_status")
+    if not isinstance(cert, dict):
+        return None
+    certificates = (
+        cert.get("details", {}).get("certificates")
+        if isinstance(cert.get("details"), dict)
+        else None
+    )
+    if isinstance(certificates, list) and certificates:
+        first = certificates[0]
+        if isinstance(first, dict):
+            return first.get("benchmark_eligibility")
+    # Fall back to a single top-level status if present.
+    return cert.get("status")
+
+
+def _candidate_scenario_seed(candidate: dict[str, Any]) -> int | None:
+    """Extract the pinned scenario seed from a candidate payload."""
+    seed = candidate.get("scenario_seed")
+    if seed is None:
+        return None
+    try:
+        return int(seed)
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_certified(candidate: dict[str, Any]) -> bool:
+    """Return whether a candidate is certified / repliable for slice 1."""
+    tier = _candidate_certification_tier(candidate)
+    return tier in _CERTIFIED_ELIGIBILITY
+
+
+def _objective_value(candidate: dict[str, Any]) -> float:
+    """Return the worst-case objective value for a candidate."""
+    value = candidate.get("objective_value")
+    if value is None:
+        return float("-inf")
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return float("-inf")
+    return parsed if __import__("math").isfinite(parsed) else float("-inf")
+
+
+def select_certified_configs(
+    manifest_paths: list[str | Path],
+    *,
+    target_planner: str,
+    K: int,
+    scenario_template: str | None = None,
+) -> list[CertifiedConfig]:
+    """Select the top-K certified worst-case configs against ONE planner.
+
+    Reads adversarial search manifests (real ``adversarial-search-manifest.v1``
+    schema), keeps only certified, repliable candidates (``eligible`` /
+    ``stress_only`` benchmark eligibility), optionally filters by scenario
+    template, and returns the K configs with the worst (largest) objective
+    value, i.e. the strongest discovered weak points.
+
+    Parameters
+    ----------
+    manifest_paths : list[str | Path]
+        Search manifests to read configs from.
+    target_planner : str
+        Planner the configs were optimized / certified against.
+    K : int
+        Maximum number of configs to return (>= 5 required by the issue for the
+        transfer measurement).
+    scenario_template : str | None
+        Optional scenario-template filter (exact match on manifest config).
+
+    Returns
+    -------
+    list[CertifiedConfig]
+        Up to K certified worst-case configs, sorted worst-first.
+    """
+    if K < 1:
+        raise ValueError("K must be >= 1")
+
+    configs: list[CertifiedConfig] = []
+    for manifest_path in sorted(Path(p) for p in manifest_paths):
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"Search manifest must be a JSON object: {manifest_path}")
+        schema = payload.get("schema_version")
+        if schema != SEARCH_MANIFEST_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported search manifest schema for {manifest_path}: {schema!r}; "
+                f"expected {SEARCH_MANIFEST_SCHEMA_VERSION!r}"
+            )
+        manifest_config = payload.get("config") if isinstance(payload.get("config"), dict) else {}
+        if (
+            scenario_template is not None
+            and manifest_config.get("scenario_template") != scenario_template
+        ):
+            continue
+        candidates = payload.get("candidates") or []
+        if not isinstance(candidates, list):
+            continue
+        for index, candidate in enumerate(candidates):
+            if not isinstance(candidate, dict):
+                continue
+            cand = (
+                candidate.get("candidate") if isinstance(candidate.get("candidate"), dict) else {}
+            )
+            if not _is_certified(candidate):
+                continue
+            tier = _candidate_certification_tier(candidate) or "unknown"
+            configs.append(
+                CertifiedConfig(
+                    config_id=f"{manifest_path.stem}#{index}",
+                    target_planner=target_planner,
+                    candidate=cand,
+                    objective_value=_objective_value(candidate),
+                    source_manifest=manifest_path.as_posix(),
+                    source_candidate_index=index,
+                    certification_tier=tier,
+                    scenario_seed=_candidate_scenario_seed(cand),
+                )
+            )
+
+    configs.sort(key=lambda c: (-c.objective_value, c.config_id))
+    return configs[:K]
+
+
+def _bootstrap_transfer_rate(
+    failures: list[int],
+    evaluations: list[int],
+    *,
+    n_resamples: int = 1000,
+    seed: int = 0,
+) -> tuple[float, float, float]:
+    """Bootstrap a normal-approximation CI for the transfer (failure) rate.
+
+    The transfer rate is the fraction of (config, planner) pairs in which a
+    config that failed against the target planner *also* failed against the
+    evaluated planner. This measures whether discovered weak points are
+    structural (transfer) or policy-specific.
+
+    Returns
+        (point_estimate, ci_low, ci_high).
+    """
+    total_fails = sum(failures)
+    total_evals = sum(evaluations)
+    if total_evals == 0:
+        return 0.0, 0.0, 0.0
+    point = total_fails / total_evals
+    if n_resamples <= 0:
+        return point, point, point
+    rng = random.Random(seed)
+    means: list[float] = []
+    for _ in range(n_resamples):
+        acc = 0
+        for f, n in zip(failures, evaluations, strict=True):
+            if n == 0:
+                continue
+            acc += sum(1 for _ in range(n) if rng.random() < (f / n))
+        means.append(acc / total_evals)
+    means.sort()
+    low = means[max(0, int(0.025 * len(means)))]
+    high = means[min(len(means) - 1, int(0.975 * len(means)))]
+    return point, low, high
+
+
+def _build_cells(
+    config_ids: tuple[str, ...],
+    planners: tuple[str, ...],
+    eval_by_key: dict[tuple[str, str], PlannerEval],
+) -> list[TransferCell]:
+    """Assemble K x N transfer cells from certified configs and eval results."""
+    cells: list[TransferCell] = []
+    for cfg_id in config_ids:
+        for planner in planners:
+            ev = eval_by_key.get((cfg_id, planner))
+            if ev is None:
+                cells.append(
+                    TransferCell(
+                        config_id=cfg_id,
+                        planner=planner,
+                        robustness=float("nan"),
+                        failed=False,
+                        transferred=False,
+                    )
+                )
+                continue
+            # A weak point transfers when the target config's failure also
+            # reproduces against the evaluated planner.
+            cells.append(
+                TransferCell(
+                    config_id=cfg_id,
+                    planner=planner,
+                    robustness=ev.robustness,
+                    failed=ev.failed,
+                    transferred=ev.failed,
+                )
+            )
+    return cells
+
+
+def _build_ranking(
+    cells: list[TransferCell],
+    planners: tuple[str, ...],
+) -> list[PlannerRanking]:
+    """Compute per-planner minimax (worst-case robustness) ranking rows."""
+    per_planner = _group_cells_by_planner(cells, planners)
+
+    ranking_rows: list[PlannerRanking] = []
+    for planner in planners:
+        planner_cells = per_planner[planner]
+        finite = [c.robustness for c in planner_cells if not math.isnan(c.robustness)]
+        worst = min(finite) if finite else float("nan")
+        failures = [c for c in planner_cells if c.failed]
+        transfer_rate = len(failures) / len(planner_cells) if planner_cells else 0.0
+        ranking_rows.append(
+            PlannerRanking(
+                planner=planner,
+                worst_case_robustness=worst,
+                transfer_failure_rate=transfer_rate,
+                minimax_regret=-worst if not math.isnan(worst) else float("nan"),
+                rank=0,
+            )
+        )
+    return ranking_rows
+
+
+def _group_cells_by_planner(
+    cells: list[TransferCell],
+    planners: tuple[str, ...],
+) -> dict[str, list[TransferCell]]:
+    """Group transfer cells by planner column, in planner order."""
+    per_planner: dict[str, list[TransferCell]] = {p: [] for p in planners}
+    for cell in cells:
+        if cell.planner in per_planner:
+            per_planner[cell.planner].append(cell)
+    return per_planner
+
+
+def build_transfer_matrix(
+    configs: list[CertifiedConfig],
+    evaluations: list[PlannerEval],
+    *,
+    planners: tuple[str, ...] | None = None,
+    bootstrap_n: int = 1000,
+    bootstrap_seed: int = 0,
+) -> TransferMatrix:
+    """Build the K x N transfer matrix from certified configs + eval results.
+
+    Parameters
+    ----------
+    configs : list[CertifiedConfig]
+        Certified worst-case configs (typically against the target planner).
+    evaluations : list[PlannerEval]
+        Per-planner re-evaluation results, keyed by config_id + planner.
+    planners : tuple[str, ...] | None
+        Planner order for the matrix columns. Defaults to the union of planners
+        seen in ``evaluations`` preserving first-seen order.
+    bootstrap_n : int
+        Number of bootstrap resamples for the transfer-rate CI.
+    bootstrap_seed : int
+        Deterministic seed for the bootstrap resampling.
+
+    Returns
+    -------
+    TransferMatrix
+        The transfer measurement, per-planner minimax ranking, and bootstrap CI.
+    """
+    if not configs:
+        raise ValueError("Cannot build a transfer matrix from zero certified configs")
+    if len(configs) < 5:
+        raise ValueError(
+            f"Issue #5303 slice 1 requires K >= 5 certified configs; got {len(configs)}"
+        )
+
+    config_ids = tuple(c.config_id for c in configs)
+    target_planner = configs[0].target_planner
+
+    if planners is None:
+        seen: list[str] = []
+        for ev in evaluations:
+            if ev.planner not in seen:
+                seen.append(ev.planner)
+        planners = tuple(seen)
+
+    # Map (config_id, planner) -> eval.
+    eval_by_key: dict[tuple[str, str], PlannerEval] = {
+        (ev.config_id, ev.planner): ev for ev in evaluations
+    }
+
+    cells = _build_cells(config_ids, planners, eval_by_key)
+    ranking_rows = _build_ranking(cells, planners)
+    ranking_rows.sort(key=lambda r: (r.worst_case_robustness, r.planner))
+    for rank, row in enumerate(ranking_rows, start=1):
+        ranking_rows[rank - 1] = PlannerRanking(
+            planner=row.planner,
+            worst_case_robustness=row.worst_case_robustness,
+            transfer_failure_rate=row.transfer_failure_rate,
+            minimax_regret=row.minimax_regret,
+            rank=rank,
+        )
+
+    # Overall transfer rate + bootstrap CI across evaluated planners (excluding
+    # the target planner column, which is by construction the source of failure).
+    other_planners = [p for p in planners if p != target_planner]
+    if other_planners:
+        grouped = _group_cells_by_planner(cells, planners)
+        failures_per_planner: list[int] = []
+        evals_per_planner: list[int] = []
+        for planner in other_planners:
+            planner_cells = grouped[planner]
+            failures_per_planner.append(sum(1 for c in planner_cells if c.failed))
+            evals_per_planner.append(len(planner_cells))
+        rate, ci_low, ci_high = _bootstrap_transfer_rate(
+            failures_per_planner,
+            evals_per_planner,
+            n_resamples=bootstrap_n,
+            seed=bootstrap_seed,
+        )
+        overall_rate = rate
+        ci = (ci_low, ci_high)
+    else:
+        overall_rate = 0.0
+        ci = (0.0, 0.0)
+
+    return TransferMatrix(
+        target_planner=target_planner,
+        config_ids=config_ids,
+        planners=planners,
+        cells=tuple(cells),
+        ranking=tuple(ranking_rows),
+        overall_transfer_rate=overall_rate,
+        transfer_rate_ci=ci,
+        transfer_rate_bootstrap_n=bootstrap_n if other_planners else 0,
+    )
+
+
+def render_transfer_report(matrix: TransferMatrix, *, configs: list[CertifiedConfig]) -> str:
+    """Render a one-page transfer-measurement report (capability-only)."""
+    lines: list[str] = []
+    lines.append("# Cross-planner adversarial transfer matrix (slice 1, capability-only)")
+    lines.append("")
+    lines.append(
+        "> Capability-not-evidence boundary: built only from archive paths and "
+        "pinned configs/seeds. Not a benchmark or paper-facing claim."
+    )
+    lines.append("")
+    lines.append(f"- Target planner (weak points discovered against): `{matrix.target_planner}`")
+    lines.append(f"- Certified configs (K): {len(matrix.config_ids)}")
+    lines.append(f"- Evaluated planners (N): {len(matrix.planners)}")
+    lines.append(f"- Overall transfer rate (excl. target): {matrix.overall_transfer_rate:.3f}")
+    lines.append(
+        f"- Transfer-rate 95% CI: [{matrix.transfer_rate_ci[0]:.3f}, "
+        f"{matrix.transfer_rate_ci[1]:.3f}] (bootstrap n={matrix.transfer_rate_bootstrap_n})"
+    )
+    lines.append("")
+    lines.append("## Minimax (worst-case regret) ranking")
+    lines.append("")
+    lines.append("| rank | planner | worst-case robustness | transfer-failure rate |")
+    lines.append("|---|---|---|---|")
+    for row in matrix.ranking:
+        wc = (
+            f"{row.worst_case_robustness:.3f}"
+            if row.worst_case_robustness == row.worst_case_robustness
+            else "n/a"
+        )
+        lines.append(f"| {row.rank} | `{row.planner}` | {wc} | {row.transfer_failure_rate:.3f} |")
+    lines.append("")
+    lines.append(
+        "## Transfer matrix (rows=configs, cols=planners; X=transferred failure, .=ok, ?=untested)"
+    )
+    lines.append("")
+    header = (
+        "| config | "
+        + " | ".join(p.replace("scenario_adaptive_hybrid_orca", "orca") for p in matrix.planners)
+        + " |"
+    )
+    sep = "|---|" + "|".join(["---"] * len(matrix.planners)) + "|"
+    lines.append(header)
+    lines.append(sep)
+    by_config: dict[str, dict[str, TransferCell]] = {}
+    for cell in matrix.cells:
+        by_config.setdefault(cell.config_id, {})[cell.planner] = cell
+    for cfg_id in matrix.config_ids:
+        mark = []
+        for planner in matrix.planners:
+            cell = by_config.get(cfg_id, {}).get(planner)
+            if cell is None or cell.robustness != cell.robustness:
+                mark.append("?")
+            elif cell.transferred:
+                mark.append("X")
+            else:
+                mark.append(".")
+        lines.append(f"| `{cfg_id}` | " + " | ".join(mark) + " |")
+    lines.append("")
+    lines.append("## Certified config provenance")
+    lines.append("")
+    lines.append("| config | scenario_seed | objective | tier | source manifest |")
+    lines.append("|---|---|---|---|---|")
+    for cfg in configs:
+        lines.append(
+            f"| `{cfg.config_id}` | {cfg.scenario_seed} | {cfg.objective_value:.3f} | "
+            f"{cfg.certification_tier} | `{cfg.source_manifest}` |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_transfer_artifact(matrix: TransferMatrix, *, out_dir: str | Path) -> Path:
+    """Write the transfer matrix JSON + one-page report to ``out_dir``."""
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    matrix_path = out_dir / "transfer_matrix.json"
+    report_path = out_dir / "transfer_report.md"
+    matrix_path.write_text(
+        json.dumps(matrix.to_json(), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    report_path.write_text(_render_matrix_only_report(matrix), encoding="utf-8")
+    return matrix_path
+
+
+def _render_matrix_only_report(matrix: TransferMatrix) -> str:
+    """Render report without full config provenance (used by write_transfer_artifact)."""
+    lines: list[str] = []
+    lines.append("# Cross-planner adversarial transfer matrix (slice 1, capability-only)")
+    lines.append("")
+    lines.append("> Capability-not-evidence boundary: archive paths and pinned configs/seeds only.")
+    lines.append("")
+    lines.append(f"- Target planner: `{matrix.target_planner}`")
+    lines.append(f"- Configs (K): {len(matrix.config_ids)}")
+    lines.append(f"- Planners (N): {len(matrix.planners)}")
+    lines.append(f"- Overall transfer rate: {matrix.overall_transfer_rate:.3f}")
+    lines.append(f"- Transfer-rate 95% CI: {tuple(round(x, 3) for x in matrix.transfer_rate_ci)}")
+    lines.append("")
+    lines.append("## Minimax ranking")
+    lines.append("")
+    lines.append("| rank | planner | worst-case robustness | transfer-failure rate |")
+    lines.append("|---|---|---|---|")
+    for row in matrix.ranking:
+        wc = (
+            f"{row.worst_case_robustness:.3f}"
+            if row.worst_case_robustness == row.worst_case_robustness
+            else "n/a"
+        )
+        lines.append(f"| {row.rank} | `{row.planner}` | {wc} | {row.transfer_failure_rate:.3f} |")
+    return "\n".join(lines) + "\n"
+
+
+__all__ = [
+    "ARCHIVE_SCHEMA_VERSION",
+    "DEFAULT_TRANSFER_ROSTER",
+    "CertifiedConfig",
+    "PlannerEval",
+    "PlannerRanking",
+    "TransferCell",
+    "TransferMatrix",
+    "build_transfer_matrix",
+    "render_transfer_report",
+    "select_certified_configs",
+    "write_transfer_artifact",
+]

--- a/robot_sf/adversarial/transfer_matrix.py
+++ b/robot_sf/adversarial/transfer_matrix.py
@@ -42,6 +42,7 @@ _TRANSFER_MATRIX_SCHEMA_VERSION = "adversarial_transfer_matrix.v1"
 
 # Benchmark eligibility tiers that count as "certified / repliable" for slice 1.
 _CERTIFIED_ELIGIBILITY = frozenset({"eligible", "stress_only"})
+_ELIGIBILITY_SEVERITY = {"eligible": 0, "stress_only": 1, "excluded": 2}
 
 # Default 3-planner mechanism-stratified roster for slice 1: the issue asks for
 # the target planner plus 2 other planners. The roster mirrors the engineered
@@ -141,6 +142,7 @@ class TransferMatrix:
 
     schema_version: str = _TRANSFER_MATRIX_SCHEMA_VERSION
     target_planner: str = ""
+    configs: tuple[CertifiedConfig, ...] = ()
     config_ids: tuple[str, ...] = ()
     planners: tuple[str, ...] = ()
     cells: tuple[TransferCell, ...] = ()
@@ -154,6 +156,7 @@ class TransferMatrix:
         return {
             "schema_version": self.schema_version,
             "target_planner": self.target_planner,
+            "configs": [config.__dict__ for config in self.configs],
             "config_ids": list(self.config_ids),
             "planners": list(self.planners),
             "cells": [c.__dict__ for c in self.cells],
@@ -175,11 +178,18 @@ def _candidate_certification_tier(candidate: dict[str, Any]) -> str | None:
         else None
     )
     if isinstance(certificates, list) and certificates:
-        first = certificates[0]
-        if isinstance(first, dict):
-            return first.get("benchmark_eligibility")
-    # Fall back to a single top-level status if present.
-    return cert.get("status")
+        tiers: list[str] = []
+        for certificate in certificates:
+            if not isinstance(certificate, dict):
+                return None
+            tier = str(certificate.get("benchmark_eligibility", "")).strip().lower()
+            if tier not in _ELIGIBILITY_SEVERITY:
+                return None
+            tiers.append(tier)
+        return max(tiers, key=_ELIGIBILITY_SEVERITY.__getitem__)
+    # Fall back only when a top-level status already uses the eligibility vocabulary.
+    status = str(cert.get("status", "")).strip().lower()
+    return status if status in _ELIGIBILITY_SEVERITY else None
 
 
 def _candidate_scenario_seed(candidate: dict[str, Any]) -> int | None:
@@ -188,9 +198,12 @@ def _candidate_scenario_seed(candidate: dict[str, Any]) -> int | None:
     if seed is None:
         return None
     try:
-        return int(seed)
+        parsed = float(seed)
     except (TypeError, ValueError):
         return None
+    if not math.isfinite(parsed) or not parsed.is_integer() or parsed < 0:
+        return None
+    return int(parsed)
 
 
 def _is_certified(candidate: dict[str, Any]) -> bool:
@@ -199,16 +212,71 @@ def _is_certified(candidate: dict[str, Any]) -> bool:
     return tier in _CERTIFIED_ELIGIBILITY
 
 
-def _objective_value(candidate: dict[str, Any]) -> float:
+def _objective_value(candidate: dict[str, Any]) -> float | None:
     """Return the worst-case objective value for a candidate."""
     value = candidate.get("objective_value")
     if value is None:
-        return float("-inf")
+        return None
     try:
         parsed = float(value)
     except (TypeError, ValueError):
-        return float("-inf")
-    return parsed if __import__("math").isfinite(parsed) else float("-inf")
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _load_target_manifest(
+    manifest_path: Path, *, target_planner: str
+) -> tuple[dict[str, Any], list[Any]]:
+    """Load one search manifest and verify its schema and target-planner lineage."""
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Search manifest must be a JSON object: {manifest_path}")
+    schema = payload.get("schema_version")
+    if schema != SEARCH_MANIFEST_SCHEMA_VERSION:
+        raise ValueError(
+            f"Unsupported search manifest schema for {manifest_path}: {schema!r}; "
+            f"expected {SEARCH_MANIFEST_SCHEMA_VERSION!r}"
+        )
+    manifest_config = payload.get("config") if isinstance(payload.get("config"), dict) else {}
+    manifest_policy = str(manifest_config.get("policy", "")).strip()
+    if manifest_policy != target_planner:
+        raise ValueError(
+            f"Target planner mismatch for {manifest_path}: manifest policy "
+            f"{manifest_policy!r} != {target_planner!r}"
+        )
+    candidates = payload.get("candidates") or []
+    return manifest_config, candidates if isinstance(candidates, list) else []
+
+
+def _certified_config_from_payload(
+    candidate_payload: Any,
+    *,
+    manifest_path: Path,
+    target_planner: str,
+    index: int,
+) -> CertifiedConfig | None:
+    """Build one fail-closed selected config or return None when it is not repliable."""
+    if not isinstance(candidate_payload, dict) or not _is_certified(candidate_payload):
+        return None
+    candidate = (
+        candidate_payload.get("candidate")
+        if isinstance(candidate_payload.get("candidate"), dict)
+        else {}
+    )
+    objective_value = _objective_value(candidate_payload)
+    scenario_seed = _candidate_scenario_seed(candidate)
+    if not candidate or objective_value is None or scenario_seed is None:
+        return None
+    return CertifiedConfig(
+        config_id=f"{manifest_path.as_posix()}#{index}",
+        target_planner=target_planner,
+        candidate=candidate,
+        objective_value=objective_value,
+        source_manifest=manifest_path.as_posix(),
+        source_candidate_index=index,
+        certification_tier=_candidate_certification_tier(candidate_payload) or "unknown",
+        scenario_seed=scenario_seed,
+    )
 
 
 def select_certified_configs(
@@ -245,48 +313,28 @@ def select_certified_configs(
     """
     if K < 1:
         raise ValueError("K must be >= 1")
+    if not target_planner.strip():
+        raise ValueError("target_planner must be non-empty")
 
     configs: list[CertifiedConfig] = []
     for manifest_path in sorted(Path(p) for p in manifest_paths):
-        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
-        if not isinstance(payload, dict):
-            raise ValueError(f"Search manifest must be a JSON object: {manifest_path}")
-        schema = payload.get("schema_version")
-        if schema != SEARCH_MANIFEST_SCHEMA_VERSION:
-            raise ValueError(
-                f"Unsupported search manifest schema for {manifest_path}: {schema!r}; "
-                f"expected {SEARCH_MANIFEST_SCHEMA_VERSION!r}"
-            )
-        manifest_config = payload.get("config") if isinstance(payload.get("config"), dict) else {}
+        manifest_config, candidates = _load_target_manifest(
+            manifest_path, target_planner=target_planner
+        )
         if (
             scenario_template is not None
             and manifest_config.get("scenario_template") != scenario_template
         ):
             continue
-        candidates = payload.get("candidates") or []
-        if not isinstance(candidates, list):
-            continue
-        for index, candidate in enumerate(candidates):
-            if not isinstance(candidate, dict):
-                continue
-            cand = (
-                candidate.get("candidate") if isinstance(candidate.get("candidate"), dict) else {}
+        for index, candidate_payload in enumerate(candidates):
+            config = _certified_config_from_payload(
+                candidate_payload,
+                manifest_path=manifest_path,
+                target_planner=target_planner,
+                index=index,
             )
-            if not _is_certified(candidate):
-                continue
-            tier = _candidate_certification_tier(candidate) or "unknown"
-            configs.append(
-                CertifiedConfig(
-                    config_id=f"{manifest_path.stem}#{index}",
-                    target_planner=target_planner,
-                    candidate=cand,
-                    objective_value=_objective_value(candidate),
-                    source_manifest=manifest_path.as_posix(),
-                    source_candidate_index=index,
-                    certification_tier=tier,
-                    scenario_seed=_candidate_scenario_seed(cand),
-                )
-            )
+            if config is not None:
+                configs.append(config)
 
     configs.sort(key=lambda c: (-c.objective_value, c.config_id))
     return configs[:K]
@@ -342,16 +390,7 @@ def _build_cells(
         for planner in planners:
             ev = eval_by_key.get((cfg_id, planner))
             if ev is None:
-                cells.append(
-                    TransferCell(
-                        config_id=cfg_id,
-                        planner=planner,
-                        robustness=float("nan"),
-                        failed=False,
-                        transferred=False,
-                    )
-                )
-                continue
+                raise ValueError(f"Missing evaluation for config={cfg_id!r}, planner={planner!r}")
             # A weak point transfers when the target config's failure also
             # reproduces against the evaluated planner.
             cells.append(
@@ -376,7 +415,7 @@ def _build_ranking(
     ranking_rows: list[PlannerRanking] = []
     for planner in planners:
         planner_cells = per_planner[planner]
-        finite = [c.robustness for c in planner_cells if not math.isnan(c.robustness)]
+        finite = [c.robustness for c in planner_cells if math.isfinite(c.robustness)]
         worst = min(finite) if finite else float("nan")
         failures = [c for c in planner_cells if c.failed]
         transfer_rate = len(failures) / len(planner_cells) if planner_cells else 0.0
@@ -385,7 +424,7 @@ def _build_ranking(
                 planner=planner,
                 worst_case_robustness=worst,
                 transfer_failure_rate=transfer_rate,
-                minimax_regret=-worst if not math.isnan(worst) else float("nan"),
+                minimax_regret=-worst if math.isfinite(worst) else float("nan"),
                 rank=0,
             )
         )
@@ -402,6 +441,106 @@ def _group_cells_by_planner(
         if cell.planner in per_planner:
             per_planner[cell.planner].append(cell)
     return per_planner
+
+
+def _validate_matrix_configs(
+    configs: list[CertifiedConfig], *, bootstrap_n: int
+) -> tuple[tuple[str, ...], str]:
+    """Validate selected config provenance and return ids plus the shared target planner."""
+    if not configs:
+        raise ValueError("Cannot build a transfer matrix from zero certified configs")
+    if len(configs) < 5:
+        raise ValueError(
+            f"Issue #5303 slice 1 requires K >= 5 certified configs; got {len(configs)}"
+        )
+    config_ids = tuple(config.config_id for config in configs)
+    target_planner = configs[0].target_planner
+    if not target_planner.strip():
+        raise ValueError("Certified configs must name a target planner")
+    if len(set(config_ids)) != len(config_ids):
+        raise ValueError("Certified config ids must be unique")
+    if any(config.target_planner != target_planner for config in configs):
+        raise ValueError("All certified configs must share one target planner")
+    if any(config.certification_tier not in _CERTIFIED_ELIGIBILITY for config in configs):
+        raise ValueError("All configs must have eligible or stress_only certification")
+    if any(not math.isfinite(config.objective_value) for config in configs):
+        raise ValueError("All certified configs must have a finite objective value")
+    if any(config.scenario_seed is None for config in configs):
+        raise ValueError("All certified configs must pin scenario_seed")
+    if bootstrap_n < 0:
+        raise ValueError("bootstrap_n must be >= 0")
+    return config_ids, target_planner
+
+
+def _resolve_matrix_planners(
+    evaluations: list[PlannerEval],
+    *,
+    target_planner: str,
+    planners: tuple[str, ...] | None,
+) -> tuple[str, ...]:
+    """Resolve and validate the target-plus-two planner roster."""
+    if planners is None:
+        planners = tuple(dict.fromkeys(evaluation.planner for evaluation in evaluations))
+    if len(planners) < 3:
+        raise ValueError("Issue #5303 slice 1 requires the target planner plus 2 others")
+    if len(set(planners)) != len(planners):
+        raise ValueError("Planner names must be unique")
+    if target_planner not in planners:
+        raise ValueError("The target planner must be present in the matrix roster")
+    return planners
+
+
+def _validate_evaluation(evaluation: PlannerEval) -> None:
+    """Validate one signed-robustness evaluation before aggregation."""
+    if not math.isfinite(evaluation.robustness):
+        raise ValueError(
+            f"Evaluation robustness must be finite for config={evaluation.config_id!r}, "
+            f"planner={evaluation.planner!r}"
+        )
+    if evaluation.seed is None or evaluation.seed < 0:
+        raise ValueError(
+            f"Evaluation seed must be pinned and non-negative for config={evaluation.config_id!r}, "
+            f"planner={evaluation.planner!r}"
+        )
+    if evaluation.failed != (evaluation.robustness < 0.0):
+        raise ValueError(
+            "Evaluation failed flag disagrees with signed robustness for "
+            f"config={evaluation.config_id!r}, planner={evaluation.planner!r}"
+        )
+
+
+def _index_complete_evaluations(
+    evaluations: list[PlannerEval],
+    *,
+    config_ids: tuple[str, ...],
+    planners: tuple[str, ...],
+) -> dict[tuple[str, str], PlannerEval]:
+    """Return a complete unique evaluation index or fail closed."""
+    valid_config_ids = set(config_ids)
+    valid_planners = set(planners)
+    indexed: dict[tuple[str, str], PlannerEval] = {}
+    for evaluation in evaluations:
+        key = (evaluation.config_id, evaluation.planner)
+        if evaluation.config_id not in valid_config_ids:
+            raise ValueError(f"Evaluation references unknown config: {evaluation.config_id!r}")
+        if evaluation.planner not in valid_planners:
+            raise ValueError(f"Evaluation references unknown planner: {evaluation.planner!r}")
+        if key in indexed:
+            raise ValueError(
+                f"Duplicate evaluation for config={evaluation.config_id!r}, "
+                f"planner={evaluation.planner!r}"
+            )
+        _validate_evaluation(evaluation)
+        indexed[key] = evaluation
+    expected = {(config_id, planner) for config_id in config_ids for planner in planners}
+    missing = sorted(expected - set(indexed))
+    if missing:
+        config_id, planner = missing[0]
+        raise ValueError(
+            f"Transfer matrix is incomplete; missing {len(missing)} evaluation(s), "
+            f"including config={config_id!r}, planner={planner!r}"
+        )
+    return indexed
 
 
 def build_transfer_matrix(
@@ -433,31 +572,21 @@ def build_transfer_matrix(
     TransferMatrix
         The transfer measurement, per-planner minimax ranking, and bootstrap CI.
     """
-    if not configs:
-        raise ValueError("Cannot build a transfer matrix from zero certified configs")
-    if len(configs) < 5:
-        raise ValueError(
-            f"Issue #5303 slice 1 requires K >= 5 certified configs; got {len(configs)}"
-        )
-
-    config_ids = tuple(c.config_id for c in configs)
-    target_planner = configs[0].target_planner
-
-    if planners is None:
-        seen: list[str] = []
-        for ev in evaluations:
-            if ev.planner not in seen:
-                seen.append(ev.planner)
-        planners = tuple(seen)
-
-    # Map (config_id, planner) -> eval.
-    eval_by_key: dict[tuple[str, str], PlannerEval] = {
-        (ev.config_id, ev.planner): ev for ev in evaluations
-    }
+    config_ids, target_planner = _validate_matrix_configs(configs, bootstrap_n=bootstrap_n)
+    planners = _resolve_matrix_planners(
+        evaluations, target_planner=target_planner, planners=planners
+    )
+    eval_by_key = _index_complete_evaluations(evaluations, config_ids=config_ids, planners=planners)
 
     cells = _build_cells(config_ids, planners, eval_by_key)
     ranking_rows = _build_ranking(cells, planners)
-    ranking_rows.sort(key=lambda r: (r.worst_case_robustness, r.planner))
+    ranking_rows.sort(
+        key=lambda row: (
+            not math.isfinite(row.worst_case_robustness),
+            -row.worst_case_robustness if math.isfinite(row.worst_case_robustness) else 0.0,
+            row.planner,
+        )
+    )
     for rank, row in enumerate(ranking_rows, start=1):
         ranking_rows[rank - 1] = PlannerRanking(
             planner=row.planner,
@@ -492,6 +621,7 @@ def build_transfer_matrix(
 
     return TransferMatrix(
         target_planner=target_planner,
+        configs=tuple(configs),
         config_ids=config_ids,
         planners=planners,
         cells=tuple(cells),
@@ -504,6 +634,8 @@ def build_transfer_matrix(
 
 def render_transfer_report(matrix: TransferMatrix, *, configs: list[CertifiedConfig]) -> str:
     """Render a one-page transfer-measurement report (capability-only)."""
+    if tuple(config.config_id for config in configs) != matrix.config_ids:
+        raise ValueError("Report configs must match the transfer matrix config order")
     lines: list[str] = []
     lines.append("# Cross-planner adversarial transfer matrix (slice 1, capability-only)")
     lines.append("")
@@ -528,7 +660,7 @@ def render_transfer_report(matrix: TransferMatrix, *, configs: list[CertifiedCon
     for row in matrix.ranking:
         wc = (
             f"{row.worst_case_robustness:.3f}"
-            if row.worst_case_robustness == row.worst_case_robustness
+            if math.isfinite(row.worst_case_robustness)
             else "n/a"
         )
         lines.append(f"| {row.rank} | `{row.planner}` | {wc} | {row.transfer_failure_rate:.3f} |")
@@ -552,7 +684,7 @@ def render_transfer_report(matrix: TransferMatrix, *, configs: list[CertifiedCon
         mark = []
         for planner in matrix.planners:
             cell = by_config.get(cfg_id, {}).get(planner)
-            if cell is None or cell.robustness != cell.robustness:
+            if cell is None or not math.isfinite(cell.robustness):
                 mark.append("?")
             elif cell.transferred:
                 mark.append("X")
@@ -582,35 +714,10 @@ def write_transfer_artifact(matrix: TransferMatrix, *, out_dir: str | Path) -> P
     matrix_path.write_text(
         json.dumps(matrix.to_json(), indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
-    report_path.write_text(_render_matrix_only_report(matrix), encoding="utf-8")
+    report_path.write_text(
+        render_transfer_report(matrix, configs=list(matrix.configs)), encoding="utf-8"
+    )
     return matrix_path
-
-
-def _render_matrix_only_report(matrix: TransferMatrix) -> str:
-    """Render report without full config provenance (used by write_transfer_artifact)."""
-    lines: list[str] = []
-    lines.append("# Cross-planner adversarial transfer matrix (slice 1, capability-only)")
-    lines.append("")
-    lines.append("> Capability-not-evidence boundary: archive paths and pinned configs/seeds only.")
-    lines.append("")
-    lines.append(f"- Target planner: `{matrix.target_planner}`")
-    lines.append(f"- Configs (K): {len(matrix.config_ids)}")
-    lines.append(f"- Planners (N): {len(matrix.planners)}")
-    lines.append(f"- Overall transfer rate: {matrix.overall_transfer_rate:.3f}")
-    lines.append(f"- Transfer-rate 95% CI: {tuple(round(x, 3) for x in matrix.transfer_rate_ci)}")
-    lines.append("")
-    lines.append("## Minimax ranking")
-    lines.append("")
-    lines.append("| rank | planner | worst-case robustness | transfer-failure rate |")
-    lines.append("|---|---|---|---|")
-    for row in matrix.ranking:
-        wc = (
-            f"{row.worst_case_robustness:.3f}"
-            if row.worst_case_robustness == row.worst_case_robustness
-            else "n/a"
-        )
-        lines.append(f"| {row.rank} | `{row.planner}` | {wc} | {row.transfer_failure_rate:.3f} |")
-    return "\n".join(lines) + "\n"
 
 
 __all__ = [

--- a/tests/adversarial/test_transfer_matrix_issue_5303.py
+++ b/tests/adversarial/test_transfer_matrix_issue_5303.py
@@ -1,0 +1,284 @@
+"""Tests for the issue #5303 slice 1 cross-planner transfer matrix (cheap lane)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from robot_sf.adversarial.transfer_matrix import (
+    DEFAULT_TRANSFER_ROSTER,
+    PlannerEval,
+    build_transfer_matrix,
+    render_transfer_report,
+    select_certified_configs,
+    write_transfer_artifact,
+)
+
+
+def _certified_candidate(start_x: float, *, seed: int, objective: float) -> dict:
+    """Build a candidate payload using the real certification_status schema."""
+    return {
+        "candidate": {
+            "start": {"x": start_x, "y": 2.0, "theta": 0.0},
+            "goal": {"x": 5.0, "y": 2.0, "theta": 0.0},
+            "spawn_time_s": 0.0,
+            "pedestrian_speed_mps": 1.0,
+            "pedestrian_delay_s": 0.0,
+            "scenario_seed": seed,
+        },
+        "objective_value": objective,
+        "bundle_path": f"output/adversarial/run/cand_{seed}",
+        "scenario_yaml_path": "output/adversarial/run/cand_{seed}/scenario.yaml",
+        "certification_status": {
+            "schema_version": "scenario_cert.v1",
+            "status": "passed",
+            "details": {
+                "certificates": [
+                    {
+                        "benchmark_eligibility": "eligible",
+                        "classification": "hard_but_solvable",
+                    }
+                ]
+            },
+        },
+    }
+
+
+def _stress_only_candidate(start_x: float, *, seed: int, objective: float) -> dict:
+    """Build a knife-edge (stress_only) certified candidate."""
+    payload = _certified_candidate(start_x, seed=seed, objective=objective)
+    payload["certification_status"]["details"]["certificates"][0]["benchmark_eligibility"] = (
+        "stress_only"
+    )
+    payload["certification_status"]["details"]["certificates"][0]["classification"] = "knife_edge"
+    return payload
+
+
+def _uncertified_candidate(start_x: float, *, seed: int, objective: float) -> dict:
+    """Build an excluded/infeasible candidate that must NOT be selected."""
+    payload = _certified_candidate(start_x, seed=seed, objective=objective)
+    payload["certification_status"]["details"]["certificates"][0]["benchmark_eligibility"] = (
+        "excluded"
+    )
+    payload["certification_status"]["details"]["certificates"][0]["classification"] = (
+        "geometrically_infeasible"
+    )
+    return payload
+
+
+def _manifest(tmp_path: Path, *, name: str, candidates: list[dict]) -> Path:
+    """Write a synthetic adversarial search manifest (real schema)."""
+    payload = {
+        "schema_version": "adversarial-search-manifest.v1",
+        "config": {
+            "policy": "scenario_adaptive_hybrid_orca_v1",
+            "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+            "search_space": {
+                "variables": {
+                    "start_x": {"min": 0.0, "max": 4.0},
+                    "scenario_seed": {"min": 700, "max": 800},
+                }
+            },
+        },
+        "candidates": candidates,
+    }
+    path = tmp_path / name
+    path.write_text(__import__("json").dumps(payload), encoding="utf-8")
+    return path
+
+
+def _evals_for_configs(configs, *, planner_robustness, failed):
+    """Build per-planner eval results for every config/planner pair."""
+    evals = []
+    for cfg in configs:
+        for planner in DEFAULT_TRANSFER_ROSTER:
+            if planner == cfg.target_planner:
+                continue
+            evals.append(
+                PlannerEval(
+                    config_id=cfg.config_id,
+                    planner=planner,
+                    robustness=planner_robustness,
+                    failed=failed,
+                    seed=cfg.scenario_seed,
+                )
+            )
+    return evals
+
+
+def test_select_certified_configs_keeps_only_certified(tmp_path):
+    m = _manifest(
+        tmp_path,
+        name="m1.json",
+        candidates=[
+            _uncertified_candidate(0.1, seed=701, objective=20.0),  # must be excluded
+            _certified_candidate(0.2, seed=702, objective=9.0),
+            _stress_only_candidate(0.3, seed=703, objective=15.0),
+        ],
+    )
+    configs = select_certified_configs([m], target_planner="orca_v1", K=10)
+    assert len(configs) == 2
+    # Sorted worst-first: objective 15 before 9.
+    assert configs[0].objective_value == 15.0
+    assert configs[0].certification_tier == "stress_only"
+    assert all(c.target_planner == "orca_v1" for c in configs)
+
+
+def test_select_certified_configs_respects_k(tmp_path):
+    candidates = [
+        _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(8)
+    ]
+    m = _manifest(tmp_path, name="m.json", candidates=candidates)
+    configs = select_certified_configs([m], target_planner="orca_v1", K=5)
+    assert len(configs) == 5
+    # Largest objectives kept (worst-first).
+    assert [c.objective_value for c in configs] == [7.0, 6.0, 5.0, 4.0, 3.0]
+
+
+def test_select_requires_real_manifest_schema(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text(__import__("json").dumps({"schema_version": "wrong"}), encoding="utf-8")
+    with pytest.raises(ValueError):
+        select_certified_configs([bad], target_planner="orca_v1", K=5)
+
+
+def test_build_transfer_matrix_structure_and_ranking(tmp_path):
+    m = _manifest(
+        tmp_path,
+        name="m.json",
+        candidates=[
+            _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(6)
+        ],
+    )
+    configs = select_certified_configs([m], target_planner="orca_v1", K=6)
+    # All non-target planners fail => full transfer.
+    evals = _evals_for_configs(configs, planner_robustness=-1.0, failed=True)
+    matrix = build_transfer_matrix(configs, evals)
+    assert matrix.target_planner == "orca_v1"
+    assert len(matrix.config_ids) == 6
+    assert len(matrix.planners) == 3
+    assert len(matrix.cells) == 6 * 3
+    assert matrix.overall_transfer_rate == 1.0
+    assert matrix.transfer_rate_ci == (1.0, 1.0)
+    # Worst-case robustness equal across planners => stable deterministic ranking.
+    assert matrix.ranking[0].worst_case_robustness == -1.0
+
+
+def test_build_transfer_matrix_no_transfer(tmp_path):
+    m = _manifest(
+        tmp_path,
+        name="m.json",
+        candidates=[
+            _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(5)
+        ],
+    )
+    configs = select_certified_configs([m], target_planner="orca_v1", K=5)
+    # Non-target planners succeed => weak points are policy-specific.
+    evals = _evals_for_configs(configs, planner_robustness=2.0, failed=False)
+    matrix = build_transfer_matrix(configs, evals)
+    assert matrix.overall_transfer_rate == 0.0
+    assert matrix.transfer_rate_ci == (0.0, 0.0)
+    assert all(not c.transferred for c in matrix.cells if c.planner != "orca_v1")
+
+
+def test_build_requires_k_at_least_5(tmp_path):
+    m = _manifest(
+        tmp_path,
+        name="m.json",
+        candidates=[_certified_candidate(0.1, seed=700, objective=1.0)],
+    )
+    configs = select_certified_configs([m], target_planner="orca_v1", K=1)
+    evals = _evals_for_configs(configs, planner_robustness=2.0, failed=False)
+    with pytest.raises(ValueError):
+        build_transfer_matrix(configs, evals)
+
+
+def test_bootstrap_ci_covers_point_estimate(tmp_path):
+    m = _manifest(
+        tmp_path,
+        name="m.json",
+        candidates=[
+            _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(8)
+        ],
+    )
+    configs = select_certified_configs([m], target_planner="orca_v1", K=8)
+    # Mixed: half transfer, half not.
+    evals = []
+    for idx, cfg in enumerate(configs):
+        for planner in DEFAULT_TRANSFER_ROSTER:
+            if planner == cfg.target_planner:
+                continue
+            failed = (idx % 2) == 0
+            evals.append(
+                PlannerEval(
+                    config_id=cfg.config_id,
+                    planner=planner,
+                    robustness=-1.0 if failed else 2.0,
+                    failed=failed,
+                    seed=cfg.scenario_seed,
+                )
+            )
+    matrix = build_transfer_matrix(configs, evals, bootstrap_n=500, bootstrap_seed=7)
+    lo, hi = matrix.transfer_rate_ci
+    assert lo <= matrix.overall_transfer_rate <= hi
+    assert matrix.transfer_rate_bootstrap_n == 500
+
+
+def test_render_report_contains_markers_and_ranking(tmp_path):
+    m = _manifest(
+        tmp_path,
+        name="m.json",
+        candidates=[
+            _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(6)
+        ],
+    )
+    configs = select_certified_configs([m], target_planner="orca_v1", K=6)
+    evals = _evals_for_configs(configs, planner_robustness=-1.0, failed=True)
+    matrix = build_transfer_matrix(configs, evals)
+    report = render_transfer_report(matrix, configs=configs)
+    assert "capability-only" in report
+    assert "minimax" in report.lower() or "Minimax" in report
+    assert "X" in report  # transferred failure marker
+    assert "Transfer matrix" in report
+
+
+def test_write_artifact_roundtrip(tmp_path):
+    m = _manifest(
+        tmp_path,
+        name="m.json",
+        candidates=[
+            _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(6)
+        ],
+    )
+    configs = select_certified_configs([m], target_planner="orca_v1", K=6)
+    evals = _evals_for_configs(configs, planner_robustness=-1.0, failed=True)
+    matrix = build_transfer_matrix(configs, evals)
+    out = tmp_path / "out"
+    path = write_transfer_artifact(matrix, out_dir=out)
+    assert path.exists()
+    reloaded = __import__("json").loads(path.read_text())
+    assert reloaded["schema_version"] == "adversarial_transfer_matrix.v1"
+    assert len(reloaded["cells"]) == 18
+    assert (out / "transfer_report.md").exists()
+
+
+def test_default_roster_has_three_planners():
+    assert len(DEFAULT_TRANSFER_ROSTER) == 3
+    assert DEFAULT_TRANSFER_ROSTER[0] == "scenario_adaptive_hybrid_orca_v1"
+
+
+def test_transfer_matrix_is_frozen_and_jsonable(tmp_path):
+    m = _manifest(
+        tmp_path,
+        name="m.json",
+        candidates=[
+            _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(5)
+        ],
+    )
+    configs = select_certified_configs([m], target_planner="orca_v1", K=5)
+    evals = _evals_for_configs(configs, planner_robustness=-1.0, failed=True)
+    matrix = build_transfer_matrix(configs, evals)
+    payload = matrix.to_json()
+    assert isinstance(payload, dict)
+    assert payload["schema_version"] == "adversarial_transfer_matrix.v1"

--- a/tests/adversarial/test_transfer_matrix_issue_5303.py
+++ b/tests/adversarial/test_transfer_matrix_issue_5303.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -14,6 +16,8 @@ from robot_sf.adversarial.transfer_matrix import (
     select_certified_configs,
     write_transfer_artifact,
 )
+
+_TARGET_PLANNER = DEFAULT_TRANSFER_ROSTER[0]
 
 
 def _certified_candidate(start_x: float, *, seed: int, objective: float) -> dict:
@@ -29,7 +33,7 @@ def _certified_candidate(start_x: float, *, seed: int, objective: float) -> dict
         },
         "objective_value": objective,
         "bundle_path": f"output/adversarial/run/cand_{seed}",
-        "scenario_yaml_path": "output/adversarial/run/cand_{seed}/scenario.yaml",
+        "scenario_yaml_path": f"output/adversarial/run/cand_{seed}/scenario.yaml",
         "certification_status": {
             "schema_version": "scenario_cert.v1",
             "status": "passed",
@@ -67,12 +71,18 @@ def _uncertified_candidate(start_x: float, *, seed: int, objective: float) -> di
     return payload
 
 
-def _manifest(tmp_path: Path, *, name: str, candidates: list[dict]) -> Path:
+def _manifest(
+    tmp_path: Path,
+    *,
+    name: str,
+    candidates: list[dict],
+    policy: str = _TARGET_PLANNER,
+) -> Path:
     """Write a synthetic adversarial search manifest (real schema)."""
     payload = {
         "schema_version": "adversarial-search-manifest.v1",
         "config": {
-            "policy": "scenario_adaptive_hybrid_orca_v1",
+            "policy": policy,
             "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
             "search_space": {
                 "variables": {
@@ -84,7 +94,8 @@ def _manifest(tmp_path: Path, *, name: str, candidates: list[dict]) -> Path:
         "candidates": candidates,
     }
     path = tmp_path / name
-    path.write_text(__import__("json").dumps(payload), encoding="utf-8")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
     return path
 
 
@@ -93,8 +104,6 @@ def _evals_for_configs(configs, *, planner_robustness, failed):
     evals = []
     for cfg in configs:
         for planner in DEFAULT_TRANSFER_ROSTER:
-            if planner == cfg.target_planner:
-                continue
             evals.append(
                 PlannerEval(
                     config_id=cfg.config_id,
@@ -117,12 +126,12 @@ def test_select_certified_configs_keeps_only_certified(tmp_path):
             _stress_only_candidate(0.3, seed=703, objective=15.0),
         ],
     )
-    configs = select_certified_configs([m], target_planner="orca_v1", K=10)
+    configs = select_certified_configs([m], target_planner=_TARGET_PLANNER, K=10)
     assert len(configs) == 2
     # Sorted worst-first: objective 15 before 9.
     assert configs[0].objective_value == 15.0
     assert configs[0].certification_tier == "stress_only"
-    assert all(c.target_planner == "orca_v1" for c in configs)
+    assert all(c.target_planner == _TARGET_PLANNER for c in configs)
 
 
 def test_select_certified_configs_respects_k(tmp_path):
@@ -130,7 +139,7 @@ def test_select_certified_configs_respects_k(tmp_path):
         _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(8)
     ]
     m = _manifest(tmp_path, name="m.json", candidates=candidates)
-    configs = select_certified_configs([m], target_planner="orca_v1", K=5)
+    configs = select_certified_configs([m], target_planner=_TARGET_PLANNER, K=5)
     assert len(configs) == 5
     # Largest objectives kept (worst-first).
     assert [c.objective_value for c in configs] == [7.0, 6.0, 5.0, 4.0, 3.0]
@@ -138,9 +147,9 @@ def test_select_certified_configs_respects_k(tmp_path):
 
 def test_select_requires_real_manifest_schema(tmp_path):
     bad = tmp_path / "bad.json"
-    bad.write_text(__import__("json").dumps({"schema_version": "wrong"}), encoding="utf-8")
+    bad.write_text(json.dumps({"schema_version": "wrong"}), encoding="utf-8")
     with pytest.raises(ValueError):
-        select_certified_configs([bad], target_planner="orca_v1", K=5)
+        select_certified_configs([bad], target_planner=_TARGET_PLANNER, K=5)
 
 
 def test_build_transfer_matrix_structure_and_ranking(tmp_path):
@@ -151,11 +160,11 @@ def test_build_transfer_matrix_structure_and_ranking(tmp_path):
             _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(6)
         ],
     )
-    configs = select_certified_configs([m], target_planner="orca_v1", K=6)
+    configs = select_certified_configs([m], target_planner=_TARGET_PLANNER, K=6)
     # All non-target planners fail => full transfer.
     evals = _evals_for_configs(configs, planner_robustness=-1.0, failed=True)
     matrix = build_transfer_matrix(configs, evals)
-    assert matrix.target_planner == "orca_v1"
+    assert matrix.target_planner == _TARGET_PLANNER
     assert len(matrix.config_ids) == 6
     assert len(matrix.planners) == 3
     assert len(matrix.cells) == 6 * 3
@@ -173,13 +182,13 @@ def test_build_transfer_matrix_no_transfer(tmp_path):
             _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(5)
         ],
     )
-    configs = select_certified_configs([m], target_planner="orca_v1", K=5)
+    configs = select_certified_configs([m], target_planner=_TARGET_PLANNER, K=5)
     # Non-target planners succeed => weak points are policy-specific.
     evals = _evals_for_configs(configs, planner_robustness=2.0, failed=False)
     matrix = build_transfer_matrix(configs, evals)
     assert matrix.overall_transfer_rate == 0.0
     assert matrix.transfer_rate_ci == (0.0, 0.0)
-    assert all(not c.transferred for c in matrix.cells if c.planner != "orca_v1")
+    assert all(not c.transferred for c in matrix.cells if c.planner != _TARGET_PLANNER)
 
 
 def test_build_requires_k_at_least_5(tmp_path):
@@ -188,7 +197,7 @@ def test_build_requires_k_at_least_5(tmp_path):
         name="m.json",
         candidates=[_certified_candidate(0.1, seed=700, objective=1.0)],
     )
-    configs = select_certified_configs([m], target_planner="orca_v1", K=1)
+    configs = select_certified_configs([m], target_planner=_TARGET_PLANNER, K=1)
     evals = _evals_for_configs(configs, planner_robustness=2.0, failed=False)
     with pytest.raises(ValueError):
         build_transfer_matrix(configs, evals)
@@ -202,13 +211,11 @@ def test_bootstrap_ci_covers_point_estimate(tmp_path):
             _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(8)
         ],
     )
-    configs = select_certified_configs([m], target_planner="orca_v1", K=8)
+    configs = select_certified_configs([m], target_planner=_TARGET_PLANNER, K=8)
     # Mixed: half transfer, half not.
     evals = []
     for idx, cfg in enumerate(configs):
         for planner in DEFAULT_TRANSFER_ROSTER:
-            if planner == cfg.target_planner:
-                continue
             failed = (idx % 2) == 0
             evals.append(
                 PlannerEval(
@@ -233,7 +240,7 @@ def test_render_report_contains_markers_and_ranking(tmp_path):
             _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(6)
         ],
     )
-    configs = select_certified_configs([m], target_planner="orca_v1", K=6)
+    configs = select_certified_configs([m], target_planner=_TARGET_PLANNER, K=6)
     evals = _evals_for_configs(configs, planner_robustness=-1.0, failed=True)
     matrix = build_transfer_matrix(configs, evals)
     report = render_transfer_report(matrix, configs=configs)
@@ -251,16 +258,21 @@ def test_write_artifact_roundtrip(tmp_path):
             _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(6)
         ],
     )
-    configs = select_certified_configs([m], target_planner="orca_v1", K=6)
+    configs = select_certified_configs([m], target_planner=_TARGET_PLANNER, K=6)
     evals = _evals_for_configs(configs, planner_robustness=-1.0, failed=True)
     matrix = build_transfer_matrix(configs, evals)
     out = tmp_path / "out"
     path = write_transfer_artifact(matrix, out_dir=out)
     assert path.exists()
-    reloaded = __import__("json").loads(path.read_text())
+    reloaded = json.loads(path.read_text())
     assert reloaded["schema_version"] == "adversarial_transfer_matrix.v1"
+    assert len(reloaded["configs"]) == 6
+    assert all(config["scenario_seed"] is not None for config in reloaded["configs"])
     assert len(reloaded["cells"]) == 18
     assert (out / "transfer_report.md").exists()
+    report = (out / "transfer_report.md").read_text(encoding="utf-8")
+    assert "Certified config provenance" in report
+    assert configs[0].source_manifest in report
 
 
 def test_default_roster_has_three_planners():
@@ -276,9 +288,115 @@ def test_transfer_matrix_is_frozen_and_jsonable(tmp_path):
             _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(5)
         ],
     )
-    configs = select_certified_configs([m], target_planner="orca_v1", K=5)
+    configs = select_certified_configs([m], target_planner=_TARGET_PLANNER, K=5)
     evals = _evals_for_configs(configs, planner_robustness=-1.0, failed=True)
     matrix = build_transfer_matrix(configs, evals)
     payload = matrix.to_json()
     assert isinstance(payload, dict)
     assert payload["schema_version"] == "adversarial_transfer_matrix.v1"
+
+
+def test_ranking_places_best_worst_case_robustness_first(tmp_path: Path) -> None:
+    """Minimax rank 1 must mean the strongest, not the most brittle, planner."""
+    manifest = _manifest(
+        tmp_path,
+        name="ranking.json",
+        candidates=[
+            _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(5)
+        ],
+    )
+    configs = select_certified_configs([manifest], target_planner=_TARGET_PLANNER, K=5)
+    robustness_by_planner = {
+        _TARGET_PLANNER: -2.0,
+        DEFAULT_TRANSFER_ROSTER[1]: -0.5,
+        DEFAULT_TRANSFER_ROSTER[2]: 1.0,
+    }
+    evaluations = [
+        PlannerEval(
+            config_id=config.config_id,
+            planner=planner,
+            robustness=robustness,
+            failed=robustness < 0.0,
+            seed=config.scenario_seed,
+        )
+        for config in configs
+        for planner, robustness in robustness_by_planner.items()
+    ]
+    matrix = build_transfer_matrix(configs, evaluations)
+    assert [row.planner for row in matrix.ranking] == [
+        DEFAULT_TRANSFER_ROSTER[2],
+        DEFAULT_TRANSFER_ROSTER[1],
+        _TARGET_PLANNER,
+    ]
+
+
+def test_matrix_rejects_incomplete_duplicate_and_nonfinite_evaluations(tmp_path: Path) -> None:
+    """Bad evaluation tables must fail rather than dilute missing runs into successes."""
+    manifest = _manifest(
+        tmp_path,
+        name="matrix.json",
+        candidates=[
+            _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(5)
+        ],
+    )
+    configs = select_certified_configs([manifest], target_planner=_TARGET_PLANNER, K=5)
+    evaluations = _evals_for_configs(configs, planner_robustness=-1.0, failed=True)
+    with pytest.raises(ValueError, match="incomplete"):
+        build_transfer_matrix(configs, evaluations[:-1])
+    with pytest.raises(ValueError, match="Duplicate"):
+        build_transfer_matrix(configs, [*evaluations, evaluations[0]])
+    nonfinite = [*evaluations]
+    nonfinite[0] = replace(nonfinite[0], robustness=float("inf"))
+    with pytest.raises(ValueError, match="finite"):
+        build_transfer_matrix(configs, nonfinite)
+    inconsistent = [*evaluations]
+    inconsistent[0] = replace(inconsistent[0], failed=False)
+    with pytest.raises(ValueError, match="disagrees"):
+        build_transfer_matrix(configs, inconsistent)
+
+
+def test_selection_preserves_unique_lineage_and_uses_conservative_certification(
+    tmp_path: Path,
+) -> None:
+    """Common manifest names stay unique and any excluded certificate blocks selection."""
+    eligible = _certified_candidate(0.1, seed=701, objective=2.0)
+    mixed = _certified_candidate(0.2, seed=702, objective=9.0)
+    mixed["certification_status"]["details"]["certificates"].append(
+        {"benchmark_eligibility": "excluded", "classification": "invalid"}
+    )
+    nonfinite = _certified_candidate(0.3, seed=703, objective=float("nan"))
+    first = _manifest(tmp_path, name="run-a/manifest.json", candidates=[eligible, mixed, nonfinite])
+    second = _manifest(
+        tmp_path,
+        name="run-b/manifest.json",
+        candidates=[_certified_candidate(0.4, seed=704, objective=3.0)],
+    )
+    configs = select_certified_configs([first, second], target_planner=_TARGET_PLANNER, K=10)
+    assert len(configs) == 2
+    assert len({config.config_id for config in configs}) == 2
+    assert all(config.source_manifest in config.config_id for config in configs)
+
+
+def test_lineage_and_matrix_configuration_fail_closed(tmp_path: Path) -> None:
+    """Target, roster, seed, and bootstrap settings must preserve the slice contract."""
+    manifest = _manifest(
+        tmp_path,
+        name="config.json",
+        candidates=[
+            _certified_candidate(0.1 + i * 0.01, seed=700 + i, objective=float(i)) for i in range(5)
+        ],
+    )
+    with pytest.raises(ValueError, match="Target planner mismatch"):
+        select_certified_configs([manifest], target_planner="wrong-planner", K=5)
+    configs = select_certified_configs([manifest], target_planner=_TARGET_PLANNER, K=5)
+    evaluations = _evals_for_configs(configs, planner_robustness=-1.0, failed=True)
+    with pytest.raises(ValueError, match="target planner plus 2"):
+        build_transfer_matrix(configs, evaluations, planners=DEFAULT_TRANSFER_ROSTER[:2])
+    with pytest.raises(ValueError, match="unique"):
+        build_transfer_matrix(
+            configs,
+            evaluations,
+            planners=(_TARGET_PLANNER, DEFAULT_TRANSFER_ROSTER[1], DEFAULT_TRANSFER_ROSTER[1]),
+        )
+    with pytest.raises(ValueError, match="bootstrap_n"):
+        build_transfer_matrix(configs, evaluations, bootstrap_n=-1)


### PR DESCRIPTION
## What / Why

Adds capability-only plumbing for the first bounded part of Issue #5303: select certified worst-case configurations from one target planner's adversarial search manifests, ingest a complete K×3 signed-robustness evaluation table, and emit a cross-planner transfer matrix, minimax robustness ranking, bootstrap interval, JSON artifact, and one-page report.

This PR does **not** run the ops-queue campaign and does not contain an empirical K×3 transfer result. Issue #5303 remains open for the real re-evaluation campaign and any later minimax search game.

## Contract Hardened By The Gate

- Source manifests must use `adversarial-search-manifest.v1` and their recorded policy must exactly match the requested target planner.
- Selection conservatively uses the worst benchmark-eligibility tier across all certificates and excludes unpinned seeds or non-finite objectives.
- Config IDs include source-manifest lineage, avoiding collisions between the normal `manifest.json` filenames from different run directories.
- A matrix requires K>=5 configs, the target planner plus at least two distinct comparison planners, one complete unique evaluation per config/planner cell, finite signed robustness, and pinned non-negative evaluation seeds.
- Missing, duplicate, unknown, non-finite, or `failed`/robustness-inconsistent rows fail closed instead of becoming apparent successes.
- Minimax rank 1 is the planner with the strongest worst-case robustness (equivalently lowest regret), with deterministic tie-breaking.
- JSON and Markdown artifacts retain selected config payloads, seeds, certification tiers, source manifests, and candidate indices.

## Evidence Boundary

Evidence status: **capability-only / synthetic fixture proof**. The tests use manifest-shaped fixtures and deterministic evaluation tables; they prove implementation contracts, not cross-planner robustness or benchmark results. No fallback/degraded row is treated as evidence, and no release or paper-facing claim is made.

The remaining work stays in Issue #5303:

1. author approval of the evidence-grade promotion plan;
2. replay top-K certified configs against the two comparison planners using the standard seed protocol;
3. archive the durable K×3 result and report with execution provenance;
4. consider the minimax game only if the measured transfer structure justifies it.

## Validation / Proof

- `uv run ruff check robot_sf/adversarial/transfer_matrix.py tests/adversarial/test_transfer_matrix_issue_5303.py` — passed.
- `scripts/dev/run_focused_tests.sh tests/adversarial/test_transfer_matrix_issue_5303.py -q` — 15 passed.
- `scripts/dev/run_focused_tests.sh tests/adversarial -q` — 286 passed.
- The original head's CI was green; the gate-repair head must complete fresh CI before acceptance.

## Downstream Propagation

- Parent issue: Issue #5303 remains open and owns the campaign, evidence-grade sign-off, and later minimax decision.
- Claim map / benchmark report / leaderboard / registry: NA for this capability-only PR; no empirical result exists yet.
- Durable artifact: none generated by this review; unit-test outputs are disposable fixtures.

Refs #5303
