### PR TITLE
Issue #5856: reject NEW placeholder docstrings in PR diffs (cheap-lane worker)

### DIFF
--- a/scripts/ci/pr_contract_check.py
+++ b/scripts/ci/pr_contract_check.py
@@ -44,6 +44,21 @@ EVIDENCE_REVIEW_SIDECAR_SUFFIX = ".review.json"
 EVIDENCE_REVIEW_SCHEMA_VERSION = "evidence-review-marker.v1"
 LOWERCASE_SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
 
+# Issue #5856: ratchet against NEW placeholder docstrings introduced in a PR diff.
+# Only ADDED lines count (pre-existing stubs are grandfathered), so unrelated PRs
+# that merely touch a file already carrying old stubs still pass.
+PLACEHOLDER_DOCSTRING_PATTERNS = [
+    re.compile(r"TODO docstring", re.IGNORECASE),
+    re.compile(r"Document this (?:function|class|module|method)", re.IGNORECASE),
+    re.compile(r'^\s*"""\."""\s*$'),  # trivially-empty docstring """."""
+    re.compile(r"^\s*'''\.'''\\s*$", re.IGNORECASE),  # trivially-empty docstring '''.
+]
+PLACEHOLDER_LINE_HINT = re.compile(
+    r"TODO docstring|Document this (?:function|class|module|method)"
+    r'|^\s*"""\."""\s*$|^\s*\'\'\'\.\'\'\'\s*$',
+    re.IGNORECASE,
+)
+
 
 def is_negated(text: str, match_start: int) -> bool:
     """Check if the matched word is negated in the preceding context."""
@@ -711,6 +726,114 @@ def post_or_update_comment(pr_number: str, repo: str, comment_body: str) -> None
             print(f"Error creating comment: {e}", file=sys.stderr)
 
 
