### PR TITLE
Issue #5556: CUDA-device determinism path coverage (cheap-lane worker)

### DIFF
--- a/tests/test_seed_utils.py
+++ b/tests/test_seed_utils.py
@@ -292,6 +292,7 @@ def test_torch_213_cuda_seed_is_reproducible_across_calls():
     the GPU without importing the Dynamo/Triton wrapper that segfaulted before the
     Torch 2.13.0 fix landed.
     """
+    assert torch is not None
     set_global_seed(7, deterministic=True)
     a = torch.randn(4, 4, device="cuda")
 

--- a/tests/test_seed_utils.py
+++ b/tests/test_seed_utils.py
@@ -253,3 +253,49 @@ def test_torch_determinism_reports_unavailable_setter(monkeypatch):
     assert report.to_dict()["seed"] == 11
     assert report.torch_deterministic is None
     assert report.notes == "torch deterministic algorithm flag could not be applied"
+
+
+torch = _import_torch()
+_HAS_CUDA = torch is not None and torch.cuda.is_available()
+requires_cuda = pytest.mark.skipif(
+    not _HAS_CUDA,
+    reason="CUDA device required to exercise the Torch 2.13.0 GPU determinism path (issue #5556)",
+)
+
+
+@requires_cuda
+def test_torch_213_determinism_guard_runs_on_cuda_device():
+    """Exercise the merged Torch 2.13.0 determinism helpers on a real CUDA device.
+
+    This is the remaining Definition-of-DoD item for issue #5556: prove the
+    ``_set_torch_deterministic_algorithms`` C-level path does not segfault and
+    actually enables deterministic algorithms when ``set_global_seed`` runs on a
+    GPU. Skipped when no CUDA device is present, so it stays cheap-lane safe on
+    CPU-only runners (it does not duplicate the mocked CPU-path coverage).
+    """
+    assert torch is not None and torch.cuda.is_available()
+
+    report = set_global_seed(42, deterministic=True)
+    assert report.has_torch is True
+    assert report.torch_deterministic is True
+    # The C-level setter must have flipped the global flag on, not silently no-op'd.
+    assert torch.are_deterministic_algorithms_enabled() is True
+    if hasattr(torch.backends, "cudnn"):
+        assert torch.backends.cudnn.deterministic is True
+
+
+@requires_cuda
+def test_torch_213_cuda_seed_is_reproducible_across_calls():
+    """A seeded CUDA RNG must produce identical tensors across two seeded calls.
+
+    Reproduces the original regression contract (deterministic benchmark RNG) on
+    the GPU without importing the Dynamo/Triton wrapper that segfaulted before the
+    Torch 2.13.0 fix landed.
+    """
+    set_global_seed(7, deterministic=True)
+    a = torch.randn(4, 4, device="cuda")
+
+    set_global_seed(7, deterministic=True)
+    b = torch.randn(4, 4, device="cuda")
+
+    assert torch.equal(a, b)


### PR DESCRIPTION
## What / Why

Issue #5556 was closed after supported-host CUDA validation completed. This PR adds a small post-closure hardening slice: two in-tree tests that keep the already-merged Torch 2.13 determinism fix executable on future CUDA-capable test hosts.

This is regression-test coverage, not new evidence required to close #5556 and not a replacement for its recorded supported-host validation.

## Changes

- `test_torch_213_determinism_guard_runs_on_cuda_device` runs `set_global_seed` on CUDA and verifies that deterministic algorithms and the cuDNN deterministic flag are enabled without entering the former crashing public wrapper path.
- `test_torch_213_cuda_seed_is_reproducible_across_calls` verifies that two CUDA tensors generated after identical seeds are byte-equal.
- Both tests skip explicitly when CUDA is unavailable, so CPU-only runners retain their existing contract.

## Validation / Proof

Gate-verified on 2026-07-16:

- Python 3.13 worktree environment
- Torch `2.13.0+cu130`
- CUDA runtime 13.0 available
- NVIDIA GeForce RTX 3070
- `scripts/dev/run_focused_tests.sh tests/test_seed_utils.py -q` — **14 passed**, including both CUDA tests
- `uv run ruff check tests/test_seed_utils.py` — passed
- `uv run ruff format --check tests/test_seed_utils.py` — passed

Claim boundary: this proves the in-tree CUDA regression tests execute on the gate host. It does not create benchmark evidence or reopen #5556's completed supported-host validation.

## Successor statement

This slice does not duplicate PRs #5577, #5652, #5685, or #5767, which added the runtime helpers, dependency contract, and CPU/mocked regression coverage. It preserves a direct real-device regression check after #5556's closure.

## Exact sentence

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

Refs #5556
