### PR TITLE
Issue #5707: guard run_post_campaign_stage argv dispatch contract (cheap-lane worker)

### DIFF
--- a/scripts/tools/run_post_campaign_stage.py
+++ b/scripts/tools/run_post_campaign_stage.py
@@ -92,7 +92,7 @@ def build_post_campaign_stage_payload(
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse CLI arguments."""
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
     parser.add_argument("--campaign-summary", type=Path, required=True)
     parser.add_argument("--campaign-exit-code", type=_exit_code, required=True)
     parser.add_argument("--stage-name", required=True)

--- a/tests/tools/test_run_post_campaign_stage.py
+++ b/tests/tools/test_run_post_campaign_stage.py
@@ -261,5 +261,62 @@ class TestPostCampaignStageRunner:
         assert lanes["post_campaign_stage"]["exit_code"] == 0
 
 
+class TestWrapperArgvContractIssue5707:
+    """Issue #5707: the issue-3216 wrapper must dispatch a ``run_post_campaign_stage``
+    argv shape that argparse accepts without ambiguity.
+
+    A prior regression passed ``--campaign`` (an option the report builder owns) in a
+    position where ``run_post_campaign_stage``'s parser rejected it as ambiguous against
+    its own ``--campaign-summary`` / ``--campaign-exit-code`` options. The wrapper now
+    emits ``--campaign`` only inside ``--stage-command`` (argparse.REMAINDER), so it must
+    parse cleanly. This test guards the exact dispatch contract so the optional
+    predictive readiness lane cannot silently regress again.
+    """
+
+    def test_argparse_accepts_wrapper_dispatch_shape(self, tmp_path: Path) -> None:
+        """The wrapper's exact argv parses without an ambiguous-option error."""
+        campaign_root = tmp_path / "issue3216_s20_headline_ci"
+        config = tmp_path / "benchmark.yaml"
+        stage_status = campaign_root / "reports" / "post_campaign_stage_status.json"
+        summary = campaign_root / "reports" / "campaign_summary.json"
+
+        argv = [
+            "--campaign-summary",
+            str(summary),
+            "--campaign-exit-code",
+            "0",
+            "--stage-name",
+            "headline_ci_rank_stability_report",
+            "--output",
+            str(stage_status),
+            "--stage-command",
+            "uv",
+            "run",
+            "python",
+            "scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py",
+            "--campaign",
+            str(campaign_root),
+            "--rank-metric",
+            "snqi",
+            "--expected-planners-from-config",
+            str(config),
+            "--output-dir",
+            str(tmp_path / "report"),
+        ]
+
+        # Must not raise argparse.ArgumentError / SystemExit (ambiguous option).
+        args = run_post_campaign_stage._parse_args(argv)
+
+        assert args.campaign_summary == summary
+        assert args.campaign_exit_code == 0
+        assert args.stage_name == "headline_ci_rank_stability_report"
+        assert args.output == stage_status
+        # The nested ``--campaign`` stays inside the REMAINDER-based stage command.
+        assert "--campaign" in args.stage_command
+        assert str(campaign_root) in args.stage_command
+        # ``--campaign`` must NOT leak into the primitive's own top-level options.
+        assert not hasattr(args, "campaign")
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/tools/test_run_post_campaign_stage.py
+++ b/tests/tools/test_run_post_campaign_stage.py
@@ -311,10 +311,22 @@ class TestWrapperArgvContractIssue5707:
         assert args.campaign_exit_code == 0
         assert args.stage_name == "headline_ci_rank_stability_report"
         assert args.output == stage_status
-        # The nested ``--campaign`` stays inside the REMAINDER-based stage command.
-        assert "--campaign" in args.stage_command
-        assert str(campaign_root) in args.stage_command
-        # ``--campaign`` must NOT leak into the primitive's own top-level options.
+        # The nested command is preserved exactly, including ordering and all options.
+        assert args.stage_command == [
+            "uv",
+            "run",
+            "python",
+            "scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py",
+            "--campaign",
+            str(campaign_root),
+            "--rank-metric",
+            "snqi",
+            "--expected-planners-from-config",
+            str(config),
+            "--output-dir",
+            str(tmp_path / "report"),
+        ]
+        # ``--campaign`` must not leak into the primitive's own top-level options.
         assert not hasattr(args, "campaign")
 
 


### PR DESCRIPTION
## What / Why

Issue #5707 tracks a main-branch readiness regression in the optional predictive
lane: the issue-3216 wrapper's post-campaign dispatch had an ambiguous `--campaign`
argument boundary, so the wrapper tests could not exercise the status-envelope
behavior.

PR #5717 / #5730 updated the fixture to recognize and execute the current
`scripts/tools/run_post_campaign_stage.py` dispatch. This PR completes the contract
by fixing the parser boundary (`allow_abbrev=False`) and adding a focused regression
test that codifies the exact argv shape emitted by
`scripts/benchmark/run_issue3216_headline_campaign.sh`, including the report builder's
nested `--campaign` flag inside `--stage-command` (`argparse.REMAINDER`). The regression
test compares the complete ordered nested command so arguments cannot be silently
dropped or reordered.

## Validation

```bash
ROBOT_SF_TEST_LANE=optional uv run pytest \
  tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py \
  tests/tools/test_run_post_campaign_stage.py -q
# 31 passed
```

The two originally named wrapper paths and the new parser contract guard pass. Ruff
check and format checks are clean for the changed files.

## Acceptance-criteria coverage

- Wrapper fixture recognizes and executes the current `run_post_campaign_stage.py` dispatch (`--stage-command` shape): satisfied by the merged fixture update from PRs #5717/#5730 and exercised here.
- Assertions that the report builder runs before headline-row validation and that both status-recorder success/failure paths are covered: preserved and green.
- Post-campaign status-envelope contract stays fail-closed: preserved by the existing soft-warning and hard-failure wrapper tests.
- Parser abbreviation cannot reinterpret nested stage arguments as top-level options: fixed and covered by the exact argv regression test.

Successor statement: this is the final successor slice for #5707; it does not duplicate PRs #5717/#5730, which repaired the fixture dispatch, and instead closes the remaining parser-boundary contract gap.

Closes #5707

This PR was produced by the CommandCode/Tencent-Hy3 cheap implementation lane; the review gate hardens and merges.

## Gate contract metadata

### Research Result Guidance

- Target claim / hypothesis / blocker: NA — support/test/parser contract repair; no benchmark result or research claim changes.
- Comparator or baseline: NA.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution.
- Decision or stop rule: retain the parser and exact-argv guard while the linked optional-lane wrapper paths remain green.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #5707; no benchmark-result or claim-map update.

### Domain-Aware Approval

- Required for this PR: no — this is a test and CLI-parser boundary repair; it does not change evidence classification, comparison methodology, figure eligibility, or paper-facing claims.
- Domains reviewed: NA.
- Status: not required.

### Downstream Propagation

- Parent issue updated: yes — #5707 is completed by this PR.
- Claim map / benchmark report updated: NA — no benchmark result changed.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened for deferred propagation: NA — no capability remains deferred.

### Follow-Up Issues

- Deferred work: none.
- Issues opened for follow-up: #5854 (TODO-docstring backlog ratchet regression on current main).