+def _diff_added_python_lines(base_ref: str, repo_root: str | None = None) -> dict[str, list[int]]:
+    """Return the set of NEW-file line numbers added per Python file vs ``base_ref``.
+
+    Parses zero-context ``git diff`` hunk headers and keeps only ``+``-prefixed
+    new-file line numbers. This is the ratchet signal: only ADDED content can
+    introduce new placeholder docstrings; removed/context lines are ignored so
+    pre-existing stubs are grandfathered (issue #5856). When ``repo_root`` is
+    given, the diff runs scoped to that git repository so callers (notably tests
+    in a nested throwaway repo) are not polluted by a parent checkout's history.
+    """
+    added: dict[str, list[int]] = {}
+    git_cmd = ["git"]
+    if repo_root is not None:
+        git_cmd += [f"--git-dir={repo_root}/.git", f"--work-tree={repo_root}"]
+    try:
+        res = subprocess.run(
+            git_cmd + ["diff", "--unified=0", f"{base_ref}...HEAD", "--", "*.py"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if res.returncode != 0:
+            return added
+        current_file: str | None = None
+        for line in res.stdout.splitlines():
+            if line.startswith("+++ b/"):
+                current_file = line[len("+++ b/") :].strip()
+                added.setdefault(current_file, [])
+                continue
+            if current_file is None or not line.startswith("@@"):
+                continue
+            span = _parse_added_line_span(line)
+            if span is None:
+                continue
+            start, count = span
+            added[current_file].extend(range(start, start + count))
+    except _BEST_EFFORT_ERRORS:
+        return {}
+    return added
+
+
+def _parse_added_line_span(hunk_header: str) -> tuple[int, int] | None:
+    """Parse the ``+c,d`` part of a ``git diff --unified=0`` hunk header.
+
+    Returns ``(start, count)`` for the added lines, or ``None`` when the header
+    cannot be parsed. A missing ``,count`` means a single added line.
+    """
+    try:
+        new_part = hunk_header.split("+", 1)[1].split("@@", 1)[0].strip()
+    except IndexError:
+        return None
+    try:
+        if "," in new_part:
+            start = int(new_part.split(",", 1)[0])
+            count = int(new_part.split(",", 1)[1])
+        else:
+            start = int(new_part)
+            count = 1
+    except ValueError:
+        return None
+    if count <= 0:
+        return None
+    return start, count
+
+
+def check_placeholder_docstrings(base_ref: str, repo_root: str | None = None) -> list[str]:
+    """Rule 8: Reject NEW placeholder docstrings added in the PR diff (issue #5856).
+
+    Only ADDED lines (vs ``base_ref``) are inspected. Pre-existing stubs that the
+    PR merely touches are grandfathered and do not fail. Returns BLOCKER messages
+    that name the exact added file:line for each flagged placeholder. When
+    ``repo_root`` is given the scan is scoped to that repository (used by tests).
+    """
+    blockers: list[str] = []
+    added = _diff_added_python_lines(base_ref, repo_root)
+    for rel_path, line_numbers in sorted(added.items()):
+        if not line_numbers:
+            continue
+        path = rel_path.replace("\\", "/").strip()
+        # When the diff was scoped to a throwaway repo (tests), resolve the file
+        # against that root; otherwise open relative to the current working dir.
+        fs_path = os.path.join(repo_root, path) if repo_root else path
+        try:
+            with open(fs_path, encoding="utf-8") as handle:
+                file_lines = handle.readlines()
+        except _BEST_EFFORT_ERRORS:
+            continue
+        for lineno in line_numbers:
+            idx = lineno - 1
+            if idx < 0 or idx >= len(file_lines):
+                continue
+            text = file_lines[idx].rstrip("\n")
+            matched = None
+            for pattern in PLACEHOLDER_DOCSTRING_PATTERNS:
+                if pattern.search(text):
+                    matched = pattern.pattern
+                    break
+            if matched is not None:
+                blockers.append(
+                    f"BLOCKER: PR diff adds placeholder docstring content at "
+                    f"'{path}:{lineno}' matching /{matched}/. New placeholder docstrings "
+                    f"('TODO docstring', 'Document this function/class/module/method', "
+                    f'or trivially-empty \'"""."""\') are rejected by the issue #5856 ratchet. '
+                    f"Replace it with a real one-line docstring."
+                )
+    return blockers
+
+
 def run_all_checks(
     title: str,
     body: str,
@@ -752,6 +875,9 @@ def run_all_checks(
     lane_info, _ = check_worker_lane_provenance(body, pr_number, repo)
     infos.append(lane_info)
 
+    # 8. Placeholder docstring ratchet (issue #5856): reject NEW placeholder docstrings.
+    blockers.extend(check_placeholder_docstrings(base_ref))
+
     return blockers, warnings, infos
 
 
@@ -788,6 +914,11 @@ def build_comment_body(
     lane_detected = "Added 'cheap-lane' label" in "".join(infos)
     rows.append(
         f"| 7. Worker-lane label | {'🏷️ cheap-lane' if lane_detected else '⚪ None'} | Label PRs from cheap worker lane |"
+    )
+    rows.append(
+        f"| 8. Placeholder docstring ratchet | "
+        f"{get_status_str(any('placeholder docstring' in b.lower() for b in blockers))} | "
+        f"Reject NEW TODO/empty docstrings in added diff lines |"
     )
 
     comment = [

--- a/scripts/ci/pr_contract_check.py
+++ b/scripts/ci/pr_contract_check.py
@@ -48,16 +48,15 @@ LOWERCASE_SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
 # Only ADDED lines count (pre-existing stubs are grandfathered), so unrelated PRs
 # that merely touch a file already carrying old stubs still pass.
 PLACEHOLDER_DOCSTRING_PATTERNS = [
-    re.compile(r"TODO docstring", re.IGNORECASE),
-    re.compile(r"Document this (?:function|class|module|method)", re.IGNORECASE),
+    re.compile(r"^\s*(?:[ru]{0,2})?(?:\"\"\"|''')\s*TODO docstring", re.IGNORECASE),
+    re.compile(
+        r"^\s*(?:[ru]{0,2})?(?:\"\"\"|''')\s*Document this "
+        r"(?:function|class|module|method)",
+        re.IGNORECASE,
+    ),
     re.compile(r'^\s*"""\."""\s*$'),  # trivially-empty docstring """."""
-    re.compile(r"^\s*'''\.'''\\s*$", re.IGNORECASE),  # trivially-empty docstring '''.
+    re.compile(r"^\s*'''\.'''\s*$", re.IGNORECASE),  # trivially-empty docstring '''.
 ]
-PLACEHOLDER_LINE_HINT = re.compile(
-    r"TODO docstring|Document this (?:function|class|module|method)"
-    r'|^\s*"""\."""\s*$|^\s*\'\'\'\.\'\'\'\s*$',
-    re.IGNORECASE,
-)
 
 
 def is_negated(text: str, match_start: int) -> bool:
@@ -742,7 +741,16 @@ def _diff_added_python_lines(base_ref: str, repo_root: str | None = None) -> dic
         git_cmd += [f"--git-dir={repo_root}/.git", f"--work-tree={repo_root}"]
     try:
         res = subprocess.run(
-            git_cmd + ["diff", "--unified=0", f"{base_ref}...HEAD", "--", "*.py"],
+            git_cmd
+            + [
+                "diff",
+                "--unified=0",
+                "--src-prefix=a/",
+                "--dst-prefix=b/",
+                f"{base_ref}...HEAD",
+                "--",
+                "*.py",
+            ],
             capture_output=True,
             text=True,
             check=False,

--- a/tests/validation/test_pr_contract_check.py
+++ b/tests/validation/test_pr_contract_check.py
@@ -502,6 +502,98 @@ def test_regression_last_20_merged_prs() -> None:
         assert not blockers, f"PR #{number} ('{title}') triggered false blockers: {blockers}"
 
 
+class TestPlaceholderDocstringRatchet:
+    """Issue #5856: reject NEW placeholder docstrings added in the PR diff.
+
+    These tests exercise the git-diff-backed ratchet in an isolated throwaway git
+    repository so they do not depend on the surrounding robot_sf_ll7 history.
+    """
+
+    def _init_repo(self, tmp_path: Path) -> Path:
+        """Create and initialize a throwaway git repo rooted at ``tmp_path``."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "ci@example.com"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "CI"], cwd=repo, check=True)
+        # A base commit with a pre-existing (grandfathered) stub.
+        legacy = repo / "tool.py"
+        legacy.write_text(
+            'def legacy():\n    """TODO docstring. Document this function."""\n    return 1\n',
+            encoding="utf-8",
+        )
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=repo, check=True)
+        return repo
+
+    def _commit_change(self, repo: Path, filename: str, content: str) -> None:
+        """Write a tracked file at ``repo`` and commit it as a new HEAD."""
+        (repo / filename).write_text(content, encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "change"], cwd=repo, check=True)
+
+    def test_adds_placeholder_docstring_fails(self, tmp_path: Path) -> None:
+        """A PR that ADDS a 'TODO docstring' line is blocked with file:line."""
+        repo = self._init_repo(tmp_path)
+        self._commit_change(
+            repo,
+            "new.py",
+            'def do_thing():\n    """TODO docstring. Document this function."""\n    return 0\n',
+        )
+        blockers = pr_contract_check.check_placeholder_docstrings("HEAD~1", repo_root=str(repo))
+        blocker = next((b for b in blockers if "new.py" in b), None)
+        assert blocker is not None, f"expected blocker for new.py, got: {blockers}"
+        assert "new.py:2" in blocker
+
+    def test_adds_empty_docstring_fails(self, tmp_path: Path) -> None:
+        """A PR that ADDS a trivially-empty '\"\"\".\"\"\"' line is blocked."""
+        repo = self._init_repo(tmp_path)
+        self._commit_change(
+            repo,
+            "new.py",
+            'def do_thing():\n    """."""\n    return 0\n',
+        )
+        blockers = pr_contract_check.check_placeholder_docstrings("HEAD~1", repo_root=str(repo))
+        assert any("new.py:2" in b for b in blockers)
+
+    def test_touching_legacy_stub_passes(self, tmp_path: Path) -> None:
+        """Touching a file that already has a stub (without adding new ones) passes."""
+        repo = self._init_repo(tmp_path)
+        # Only modify a non-docstring line; the old stub remains but is not ADDED.
+        legacy = repo / "tool.py"
+        legacy.write_text(
+            'def legacy():\n    """TODO docstring. Document this function."""\n    return 2\n',
+            encoding="utf-8",
+        )
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "touch"], cwd=repo, check=True)
+        blockers = pr_contract_check.check_placeholder_docstrings("HEAD~1", repo_root=str(repo))
+        assert not blockers
+
+    def test_real_docstring_passes(self, tmp_path: Path) -> None:
+        """Adding a genuine one-line docstring is accepted."""
+        repo = self._init_repo(tmp_path)
+        self._commit_change(
+            repo,
+            "new.py",
+            'def do_thing():\n    """Compute the thing and return a result."""\n    return 0\n',
+        )
+        assert not pr_contract_check.check_placeholder_docstrings("HEAD~1", repo_root=str(repo))
+
+    def test_diff_added_line_parser(self, tmp_path: Path) -> None:
+        """_diff_added_python_lines maps added line numbers per file."""
+        repo = self._init_repo(tmp_path)
+        self._commit_change(
+            repo,
+            "new.py",
+            'def a():\n    """real."""\n    return 0\n\ndef b():\n    """TODO docstring."""\n    return 1\n',
+        )
+        added = pr_contract_check._diff_added_python_lines("HEAD~1", repo_root=str(repo))
+        # The fixture file has a blank line between the two functions, so 7 lines
+        # are added; the parser must enumerate every added line number.
+        assert added.get("new.py") == [1, 2, 3, 4, 5, 6, 7]
+
+
 class TestWorkflowFetchFallback:
     """Validate the PR contract-check workflow tolerates fetch failure.
 

--- a/tests/validation/test_pr_contract_check.py
+++ b/tests/validation/test_pr_contract_check.py
@@ -556,6 +556,40 @@ class TestPlaceholderDocstringRatchet:
         blockers = pr_contract_check.check_placeholder_docstrings("HEAD~1", repo_root=str(repo))
         assert any("new.py:2" in b for b in blockers)
 
+    def test_adds_single_quoted_empty_docstring_fails(self, tmp_path: Path) -> None:
+        """A PR that ADDS a trivially-empty triple-single-quoted line is blocked."""
+        repo = self._init_repo(tmp_path)
+        self._commit_change(
+            repo,
+            "new.py",
+            "def do_thing():\n    '''.'''\n    return 0\n",
+        )
+        blockers = pr_contract_check.check_placeholder_docstrings("HEAD~1", repo_root=str(repo))
+        assert any("new.py:2" in b for b in blockers)
+
+    def test_noprefix_config_cannot_bypass_ratchet(self, tmp_path: Path) -> None:
+        """Explicit diff prefixes keep the ratchet active with ``diff.noprefix``."""
+        repo = self._init_repo(tmp_path)
+        subprocess.run(["git", "config", "diff.noprefix", "true"], cwd=repo, check=True)
+        self._commit_change(
+            repo,
+            "new.py",
+            'def do_thing():\n    """TODO docstring."""\n    return 0\n',
+        )
+        blockers = pr_contract_check.check_placeholder_docstrings("HEAD~1", repo_root=str(repo))
+        assert any("new.py:2" in b for b in blockers)
+
+    def test_placeholder_text_inside_fixture_string_passes(self, tmp_path: Path) -> None:
+        """Placeholder examples inside non-docstring source strings are allowed."""
+        repo = self._init_repo(tmp_path)
+        self._commit_change(
+            repo,
+            "test_example.py",
+            'SOURCE = \'def f():\\n    """TODO docstring."""\\n\'\n',
+        )
+        blockers = pr_contract_check.check_placeholder_docstrings("HEAD~1", repo_root=str(repo))
+        assert not blockers
+
     def test_touching_legacy_stub_passes(self, tmp_path: Path) -> None:
         """Touching a file that already has a stub (without adding new ones) passes."""
         repo = self._init_repo(tmp_path)


### PR DESCRIPTION
## What / Why

PR #5847 merged with literal placeholder docstrings (`"""TODO docstring. Document this function."""`) in `tests/conftest.py`. ruff's D-rules only assert a docstring *exists*, so a TODO stub passes. This PR adds the missing ratchet: **Rule 8** of `pr_contract_check.py` now FAILS a PR when its diff **ADDS** placeholder docstring content — `TODO docstring`, `Document this (function|class|module|method)`, or a trivially-empty `"""."""` / `'''.'''`. Only *added* diff lines are inspected (ratchet semantics), so the ~dozens of pre-existing legacy stubs are grandfathered and unrelated PRs still pass. Each blocker names the exact added `file:line`.

## Changes

- `scripts/ci/pr_contract_check.py`: new `check_placeholder_docstrings` (Rule 8) + `_diff_added_python_lines` / `_parse_added_line_span` helpers that parse zero-context `git diff` hunk headers; wired into `run_all_checks` and the summary table.
- `tests/validation/test_pr_contract_check.py`: `TestPlaceholderDocstringRatchet` — added TODO docstring fails with `file:line`, added empty docstring fails, touching a legacy stub passes, real docstring passes, diff-line parser correct.
- Workflow unchanged: the check self-computes `git diff origin/<base>...HEAD -- *.py`; the existing fetch-base step already makes `origin/main` resolvable.

## Acceptance (from issue)

- A PR adding `"""TODO docstring."""` fails the contract check naming the added line. ✅ (verified end-to-end against `origin/main`: blocker `_ratchet_probe.py:2`)
- A PR touching a file that already contains old stubs (without adding new ones) passes. ✅
- Fixture tests for both directions. ✅

## Validation

- `uv run pytest tests/validation/test_pr_contract_check.py` → 37 passed (incl. the 20-merged-PR regression check: zero false blockers).
- `uv run ruff check` / `ruff format --check` clean on both changed files.
- End-to-end probe: added `TODO docstring` line produced `BLOCKER ... _ratchet_probe.py:2`; probe reverted.

## Scope note

This fully resolves the **ratchet check** (the fix, §1 of the issue) and its acceptance criteria. The optional **legacy stub cleanup** (§2, "queue filler, low priority", explicitly splittable per directory) is intentionally left for follow-up cleanup slices — it is not required for the ratchet to enforce, and this PR adds no new stubs. Remaining: file-by-file replacement of the ~222 existing `TODO docstring` stubs (tracked via `git grep -c "TODO docstring"`).

Closes #5856

This PR was produced by the CommandCode/Tencent-Hy3 cheap implementation lane; the review gate hardens and merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pull request checks now detect newly added placeholder or empty Python docstrings.
  - Validation reports the affected file and line when a placeholder docstring is found.
  - Check results now include a dedicated placeholder-docstring status in the summary.

- **Bug Fixes**
  - Existing legacy placeholder docstrings are preserved without triggering new warnings.

- **Tests**
  - Added coverage for placeholder detection, legitimate docstrings, legacy content, and changed-line tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->