### PR TITLE
Issue #5308: wire QD archive to production pipeline (slice 2, cheap-lane worker)

### DIFF
--- a/robot_sf/adversarial/__init__.py
+++ b/robot_sf/adversarial/__init__.py
@@ -1,6 +1,6 @@
 """Programmable adversarial scenario search helpers."""
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from robot_sf.adversarial.batch_certification import (
     ADVERSARIAL_CANDIDATE_QUALITY_SCHEMA,
@@ -71,10 +71,6 @@ from robot_sf.adversarial.scenario_manifest import (
     validate_manifest_payload,
     write_manifest_yaml,
 )
-from robot_sf.adversarial.search import (
-    production_candidate_evaluator,
-    run_adversarial_search,
-)
 from robot_sf.adversarial.seed_sensitivity import (
     SeedSensitivityPerturbation,
     SeedSensitivityReplay,
@@ -82,10 +78,20 @@ from robot_sf.adversarial.seed_sensitivity import (
     run_seed_sensitivity,
 )
 
+if TYPE_CHECKING:
+    from robot_sf.adversarial.search import (
+        production_candidate_evaluator,
+        run_adversarial_search,
+    )
+
 
 def __getattr__(name: str) -> Any:
     """Load heavyweight adversarial search dependencies only when requested."""
 
+    if name in {"production_candidate_evaluator", "run_adversarial_search"}:
+        from robot_sf.adversarial import search  # noqa: PLC0415
+
+        return getattr(search, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/robot_sf/adversarial/__init__.py
+++ b/robot_sf/adversarial/__init__.py
@@ -1,6 +1,6 @@
 """Programmable adversarial scenario search helpers."""
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from robot_sf.adversarial.batch_certification import (
     ADVERSARIAL_CANDIDATE_QUALITY_SCHEMA,
@@ -44,6 +44,7 @@ from robot_sf.adversarial.qd import (
     QDSearchResult,
     compare_qd_vs_single_objective,
     default_behavior_descriptor,
+    production_qd_evaluator,
     run_map_elites,
     write_qd_archive,
 )
@@ -70,6 +71,10 @@ from robot_sf.adversarial.scenario_manifest import (
     validate_manifest_payload,
     write_manifest_yaml,
 )
+from robot_sf.adversarial.search import (
+    production_candidate_evaluator,
+    run_adversarial_search,
+)
 from robot_sf.adversarial.seed_sensitivity import (
     SeedSensitivityPerturbation,
     SeedSensitivityReplay,
@@ -77,17 +82,10 @@ from robot_sf.adversarial.seed_sensitivity import (
     run_seed_sensitivity,
 )
 
-if TYPE_CHECKING:
-    from robot_sf.adversarial.search import run_adversarial_search
-
 
 def __getattr__(name: str) -> Any:
     """Load heavyweight adversarial search dependencies only when requested."""
 
-    if name == "run_adversarial_search":
-        from robot_sf.adversarial.search import run_adversarial_search  # noqa: PLC0415
-
-        return run_adversarial_search
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -139,6 +137,8 @@ __all__ = [
     "materialize_multi_ped_scenario_payload",
     "materialize_multi_ped_single_pedestrian_overrides",
     "multi_ped_config_to_single_pedestrian_definitions",
+    "production_candidate_evaluator",
+    "production_qd_evaluator",
     "run_adversarial_search",
     "run_map_elites",
     "run_seed_sensitivity",

--- a/robot_sf/adversarial/qd.py
+++ b/robot_sf/adversarial/qd.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import json
 import math
 from dataclasses import dataclass, field
+from itertools import count
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -42,11 +43,8 @@ from robot_sf.adversarial.samplers import (
     CoordinateRefinementSampler,
     RandomCandidateSampler,
 )
-from robot_sf.adversarial.search import production_candidate_evaluator
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from robot_sf.adversarial.certification import CertificationStatus
 
 QD_ARCHIVE_SCHEMA_VERSION = "adversarial_qd_archive.v1"
@@ -485,13 +483,16 @@ def production_qd_evaluator(
         candidate_evaluator: Optional injected four-argument production evaluator.
         certifier: Optional injected production certifier.
     """
+    search_config.validate()
+    from robot_sf.adversarial.search import production_candidate_evaluator  # noqa: PLC0415
+
     production_step = production_candidate_evaluator(
         evaluator=candidate_evaluator, certifier=certifier
     )
-    counter: Iterator[int] = iter(range(search_config.budget))
+    counter = count()
 
     def _evaluate(qd_config: QDSearchConfig, candidate: CandidateSpec) -> CandidateEvaluation:
-        index = next(counter, search_config.budget)
+        index = next(counter)
         return production_step(search_config, candidate, index)
 
     return _evaluate

--- a/robot_sf/adversarial/qd.py
+++ b/robot_sf/adversarial/qd.py
@@ -27,10 +27,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
+import yaml
+
 from robot_sf.adversarial.certification import candidate_allowed
 from robot_sf.adversarial.config import (
     CandidateEvaluation,
     CandidateSpec,
+    SearchConfig,
     SearchSpaceConfig,
 )
 from robot_sf.adversarial.io import read_first_jsonl_record
@@ -39,8 +42,11 @@ from robot_sf.adversarial.samplers import (
     CoordinateRefinementSampler,
     RandomCandidateSampler,
 )
+from robot_sf.adversarial.search import production_candidate_evaluator
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from robot_sf.adversarial.certification import CertificationStatus
 
 QD_ARCHIVE_SCHEMA_VERSION = "adversarial_qd_archive.v1"
@@ -300,6 +306,52 @@ class QDSearchConfig:
         if self.budget < 1:
             raise ValueError("budget must be >= 1")
 
+    def to_search_config(  # noqa: PLR0913
+        self,
+        *,
+        policy: str,
+        scenario_template: str | Path,
+        output_dir: str | Path,
+        algo_config_path: str | Path | None = None,
+        horizon: int | None = None,
+        dt: float | None = None,
+        workers: int = 1,
+        record_forces: bool = True,
+        benchmark_profile: str = "baseline-safe",
+        snqi_weights_path: str | Path | None = None,
+        snqi_baseline_path: str | Path | None = None,
+    ) -> SearchConfig:
+        """Build the production ``SearchConfig`` needed to evaluate QD candidates.
+
+        The MAP-Elites capability slice keeps the cheap-lane contract (no scenario
+        template / policy), so the production fields required by the real evaluator are
+        supplied here when wiring ``run_map_elites`` to ``production_qd_evaluator``.
+        """
+        search_space_path = Path(output_dir) / "qd_search_space.yaml"
+        search_space_path.parent.mkdir(parents=True, exist_ok=True)
+        search_space_path.write_text(
+            yaml.safe_dump(self.search_space.to_json(), sort_keys=False), encoding="utf-8"
+        )
+        return SearchConfig(
+            policy=policy,
+            scenario_template=Path(scenario_template),
+            search_space_path=search_space_path,
+            search_space=self.search_space,
+            objective=self.objective,
+            output_dir=Path(output_dir),
+            budget=self.budget,
+            seed=self.seed,
+            algo_config_path=Path(algo_config_path) if algo_config_path else None,
+            horizon=horizon,
+            dt=dt,
+            workers=workers,
+            record_forces=record_forces,
+            require_certification=self.require_certification,
+            benchmark_profile=benchmark_profile,
+            snqi_weights_path=Path(snqi_weights_path) if snqi_weights_path else None,
+            snqi_baseline_path=Path(snqi_baseline_path) if snqi_baseline_path else None,
+        )
+
 
 @dataclass(frozen=True)
 class QDSearchResult:
@@ -408,6 +460,41 @@ def write_qd_archive(result: QDSearchResult, output_path: str | Path) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(result.to_json(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return path
+
+
+def production_qd_evaluator(
+    search_config: SearchConfig,
+    *,
+    candidate_evaluator: Any | None = None,
+    certifier: Any | None = None,
+) -> QDEvaluator:
+    """Adapt the canonical production pipeline to the MAP-Elites ``QDEvaluator`` contract.
+
+    Returns a callable ``(qd_config, candidate) -> CandidateEvaluation`` that runs the
+    real validation -> materialization -> certification -> benchmark-evaluation sequence
+    (``search.production_candidate_evaluator``) for each QD candidate. This wires
+    ``run_map_elites`` to the actual adversarial evaluator instead of an injected stub,
+    which is the first deferred integration item for issue #5308.
+
+    Each candidate is evaluated under ``search_config.output_dir / f"candidate_{index:04d}"``;
+    the internal index advances deterministically per call so QD bundles stay replayable.
+
+    Args:
+        search_config: Production configuration carrying the scenario template, policy,
+            output dir, and all evaluator settings.
+        candidate_evaluator: Optional injected four-argument production evaluator.
+        certifier: Optional injected production certifier.
+    """
+    production_step = production_candidate_evaluator(
+        evaluator=candidate_evaluator, certifier=certifier
+    )
+    counter: Iterator[int] = iter(range(search_config.budget))
+
+    def _evaluate(qd_config: QDSearchConfig, candidate: CandidateSpec) -> CandidateEvaluation:
+        index = next(counter, search_config.budget)
+        return production_step(search_config, candidate, index)
+
+    return _evaluate
 
 
 @dataclass(frozen=True)
@@ -541,6 +628,7 @@ __all__ = [
     "QDSearchResult",
     "compare_qd_vs_single_objective",
     "default_behavior_descriptor",
+    "production_qd_evaluator",
     "run_map_elites",
     "write_qd_archive",
 ]

--- a/robot_sf/adversarial/search.py
+++ b/robot_sf/adversarial/search.py
@@ -36,6 +36,7 @@ from robot_sf.benchmark.runner import run_batch
 
 CandidateEvaluator = Callable[[SearchConfig, CandidateSpec, Path, Path], CandidateEvaluation]
 CandidateCertifier = Callable[[CandidateSpec, Path, bool], CertificationStatus]
+ProductionCandidateEvaluator = Callable[[SearchConfig, CandidateSpec, int], CandidateEvaluation]
 
 DEFAULT_SCHEMA_PATH = (
     Path(__file__).parent.parent / "benchmark" / "schemas" / "episode.schema.v1.json"
@@ -264,3 +265,90 @@ def _observe_candidate(sampler: CandidateSampler, evaluation: CandidateEvaluatio
     observe = getattr(sampler, "observe", None)
     if callable(observe):
         observe(evaluation)
+
+
+def production_candidate_evaluator(
+    *,
+    evaluator: CandidateEvaluator | None = None,
+    certifier: CandidateCertifier | None = None,
+) -> ProductionCandidateEvaluator:
+    """Return the canonical per-candidate production pipeline for adversarial search.
+
+    The returned callable runs the same validation -> materialization ->
+    certification -> benchmark-evaluation sequence as ``run_adversarial_search`` for
+    one candidate, writing its bundle under ``config.output_dir / f"candidate_{index:04d}"``.
+    It is the integration point that lets the MAP-Elites quality-diversity archive
+    (``robot_sf/adversarial/qd.py``) run against the real adversarial pipeline instead of
+    an injected stub: see ``qd.production_qd_evaluator``.
+
+    Args:
+        evaluator: Optional injected four-argument evaluator; defaults to the benchmark
+            batch runner (``SearchConfig``/scenario/bundle contract).
+        certifier: Optional injected certifier; defaults to ``certify_candidate``.
+
+    Returns:
+        A callable ``(config, candidate, index) -> CandidateEvaluation``.
+    """
+
+    def _evaluate(
+        config: SearchConfig, candidate: CandidateSpec, index: int
+    ) -> CandidateEvaluation:
+        candidate_dir = config.output_dir / f"candidate_{index:04d}"
+        validation_errors = config.search_space.validate_candidate(candidate)
+        if validation_errors:
+            return _invalid_evaluation(
+                candidate=candidate,
+                certification_status=failed_status(
+                    "search-space validation failed",
+                    details={"errors": validation_errors},
+                ),
+                scenario_yaml_path=None,
+                bundle_path=None,
+                reason="; ".join(validation_errors),
+            )
+
+        scenario_yaml_path, _route_path = write_candidate_inputs(
+            config=config,
+            candidate=candidate,
+            candidate_dir=candidate_dir,
+            index=index,
+        )
+        active_certifier = certifier or _default_certifier
+        certification_status = active_certifier(
+            candidate, scenario_yaml_path, config.require_certification
+        )
+        if not candidate_allowed(
+            certification_status, require_certification=config.require_certification
+        ):
+            return _invalid_evaluation(
+                candidate=candidate,
+                certification_status=certification_status,
+                scenario_yaml_path=scenario_yaml_path,
+                bundle_path=candidate_dir,
+                reason=certification_status.reason,
+            )
+
+        active_evaluator = evaluator or _default_evaluator
+        objective = get_objective(config.objective)
+        try:
+            evaluation = active_evaluator(config, candidate, scenario_yaml_path, candidate_dir)
+            evaluation = replace(evaluation, certification_status=certification_status)
+            score = objective(evaluation)
+            return evaluation.with_objective(score)
+        except Exception as exc:
+            error = repr(exc)
+            attribution = attribution_from_error(error)
+            write_json(candidate_dir / "failure_attribution.json", attribution.to_json())
+            return CandidateEvaluation(
+                candidate=candidate,
+                certification_status=certification_status,
+                objective_value=None,
+                failure_attribution=attribution,
+                episode_record_path=candidate_dir / "episode_records.jsonl",
+                trajectory_csv_path=None,
+                scenario_yaml_path=scenario_yaml_path,
+                bundle_path=candidate_dir,
+                error=error,
+            )
+
+    return _evaluate

--- a/robot_sf/adversarial/search.py
+++ b/robot_sf/adversarial/search.py
@@ -320,13 +320,18 @@ def production_candidate_evaluator(
         if not candidate_allowed(
             certification_status, require_certification=config.require_certification
         ):
-            return _invalid_evaluation(
+            evaluation = _invalid_evaluation(
                 candidate=candidate,
                 certification_status=certification_status,
                 scenario_yaml_path=scenario_yaml_path,
                 bundle_path=candidate_dir,
                 reason=certification_status.reason,
             )
+            write_json(
+                candidate_dir / "failure_attribution.json",
+                evaluation.failure_attribution.to_json(),
+            )
+            return evaluation
 
         active_evaluator = evaluator or _default_evaluator
         objective = get_objective(config.objective)

--- a/tests/adversarial/test_adversarial_package_imports.py
+++ b/tests/adversarial/test_adversarial_package_imports.py
@@ -23,9 +23,13 @@ def test_adversarial_search_reexport_is_lazy() -> None:
     """The package-level search re-export resolves through module __getattr__."""
 
     from robot_sf import adversarial
-    from robot_sf.adversarial.search import run_adversarial_search
+    from robot_sf.adversarial.search import (
+        production_candidate_evaluator,
+        run_adversarial_search,
+    )
 
     assert adversarial.run_adversarial_search is run_adversarial_search
+    assert adversarial.production_candidate_evaluator is production_candidate_evaluator
     missing_name = "definitely_missing"
     with pytest.raises(AttributeError, match="definitely_missing"):
         getattr(adversarial, missing_name)

--- a/tests/adversarial/test_issue_5308_qd_production.py
+++ b/tests/adversarial/test_issue_5308_qd_production.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import yaml
 
 from robot_sf.adversarial.attribution import attribution_from_episode_record
-from robot_sf.adversarial.certification import passed_status
+from robot_sf.adversarial.certification import failed_status, passed_status
 from robot_sf.adversarial.config import (
     CandidateEvaluation,
     CandidateSpec,
@@ -85,7 +85,7 @@ def _record(min_distance: float, critical_time: float, failure: str = "collision
     }
 
 
-def _production_evaluator(tmp_root: Path) -> object:
+def _production_evaluator() -> object:
     """Injected four-argument production evaluator that writes a real bundle + record.
 
     Mirrors the contract of ``search._default_evaluator``: write the scenario-derived
@@ -178,7 +178,7 @@ def test_production_evaluator_populates_archive_with_real_bundles(tmp_path: Path
     )
     evaluator = production_qd_evaluator(
         search_config,
-        candidate_evaluator=_production_evaluator(tmp_path),
+        candidate_evaluator=_production_evaluator(),
         certifier=_passing_certifier(),
     )
 
@@ -202,7 +202,7 @@ def test_production_evaluator_writes_archive_artifact(tmp_path: Path) -> None:
     )
     evaluator = production_qd_evaluator(
         search_config,
-        candidate_evaluator=_production_evaluator(tmp_path),
+        candidate_evaluator=_production_evaluator(),
         certifier=_passing_certifier(),
     )
     result = run_map_elites(qd_config, evaluator=evaluator)
@@ -228,7 +228,7 @@ def test_production_evaluator_is_reproducible(tmp_path: Path) -> None:
         )
         evaluator = production_qd_evaluator(
             search_config,
-            candidate_evaluator=_production_evaluator(tmp_path),
+            candidate_evaluator=_production_evaluator(),
             certifier=_passing_certifier(),
         )
         return run_map_elites(qd_config, evaluator=evaluator).to_json()
@@ -273,7 +273,7 @@ def test_production_evaluator_handles_invalid_candidate(tmp_path: Path) -> None:
         output_dir=tmp_path / "out",
     )
     step = production_candidate_evaluator(
-        evaluator=_production_evaluator(tmp_path),
+        evaluator=_production_evaluator(),
         certifier=_passing_certifier(),
     )
     out_of_range = CandidateSpec(
@@ -288,3 +288,81 @@ def test_production_evaluator_handles_invalid_candidate(tmp_path: Path) -> None:
     assert evaluation.error is not None
     assert evaluation.certification_status.status == "failed"
     assert evaluation.episode_record_path is None
+
+
+def test_production_qd_evaluator_validates_config_before_first_candidate(
+    tmp_path: Path,
+) -> None:
+    """Invalid production inputs fail before the QD evaluation loop starts."""
+    qd_config = _qd_config(
+        GridSpec(x_min=0.0, x_max=2.5, y_min=0.0, y_max=3.0, bins=4),
+        budget=1,
+    )
+    search_config = qd_config.to_search_config(
+        policy="social_force",
+        scenario_template=tmp_path / "missing-template.yaml",
+        output_dir=tmp_path / "out",
+    )
+
+    try:
+        production_qd_evaluator(search_config)
+    except FileNotFoundError as exc:
+        assert "missing-template.yaml" in str(exc)
+    else:
+        raise AssertionError("production_qd_evaluator accepted a missing scenario template")
+
+
+def test_production_qd_evaluator_never_reuses_candidate_directory(tmp_path: Path) -> None:
+    """Adapter reuse beyond the nominal budget keeps bundle indices monotonic."""
+    qd_config = _qd_config(
+        GridSpec(x_min=0.0, x_max=2.5, y_min=0.0, y_max=3.0, bins=4),
+        budget=1,
+    )
+    template = _write_template(tmp_path / "template.yaml")
+    search_config = qd_config.to_search_config(
+        policy="social_force",
+        scenario_template=template,
+        output_dir=tmp_path / "out",
+    )
+    evaluator = production_qd_evaluator(
+        search_config,
+        candidate_evaluator=_production_evaluator(),
+        certifier=_passing_certifier(),
+    )
+
+    evaluator(qd_config, _candidate(0))
+    evaluator(qd_config, _candidate(1))
+
+    assert (search_config.output_dir / "candidate_0000").is_dir()
+    assert (search_config.output_dir / "candidate_0001").is_dir()
+
+
+def test_production_candidate_rejection_writes_failure_attribution(
+    tmp_path: Path,
+) -> None:
+    """Certification rejection preserves canonical failure-attribution provenance."""
+    qd_config = _qd_config(
+        GridSpec(x_min=0.0, x_max=2.5, y_min=0.0, y_max=3.0, bins=4),
+        budget=1,
+    )
+    template = _write_template(tmp_path / "template.yaml")
+    search_config = qd_config.to_search_config(
+        policy="social_force",
+        scenario_template=template,
+        output_dir=tmp_path / "out",
+    )
+
+    def _reject(candidate, scenario_yaml_path, require_certification):
+        return failed_status("fixture certification rejection")
+
+    evaluator = production_candidate_evaluator(
+        evaluator=_production_evaluator(),
+        certifier=_reject,
+    )
+    evaluation = evaluator(search_config, _candidate(0), 0)
+    attribution_path = search_config.output_dir / "candidate_0000" / "failure_attribution.json"
+
+    assert evaluation.failure_attribution is not None
+    assert json.loads(attribution_path.read_text(encoding="utf-8")) == (
+        evaluation.failure_attribution.to_json()
+    )

--- a/tests/adversarial/test_issue_5308_qd_production.py
+++ b/tests/adversarial/test_issue_5308_qd_production.py
@@ -1,0 +1,290 @@
+"""CPU tests for the production integration of MAP-Elites QD search (issue #5308).
+
+These tests wire ``run_map_elites`` to the real adversarial validation /
+materialization / certification / evaluation pipeline through
+``production_qd_evaluator`` and ``QDSearchConfig.to_search_config``. The heavyweight
+benchmark runner is replaced by an injected production evaluator so the integration
+contract (bundle layout, certification gate, objective attachment, descriptor path)
+is exercised on CPU without running a simulator. This is capability plumbing, not a
+benchmark claim.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from robot_sf.adversarial.attribution import attribution_from_episode_record
+from robot_sf.adversarial.certification import passed_status
+from robot_sf.adversarial.config import (
+    CandidateEvaluation,
+    CandidateSpec,
+    Pose2D,
+    RangeConfig,
+    SearchConfig,
+    SearchSpaceConfig,
+)
+from robot_sf.adversarial.qd import (
+    QD_ARCHIVE_SCHEMA_VERSION,
+    GridSpec,
+    QDSearchConfig,
+    production_qd_evaluator,
+    run_map_elites,
+    write_qd_archive,
+)
+from robot_sf.adversarial.search import production_candidate_evaluator
+
+
+def _space() -> SearchSpaceConfig:
+    """Build a 2D search space spanning start/goal x with fixed seeds."""
+    return SearchSpaceConfig(
+        start_x=RangeConfig(0.0, 4.0),
+        start_y=RangeConfig(0.0, 0.0),
+        goal_x=RangeConfig(0.0, 4.0),
+        goal_y=RangeConfig(0.0, 0.0),
+        spawn_time_s=RangeConfig(0.0, 0.0),
+        pedestrian_speed_mps=RangeConfig(1.0, 1.0),
+        pedestrian_delay_s=RangeConfig(0.0, 0.0),
+        scenario_seed=RangeConfig(1.0, 1.0),
+    )
+
+
+def _candidate(index: int) -> CandidateSpec:
+    """Build one candidate spanning the search space by index."""
+    return CandidateSpec(
+        start=Pose2D(float(index) * 0.4, 0.0),
+        goal=Pose2D(4.0 - float(index) * 0.4, 0.0),
+        spawn_time_s=0.0,
+        pedestrian_speed_mps=1.0,
+        pedestrian_delay_s=0.0,
+        scenario_seed=1,
+    )
+
+
+def _record(min_distance: float, critical_time: float, failure: str = "collision") -> dict:
+    """Build a minimal episode record carrying the QD behavior descriptors."""
+    if failure == "collision":
+        termination = "collision"
+        outcome = {"route_complete": False, "collision": True}
+    elif failure == "timeout":
+        termination = "timeout"
+        outcome = {"route_complete": False, "timeout": True}
+    else:
+        termination = "incomplete"
+        outcome = {"route_complete": False}
+    return {
+        "status": "completed",
+        "termination_reason": termination,
+        "outcome": outcome,
+        "metrics": {
+            "distance_to_human_min": min_distance,
+            "time_to_collision_min": critical_time,
+        },
+    }
+
+
+def _production_evaluator(tmp_root: Path) -> object:
+    """Injected four-argument production evaluator that writes a real bundle + record.
+
+    Mirrors the contract of ``search._default_evaluator``: write the scenario-derived
+    episode record into ``candidate_dir/episode_records.jsonl`` and return a
+    ``CandidateEvaluation`` carrying the path so the QD behavior descriptor can be read.
+    """
+    count = {"n": 0}
+
+    def _evaluate(
+        config: SearchConfig,
+        candidate: CandidateSpec,
+        scenario_yaml_path: Path,
+        candidate_dir: Path,
+    ) -> CandidateEvaluation:
+        index = count["n"]
+        count["n"] += 1
+        record = _record(
+            min_distance=2.5 * ((index % 4) / 3.0),
+            critical_time=3.0 * ((index % 3) / 2.0),
+            failure=["collision", "timeout", "incomplete"][index % 3],
+        )
+        episode_path = candidate_dir / "episode_records.jsonl"
+        episode_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+        attribution = attribution_from_episode_record(record)
+        return CandidateEvaluation(
+            candidate=candidate,
+            certification_status=passed_status("production adapter fixture"),
+            objective_value=None,
+            failure_attribution=attribution,
+            episode_record_path=episode_path,
+            trajectory_csv_path=None,
+            scenario_yaml_path=scenario_yaml_path,
+            bundle_path=candidate_dir,
+        )
+
+    return _evaluate
+
+
+def _passing_certifier() -> object:
+    """Injected certifier that always passes, so the integration test exercises the
+    materialization / evaluation / archive path without a real certification package."""
+
+    def _certify(candidate, scenario_yaml_path, require_certification):
+        return passed_status("injected passing certifier")
+
+    return _certify
+
+
+def _qd_config(grid: GridSpec, *, budget: int = 12, seed: int = 7) -> QDSearchConfig:
+    """Build a QD search config over the shared search space."""
+    return QDSearchConfig(
+        search_space=_space(),
+        objective="worst_case_snqi",
+        grid=grid,
+        budget=budget,
+        seed=seed,
+        require_certification=False,
+    )
+
+
+def _write_template(path: Path) -> Path:
+    """Write a minimal valid scenario template so materialization can run."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "scenarios": [
+                    {
+                        "name": "doorway",
+                        "robot": {"start": [0.0, 0.0], "goal": [4.0, 0.0]},
+                    }
+                ]
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_production_evaluator_populates_archive_with_real_bundles(tmp_path: Path) -> None:
+    """production_qd_evaluator runs the real pipeline and fills the QD grid."""
+    grid = GridSpec(x_min=0.0, x_max=2.5, y_min=0.0, y_max=3.0, bins=4)
+    qd_config = _qd_config(grid)
+    template = _write_template(tmp_path / "template.yaml")
+    search_config = qd_config.to_search_config(
+        policy="social_force",
+        scenario_template=template,
+        output_dir=tmp_path / "prod_out",
+    )
+    evaluator = production_qd_evaluator(
+        search_config,
+        candidate_evaluator=_production_evaluator(tmp_path),
+        certifier=_passing_certifier(),
+    )
+
+    result = run_map_elites(qd_config, evaluator=evaluator)
+
+    assert result.num_evaluated == 12
+    assert result.archive.filled_cell_count() >= 2
+    assert len(result.archive.distinct_failure_modes()) >= 2
+    assert (search_config.output_dir / "candidate_0000").is_dir()
+
+
+def test_production_evaluator_writes_archive_artifact(tmp_path: Path) -> None:
+    """The production-wired QD run emits a schema-versioned coverage artifact."""
+    grid = GridSpec(x_min=0.0, x_max=2.5, y_min=0.0, y_max=3.0, bins=4)
+    qd_config = _qd_config(grid)
+    template = _write_template(tmp_path / "template.yaml")
+    search_config = qd_config.to_search_config(
+        policy="social_force",
+        scenario_template=template,
+        output_dir=tmp_path / "prod_out",
+    )
+    evaluator = production_qd_evaluator(
+        search_config,
+        candidate_evaluator=_production_evaluator(tmp_path),
+        certifier=_passing_certifier(),
+    )
+    result = run_map_elites(qd_config, evaluator=evaluator)
+
+    artifact = write_qd_archive(result, tmp_path / "prod_archive.json")
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == QD_ARCHIVE_SCHEMA_VERSION
+    assert payload["summary"]["filled_cell_count"] == result.archive.filled_cell_count()
+    assert payload["summary"]["qd_score"] > 0.0
+
+
+def test_production_evaluator_is_reproducible(tmp_path: Path) -> None:
+    """Same config + injected production evaluator yields an identical archive."""
+    grid = GridSpec(x_min=0.0, x_max=2.5, y_min=0.0, y_max=3.0, bins=4)
+    qd_config = _qd_config(grid, budget=11)
+
+    def _run() -> dict:
+        template = _write_template(tmp_path / "template.yaml")
+        search_config = qd_config.to_search_config(
+            policy="social_force",
+            scenario_template=template,
+            output_dir=tmp_path / f"out_{id(_run)}",
+        )
+        evaluator = production_qd_evaluator(
+            search_config,
+            candidate_evaluator=_production_evaluator(tmp_path),
+            certifier=_passing_certifier(),
+        )
+        return run_map_elites(qd_config, evaluator=evaluator).to_json()
+
+    assert _run() == _run()
+
+
+def test_to_search_config_writes_search_space(tmp_path: Path) -> None:
+    """QDSearchConfig.to_search_config materializes a loadable search-space YAML."""
+    grid = GridSpec(x_min=0.0, x_max=2.5, y_min=0.0, y_max=3.0, bins=4)
+    qd_config = _qd_config(grid)
+    template = _write_template(tmp_path / "template.yaml")
+    search_config = qd_config.to_search_config(
+        policy="social_force",
+        scenario_template=template,
+        output_dir=tmp_path / "out",
+    )
+    assert search_config.budget == 12
+    assert search_config.objective == "worst_case_snqi"
+    assert search_config.search_space_path.exists()
+    reloaded = SearchSpaceConfig.from_file(search_config.search_space_path)
+    assert reloaded.start_x.min == 0.0
+    assert reloaded.start_x.max == 4.0
+
+
+def test_production_evaluator_handles_invalid_candidate(tmp_path: Path) -> None:
+    """Candidates failing search-space validation are skipped, not evaluated."""
+    grid = GridSpec(x_min=0.0, x_max=2.5, y_min=0.0, y_max=3.0, bins=4)
+    space = _space()
+    qd_config = QDSearchConfig(
+        search_space=space,
+        objective="worst_case_snqi",
+        grid=grid,
+        budget=4,
+        seed=7,
+        require_certification=False,
+    )
+    template = _write_template(tmp_path / "template.yaml")
+    search_config = qd_config.to_search_config(
+        policy="social_force",
+        scenario_template=template,
+        output_dir=tmp_path / "out",
+    )
+    step = production_candidate_evaluator(
+        evaluator=_production_evaluator(tmp_path),
+        certifier=_passing_certifier(),
+    )
+    out_of_range = CandidateSpec(
+        start=Pose2D(99.0, 0.0),
+        goal=Pose2D(4.0, 0.0),
+        spawn_time_s=0.0,
+        pedestrian_speed_mps=1.0,
+        pedestrian_delay_s=0.0,
+        scenario_seed=1,
+    )
+    evaluation = step(search_config, out_of_range, 0)
+    assert evaluation.error is not None
+    assert evaluation.certification_status.status == "failed"
+    assert evaluation.episode_record_path is None


### PR DESCRIPTION
## What / Why

This is slice 2 of issue #5308 (MAP-Elites / CMA-ME quality-diversity adversarial
search). PR #5846 already merged the dependency-light archive capability and the
equal-budget comparison contracts. The issue thread lists a remaining
production-integration item:

> 1. integrate canonical candidate validation/materialization/certification/evaluation;

This PR adds exactly that: it wires the QD archive to the **real adversarial
pipeline** so `run_map_elites` can run against the actual
validation → materialization → certification → benchmark-evaluation sequence
instead of an injected stub.

### Capability added (new, not duplicative of PR #5846)

- `qd.production_qd_evaluator(search_config)` — adapts a production `SearchConfig`
  to the QD `QDEvaluator` contract `(qd_config, candidate) -> CandidateEvaluation`.
  Each candidate is run through the canonical per-candidate pipeline
  (`search.production_candidate_evaluator`) under a replayable bundle layout
  `output_dir/candidate_NNNN/`.
- `qd.QDSearchConfig.to_search_config(...)` — materializes the production
  `SearchConfig` (scenario template, policy, output dir, evaluator settings) that
  the cheap-lane QD config deliberately omits.
- `search.production_candidate_evaluator(...)` — exposes the per-candidate
  production step, reusing the existing `run_adversarial_search` helpers
  (validation, `write_candidate_inputs`, certifier, objective attachment,
  failure-attribution on exceptions).

This is capability plumbing only. It does **not** run the doorway campaign,
establish stable real failure modes, or add CMA-ME / #5833 warm starts — those
remain open in issue #5308.

## Validation

- `uv run ruff check robot_sf/adversarial/qd.py robot_sf/adversarial/search.py
  robot_sf/adversarial/__init__.py tests/adversarial/test_issue_5308_qd_production.py`
  — All checks passed.
- `uv run pytest tests/adversarial/test_issue_5308_qd_production.py -q` — 5 passed.
- `uv run pytest tests/adversarial/test_issue_5308_qd.py -q` (regression) — 12 passed.

The 5 new CPU-level tests cover: archive population via the real pipeline with
replayable bundles, schema-versioned archive artifact emission, reproducibility
under fixed seed, `to_search_config` materializing a loadable search-space YAML,
and invalid-candidate skipping (failed validation is not evaluated or admitted).
The heavyweight benchmark runner is replaced by an injected production evaluator +
passing certifier in tests so the integration contract is exercised on CPU without
running a simulator — this is not a benchmark or camera-ready claim.

## Scope And Evidence Boundary

- Proves the integration wiring (bundle layout, certification gate, objective
  attachment, descriptor read path) on CPU.
- No campaign, no Slurm, no training, no empirical QD evidence.
- The generated archive from tests is a synthetic test artifact, not nominal
  benchmark evidence.

## Successor statement

This PR adds the production-integration capability (item 1 of the issue thread)
and does **not** duplicate PR #5846 (archive capability + comparison contracts).
Still open in issue #5308: the bounded <=4h doorway campaign with real episode
records, stable real-failure evidence at matched budgets, and the #5833 warm-start
/ optional CMA-ME emitter work.

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation
lane; the review gate hardens and merges.

Refs #5308
