### PR TITLE
Issue #5858: reconcile stale TODO-docstring ratchet baseline + drift guard (cheap-lane worker)

### DIFF
--- a/scripts/dev/check_docstring_todos_baseline_freshness.sh
+++ b/scripts/dev/check_docstring_todos_baseline_freshness.sh
@@ -7,4 +7,6 @@ source "$SCRIPT_DIR/common_setup.sh"
 
 BASE_REF="${BASE_REF:-origin/main}"
 
-uv run python scripts/validation/check_docstring_todos.py --mode verify-baseline --base "$BASE_REF"
+uv run python "$SCRIPT_DIR/../validation/check_docstring_todos.py" \
+  --mode verify-baseline \
+  --base "$BASE_REF"

--- a/scripts/dev/check_docstring_todos_baseline_freshness.sh
+++ b/scripts/dev/check_docstring_todos_baseline_freshness.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common_setup.sh
+source "$SCRIPT_DIR/common_setup.sh"
+
+BASE_REF="${BASE_REF:-origin/main}"
+
+uv run python scripts/validation/check_docstring_todos.py --mode verify-baseline --base "$BASE_REF"

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -340,6 +340,7 @@ fi
 "$SCRIPT_DIR/check_changed_coverage.sh"
 "$SCRIPT_DIR/check_docstring_todos_diff.sh"
 "$SCRIPT_DIR/check_docstring_todos_ratchet.sh"
+"$SCRIPT_DIR/check_docstring_todos_baseline_freshness.sh"
 uv run python "$SCRIPT_DIR/check_optional_import_pr_freshness.py" --base-ref "$BASE_REF"
 uv run python "$SCRIPT_DIR/../validation/check_broad_exceptions.py"
 

--- a/scripts/validation/check_docstring_todos.py
+++ b/scripts/validation/check_docstring_todos.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 DEFAULT_BACKLOG_ROOTS = ("robot_sf", "scripts", "tests", "examples")
 DEFAULT_BASELINE_PATH = Path("scripts/validation/docstring_todo_baseline.json")
+_PLACEHOLDER = "TODO docstring"
 
 
 @dataclass(frozen=True)
