### PR TITLE
Issue #5308: CMA-ME emitter for MAP-Elites QD grid (successor slice 3, cheap-lane worker)

### DIFF
--- a/robot_sf/adversarial/__init__.py
+++ b/robot_sf/adversarial/__init__.py
@@ -10,6 +10,7 @@ from robot_sf.adversarial.batch_certification import (
     certify_candidate_batch,
     certify_records,
 )
+from robot_sf.adversarial.cma_me import CMaMeEmitter
 from robot_sf.adversarial.config import (
     CandidateEvaluation,
     CandidateSpec,
@@ -101,6 +102,7 @@ __all__ = [
     "AdversarialScenarioManifest",
     "BatchCertification",
     "BatchCertificationPolicy",
+    "CMaMeEmitter",
     "CandidateCertification",
     "CandidateEvaluation",
     "CandidateSpec",

--- a/robot_sf/adversarial/cma_me.py
+++ b/robot_sf/adversarial/cma_me.py
@@ -1,0 +1,388 @@
+"""CMA-ME emitter for the MAP-Elites quality-diversity adversarial search (issue #5308).
+
+Implements a CMA-ME (CMA-ES-Multimodal-Evolution) emitter that feeds the
+``robot_sf/adversarial/qd.py`` MAP-Elites grid. Unlike the single-objective
+``CmaEsCandidateSampler`` (which improves one global incumbent), a CMA-ME emitter
+runs a separate CMA-ES instance **per target archive cell** so the search populates
+DISTINCT behavior cells instead of only the globally best worst case. This is the
+remaining "later CMA-ME work" named in issue #5308; it is a NEW capability, not a
+duplicate of PR #5846 (grid archive) or PR #5852 (production wiring).
+
+Target-cell selection is diversity-driven: the emitter repeatedly picks the
+least-filled cell and seeds a local CMA-ES around that cell's incumbent candidate
+(resampling inside the cell bounds). Every evaluated candidate is observed so the
+active optimizer's generation is fed back once the population is fully observed, and
+so the cell-selection frontier advances.
+
+The heavyweight ``cma`` dependency is imported lazily. The emitter also accepts an
+injected ``optimizer_factory`` so the CMA-ME scheduling/selection logic can be
+validated on CPU without ``cma`` installed (the canonical QD test contract).
+
+This module is capability plumbing only. It does not run benchmarks or claim
+evidence; the populated archive artifact is an archive path, not a camera-ready
+finding.
+"""
+
+from __future__ import annotations
+
+import math
+from random import Random
+from typing import TYPE_CHECKING, Any, Protocol
+
+from robot_sf.adversarial.config import CandidateEvaluation, CandidateSpec
+from robot_sf.adversarial.qd import QDArchive
+
+if TYPE_CHECKING:
+    from robot_sf.adversarial.qd import BehaviorDescriptorFn
+
+_CMA_ME_SCHEMA_VERSION = "adversarial_cma_me_emitter.v1"
+
+
+class CellOptimizer(Protocol):
+    """Protocol for a per-cell continuous optimizer backing a CMA-ME emitter."""
+
+    def ask(self) -> list[float]:
+        """Return one proposed active-dimension vector."""
+
+    def tell(self, vectors: list[list[float]], values: list[float]) -> None:
+        """Feed a finished population (vectors + objective values) to the optimizer."""
+
+    def stop(self) -> bool:
+        """Return True when the optimizer should be restarted around the incumbent."""
+
+    @property
+    def mean(self) -> list[float]:
+        """Return the current distribution mean (active-dimension vector)."""
+
+
+class OptimizerFactory(Protocol):
+    """Protocol for building a per-cell optimizer on demand."""
+
+    def __call__(
+        self,
+        *,
+        lower: list[float],
+        upper: list[float],
+        x0: list[float],
+        seed: int,
+    ) -> CellOptimizer:
+        """Build a fresh optimizer for one target cell."""
+
+
+def default_optimizer_factory(
+    *,
+    sigma_fraction: float = 0.25,
+    popsize: int | None = None,
+) -> OptimizerFactory:
+    """Return a CMA-ES-backed optimizer factory (imports ``cma`` lazily)."""
+
+    def _build(
+        *,
+        lower: list[float],
+        upper: list[float],
+        x0: list[float],
+        seed: int,
+    ) -> CellOptimizer:
+        return _CmaCellOptimizer(
+            lower=lower,
+            upper=upper,
+            x0=x0,
+            seed=seed,
+            sigma_fraction=sigma_fraction,
+            popsize=popsize,
+        )
+
+    return _build
+
+
+class _CmaCellOptimizer:
+    """Per-cell CMA-ES optimizer wrapping the ``cma`` package lazily."""
+
+    def __init__(
+        self,
+        *,
+        lower: list[float],
+        upper: list[float],
+        x0: list[float],
+        seed: int,
+        sigma_fraction: float = 0.25,
+        popsize: int | None = None,
+    ) -> None:
+        """Initialize a bounded CMA-ES instance for one cell."""
+        cma = _import_cma()
+        self._cma = cma
+        spans = [upper[i] - lower[i] for i in range(len(lower))]
+        max_span = max(spans) if spans else 1.0
+        sigma0 = max(1e-3, sigma_fraction * max_span)
+        opts: dict[str, Any] = {
+            "bounds": [lower, upper],
+            "seed": int(seed),
+            "verbose": -9,
+        }
+        if popsize is not None:
+            if popsize < 1:
+                raise ValueError("popsize must be >= 1")
+            opts["popsize"] = int(popsize)
+        self._es = cma.CMAEvolutionStrategy(list(x0), sigma0, opts)
+        self._lower = list(lower)
+        self._upper = list(upper)
+
+    def ask(self) -> list[float]:
+        """Return one CMA-ES proposal."""
+        population = self._es.ask()
+        self._pending = list(population)
+        return list(population[0])
+
+    def tell(self, vectors: list[list[float]], values: list[float]) -> None:
+        """Feed a finished population to CMA-ES."""
+        self._es.tell(vectors, values)
+
+    def stop(self) -> bool:
+        """Return True when CMA-ES converged and should be restarted."""
+        return bool(self._es.stop())
+
+    @property
+    def mean(self) -> list[float]:
+        """Return the current CMA-ES mean vector."""
+        return list(self._es.mean)
+
+
+def _import_cma() -> Any:
+    """Import the cma package or raise an actionable optional-dependency error."""
+    from robot_sf.common.optional_import import try_import  # noqa: PLC0415
+
+    cma = try_import("cma")
+    if cma is None:
+        raise RuntimeError(
+            "CMA-ME emitter requires cma. Install project dependencies with "
+            "`uv sync --all-extras` before using the CMA-ES-backed quality-diversity emitter."
+        )
+    return cma
+
+
+def _continuous_bounds(space: Any) -> dict[str, tuple[float, float]]:
+    """Return the (min, max) bound for each continuous candidate dimension."""
+    ranges: dict[str, Any] = {
+        "start.x": space.start_x,
+        "start.y": space.start_y,
+        "goal.x": space.goal_x,
+        "goal.y": space.goal_y,
+        "spawn_time_s": space.spawn_time_s,
+        "pedestrian_speed_mps": space.pedestrian_speed_mps,
+        "pedestrian_delay_s": space.pedestrian_delay_s,
+    }
+    return {name: (float(r.min), float(r.max)) for name, r in ranges.items()}
+
+
+def _clamp(bounds: tuple[float, float], value: float) -> float:
+    """Clamp a scalar into its inclusive range."""
+    return min(float(bounds[1]), max(float(bounds[0]), float(value)))
+
+
+class CMaMeEmitter:
+    """CMA-ME emitter that targets least-filled archive cells with per-cell CMA-ES.
+
+    The emitter implements the ``QDEmitter`` protocol (``sample`` / ``observe``) so it
+    can be mixed with the existing Random + CoordinateRefinement emitters in
+    ``run_map_elites``. It reads the live ``QDArchive`` to pick the next least-filled
+    cell, seeds a CMA-ES around that cell's incumbent candidate, and proposes vectors
+    mapped back into the continuous search space. Discrete ``scenario_seed`` is drawn
+    per proposal from the seeded RNG.
+
+    When ``cma`` is unavailable, inject an ``optimizer_factory`` (e.g. a lightweight
+    Gaussian stub) so the cell-selection and proposal-mapping logic still runs on CPU.
+    """
+
+    _CONTINUOUS_DIMENSIONS = (
+        "start.x",
+        "start.y",
+        "goal.x",
+        "goal.y",
+        "spawn_time_s",
+        "pedestrian_speed_mps",
+        "pedestrian_delay_s",
+    )
+
+    def __init__(
+        self,
+        search_space: Any,
+        archive: QDArchive,
+        *,
+        seed: int,
+        behavior_descriptor: BehaviorDescriptorFn | None = None,
+        optimizer_factory: OptimizerFactory | None = None,
+        sigma_fraction: float = 0.25,
+        popsize: int | None = None,
+    ) -> None:
+        """Initialize a diversity-driven CMA-ME emitter over the archive grid.
+
+        Args:
+            search_space: ``SearchSpaceConfig`` supplying continuous bounds + seeds.
+            archive: Live MAP-Elites archive whose cells drive target selection.
+            seed: Deterministic RNG seed for proposal / seed sampling.
+            behavior_descriptor: Descriptor used to map candidates to cells; defaults
+                to ``qd.default_behavior_descriptor``.
+            optimizer_factory: Injected per-cell optimizer builder; defaults to CMA-ES
+                (``default_optimizer_factory``), which imports ``cma`` lazily.
+            sigma_fraction: Initial CMA-ES step fraction of the largest span.
+            popsize: Optional explicit CMA-ES population size.
+        """
+        if not math.isfinite(sigma_fraction) or sigma_fraction <= 0.0:
+            raise ValueError("sigma_fraction must be finite and positive")
+        from robot_sf.adversarial.qd import default_behavior_descriptor  # noqa: PLC0415
+
+        self._search_space = search_space
+        self._archive = archive
+        self._rng = Random(seed)
+        self._seed_rng = Random(seed ^ 0x9E3779B9)
+        self._behavior_descriptor = behavior_descriptor or default_behavior_descriptor
+        self._optimizer_factory = optimizer_factory or default_optimizer_factory(
+            sigma_fraction=sigma_fraction, popsize=popsize
+        )
+        self._bounds = _continuous_bounds(search_space)
+        self._active_dims = [
+            name
+            for name in self._CONTINUOUS_DIMENSIONS
+            if self._bounds[name][0] != self._bounds[name][1]
+        ]
+        self._fixed_values = {
+            name: 0.5 * (self._bounds[name][0] + self._bounds[name][1])
+            for name in self._CONTINUOUS_DIMENSIONS
+            if self._bounds[name][0] == self._bounds[name][1]
+        }
+        self._current_cell: tuple[int, int] | None = None
+        self._optimizer: CellOptimizer | None = None
+        self._pending_vec: list[float] | None = None
+        self._in_flight: list[tuple[CandidateSpec, list[float]]] = []
+        self._observed: list[tuple[list[float], float]] = []
+
+    def _select_target_cell(self) -> tuple[int, int] | None:
+        """Pick the least-filled cell; return None when the grid is full."""
+        counts = {cell: self._archive.cells.get(cell) is not None for cell in self._all_cells()}
+        empty = [cell for cell, filled in counts.items() if not filled]
+        if not empty:
+            return None
+        return empty[(self._rng.randint(0, len(empty) - 1))]
+
+    def _all_cells(self) -> list[tuple[int, int]]:
+        """Return every grid cell coordinate in row-major order."""
+        grid = self._archive.grid
+        return [(ix, iy) for ix in range(grid.bins) for iy in range(grid.bins)]
+
+    def _incumbent_vec(self, cell: tuple[int, int]) -> list[float]:
+        """Return the active-dimension vector of the cell incumbent, else the midpoint."""
+        incumbent = self._archive.cells.get(cell)
+        if incumbent is not None:
+            candidate = incumbent.candidate
+            return self._candidate_vec(candidate)
+        lower = [self._bounds[name][0] for name in self._active_dims]
+        upper = [self._bounds[name][1] for name in self._active_dims]
+        return [0.5 * (lower[i] + upper[i]) for i in range(len(lower))]
+
+    def _candidate_vec(self, candidate: CandidateSpec) -> list[float]:
+        """Return the active-dimension vector of a candidate."""
+        values = {
+            "start.x": candidate.start.x,
+            "start.y": candidate.start.y,
+            "goal.x": candidate.goal.x,
+            "goal.y": candidate.goal.y,
+            "spawn_time_s": candidate.spawn_time_s,
+            "pedestrian_speed_mps": candidate.pedestrian_speed_mps,
+            "pedestrian_delay_s": candidate.pedestrian_delay_s,
+        }
+        return [float(values[name]) for name in self._active_dims]
+
+    def _make_candidate(self, vec: list[float]) -> CandidateSpec:
+        """Build a candidate from an active-dimension vector plus fixed dims."""
+        values = dict(self._fixed_values)
+        for idx, name in enumerate(self._active_dims):
+            values[name] = _clamp(self._bounds[name], vec[idx])
+        return CandidateSpec(
+            start=_Pose2D(values["start.x"], values["start.y"]),
+            goal=_Pose2D(values["goal.x"], values["goal.y"]),
+            spawn_time_s=values["spawn_time_s"],
+            pedestrian_speed_mps=values["pedestrian_speed_mps"],
+            pedestrian_delay_s=values["pedestrian_delay_s"],
+            scenario_seed=self._seed_rng.randint(
+                int(self._search_space.scenario_seed.min),
+                int(self._search_space.scenario_seed.max),
+            ),
+        )
+
+    def _start_cell_optimizer(self, cell: tuple[int, int]) -> None:
+        """Seed a fresh per-cell optimizer around the cell incumbent."""
+        lower = [self._bounds[name][0] for name in self._active_dims]
+        upper = [self._bounds[name][1] for name in self._active_dims]
+        x0 = self._incumbent_vec(cell)
+        self._current_cell = cell
+        seed = self._rng.randint(0, 2**31 - 1)
+        self._optimizer = self._optimizer_factory(lower=lower, upper=upper, x0=x0, seed=seed)
+
+    def sample(self) -> CandidateSpec:
+        """Return the next CMA-ME proposal, reseeding on a full grid or restart."""
+        if self._current_cell is None or self._optimizer is None:
+            cell = self._select_target_cell()
+            if cell is None:
+                return self._random_fallback()
+            self._start_cell_optimizer(cell)
+        if self._pending_vec is not None:
+            vec = self._pending_vec
+            self._pending_vec = None
+        elif self._optimizer.stop():
+            cell = self._select_target_cell()
+            if cell is None:
+                return self._random_fallback()
+            self._start_cell_optimizer(cell)
+            vec = self._optimizer.ask()
+        else:
+            vec = self._optimizer.ask()
+        candidate = self._make_candidate(vec)
+        self._in_flight.append((candidate, vec))
+        return candidate
+
+    def _random_fallback(self) -> CandidateSpec:
+        """Proposal used only when the grid is full (emitter becomes a pass-through)."""
+        return self._search_space.sample_candidate(self._seed_rng)
+
+    def observe(self, evaluation: CandidateEvaluation) -> None:
+        """Observe one evaluated candidate and feed the active optimizer generation.
+
+        The optimizer is told only once its full population has been observed; scores
+        of unevaluable candidates are treated as the worst value so the optimizer steps
+        away from them.
+        """
+        if self._optimizer is None:
+            return
+        for index, (_candidate, vec) in enumerate(self._in_flight):
+            if _candidate == evaluation.candidate:
+                self._in_flight.pop(index)
+                score = evaluation.objective_value
+                value = float(score) if score is not None and math.isfinite(float(score)) else -1e9
+                self._observed.append((list(vec), value))
+                if not self._in_flight:
+                    self._flush_generation()
+                return
+
+    def _flush_generation(self) -> None:
+        """Feed the buffered generation to the optimizer once fully observed."""
+        vectors = [vec for vec, _value in self._observed]
+        values = [value for _vec, value in self._observed]
+        if vectors:
+            self._optimizer.tell(vectors, values)
+        self._observed = []
+
+
+def _Pose2D(x: float, y: float) -> Any:
+    """Build a ``Pose2D`` from scalars (kept local to avoid a top-level import cycle)."""
+    from robot_sf.adversarial.config import Pose2D  # noqa: PLC0415
+
+    return Pose2D(float(x), float(y))
+
+
+__all__ = [
+    "_CMA_ME_SCHEMA_VERSION",
+    "CMaMeEmitter",
+    "CellOptimizer",
+    "OptimizerFactory",
+    "default_optimizer_factory",
+]

--- a/robot_sf/adversarial/cma_me.py
+++ b/robot_sf/adversarial/cma_me.py
@@ -54,6 +54,10 @@ class CellOptimizer(Protocol):
     def mean(self) -> list[float]:
         """Return the current distribution mean (active-dimension vector)."""
 
+    @property
+    def popsize(self) -> int:
+        """Return the optimizer population size."""
+
 
 class OptimizerFactory(Protocol):
     """Protocol for building a per-cell optimizer on demand."""
@@ -126,16 +130,27 @@ class _CmaCellOptimizer:
         self._es = cma.CMAEvolutionStrategy(list(x0), sigma0, opts)
         self._lower = list(lower)
         self._upper = list(upper)
+        self._pending: list[list[float]] = []
 
     def ask(self) -> list[float]:
         """Return one CMA-ES proposal."""
-        population = self._es.ask()
-        self._pending = list(population)
-        return list(population[0])
+        if not self._pending:
+            population = [list(vector) for vector in self._es.ask()]
+            if len(population) != self.popsize:
+                raise RuntimeError(
+                    f"CMA-ES returned {len(population)} proposals; expected {self.popsize}"
+                )
+            self._pending = population
+        return self._pending.pop(0)
 
     def tell(self, vectors: list[list[float]], values: list[float]) -> None:
-        """Feed a finished population to CMA-ES."""
-        self._es.tell(vectors, values)
+        """Feed one maximize-oriented population to minimizing CMA-ES."""
+        if len(vectors) != self.popsize or len(values) != self.popsize:
+            raise ValueError(
+                f"CMA-ES tell requires one full population ({self.popsize}); "
+                f"got {len(vectors)} vectors and {len(values)} values"
+            )
+        self._es.tell(vectors, [-float(value) for value in values])
 
     def stop(self) -> bool:
         """Return True when CMA-ES converged and should be restarted."""
@@ -145,6 +160,11 @@ class _CmaCellOptimizer:
     def mean(self) -> list[float]:
         """Return the current CMA-ES mean vector."""
         return list(self._es.mean)
+
+    @property
+    def popsize(self) -> int:
+        """Return the CMA-ES population size."""
+        return int(self._es.popsize)
 
 
 def _import_cma() -> Any:
@@ -252,7 +272,6 @@ class CMaMeEmitter:
         }
         self._current_cell: tuple[int, int] | None = None
         self._optimizer: CellOptimizer | None = None
-        self._pending_vec: list[float] | None = None
         self._in_flight: list[tuple[CandidateSpec, list[float]]] = []
         self._observed: list[tuple[list[float], float]] = []
 
@@ -320,15 +339,14 @@ class CMaMeEmitter:
 
     def sample(self) -> CandidateSpec:
         """Return the next CMA-ME proposal, reseeding on a full grid or restart."""
+        if not self._active_dims:
+            return self._random_fallback()
         if self._current_cell is None or self._optimizer is None:
             cell = self._select_target_cell()
             if cell is None:
                 return self._random_fallback()
             self._start_cell_optimizer(cell)
-        if self._pending_vec is not None:
-            vec = self._pending_vec
-            self._pending_vec = None
-        elif self._optimizer.stop():
+        if self._optimizer.stop():
             cell = self._select_target_cell()
             if cell is None:
                 return self._random_fallback()
@@ -359,17 +377,26 @@ class CMaMeEmitter:
                 score = evaluation.objective_value
                 value = float(score) if score is not None and math.isfinite(float(score)) else -1e9
                 self._observed.append((list(vec), value))
-                if not self._in_flight:
+                if len(self._observed) >= self._optimizer.popsize:
                     self._flush_generation()
                 return
 
     def _flush_generation(self) -> None:
         """Feed the buffered generation to the optimizer once fully observed."""
+        if self._optimizer is None:
+            raise RuntimeError("cannot flush a CMA-ME generation without an active optimizer")
+        if len(self._observed) != self._optimizer.popsize:
+            raise RuntimeError(
+                f"cannot flush partial CMA-ME generation: expected {self._optimizer.popsize}, "
+                f"observed {len(self._observed)}"
+            )
         vectors = [vec for vec, _value in self._observed]
         values = [value for _vec, value in self._observed]
-        if vectors:
-            self._optimizer.tell(vectors, values)
+        self._optimizer.tell(vectors, values)
         self._observed = []
+        if self._current_cell in self._archive.cells:
+            self._current_cell = None
+            self._optimizer = None
 
 
 def _Pose2D(x: float, y: float) -> Any:

--- a/robot_sf/adversarial/qd.py
+++ b/robot_sf/adversarial/qd.py
@@ -375,6 +375,7 @@ def run_map_elites(
     evaluator: QDEvaluator,
     certifier: Any | None = None,
     emitters: list[QDEmitter] | None = None,
+    archive: QDArchive | None = None,
 ) -> QDSearchResult:
     """Run a bounded MAP-Elites search over the configured emitters.
 
@@ -387,6 +388,8 @@ def run_map_elites(
         certifier: Optional callable (candidate) -> CertificationStatus; when omitted
             the evaluation's own certification status is used as the gate.
         emitters: Optional list of emitters; defaults to Random + CoordinateRefinement.
+        archive: Optional live archive shared with stateful emitters. Its grid and
+            certification policy must match ``config``.
 
     Returns:
         QDSearchResult with the populated archive and run counters.
@@ -397,7 +400,12 @@ def run_map_elites(
     )
     if not active_emitters:
         raise ValueError("emitters must contain at least one emitter")
-    archive = QDArchive(grid=config.grid, require_certification=config.require_certification)
+    if archive is None:
+        archive = QDArchive(grid=config.grid, require_certification=config.require_certification)
+    elif (
+        archive.grid != config.grid or archive.require_certification != config.require_certification
+    ):
+        raise ValueError("archive grid and certification policy must match QDSearchConfig")
 
     num_evaluated = 0
     num_admitted = 0

--- a/tests/adversarial/test_issue_5308_cma_me.py
+++ b/tests/adversarial/test_issue_5308_cma_me.py
@@ -1,0 +1,286 @@
+"""CPU tests for the CMA-ME quality-diversity emitter (issue #5308, successor slice).
+
+The emitter drives distinct archive cells with per-cell CMA-ES. These tests inject a
+lightweight Gaussian optimizer factory so the CMA-ME scheduling/selection/proposal
+logic is validated on CPU without the ``cma`` dependency. This is capability plumbing,
+not a benchmark or camera-ready claim.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from robot_sf.adversarial.attribution import attribution_from_episode_record
+from robot_sf.adversarial.certification import not_available_status, passed_status
+from robot_sf.adversarial.cma_me import CMaMeEmitter
+from robot_sf.adversarial.config import (
+    CandidateEvaluation,
+    CandidateSpec,
+    Pose2D,
+    RangeConfig,
+    SearchSpaceConfig,
+)
+from robot_sf.adversarial.qd import (
+    GridSpec,
+    QDArchive,
+    QDSearchConfig,
+    run_map_elites,
+)
+
+
+def _space() -> SearchSpaceConfig:
+    """Build a 2D search space spanning start/goal x with fixed seeds."""
+    return SearchSpaceConfig(
+        start_x=RangeConfig(0.0, 4.0),
+        start_y=RangeConfig(0.0, 0.0),
+        goal_x=RangeConfig(0.0, 4.0),
+        goal_y=RangeConfig(0.0, 0.0),
+        spawn_time_s=RangeConfig(0.0, 0.0),
+        pedestrian_speed_mps=RangeConfig(1.0, 1.0),
+        pedestrian_delay_s=RangeConfig(0.0, 0.0),
+        scenario_seed=RangeConfig(1, 1),
+    )
+
+
+def _record(min_distance: float, critical_time: float, failure: str = "collision") -> dict:
+    """Build a minimal episode record carrying the QD behavior descriptors."""
+    outcome: dict = {"route_complete": False}
+    if failure == "collision":
+        outcome["collision"] = True
+        termination = "collision"
+    elif failure == "timeout":
+        outcome["timeout"] = True
+        termination = "timeout"
+    else:
+        termination = "incomplete"
+    return {
+        "status": "completed",
+        "termination_reason": termination,
+        "outcome": outcome,
+        "metrics": {
+            "distance_to_human_min": min_distance,
+            "time_to_collision_min": critical_time,
+        },
+    }
+
+
+def _make_evaluation(
+    *,
+    candidate: CandidateSpec,
+    min_distance: float,
+    critical_time: float,
+    objective: float,
+    failure: str = "collision",
+    cert_status: object = None,
+    temp_root: Path,
+) -> CandidateEvaluation:
+    """Build a candidate evaluation with a measurable behavior descriptor."""
+    record = _record(min_distance, critical_time, failure=failure)
+    episode_path = temp_root / "episode_dummy.jsonl"
+    episode_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+    return CandidateEvaluation(
+        candidate=candidate,
+        certification_status=cert_status or not_available_status("advisory"),
+        objective_value=objective,
+        failure_attribution=attribution_from_episode_record(record),
+        episode_record_path=episode_path,
+        trajectory_csv_path=None,
+        scenario_yaml_path=temp_root / "scenario_dummy.yaml",
+        bundle_path=temp_root,
+    )
+
+
+def _candidate(x: float) -> CandidateSpec:
+    """Build one candidate at start.x = x."""
+    return CandidateSpec(
+        start=Pose2D(x, 0.0),
+        goal=Pose2D(4.0 - x, 0.0),
+        spawn_time_s=0.0,
+        pedestrian_speed_mps=1.0,
+        pedestrian_delay_s=0.0,
+        scenario_seed=1,
+    )
+
+
+class _GaussianCellOptimizer:
+    """Lightweight Gaussian stub standing in for CMA-ES in CPU tests."""
+
+    def __init__(
+        self, *, lower: list[float], upper: list[float], x0: list[float], seed: int
+    ) -> None:
+        self._lower = list(lower)
+        self._upper = list(upper)
+        self._mean = list(x0)
+        self._rng = __import__("random").Random(seed)
+        self._pending: list[list[float]] = []
+        self._generation = 0
+
+    def ask(self) -> list[float]:
+        """Return one proposal spanning the cell bounds (exploratory stub)."""
+        if not self._pending:
+            self._pending = [
+                [self._rng.uniform(self._lower[i], self._upper[i]) for i in range(len(self._lower))]
+                for _ in range(3)
+            ]
+        return list(self._pending.pop(0))
+
+    def tell(self, vectors: list[list[float]], values: list[float]) -> None:
+        """Move the mean toward the best observed vector."""
+        if vectors and values:
+            best = max(range(len(values)), key=lambda i: values[i])
+            self._mean = list(vectors[best])
+        self._generation += 1
+
+    def stop(self) -> bool:
+        """Restart the optimizer every few generations to emulate convergence."""
+        return self._generation >= 2
+
+    @property
+    def mean(self) -> list[float]:
+        """Return the current mean vector."""
+        return list(self._mean)
+
+
+def _stub_optimizer_factory() -> object:
+    """Return a Gaussian-optimizer factory for CPU tests (no cma dependency)."""
+
+    def _build(*, lower, upper, x0, seed) -> _GaussianCellOptimizer:
+        return _GaussianCellOptimizer(lower=lower, upper=upper, x0=x0, seed=seed)
+
+    return _build
+
+
+def _runnable_archive() -> QDArchive:
+    """Return a fresh archive over the standard test grid."""
+    grid = GridSpec(x_min=0.0, x_max=2.5, y_min=0.0, y_max=3.0, bins=4)
+    return QDArchive(grid=grid, require_certification=True)
+
+
+def test_emitter_targets_least_filled_cells(tmp_path: Path) -> None:
+    """Emitter seeds distinct empty cells instead of the same one repeatedly."""
+    space = _space()
+    archive = _runnable_archive()
+    emitter = CMaMeEmitter(
+        space,
+        archive,
+        seed=0,
+        optimizer_factory=_stub_optimizer_factory(),
+    )
+    seen_cells: set[tuple[int, int]] = set()
+    for _ in range(8):
+        candidate = emitter.sample()
+        evaluation = _make_evaluation(
+            candidate=candidate,
+            min_distance=1.0,
+            critical_time=1.0,
+            objective=1.0,
+            cert_status=passed_status("ok"),
+            temp_root=tmp_path,
+        )
+        descriptor = (1.0, 1.0)  # all proposals target the same cell for this test
+        admitted = archive.try_insert(
+            descriptor=descriptor,
+            evaluation=evaluation,
+            certification_status=evaluation.certification_status,
+        )
+        emitter.observe(evaluation)
+        if admitted:
+            seen_cells.add(archive.grid.cell_index(descriptor))
+    assert (1, 1) in seen_cells
+
+
+def test_emitter_proposes_within_bounds(tmp_path: Path) -> None:
+    """Every CMA-ME proposal stays inside the configured search-space bounds."""
+    space = _space()
+    archive = _runnable_archive()
+    emitter = CMaMeEmitter(
+        space,
+        archive,
+        seed=3,
+        optimizer_factory=_stub_optimizer_factory(),
+    )
+    for _ in range(20):
+        candidate = emitter.sample()
+        assert 0.0 <= candidate.start.x <= 4.0
+        assert 0.0 <= candidate.goal.x <= 4.0
+        emitter.observe(
+            _make_evaluation(
+                candidate=candidate,
+                min_distance=1.0,
+                critical_time=1.0,
+                objective=0.5,
+                cert_status=passed_status("ok"),
+                temp_root=tmp_path,
+            )
+        )
+
+
+def test_emitter_fills_more_cells_than_random_baseline(tmp_path: Path) -> None:
+    """A CMA-ME emitter run diversifies the grid under an injected evaluator."""
+    space = _space()
+    grid = GridSpec(x_min=0.0, x_max=2.5, y_min=0.0, y_max=3.0, bins=4)
+
+    def _evaluator(_config: QDSearchConfig, candidate: CandidateSpec) -> CandidateEvaluation:
+        # Deterministic descriptor derived from the candidate so distinct proposals
+        # land in distinct cells; objective is constant so CMA-ME diversity wins.
+        x = candidate.start.x
+        distance = 2.5 * min(1.0, max(0.0, x / 4.0))
+        critical = 3.0 * min(1.0, max(0.0, (4.0 - x) / 4.0))
+        return _make_evaluation(
+            candidate=candidate,
+            min_distance=distance,
+            critical_time=critical,
+            objective=1.0,
+            cert_status=passed_status("ok"),
+            temp_root=tmp_path,
+        )
+
+    archive = QDArchive(grid=grid, require_certification=True)
+    emitter = CMaMeEmitter(space, archive, seed=7, optimizer_factory=_stub_optimizer_factory())
+    config = QDSearchConfig(
+        search_space=space, objective="worst_case_snqi", grid=grid, budget=48, seed=7
+    )
+    result = run_map_elites(config, evaluator=_evaluator, emitters=[emitter])
+    assert result.archive.filled_cell_count() >= 4
+    assert result.num_evaluated == 48
+    assert result.num_admitted >= result.archive.filled_cell_count()
+
+
+def test_emitter_rejects_bad_sigma_fraction() -> None:
+    """Emitter must reject non-positive sigma fractions fail-closed."""
+    space = _space()
+    archive = _runnable_archive()
+    with pytest.raises(ValueError, match="sigma_fraction"):
+        CMaMeEmitter(
+            space, archive, seed=0, sigma_fraction=0.0, optimizer_factory=_stub_optimizer_factory()
+        )
+
+
+def test_emitter_handles_full_grid_gracefully(tmp_path: Path) -> None:
+    """When the grid is full, the emitter returns valid in-bounds candidates."""
+    space = _space()
+    archive = _runnable_archive()
+    for ix in range(archive.grid.bins):
+        for iy in range(archive.grid.bins):
+            candidate = _candidate(ix * 0.5)
+            evaluation = _make_evaluation(
+                candidate=candidate,
+                min_distance=2.5 * (ix / 3.0),
+                critical_time=3.0 * (iy / 3.0),
+                objective=1.0,
+                cert_status=passed_status("ok"),
+                temp_root=tmp_path,
+            )
+            descriptor = (2.5 * (ix / 3.0), 3.0 * (iy / 3.0))
+            archive.try_insert(
+                descriptor=descriptor,
+                evaluation=evaluation,
+                certification_status=evaluation.certification_status,
+            )
+    assert archive.filled_cell_count() == archive.grid.cell_count
+    emitter = CMaMeEmitter(space, archive, seed=1, optimizer_factory=_stub_optimizer_factory())
+    candidate = emitter.sample()
+    assert 0.0 <= candidate.start.x <= 4.0

--- a/tests/adversarial/test_issue_5308_cma_me.py
+++ b/tests/adversarial/test_issue_5308_cma_me.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from robot_sf.adversarial import cma_me
 from robot_sf.adversarial.attribution import attribution_from_episode_record
 from robot_sf.adversarial.certification import not_available_status, passed_status
 from robot_sf.adversarial.cma_me import CMaMeEmitter
@@ -143,6 +144,11 @@ class _GaussianCellOptimizer:
         """Return the current mean vector."""
         return list(self._mean)
 
+    @property
+    def popsize(self) -> int:
+        """Return the population size of the test optimizer."""
+        return 3
+
 
 def _stub_optimizer_factory() -> object:
     """Return a Gaussian-optimizer factory for CPU tests (no cma dependency)."""
@@ -163,33 +169,34 @@ def test_emitter_targets_least_filled_cells(tmp_path: Path) -> None:
     """Emitter seeds distinct empty cells instead of the same one repeatedly."""
     space = _space()
     archive = _runnable_archive()
+    target_cell = (archive.grid.bins - 1, archive.grid.bins - 1)
+    for ix in range(archive.grid.bins):
+        for iy in range(archive.grid.bins):
+            if (ix, iy) == target_cell:
+                continue
+            candidate = _candidate(ix * 0.5)
+            evaluation = _make_evaluation(
+                candidate=candidate,
+                min_distance=2.5 * (ix / 3.0),
+                critical_time=3.0 * (iy / 3.0),
+                objective=1.0,
+                cert_status=passed_status("ok"),
+                temp_root=tmp_path,
+            )
+            archive.try_insert(
+                descriptor=(2.5 * (ix / 3.0), 3.0 * (iy / 3.0)),
+                evaluation=evaluation,
+                certification_status=evaluation.certification_status,
+            )
     emitter = CMaMeEmitter(
         space,
         archive,
         seed=0,
         optimizer_factory=_stub_optimizer_factory(),
     )
-    seen_cells: set[tuple[int, int]] = set()
-    for _ in range(8):
-        candidate = emitter.sample()
-        evaluation = _make_evaluation(
-            candidate=candidate,
-            min_distance=1.0,
-            critical_time=1.0,
-            objective=1.0,
-            cert_status=passed_status("ok"),
-            temp_root=tmp_path,
-        )
-        descriptor = (1.0, 1.0)  # all proposals target the same cell for this test
-        admitted = archive.try_insert(
-            descriptor=descriptor,
-            evaluation=evaluation,
-            certification_status=evaluation.certification_status,
-        )
-        emitter.observe(evaluation)
-        if admitted:
-            seen_cells.add(archive.grid.cell_index(descriptor))
-    assert (1, 1) in seen_cells
+    emitter.sample()
+
+    assert emitter._current_cell == target_cell
 
 
 def test_emitter_proposes_within_bounds(tmp_path: Path) -> None:
@@ -241,9 +248,15 @@ def test_emitter_fills_more_cells_than_random_baseline(tmp_path: Path) -> None:
     archive = QDArchive(grid=grid, require_certification=True)
     emitter = CMaMeEmitter(space, archive, seed=7, optimizer_factory=_stub_optimizer_factory())
     config = QDSearchConfig(
-        search_space=space, objective="worst_case_snqi", grid=grid, budget=48, seed=7
+        search_space=space,
+        objective="worst_case_snqi",
+        grid=grid,
+        budget=48,
+        seed=7,
+        require_certification=True,
     )
-    result = run_map_elites(config, evaluator=_evaluator, emitters=[emitter])
+    result = run_map_elites(config, evaluator=_evaluator, emitters=[emitter], archive=archive)
+    assert result.archive is archive
     assert result.archive.filled_cell_count() >= 4
     assert result.num_evaluated == 48
     assert result.num_admitted >= result.archive.filled_cell_count()
@@ -284,3 +297,104 @@ def test_emitter_handles_full_grid_gracefully(tmp_path: Path) -> None:
     emitter = CMaMeEmitter(space, archive, seed=1, optimizer_factory=_stub_optimizer_factory())
     candidate = emitter.sample()
     assert 0.0 <= candidate.start.x <= 4.0
+
+
+def test_emitter_waits_for_full_population(tmp_path: Path) -> None:
+    """Sequential observations must produce exactly one full-population tell."""
+    built: list[_GaussianCellOptimizer] = []
+
+    def _factory(*, lower, upper, x0, seed):
+        optimizer = _GaussianCellOptimizer(lower=lower, upper=upper, x0=x0, seed=seed)
+        built.append(optimizer)
+        return optimizer
+
+    emitter = CMaMeEmitter(_space(), _runnable_archive(), seed=4, optimizer_factory=_factory)
+    for index in range(3):
+        candidate = emitter.sample()
+        emitter.observe(
+            _make_evaluation(
+                candidate=candidate,
+                min_distance=1.0,
+                critical_time=1.0,
+                objective=float(index),
+                cert_status=passed_status("ok"),
+                temp_root=tmp_path,
+            )
+        )
+        assert built[0]._generation == (1 if index == 2 else 0)
+
+
+def test_cma_adapter_queues_population_and_converts_maximization(monkeypatch) -> None:
+    """The production adapter must drain one population and negate maximize scores."""
+
+    class _FakeEs:
+        def __init__(self, x0, _sigma, _opts):
+            self.mean = list(x0)
+            self.popsize = 2
+            self.ask_calls = 0
+            self.told_values: list[float] | None = None
+
+        def ask(self):
+            self.ask_calls += 1
+            return [[0.25], [0.75]]
+
+        def tell(self, _vectors, values):
+            self.told_values = list(values)
+
+        def stop(self):
+            return {}
+
+    class _FakeCma:
+        CMAEvolutionStrategy = _FakeEs
+
+    monkeypatch.setattr(cma_me, "_import_cma", lambda: _FakeCma)
+    optimizer = cma_me._CmaCellOptimizer(lower=[0.0], upper=[1.0], x0=[0.5], seed=1, popsize=2)
+
+    assert optimizer.ask() == [0.25]
+    assert optimizer.ask() == [0.75]
+    assert optimizer._es.ask_calls == 1
+    optimizer.tell([[0.25], [0.75]], [4.0, 1.0])
+    assert optimizer._es.told_values == [-4.0, -1.0]
+
+
+def test_run_map_elites_rejects_mismatched_shared_archive() -> None:
+    """A stateful emitter archive must match the runner grid fail-closed."""
+    config = QDSearchConfig(
+        search_space=_space(),
+        objective="worst_case_snqi",
+        grid=GridSpec(x_min=0.0, x_max=2.5, y_min=0.0, y_max=3.0, bins=4),
+        budget=1,
+    )
+    mismatched = QDArchive(
+        grid=GridSpec(x_min=0.0, x_max=1.0, y_min=0.0, y_max=1.0, bins=2),
+        require_certification=False,
+    )
+
+    with pytest.raises(ValueError, match="archive grid"):
+        run_map_elites(config, evaluator=lambda _config, _candidate: None, archive=mismatched)
+
+
+def test_emitter_bypasses_optimizer_for_fixed_space() -> None:
+    """A zero-dimensional continuous space must still return a valid candidate."""
+    fixed = SearchSpaceConfig(
+        start_x=RangeConfig(1.0, 1.0),
+        start_y=RangeConfig(2.0, 2.0),
+        goal_x=RangeConfig(3.0, 3.0),
+        goal_y=RangeConfig(4.0, 4.0),
+        spawn_time_s=RangeConfig(0.0, 0.0),
+        pedestrian_speed_mps=RangeConfig(1.0, 1.0),
+        pedestrian_delay_s=RangeConfig(0.0, 0.0),
+        scenario_seed=RangeConfig(5, 5),
+    )
+
+    def _unexpected_optimizer(**_kwargs):
+        raise AssertionError("fixed search spaces must not construct CMA")
+
+    emitter = CMaMeEmitter(
+        fixed, _runnable_archive(), seed=1, optimizer_factory=_unexpected_optimizer
+    )
+    candidate = emitter.sample()
+
+    assert candidate.start == Pose2D(1.0, 2.0)
+    assert candidate.goal == Pose2D(3.0, 4.0)
+    assert candidate.scenario_seed == 5


### PR DESCRIPTION
## What / Why

Successor slice 3 of Issue #5308 (MAP-Elites / CMA-ME quality-diversity adversarial search). PR #5846 merged the fail-closed MAP-Elites grid archive and PR #5852 wired it to the production pipeline. The issue thread names later CMA-ME work as the next capability item.

This PR adds a **CMA-ME emitter** (`robot_sf/adversarial/cma_me.py`): a CMA-ES optimizer that runs per least-filled archive cell rather than improving one global incumbent. This is capability plumbing only; it does not provide campaign or benchmark evidence.

- **Diversity-driven target selection:** selects an empty archive cell, seeds a local optimizer around that cell's incumbent (or the decision-space midpoint), and maps bounded proposals back into the continuous search space.
- **Correct population semantics:** queues every proposal from one CMA population, buffers sequential evaluations, and calls `tell()` only after the full population is observed.
- **Correct objective direction:** keeps Robot SF's maximize-oriented objective contract while negating scores inside the production adapter for CMA's minimizing API.
- **Shared live archive:** `run_map_elites(..., archive=...)` accepts the same fail-closed archive used by stateful emitters and rejects grid/certification-policy mismatches.
- **Fail-closed edge handling:** population-size mismatches raise; unevaluable candidates receive the worst maximize score; fixed continuous spaces bypass zero-dimensional CMA safely.
- **Dependency-light tests plus real adapter smoke:** scheduling is tested with an injected Gaussian optimizer, while a real `cma` smoke proves production population queue/tell behavior.

**Successor statement:** this adds new CMA-ME capability; it does not duplicate PR #5846 (grid archive) or PR #5852 (production wiring).

## What remains open in #5308

- The bounded doorway campaign (<=4h CPU, seeded by #5833 knife-edge warm starts).
- Stable real-failure evidence from that campaign.
- Warm-start integration from #5833.

These items remain tracked by open parent Issue #5308 and are explicitly outside this capability-only PR.

## Validation

- `uv run ruff check robot_sf/adversarial/cma_me.py robot_sf/adversarial/qd.py tests/adversarial/test_issue_5308_cma_me.py` — passed.
- `uv run ruff format --check robot_sf/adversarial/cma_me.py robot_sf/adversarial/qd.py tests/adversarial/test_issue_5308_cma_me.py` — passed.
- `tests/adversarial/test_issue_5308_cma_me.py` — 9 passed.
- CMA-ME + QD + production QD focused bundle — 29 passed.
- `tests/adversarial/test_adversarial_search.py` — 58 passed.
- Real `_CmaCellOptimizer` population smoke with installed `cma` (`popsize=4`, full ask/tell, next-generation ask) — passed.

The tests cover least-filled target selection, shared-archive identity and mismatch rejection, bounded proposals, full-population buffering, maximize-to-minimize conversion, grid fill, fixed-space handling, invalid sigma, and full-grid fallback. This remains implementation-integrity proof, not benchmark or camera-ready evidence.

## Scope / Claim Boundary

- Evidence status: implementation-integrity smoke only.
- No campaign, training, Slurm, benchmark-success, or paper-facing claim.
- No generated artifact is required for this capability slice; durable campaign evidence remains on Issue #5308.

## Domain-Aware Approval

- Required for this PR: no - implementation-integrity capability only; this PR does not alter evidence classification, experimental comparison methodology, figure eligibility, benchmark interpretation, or paper-facing claims.
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: batch gate review of record
- Validity checklist:
  - Target claim/hypothesis: CMA-ME emitter runtime contract only.
  - Comparator or split/evidence validity: NA; no campaign comparison is included.
  - Fallback/degraded exclusions: no fallback/degraded run is presented as success evidence.
  - Claim boundary: implementation-integrity smoke only.
  - Implementation integrity vs experimental validity: implementation integrity tested; experimental validity remains open on Issue #5308.

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardened the runtime path.

Refs #5308
