### PR TITLE
Issue #5836: xdist-aware reproducibility timing guard (cheap-lane worker)

### DIFF
--- a/tests/benchmark_full/test_integration_reproducibility.py
+++ b/tests/benchmark_full/test_integration_reproducibility.py
@@ -156,9 +156,14 @@ def test_reproducibility_same_seed(
     )
     assert len(ids1) == len(set(ids1)), "Duplicate episode_ids encountered within a run."
 
-    # Soft timing guard (currently enforced as hard assert per spec envelope)
+    # Soft timing guard (currently enforced as hard assert per spec envelope).
+    # The envelope is contention-aware: under pytest-xdist the soft budget is
+    # multiplied so an unrelated full-suite worker (CPU/I/O starvation) does not
+    # fail this deterministic contract. The hard boundary is never scaled, so a
+    # genuine benchmark runtime regression still fails (issue #5836).
     ci = os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS")
-    limit = 20.0 if ci else 10.0
+    under_xdist = perf_policy.is_under_xdist()
+    limit = perf_policy.effective_soft_threshold(ci=bool(ci))
     classification = perf_policy.classify(elapsed)
     assert classification != "hard", (
         f"Elapsed {elapsed:.2f}s breached hard threshold {perf_policy.hard_timeout_seconds}s."
@@ -166,13 +171,19 @@ def test_reproducibility_same_seed(
 
     if elapsed >= limit:  # stricter accelerated envelope
         # T042: richer guidance message
+        xdist_note = (
+            " Running under pytest-xdist; soft envelope was widened to absorb sibling-worker "
+            "contention. A genuine regression would still breach the hard threshold."
+            if under_xdist
+            else ""
+        )
         guidance = (
             "Exceeded time budget. Mitigations: verify smoke=True, bootstrap_samples=0, "
             "workers=1, only 2 seeds, horizon_override minimal. If environment is legitimately slow, "
             "consider raising CI threshold (specs/123-reduce-runtime-of/spec.md)."
         )
         raise AssertionError(
-            f"Repro test exceeded time budget: {elapsed:.2f}s (limit {limit}s). {guidance}",
+            f"Repro test exceeded time budget: {elapsed:.2f}s (limit {limit}s). {guidance}{xdist_note}",
         )
 
     base_root = Path(cfg.output_root)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,6 +244,23 @@ def perf_policy():  # type: ignore[missing-return-type-doc]
         hard_timeout_seconds = 60.0
         report_count = 10
         relax_env_var = "ROBOT_SF_PERF_RELAX"
+        xdist_contention_multiplier = 3.0
+
+        def is_under_xdist(self) -> bool:
+            """TODO docstring. Document this function."""
+            worker = os.environ.get("PYTEST_XDIST_WORKER")
+            return bool(worker) and worker.strip() != ""
+
+        def effective_soft_threshold(self, *, ci: bool = False) -> float:
+            """TODO docstring. Document this function.
+
+            Args:
+                ci: TODO docstring.
+            """
+            base = self.soft_threshold_seconds
+            if self.is_under_xdist():
+                return base * self.xdist_contention_multiplier
+            return base
 
         def classify(self, duration_seconds: float):
             """TODO docstring. Document this function.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,9 +257,9 @@ def perf_policy():  # type: ignore[missing-return-type-doc]
             Args:
                 ci: TODO docstring.
             """
-            base = self.soft_threshold_seconds
+            base = self.soft_threshold_seconds if ci else (self.soft_threshold_seconds / 2.0)
             if self.is_under_xdist():
-                return base * self.xdist_contention_multiplier
+                return min(base * self.xdist_contention_multiplier, self.hard_timeout_seconds * 0.9)
             return base
 
         def classify(self, duration_seconds: float):

--- a/tests/perf_utils/policy.py
+++ b/tests/perf_utils/policy.py
@@ -55,6 +55,8 @@ class PerformanceBudgetPolicy:
             raise ValueError("soft_threshold_seconds must be > 0 and < hard_timeout_seconds")
         if self.report_count < 1:
             raise ValueError("report_count must be >= 1")
+        if self.xdist_contention_multiplier <= 0:
+            raise ValueError("xdist_contention_multiplier must be > 0")
 
     def is_under_xdist(self) -> bool:
         """Return True when running inside a pytest-xdist worker subprocess.
@@ -76,7 +78,7 @@ class PerformanceBudgetPolicy:
         The widened soft value is clamped to stay strictly below the hard boundary so it
         remains advisory rather than colliding with the hard wall.
         """
-        base = self.soft_threshold_seconds
+        base = self.soft_threshold_seconds if ci else (self.soft_threshold_seconds / 2.0)
         if self.is_under_xdist():
             widened = base * self.xdist_contention_multiplier
             return min(widened, self.hard_timeout_seconds * 0.9)

--- a/tests/perf_utils/policy.py
+++ b/tests/perf_utils/policy.py
@@ -6,10 +6,17 @@ Defines the data structure representing the per-test performance budget
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Literal
 
 BreachType = Literal["none", "soft", "hard"]
+
+# pytest-xdist sets PYTEST_XDIST_WORKER to the worker id (e.g. "gw0") in every
+# worker subprocess. The controller process leaves it unset. Detecting this lets
+# performance-sensitive tests relax their soft runtime envelope when the machine
+# is contended by sibling workers rather than failing on unrelated CPU/I/O load.
+XDIST_WORKER_ENV = "PYTEST_XDIST_WORKER"
 
 
 @dataclass(slots=True)
@@ -29,6 +36,11 @@ class PerformanceBudgetPolicy:
     report_count: int = 10
     relax_env_var: str = "ROBOT_SF_PERF_RELAX"
     enforce_env_var: str = "ROBOT_SF_PERF_ENFORCE"
+    # Multiplier applied to the soft envelope when the test runs under pytest-xdist
+    # contention. The hard boundary is never scaled (a genuine regression must still
+    # fail), only the advisory soft budget that trips when unrelated workers starve
+    # this one of CPU/I/O (issue #5836).
+    xdist_contention_multiplier: float = 3.0
 
     def __post_init__(self) -> None:  # lightweight construction validation
         """Validate configuration invariants.
@@ -43,6 +55,32 @@ class PerformanceBudgetPolicy:
             raise ValueError("soft_threshold_seconds must be > 0 and < hard_timeout_seconds")
         if self.report_count < 1:
             raise ValueError("report_count must be >= 1")
+
+    def is_under_xdist(self) -> bool:
+        """Return True when running inside a pytest-xdist worker subprocess.
+
+        pytest-xdist exports ``PYTEST_XDIST_WORKER`` (the worker id, e.g. ``gw0``)
+        in each worker; the controller and standalone runs leave it unset. This is
+        the canonical, dependency-free way to detect full-suite contention.
+        """
+        worker = os.environ.get(XDIST_WORKER_ENV)
+        return bool(worker) and worker.strip() != ""
+
+    def effective_soft_threshold(self, *, ci: bool = False) -> float:
+        """Return the soft runtime envelope to enforce for this invocation.
+
+        Under pytest-xdist the envelope is multiplied by ``xdist_contention_multiplier``
+        so a saturated machine (sibling workers consuming CPU/I/O) no longer trips the
+        advisory budget. The hard boundary is intentionally never scaled: a genuine
+        benchmark runtime regression must still fail even under contention (issue #5836).
+        The widened soft value is clamped to stay strictly below the hard boundary so it
+        remains advisory rather than colliding with the hard wall.
+        """
+        base = self.soft_threshold_seconds
+        if self.is_under_xdist():
+            widened = base * self.xdist_contention_multiplier
+            return min(widened, self.hard_timeout_seconds * 0.9)
+        return base
 
     def classify(self, duration_seconds: float) -> BreachType:
         """Classify a test duration.

--- a/tests/perf_utils/test_xdist_envelope.py
+++ b/tests/perf_utils/test_xdist_envelope.py
@@ -1,0 +1,59 @@
+"""xdist-aware performance envelope tests (issue #5836).
+
+Validates that the soft runtime budget widens under pytest-xdist contention
+(PYTEST_XDIST_WORKER set) while the hard boundary stays unscaled, so an
+unrelated full-suite worker can no longer fail the deterministic reproducibility
+test, and a genuine regression still trips the hard threshold.
+"""
+
+from __future__ import annotations
+
+import os
+
+from .policy import XDIST_WORKER_ENV, PerformanceBudgetPolicy
+
+
+def _policy(xdist: bool) -> PerformanceBudgetPolicy:
+    os.environ.pop(XDIST_WORKER_ENV, None)
+    if xdist:
+        os.environ[XDIST_WORKER_ENV] = "gw0"
+    else:
+        os.environ.pop(XDIST_WORKER_ENV, None)
+    return PerformanceBudgetPolicy()
+
+
+def test_standalone_soft_threshold_is_base():
+    policy = _policy(xdist=False)
+    assert policy.is_under_xdist() is False
+    assert policy.effective_soft_threshold() == policy.soft_threshold_seconds
+
+
+def test_xdist_soft_threshold_widened():
+    policy = _policy(xdist=True)
+    assert policy.is_under_xdist() is True
+    widened = policy.effective_soft_threshold()
+    assert widened > policy.soft_threshold_seconds
+    # Widened soft stays strictly below the hard boundary (advisory, not the wall).
+    assert widened < policy.hard_timeout_seconds
+
+
+def test_xdist_env_empty_does_not_count_as_contention():
+    os.environ[XDIST_WORKER_ENV] = "   "
+    policy = PerformanceBudgetPolicy()
+    try:
+        assert policy.is_under_xdist() is False
+        assert policy.effective_soft_threshold() == policy.soft_threshold_seconds
+    finally:
+        os.environ.pop(XDIST_WORKER_ENV, None)
+
+
+def test_hard_threshold_never_scaled_under_xdist():
+    policy = _policy(xdist=True)
+    try:
+        # A duration between the widened soft envelope and the (unscaled) hard
+        # boundary must classify as soft, not hard -- the hard wall holds.
+        soft = policy.effective_soft_threshold()
+        assert policy.classify(soft + 1.0) == "soft"
+        assert policy.classify(policy.hard_timeout_seconds) == "hard"
+    finally:
+        os.environ.pop(XDIST_WORKER_ENV, None)

--- a/tests/perf_utils/test_xdist_envelope.py
+++ b/tests/perf_utils/test_xdist_envelope.py
@@ -8,52 +8,47 @@ test, and a genuine regression still trips the hard threshold.
 
 from __future__ import annotations
 
-import os
-
 from .policy import XDIST_WORKER_ENV, PerformanceBudgetPolicy
 
 
-def _policy(xdist: bool) -> PerformanceBudgetPolicy:
-    os.environ.pop(XDIST_WORKER_ENV, None)
+def _policy(xdist: bool, monkeypatch) -> PerformanceBudgetPolicy:
+    monkeypatch.delenv(XDIST_WORKER_ENV, raising=False)
     if xdist:
-        os.environ[XDIST_WORKER_ENV] = "gw0"
-    else:
-        os.environ.pop(XDIST_WORKER_ENV, None)
+        monkeypatch.setenv(XDIST_WORKER_ENV, "gw0")
     return PerformanceBudgetPolicy()
 
 
-def test_standalone_soft_threshold_is_base():
-    policy = _policy(xdist=False)
+def test_standalone_soft_threshold_is_base(monkeypatch):
+    policy = _policy(xdist=False, monkeypatch=monkeypatch)
     assert policy.is_under_xdist() is False
-    assert policy.effective_soft_threshold() == policy.soft_threshold_seconds
+    assert policy.effective_soft_threshold(ci=True) == policy.soft_threshold_seconds
+    assert policy.effective_soft_threshold(ci=False) == policy.soft_threshold_seconds / 2.0
 
 
-def test_xdist_soft_threshold_widened():
-    policy = _policy(xdist=True)
+def test_xdist_soft_threshold_widened(monkeypatch):
+    policy = _policy(xdist=True, monkeypatch=monkeypatch)
     assert policy.is_under_xdist() is True
-    widened = policy.effective_soft_threshold()
-    assert widened > policy.soft_threshold_seconds
-    # Widened soft stays strictly below the hard boundary (advisory, not the wall).
-    assert widened < policy.hard_timeout_seconds
+    for ci in (True, False):
+        widened = policy.effective_soft_threshold(ci=ci)
+        base = policy.soft_threshold_seconds if ci else policy.soft_threshold_seconds / 2.0
+        assert widened > base
+        # Widened soft stays strictly below the hard boundary (advisory, not the wall).
+        assert widened < policy.hard_timeout_seconds
 
 
-def test_xdist_env_empty_does_not_count_as_contention():
-    os.environ[XDIST_WORKER_ENV] = "   "
+def test_xdist_env_empty_does_not_count_as_contention(monkeypatch):
+    monkeypatch.setenv(XDIST_WORKER_ENV, "   ")
     policy = PerformanceBudgetPolicy()
-    try:
-        assert policy.is_under_xdist() is False
-        assert policy.effective_soft_threshold() == policy.soft_threshold_seconds
-    finally:
-        os.environ.pop(XDIST_WORKER_ENV, None)
+    assert policy.is_under_xdist() is False
+    assert policy.effective_soft_threshold(ci=True) == policy.soft_threshold_seconds
+    assert policy.effective_soft_threshold(ci=False) == policy.soft_threshold_seconds / 2.0
 
 
-def test_hard_threshold_never_scaled_under_xdist():
-    policy = _policy(xdist=True)
-    try:
-        # A duration between the widened soft envelope and the (unscaled) hard
-        # boundary must classify as soft, not hard -- the hard wall holds.
-        soft = policy.effective_soft_threshold()
+def test_hard_threshold_never_scaled_under_xdist(monkeypatch):
+    policy = _policy(xdist=True, monkeypatch=monkeypatch)
+    # A duration between each widened soft envelope and the (unscaled) hard
+    # boundary must classify as soft, not hard -- the hard wall holds.
+    for ci in (True, False):
+        soft = policy.effective_soft_threshold(ci=ci)
         assert policy.classify(soft + 1.0) == "soft"
         assert policy.classify(policy.hard_timeout_seconds) == "hard"
-    finally:
-        os.environ.pop(XDIST_WORKER_ENV, None)


### PR DESCRIPTION
## What / Why

Issue #5836: `test_reproducibility_same_seed` fails its hard ~10s local / 20s CI
timing assertion when the full suite runs under pytest-xdist (8 workers) on a
saturated machine, even though the identical test passes in 1.64s in isolation.
The cause is that the soft runtime envelope was unconditional and therefore
tripped on *unrelated* worker CPU/I/O starvation rather than on a real benchmark
regression.

This PR makes the timing guard **xdist-aware** instead of adding another
readiness/checker packet:

- `PerformanceBudgetPolicy.is_under_xdist()` detects the `PYTEST_XDIST_WORKER`
  env var that pytest-xdist sets in every worker subprocess.
- `effective_soft_threshold()` multiplies the soft envelope by
  `xdist_contention_multiplier` (3.0, clamped strictly below the hard boundary)
  only when running under xdist. The hard boundary is never scaled, so a genuine
  benchmark runtime regression still fails.
- `tests/benchmark_full/test_integration_reproducibility.py` now uses the
  contention-aware envelope. Deterministic ordering, scenario hash, count, and
  duplicate-ID contracts are untouched.
- The conftest `_Fallback` policy mirrors the new helpers so the test degrades
  safely if perf utils are unavailable.

### Secondary note (issue "also inspect")
The repeated Loguru `ValueError: I/O operation on closed file` diagnostics from
benchmark workers during the saturated run are out of scope for this cheap lane:
they require a logging-sink lifecycle fix in the xdist worker teardown path, not
a timing change. Tracked in follow-up issue #5849 rather than bundled here to
keep the fix focused and reviewable.

## Validation

- `uv run pytest tests/perf_utils/test_xdist_envelope.py -q` → 4 passed
  (standalone and xdist envelopes, both CI/local bases, empty-env safety, hard wall intact)
- `uv run pytest tests/benchmark_full/test_integration_reproducibility.py::test_reproducibility_same_seed -v` → PASSED (1.66s, isolation)
- `uv run pytest tests/benchmark_full/test_integration_reproducibility.py::test_reproducibility_same_seed -v -n2` → PASSED under xdist (envelope widened, hard wall intact)
- `uv run ruff check/format` on changed files: clean
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` → core lane passed; optional lane reproduced the existing baseline failure tracked in #5707 (the PR does not touch that path)

## Acceptance criteria met
- Retains deterministic ordering, scenario hash, count, duplicate-ID contracts.
- Full parallel suite no longer fails solely because unrelated workers consume CPU/I/O.
- A focused performance invocation still detects a genuine benchmark runtime regression (hard threshold unscaled).

Closes #5836

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

## Gate contract metadata

### Research Result Guidance

- Target claim / hypothesis / blocker: NA — support/test helper; this changes the test's contention tolerance, not benchmark outcome metrics or a research claim.
- Comparator or baseline: NA.
- Evidence tier: targeted smoke.
- Result classification: diagnostic-only / blocker-resolution — restores the intended reproducibility guard under xdist contention.
- Decision or stop rule: retain the change only while the local/CI bases and unscaled hard boundary remain covered by tests.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #5836; no claim-map or benchmark-result update.

### Domain-Aware Approval

- Required for this PR: no — test-only timing-envelope repair; it does not change evidence classification, comparison methodology, figure eligibility, or paper-facing claims.
- Domains reviewed: NA.
- Status: not required.

### Downstream Propagation

- Parent issue updated: yes — issue #5836 is the linked acceptance contract.
- Claim map / benchmark report updated: NA — no benchmark result or paper-facing claim changed.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened for deferred propagation: #5849 — Loguru sink lifecycle under xdist.

### Follow-Up Issues

- Deferred work: diagnose and fix the repeated closed-stream Loguru diagnostics from xdist benchmark workers.
- Issues opened for follow-up: #5849.

### Readiness baseline limitation

- The configured optional lane is not green because current `origin/main` independently fails `tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py::test_campaign_wrapper_runs_builder_before_requiring_headline_rows[0]` with an ambiguous `--campaign` argument in `run_post_campaign_stage.py`; reproduced on `origin/main` and tracked by open issue #5707. This PR does not touch that path.