@@ -286,7 +287,22 @@ def compare_backlog_to_baseline(
 
 def _count_todo_docstrings(path: Path) -> int:
     """Count TODO-docstring placeholder occurrences in definition docstrings."""
-    return sum(info.docstring.count("TODO docstring") for info in _read_defs(path))
+    return sum(info.docstring.count(_PLACEHOLDER) for info in _read_defs(path))
+
+
+def _count_todo_docstrings_in_source(source: str, path_hint: str) -> int:
+    """Count placeholder docstring debt in source text using the same AST path.
+
+    Mirrors :func:`_count_todo_docstrings` but accepts raw source so the
+    ``verify-baseline`` ref build does not need a working-tree file.
+
+    Returns:
+        Number of placeholder occurrences inside definition docstrings.
+    """
+    tree = _parse_source(source, Path(path_hint))
+    if tree is None:
+        return 0
+    return sum(info.docstring.count(_PLACEHOLDER) for info in _collect_defs(tree))
 
 
 def _files_payload(report: Mapping[str, Any]) -> dict[str, int]:
@@ -323,10 +339,11 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Check TODO-docstring placeholder debt.")
     parser.add_argument(
         "--mode",
-        choices=("diff", "report", "write-baseline", "ratchet"),
+        choices=("diff", "report", "write-baseline", "ratchet", "verify-baseline"),
         default="diff",
         help="diff preserves the historical touched-definition check; ratchet compares backlog "
-        "counts to a tracked baseline.",
+        "counts to a tracked baseline; verify-baseline confirms the committed baseline still "
+        "matches the base ref (origin/main) backlog so docs-only PRs are not failed by drift.",
     )
     parser.add_argument("--base", default="origin/main", help="Base ref to diff against")
     parser.add_argument(
@@ -362,14 +379,106 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def build_backlog_report_for_ref(
+    repo_root: Path,
+    base: str,
+    *,
+    roots: Iterable[str] = DEFAULT_BACKLOG_ROOTS,
+) -> dict[str, Any]:
+    """Build a TODO-docstring backlog report for a git ref (not the working tree).
+
+    Resolves each root's tracked ``.py`` files at ``base`` and counts their TODO
+    docstrings. This lets the verification guard compare the committed baseline
+    against what the base branch actually contains, without modifying the working
+    tree.
+
+    Returns:
+        JSON-serializable backlog report for the given ref.
+    """
+    files: dict[str, int] = {}
+    areas: dict[str, dict[str, int]] = {}
+    for root in roots:
+        area = root.strip().strip("/")
+        if not area:
+            continue
+        area_files = 0
+        area_occurrences = 0
+        listed = _run(
+            ["git", "ls-tree", "-r", "--name-only", base, "--", area],
+            cwd=repo_root,
+        ).splitlines()
+        for rel_path in listed:
+            rel_path = rel_path.strip()
+            if not rel_path.endswith(".py"):
+                continue
+            source = _run(
+                ["git", "show", f"{base}:{rel_path}"],
+                cwd=repo_root,
+            )
+            occurrences = _count_todo_docstrings_in_source(source, rel_path)
+            if occurrences <= 0:
+                continue
+            files[rel_path] = occurrences
+            area_files += 1
+            area_occurrences += occurrences
+        areas[area] = {
+            "files": area_files,
+            "occurrences": area_occurrences,
+        }
+    return {
+        "schema_version": "docstring-todo-backlog.v1",
+        "roots": [root.strip().strip("/") for root in roots if root.strip().strip("/")],
+        "totals": {
+            "files": len(files),
+            "total_occurrences": sum(files.values()),
+        },
+        "areas": areas,
+        "files": dict(sorted(files.items())),
+    }
+
+
 def main() -> int:
     """Run the selected TODO-docstring check."""
     args = _parse_args()
     repo_root = _repo_root()
 
+    if args.mode == "verify-baseline":
+        return _run_verify_baseline(args, repo_root)
     if args.mode != "diff":
         return _run_backlog_mode(args, repo_root)
     return _run_diff_mode(args, repo_root)
+
+
+def _run_verify_baseline(args: argparse.Namespace, repo_root: Path) -> int:
+    """Verify the committed baseline matches the base-ref backlog (drift guard)."""
+    baseline_path = repo_root / args.baseline
+    baseline = _read_backlog_baseline(baseline_path, repo_root)
+    if baseline is None:
+        return 1
+    roots = tuple(args.roots or DEFAULT_BACKLOG_ROOTS)
+    ref_report = build_backlog_report_for_ref(repo_root, args.base, roots=roots)
+    drift = compare_backlog_to_baseline(ref_report, baseline)
+    reverse_drift = [
+        line for line in compare_backlog_to_baseline(baseline, ref_report) if line not in drift
+    ]
+    if drift or reverse_drift:
+        print(f"TODO-docstring baseline drift detected against base '{args.base}':")
+        for line in drift:
+            print(f"- baseline is stale (base has more): {line}")
+        for line in reverse_drift:
+            print(f"- baseline exceeds base (base has fewer): {line}")
+        print(
+            "Run: uv run python scripts/validation/check_docstring_todos.py --mode write-baseline"
+        )
+        return 1
+    totals = cast("dict[str, int]", ref_report["totals"])
+    if not isinstance(totals, dict):
+        raise ValueError("docstring TODO report totals must be a mapping")
+    print(
+        "TODO-docstring baseline matches base "
+        f"'{args.base}': {totals['files']} files, {totals['total_occurrences']} occurrences."
+    )
+    return 0
 
 
 def _run_diff_mode(args: argparse.Namespace, repo_root: Path) -> int:

--- a/scripts/validation/check_docstring_todos.py
+++ b/scripts/validation/check_docstring_todos.py
@@ -285,6 +285,35 @@ def compare_backlog_to_baseline(
     return increases
 
 
+def compare_baseline_drift(
+    ref_report: Mapping[str, Any],
+    baseline: Mapping[str, Any],
+) -> tuple[list[str], list[str]]:
+    """Return directional differences between a ref report and its baseline.
+
+    Returns:
+        A pair containing stale-baseline lines and baseline-exceeds-ref lines.
+    """
+    ref_files = _files_payload(ref_report)
+    baseline_files = _files_payload(baseline)
+    drift: list[str] = []
+    reverse_drift: list[str] = []
+    for path in sorted(set(ref_files) | set(baseline_files)):
+        ref_count = ref_files.get(path, 0)
+        baseline_count = baseline_files.get(path, 0)
+        if ref_count > baseline_count:
+            drift.append(
+                f"{path}: base has {ref_count}, baseline has {baseline_count} "
+                f"(stale by +{ref_count - baseline_count})"
+            )
+        elif baseline_count > ref_count:
+            reverse_drift.append(
+                f"{path}: base has {ref_count}, baseline has {baseline_count} "
+                f"(exceeds by {baseline_count - ref_count})"
+            )
+    return drift, reverse_drift
+
+
 def _count_todo_docstrings(path: Path) -> int:
     """Count TODO-docstring placeholder occurrences in definition docstrings."""
     return sum(info.docstring.count(_PLACEHOLDER) for info in _read_defs(path))
@@ -457,10 +486,7 @@ def _run_verify_baseline(args: argparse.Namespace, repo_root: Path) -> int:
         return 1
     roots = tuple(args.roots or DEFAULT_BACKLOG_ROOTS)
     ref_report = build_backlog_report_for_ref(repo_root, args.base, roots=roots)
-    drift = compare_backlog_to_baseline(ref_report, baseline)
-    reverse_drift = [
-        line for line in compare_backlog_to_baseline(baseline, ref_report) if line not in drift
-    ]
+    drift, reverse_drift = compare_baseline_drift(ref_report, baseline)
     if drift or reverse_drift:
         print(f"TODO-docstring baseline drift detected against base '{args.base}':")
         for line in drift:

--- a/scripts/validation/docstring_todo_baseline.json
+++ b/scripts/validation/docstring_todo_baseline.json
@@ -14,7 +14,7 @@
     },
     "tests": {
       "files": 183,
-      "occurrences": 1263
+      "occurrences": 1257
     }
   },
   "files": {
@@ -73,7 +73,7 @@
     "tests/classic_interactions/test_seed_determinism.py": 2,
     "tests/classic_interactions/test_smoke_demo.py": 2,
     "tests/classic_interactions/test_summary_schema.py": 2,
-    "tests/conftest.py": 18,
+    "tests/conftest.py": 12,
     "tests/contract/test_multi_extractor_summary_json.py": 2,
     "tests/contract/test_multi_extractor_summary_markdown.py": 2,
     "tests/examples/test_examples_run.py": 13,
@@ -235,6 +235,6 @@
   "schema_version": "docstring-todo-backlog.v1",
   "totals": {
     "files": 207,
-    "total_occurrences": 1850
+    "total_occurrences": 1844
   }
 }

--- a/scripts/validation/docstring_todo_baseline.json
+++ b/scripts/validation/docstring_todo_baseline.json
@@ -5,42 +5,26 @@
       "occurrences": 0
     },
     "robot_sf": {
-      "files": 11,
-      "occurrences": 174
+      "files": 0,
+      "occurrences": 0
     },
     "scripts": {
-      "files": 32,
-      "occurrences": 753
+      "files": 24,
+      "occurrences": 587
     },
     "tests": {
-      "files": 186,
-      "occurrences": 1290
+      "files": 182,
+      "occurrences": 1262
     }
   },
   "files": {
-    "robot_sf/gym_env/_factory_compat.py": 4,
-    "robot_sf/gym_env/abstract_envs.py": 15,
-    "robot_sf/gym_env/robot_env.py": 2,
-    "robot_sf/ped_ego/unicycle_drive.py": 18,
-    "robot_sf/render/sim_view.py": 7,
-    "robot_sf/sensor/fusion_adapter.py": 9,
-    "robot_sf/sensor/range_sensor.py": 10,
-    "robot_sf/telemetry/progress.py": 67,
-    "robot_sf/telemetry/recommendations.py": 3,
-    "robot_sf/telemetry/run_registry.py": 4,
-    "robot_sf/telemetry/sampler.py": 35,
     "scripts/PPO_training/train_ppo_punish_action.py": 2,
-    "scripts/analyze_feature_extractors.py": 27,
-    "scripts/benchmark02.py": 2,
-    "scripts/benchmark_workers.py": 10,
     "scripts/compare_slow_tests.py": 10,
     "scripts/debug_trained_policy.py": 1,
     "scripts/evaluate.py": 24,
     "scripts/generate_figures.py": 51,
-    "scripts/hparam_opt.py": 36,
     "scripts/multi_extractor_training.py": 75,
     "scripts/perf/baseline_factory_creation.py": 11,
-    "scripts/play_recordings.py": 1,
     "scripts/ranking_table.py": 8,
     "scripts/recompute_snqi_weights.py": 40,
     "scripts/research/compare_ablations.py": 3,
@@ -48,14 +32,12 @@
     "scripts/run_social_navigation_benchmark.py": 8,
     "scripts/scale_svgs_to_50m.py": 2,
     "scripts/snqi_sensitivity_analysis.py": 52,
-    "scripts/snqi_weight_optimization.py": 71,
     "scripts/telemetry/run_perf_tests.py": 26,
     "scripts/tools/analyze_imitation_results.py": 24,
     "scripts/tools/check_artifact_root.py": 16,
     "scripts/tools/compare_training_runs.py": 2,
     "scripts/tools/migrate_artifacts.py": 16,
     "scripts/tools/run_tracker_cli.py": 139,
-    "scripts/training/collect_expert_trajectories.py": 18,
     "scripts/training/train_ppo.py": 11,
     "scripts/training/train_ppo_with_pretrained_policy.py": 6,
     "scripts/validation/performance_smoke_test.py": 26,
@@ -91,17 +73,15 @@
     "tests/classic_interactions/test_seed_determinism.py": 2,
     "tests/classic_interactions/test_smoke_demo.py": 2,
     "tests/classic_interactions/test_summary_schema.py": 2,
-    "tests/conftest.py": 15,
+    "tests/conftest.py": 18,
     "tests/contract/test_multi_extractor_summary_json.py": 2,
     "tests/contract/test_multi_extractor_summary_markdown.py": 2,
     "tests/examples/test_examples_run.py": 13,
-    "tests/factories/test_deprecation_mapping.py": 9,
     "tests/factories/test_factory_import_purity.py": 1,
     "tests/factories/test_factory_logging_enforcement.py": 1,
     "tests/factories/test_incompatible_combinations.py": 5,
     "tests/factories/test_logging_diagnostics.py": 12,
     "tests/factories/test_normalization.py": 6,
-    "tests/factories/test_option_dataclasses_api.py": 9,
     "tests/factories/test_recording_integration.py": 2,
     "tests/fixtures/minimal_manifests/generator.py": 17,
     "tests/integration/test_classic_benchmark_alg_grouping.py": 4,
@@ -126,7 +106,6 @@
     "tests/research/test_schemas.py": 12,
     "tests/research/test_success_criteria.py": 4,
     "tests/robot_env_simple_reward_test.py": 1,
-    "tests/sensor/test_fusion_adapter_merge.py": 7,
     "tests/sensor/test_sensor_registry.py": 12,
     "tests/sim/test_backend_registry.py": 1,
     "tests/sim/test_backend_selector.py": 8,
@@ -142,13 +121,12 @@
     "tests/test_cli_plot_distributions.py": 6,
     "tests/test_cli_plot_distributions_ci.py": 6,
     "tests/test_cli_ranking.py": 6,
-    "tests/test_cli_run.py": 3,
     "tests/test_cli_run_snqi.py": 3,
     "tests/test_cli_run_snqi_from.py": 7,
     "tests/test_cli_run_video.py": 3,
     "tests/test_cli_seed_variance.py": 6,
     "tests/test_cli_snqi_ablation.py": 5,
-    "tests/test_cli_table.py": 6,
+    "tests/test_cli_table.py": 3,
     "tests/test_cli_table_tex.py": 6,
     "tests/test_collision_sanity.py": 2,
     "tests/test_env.py": 2,
@@ -255,7 +233,7 @@
   ],
   "schema_version": "docstring-todo-backlog.v1",
   "totals": {
-    "files": 229,
-    "total_occurrences": 2217
+    "files": 206,
+    "total_occurrences": 1849
   }
 }

--- a/scripts/validation/docstring_todo_baseline.json
+++ b/scripts/validation/docstring_todo_baseline.json
@@ -13,8 +13,8 @@
       "occurrences": 587
     },
     "tests": {
-      "files": 182,
-      "occurrences": 1262
+      "files": 183,
+      "occurrences": 1263
     }
   },
   "files": {
@@ -209,6 +209,7 @@
     "tests/unit/test_metrics_edge_cases.py": 5,
     "tests/unit/test_resume_manifest.py": 18,
     "tests/unit/test_runner_video.py": 10,
+    "tests/validation/test_pr_contract_check.py": 1,
     "tests/visuals/test_deterministic_selection.py": 6,
     "tests/visuals/test_encode_wrapper.py": 22,
     "tests/visuals/test_encode_write_clip_fallbacks.py": 35,
@@ -233,7 +234,7 @@
   ],
   "schema_version": "docstring-todo-backlog.v1",
   "totals": {
-    "files": 206,
-    "total_occurrences": 1849
+    "files": 207,
+    "total_occurrences": 1850
   }
 }

--- a/tests/dev/test_pr_ready_preflight.py
+++ b/tests/dev/test_pr_ready_preflight.py
@@ -37,6 +37,7 @@ _POST_PREFLIGHT_SCRIPTS = [
     "check_changed_coverage.sh",
     "check_docstring_todos_diff.sh",
     "check_docstring_todos_ratchet.sh",
+    "check_docstring_todos_baseline_freshness.sh",
     "check_optional_import_pr_freshness.py",
     # check_base_drift.py is invoked by pr_ready_check.sh as a final base-drift
     # recheck before recording the freshness stamp (issue #5782).  Stub it here so

--- a/tests/validation/test_check_docstring_todos.py
+++ b/tests/validation/test_check_docstring_todos.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import textwrap
 
 from scripts.validation import check_docstring_todos
@@ -141,3 +142,79 @@ def test_read_backlog_baseline_fails_closed_for_missing_or_invalid_files(tmp_pat
 
     assert check_docstring_todos._read_backlog_baseline(non_object, tmp_path) is None
     assert "must contain a JSON object" in capsys.readouterr().err
+
+
+def test_count_from_source_matches_file_count(tmp_path):
+    """Ref-based source counting must match the file-based counter (issue #5858)."""
+    src = (
+        textwrap.dedent(
+            '''
+        def needs_doc():
+            """TODO docstring."""
+            return 1
+
+        class Demo:
+            """TODO docstring.
+
+            TODO docstring.
+            """
+    '''
+        ).strip()
+        + "\n"
+    )
+    source_file = tmp_path / "module.py"
+    source_file.write_text(src, encoding="utf-8")
+
+    from_file = check_docstring_todos._count_todo_docstrings(source_file)
+    from_source = check_docstring_todos._count_todo_docstrings_in_source(src, "module.py")
+
+    assert from_file == from_source == 3
+
+
+def test_verify_baseline_detects_drift(tmp_path, capsys):
+    """A stale baseline must be reported as drift, not passed silently (issue #5858)."""
+    baseline = {"files": {"scripts/tool.py": 1}}
+    baseline_path = tmp_path / "docstring_todo_baseline.json"
+    baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+
+    stale_report = {
+        "totals": {"files": 1, "total_occurrences": 3},
+        "files": {"scripts/tool.py": 3},
+    }
+    increases = check_docstring_todos.compare_backlog_to_baseline(stale_report, baseline)
+    reverse = [
+        line
+        for line in check_docstring_todos.compare_backlog_to_baseline(baseline, stale_report)
+        if line not in increases
+    ]
+
+    assert increases == ["scripts/tool.py: 3 TODO docstring occurrences (baseline 1, +2)"]
+    assert reverse == []
+
+
+def test_verify_baseline_docs_only_branch_does_not_fail(tmp_path, capsys):
+    """A docs-only branch identical to base for Python must not fail readiness.
+
+    Reproduces issue #5858: when the base ref and committed baseline agree, a
+    branch that changes only non-Python files (docs) must report no drift.
+    """
+    baseline = {
+        "totals": {"files": 1, "total_occurrences": 2},
+        "files": {"scripts/tool.py": 2},
+    }
+    baseline_path = tmp_path / "docstring_todo_baseline.json"
+    baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+
+    ref_report = {
+        "totals": {"files": 1, "total_occurrences": 2},
+        "files": {"scripts/tool.py": 2},
+    }
+    increases = check_docstring_todos.compare_backlog_to_baseline(ref_report, baseline)
+    reverse = [
+        line
+        for line in check_docstring_todos.compare_backlog_to_baseline(baseline, ref_report)
+        if line not in increases
+    ]
+
+    assert increases == []
+    assert reverse == []

--- a/tests/validation/test_check_docstring_todos.py
+++ b/tests/validation/test_check_docstring_todos.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import textwrap
 
 from scripts.validation import check_docstring_todos
@@ -171,28 +170,21 @@ def test_count_from_source_matches_file_count(tmp_path):
     assert from_file == from_source == 3
 
 
-def test_verify_baseline_detects_drift(tmp_path, capsys):
+def test_verify_baseline_detects_drift():
     """A stale baseline must be reported as drift, not passed silently (issue #5858)."""
-    baseline = {"files": {"scripts/tool.py": 1}}
-    baseline_path = tmp_path / "docstring_todo_baseline.json"
-    baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+    baseline = {"files": {"scripts/removed.py": 2, "scripts/tool.py": 1}}
 
     stale_report = {
         "totals": {"files": 1, "total_occurrences": 3},
         "files": {"scripts/tool.py": 3},
     }
-    increases = check_docstring_todos.compare_backlog_to_baseline(stale_report, baseline)
-    reverse = [
-        line
-        for line in check_docstring_todos.compare_backlog_to_baseline(baseline, stale_report)
-        if line not in increases
-    ]
+    drift, reverse = check_docstring_todos.compare_baseline_drift(stale_report, baseline)
 
-    assert increases == ["scripts/tool.py: 3 TODO docstring occurrences (baseline 1, +2)"]
-    assert reverse == []
+    assert drift == ["scripts/tool.py: base has 3, baseline has 1 (stale by +2)"]
+    assert reverse == ["scripts/removed.py: base has 0, baseline has 2 (exceeds by 2)"]
 
 
-def test_verify_baseline_docs_only_branch_does_not_fail(tmp_path, capsys):
+def test_verify_baseline_docs_only_branch_does_not_fail():
     """A docs-only branch identical to base for Python must not fail readiness.
 
     Reproduces issue #5858: when the base ref and committed baseline agree, a
@@ -202,19 +194,11 @@ def test_verify_baseline_docs_only_branch_does_not_fail(tmp_path, capsys):
         "totals": {"files": 1, "total_occurrences": 2},
         "files": {"scripts/tool.py": 2},
     }
-    baseline_path = tmp_path / "docstring_todo_baseline.json"
-    baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
-
     ref_report = {
         "totals": {"files": 1, "total_occurrences": 2},
         "files": {"scripts/tool.py": 2},
     }
-    increases = check_docstring_todos.compare_backlog_to_baseline(ref_report, baseline)
-    reverse = [
-        line
-        for line in check_docstring_todos.compare_backlog_to_baseline(baseline, ref_report)
-        if line not in increases
-    ]
+    drift, reverse = check_docstring_todos.compare_baseline_drift(ref_report, baseline)
 
-    assert increases == []
+    assert drift == []
     assert reverse == []


### PR DESCRIPTION
## What / Why

Issue #5858 reports that the committed TODO-docstring ratchet baseline
(`scripts/validation/docstring_todo_baseline.json`) drifted from `origin/main`,
causing `PR_READY_MODE=final ... pr_ready_check.sh` to fail docs-only branches
that never touched `tests/conftest.py` (reported 15 -> 18 mismatch).

Root cause: the baseline was last written at `a92e127b5` and never refreshed.
Subsequent main changes both added and removed placeholder debt, so the committed
counts diverged from the actual base and failed unrelated branches.

Changes:
- Regenerated the baseline from current `origin/main` (now 207 files / 1844
  occurrences; `tests/conftest.py` correctly records 12).
- Added `--mode verify-baseline` to `scripts/validation/check_docstring_todos.py`
  that compares the committed baseline against the actual base-ref (`origin/main`)
  backlog computed from git, so future baseline drift is caught as a CI failure
  rather than silently failing unrelated branches.
- Wired `scripts/dev/check_docstring_todos_baseline_freshness.sh` into
  `pr_ready_check.sh`.
- Added focused tests for ref-based counting parity and directional drift detection.
- Hardened the wrapper path, explicit base-vs-baseline diagnostics, and synthetic
  readiness-test fixture after gate review.

## Validation

```
$ uv run python scripts/validation/check_docstring_todos.py --mode ratchet
TODO-docstring backlog ratchet passed: 207 files, 1844 occurrences.

$ uv run python scripts/validation/check_docstring_todos.py --mode verify-baseline --base origin/main
TODO-docstring baseline matches base 'origin/main': 207 files, 1844 occurrences.

$ uv run pytest tests/validation/test_check_docstring_todos.py tests/dev/test_pr_ready_preflight.py -q
Focused validator and readiness-harness tests passed.

$ uv run ruff check scripts/validation/check_docstring_todos.py tests/validation/test_check_docstring_todos.py
All checks passed!
```

A branch identical to `origin/main` for Python files now passes both
`--mode ratchet` and `--mode verify-baseline` because the baseline matches the
base ref.

## Scope

This PR fully resolves issue #5858. No slices remain. No campaigns, training,
or benchmark runs were performed (CPU-only validation per the cheap lane).

Closes #5858

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.
