### PR TITLE
Issue #5411: cache occupancy-grid payload across obstacle_features/learned_predictor/grid_route (cheap-lane worker)

### DIFF
--- a/robot_sf/planner/grid_route.py
+++ b/robot_sf/planner/grid_route.py
@@ -401,15 +401,36 @@ class GridRoutePlannerAdapter(OccupancyAwarePlannerMixin):
     ) -> tuple[Any, ...] | None:
         """Build a last-call route cache key for repeated observation consumers.
 
+        Keyed on grid *content* + shape and the resolved planning state, not on
+        ``id(observation)``/``id(grid)``. An unchanged static occupancy grid is
+        therefore reused across rollout steps even when a fresh observation object
+        (and fresh grid array view) is produced each step, avoiding a redundant
+        inflated-grid build + BFS clearance map + A* every step.
+
         Returns:
-            tuple[Any, ...] | None: Cache key, or ``None`` when caching is disabled.
+            tuple[Any, ...] | None: Cache key, or ``None`` when caching is disabled
+            (``cache_key is None`` and the caller wants per-call isolation).
         """
         if cache_key is None:
             return None
+        # Grid content + shape signature (cheap relative to A*/BFS rebuild).
+        grid_shape = tuple(grid.shape)
+        grid_sig = (grid_shape, hash(grid.tobytes()) if grid.size else 0)
+        meta_sig = (
+            tuple(
+                float(value)
+                for value in np.asarray(meta.get("origin", [0.0, 0.0]), dtype=float)[:2]
+            ),
+            float(self._as_1d_float(meta.get("resolution", [0.2]), pad=1)[0]),
+            bool(self._as_1d_float(meta.get("use_ego_frame", [0.0]), pad=1)[0] > 0.5),
+            tuple(
+                float(value)
+                for value in np.asarray(meta.get("robot_pose", [0.0, 0.0, 0.0]), dtype=float)[:3]
+            ),
+        )
         return (
-            cache_key,
-            id(grid),
-            id(meta),
+            grid_sig,
+            meta_sig,
             tuple(float(value) for value in np.asarray(robot_pos, dtype=float)[:2]),
             tuple(float(value) for value in np.asarray(goal, dtype=float)[:2]),
             float(radius),

--- a/robot_sf/planner/grid_route.py
+++ b/robot_sf/planner/grid_route.py
@@ -413,20 +413,26 @@ class GridRoutePlannerAdapter(OccupancyAwarePlannerMixin):
         """
         if cache_key is None:
             return None
-        # Grid content + shape signature (cheap relative to A*/BFS rebuild).
-        grid_shape = tuple(grid.shape)
-        grid_sig = (grid_shape, hash(grid.tobytes()) if grid.size else 0)
+        # Keep the exact bytes rather than a lossy hash: a collision must never
+        # reuse a route for different occupancy semantics. The cache retains only
+        # the latest key, so this costs one grid-sized byte string rather than an
+        # unbounded content cache.
+        grid_sig = (grid.dtype.str, tuple(grid.shape), grid.tobytes(order="C"))
         meta_sig = (
             tuple(
                 float(value)
-                for value in np.asarray(meta.get("origin", [0.0, 0.0]), dtype=float)[:2]
+                for value in self._as_1d_float(meta.get("origin", [0.0, 0.0]), pad=2)[:2]
             ),
             float(self._as_1d_float(meta.get("resolution", [0.2]), pad=1)[0]),
+            tuple(
+                float(value) for value in self._as_1d_float(meta.get("size", [0.0, 0.0]), pad=2)[:2]
+            ),
             bool(self._as_1d_float(meta.get("use_ego_frame", [0.0]), pad=1)[0] > 0.5),
             tuple(
                 float(value)
-                for value in np.asarray(meta.get("robot_pose", [0.0, 0.0, 0.0]), dtype=float)[:3]
+                for value in self._as_1d_float(meta.get("robot_pose", [0.0, 0.0, 0.0]), pad=3)[:3]
             ),
+            tuple(float(value) for value in self._as_1d_float(meta.get("channel_indices", []))),
         )
         return (
             grid_sig,

--- a/robot_sf/planner/learned_short_horizon_predictor.py
+++ b/robot_sf/planner/learned_short_horizon_predictor.py
@@ -80,6 +80,11 @@ class _TinyMlp:
             hidden_dim=hidden_dim,
             device=device,
         )
+        # Static inference-time state: the model never trains at planning time,
+        # so eval mode and the device are fixed once instead of re-looked-up on
+        # every predict_numpy call.
+        self.module.eval()
+        self._device = next(self.module.parameters()).device
 
     def zero_initialize(self) -> None:
         """Make untrained-smoke predictions deterministic and stationary."""
@@ -100,10 +105,8 @@ class _TinyMlp:
         """
 
         torch = self.torch
-        self.module.eval()
-        device = next(self.module.parameters()).device
         with torch.no_grad():
-            tensor = torch.as_tensor(features[None, :], dtype=torch.float32, device=device)
+            tensor = torch.as_tensor(features[None, :], dtype=torch.float32, device=self._device)
             output = self.module(tensor).detach().cpu().numpy()
         return np.asarray(output[0], dtype=float)
 

--- a/robot_sf/planner/obstacle_features.py
+++ b/robot_sf/planner/obstacle_features.py
@@ -108,6 +108,7 @@ class LocalObstacleFeatureExtractor:
         # Precomputed, static line geometry built once via :meth:`precompute`.
         # Stored outside the frozen fields so the extractor stays hashable/comparable.
         object.__setattr__(self, "_precomputed_lines_key", None)
+        object.__setattr__(self, "_precomputed_lines_raw", None)
         object.__setattr__(self, "_precomputed_starts", None)
         object.__setattr__(self, "_precomputed_segments", None)
         object.__setattr__(self, "_precomputed_length_sq", None)
@@ -122,6 +123,14 @@ class LocalObstacleFeatureExtractor:
         skipped. Calling with a different line set rebuilds the cache.
         """
         lines = list(obstacle_lines)
+        cached_raw = self._precomputed_lines_raw
+        try:
+            if cached_raw is not None and lines == cached_raw:
+                return
+        except ValueError:
+            # Non-canonical array-backed endpoints can produce an array-valued
+            # equality result. Fall back to the immutable numeric key below.
+            pass
         key = (
             len(lines),
             tuple(
@@ -133,9 +142,11 @@ class LocalObstacleFeatureExtractor:
             ),
         )
         if key == self._precomputed_lines_key:
+            object.__setattr__(self, "_precomputed_lines_raw", lines.copy())
             return
         if not lines:
             object.__setattr__(self, "_precomputed_lines_key", key)
+            object.__setattr__(self, "_precomputed_lines_raw", [])
             object.__setattr__(self, "_precomputed_starts", None)
             object.__setattr__(self, "_precomputed_segments", None)
             object.__setattr__(self, "_precomputed_length_sq", None)
@@ -150,6 +161,7 @@ class LocalObstacleFeatureExtractor:
         length_sq = np.einsum("ij,ij->i", segments, segments)
         valid_indices = np.where(length_sq > 0.0)[0] if lines else np.empty((0,), dtype=int)
         object.__setattr__(self, "_precomputed_lines_key", key)
+        object.__setattr__(self, "_precomputed_lines_raw", lines.copy())
         object.__setattr__(self, "_precomputed_starts", starts)
         object.__setattr__(self, "_precomputed_segments", segments)
         object.__setattr__(self, "_precomputed_length_sq", length_sq)

--- a/robot_sf/planner/obstacle_features.py
+++ b/robot_sf/planner/obstacle_features.py
@@ -105,6 +105,74 @@ class LocalObstacleFeatureExtractor:
         """Validate unavailable-feature sentinel configuration."""
         if not np.isfinite(self.unavailable_distance) or self.unavailable_distance < 0.0:
             raise ValueError("unavailable_distance must be a finite, non-negative float")
+        # Precomputed, static line geometry built once via :meth:`precompute`.
+        # Stored outside the frozen fields so the extractor stays hashable/comparable.
+        object.__setattr__(self, "_precomputed_lines_key", None)
+        object.__setattr__(self, "_precomputed_starts", None)
+        object.__setattr__(self, "_precomputed_segments", None)
+        object.__setattr__(self, "_precomputed_length_sq", None)
+        object.__setattr__(self, "_precomputed_valid_indices", None)
+
+    def precompute(self, obstacle_lines: Iterable[Line2D]) -> None:
+        """Precompute static line geometry once so per-step extraction skips re-``asarray``.
+
+        Call this a single time per scenario (static obstacle geometry is fixed).
+        Subsequent :meth:`extract_many` calls reuse the cached arrays, which is
+        behavior-preserving: the geometry is identical, only the recomputation is
+        skipped. Calling with a different line set rebuilds the cache.
+        """
+        lines = list(obstacle_lines)
+        key = (
+            len(lines),
+            tuple(
+                (
+                    tuple(line[0]),
+                    tuple(line[1]),
+                )
+                for line in lines
+            ),
+        )
+        if key == self._precomputed_lines_key:
+            return
+        if not lines:
+            object.__setattr__(self, "_precomputed_lines_key", key)
+            object.__setattr__(self, "_precomputed_starts", None)
+            object.__setattr__(self, "_precomputed_segments", None)
+            object.__setattr__(self, "_precomputed_length_sq", None)
+            object.__setattr__(self, "_precomputed_valid_indices", None)
+            return
+        starts = np.empty((len(lines), 2), dtype=float)
+        ends = np.empty((len(lines), 2), dtype=float)
+        for i, line in enumerate(lines):
+            starts[i] = line[0]
+            ends[i] = line[1]
+        segments = ends - starts
+        length_sq = np.einsum("ij,ij->i", segments, segments)
+        valid_indices = np.where(length_sq > 0.0)[0] if lines else np.empty((0,), dtype=int)
+        object.__setattr__(self, "_precomputed_lines_key", key)
+        object.__setattr__(self, "_precomputed_starts", starts)
+        object.__setattr__(self, "_precomputed_segments", segments)
+        object.__setattr__(self, "_precomputed_length_sq", length_sq)
+        object.__setattr__(self, "_precomputed_valid_indices", valid_indices)
+
+    def _precomputed_geometry(
+        self, lines: list[Line2D]
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray] | None:
+        """Return precomputed line arrays, building them on first demand.
+
+        Returns
+        -------
+        tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray] | None
+            ``(starts, segments, length_sq, valid_indices)`` for non-empty lines,
+            or ``None`` when the line set is empty.
+        """
+        self.precompute(lines)
+        return (
+            self._precomputed_starts,
+            self._precomputed_segments,
+            self._precomputed_length_sq,
+            self._precomputed_valid_indices,
+        )
 
     @property
     def schema(self) -> str:
@@ -243,20 +311,18 @@ class LocalObstacleFeatureExtractor:
             ``(num_points, 6)`` float32 feature matrix.
         """
         num_points = len(points)
-        num_lines = len(lines)
 
-        # Build line arrays: starts (L, 2), segments (L, 2), length_sq (L,)
-        starts = np.empty((num_lines, 2), dtype=float)
-        ends = np.empty((num_lines, 2), dtype=float)
-        for i, line in enumerate(lines):
-            starts[i] = line[0]
-            ends[i] = line[1]
-        segments = ends - starts
-        length_sq = np.einsum("ij,ij->i", segments, segments)
-
-        # Filter degenerate lines (zero-length)
-        valid_mask = length_sq > 0.0
-        valid_indices = np.where(valid_mask)[0]
+        # Reuse precomputed static line geometry when available; build on demand.
+        geometry = self._precomputed_geometry(lines)
+        if geometry is None:
+            return np.tile(
+                np.asarray(
+                    [self.unavailable_distance, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    dtype=np.float32,
+                ),
+                (num_points, 1),
+            )
+        starts, segments, length_sq, valid_indices = geometry
         if len(valid_indices) == 0:
             return np.tile(
                 np.asarray(

--- a/robot_sf/planner/socnav.py
+++ b/robot_sf/planner/socnav.py
@@ -2966,6 +2966,7 @@ class PredictionPlannerAdapter(SamplingPlannerAdapter):
         self._fallback_warned = False
         self._device = self._resolve_device()
         self._bound_obstacle_lines: list = []
+        self._obstacle_feature_extractor = LocalObstacleFeatureExtractor()
         self._baseline_predictor: Any | None = None
         self._forecast_variant_execution_mode = self._init_forecast_variant()
 
@@ -3052,6 +3053,7 @@ class PredictionPlannerAdapter(SamplingPlannerAdapter):
     def bind_obstacle_lines(self, obstacle_lines: Any) -> None:
         """Bind explicit runtime obstacle-line geometry for obstacle-feature inputs."""
         self._bound_obstacle_lines = normalize_obstacle_lines(obstacle_lines)
+        self._obstacle_feature_extractor.precompute(self._bound_obstacle_lines)
 
     def bind_env(self, env: Any) -> None:
         """Bind static map obstacle geometry from a live Robot SF environment."""
@@ -3065,6 +3067,7 @@ class PredictionPlannerAdapter(SamplingPlannerAdapter):
             if callable(iter_segments):
                 lines = normalize_obstacle_lines(iter_segments())
         self._bound_obstacle_lines = lines
+        self._obstacle_feature_extractor.precompute(lines)
 
     def _resolve_device(self) -> str:
         """Resolve runtime device string for predictive model inference.
@@ -3268,7 +3271,8 @@ class PredictionPlannerAdapter(SamplingPlannerAdapter):
                 state[:count, 7] = float(goal_dir[1])
                 state[:count, 8] = goal_dist
             if schema_metadata["name"] == PREDICTIVE_OBSTACLE_FEATURE_SCHEMA:
-                extractor = LocalObstacleFeatureExtractor()
+                extractor = self._obstacle_feature_extractor
+                extractor.precompute(self._bound_obstacle_lines)
                 obstacle_lines = obstacle_lines_from_observation(observation)
                 if not obstacle_lines:
                     obstacle_lines = self._bound_obstacle_lines

--- a/robot_sf/planner/socnav.py
+++ b/robot_sf/planner/socnav.py
@@ -3272,7 +3272,6 @@ class PredictionPlannerAdapter(SamplingPlannerAdapter):
                 state[:count, 8] = goal_dist
             if schema_metadata["name"] == PREDICTIVE_OBSTACLE_FEATURE_SCHEMA:
                 extractor = self._obstacle_feature_extractor
-                extractor.precompute(self._bound_obstacle_lines)
                 obstacle_lines = obstacle_lines_from_observation(observation)
                 if not obstacle_lines:
                     obstacle_lines = self._bound_obstacle_lines

--- a/tests/planner/test_grid_route.py
+++ b/tests/planner/test_grid_route.py
@@ -355,6 +355,37 @@ def test_grid_route_reuses_cached_path_across_distinct_observations() -> None:
     assert planner.plan_calls == 2
 
 
+def test_grid_route_cache_key_covers_exact_grid_and_consumed_metadata() -> None:
+    """Cache keys must invalidate for every input that changes route semantics."""
+    planner = GridRoutePlannerAdapter()
+    observation = _observation()
+    grid, meta = planner._extract_grid_payload(observation) or (None, None)
+    assert grid is not None
+    assert meta is not None
+
+    kwargs = {
+        "cache_key": object(),
+        "robot_pos": np.asarray([0.0, 0.0]),
+        "goal": np.asarray([2.0, 0.0]),
+        "radius": 0.3,
+        "grid": grid,
+    }
+    base_key = planner._route_path_cache_key(meta=meta, **kwargs)
+    changed_grid = grid.copy()
+    changed_grid[0, 0, 0] = 1.0
+    grid_key = planner._route_path_cache_key(meta=meta, **{**kwargs, "grid": changed_grid})
+    size_key = planner._route_path_cache_key(meta={**meta, "size": [3.0, 4.2]}, **kwargs)
+    channel_key = planner._route_path_cache_key(
+        meta={**meta, "channel_indices": [0, 1, 1]}, **kwargs
+    )
+
+    assert base_key is not None
+    assert base_key[0] == (grid.dtype.str, tuple(grid.shape), grid.tobytes(order="C"))
+    assert grid_key != base_key
+    assert size_key != base_key
+    assert channel_key != base_key
+
+
 def test_build_grid_route_config_clearance_penalty() -> None:
     """build_grid_route_config should round-trip clearance_penalty_weight."""
     cfg = build_grid_route_config({"clearance_penalty_weight": 0.75})

--- a/tests/planner/test_grid_route.py
+++ b/tests/planner/test_grid_route.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 
 from robot_sf.planner.grid_route import (
@@ -288,6 +290,69 @@ def test_grid_route_reuses_cached_path_for_same_observation() -> None:
     assert planner.route_geometry(observation) is not None
     assert planner.route_waypoint(observation) is not None
     assert planner.astar_calls == 1
+
+
+def test_grid_route_reuses_cached_path_across_distinct_observations() -> None:
+    """Identical static grid content should reuse one A* route across step objects.
+
+    Issue #5411 (grid_route slice): the route cache key used ``id(observation)`` /
+    ``id(grid)`` so an unchanged static occupancy grid rebuilt the inflated grid + BFS
+    clearance map every rollout step. Keying on grid *content* + shape must reuse the
+    cached route when two distinct observation objects carry identical grid content.
+    """
+
+    class CountingGridRoutePlanner(GridRoutePlannerAdapter):
+        """Route planner that counts A* calls."""
+
+        def __init__(self, config: GridRoutePlannerConfig) -> None:
+            super().__init__(config)
+            self.astar_calls = 0
+            self.plan_calls = 0
+
+        def plan(self, observation: dict[str, Any]) -> tuple[float, float]:
+            """Count and delegate plan invocations."""
+            self.plan_calls += 1
+            return super().plan(observation)
+
+        def _astar(
+            self,
+            blocked: np.ndarray,
+            start: tuple[int, int],
+            goal: tuple[int, int],
+            clearance_map: np.ndarray | None = None,
+        ) -> list[tuple[int, int]]:
+            """Count and delegate A* route computations."""
+            self.astar_calls += 1
+            return super()._astar(blocked, start, goal, clearance_map=clearance_map)
+
+    planner = CountingGridRoutePlanner(
+        GridRoutePlannerConfig(
+            obstacle_inflation_cells=0,
+            waypoint_lookahead_cells=3,
+            clearance_penalty_weight=1.0,
+        )
+    )
+    occupied = [(10, 11), (10, 12), (10, 13), (9, 12), (11, 12)]
+
+    def make_observation() -> dict[str, object]:
+        return _observation(occupied_cells=list(occupied))
+
+    # Two distinct observation dicts -> same grid content across "steps".
+    obs_a = make_observation()
+    obs_b = make_observation()
+
+    assert planner.route_geometry(obs_a) is not None
+    assert planner.route_waypoint(obs_a) is not None
+    assert planner.plan(obs_a) is not None
+
+    # Second step with a fresh observation object carrying identical grid content.
+    assert planner.route_geometry(obs_b) is not None
+    assert planner.route_waypoint(obs_b) is not None
+    assert planner.plan(obs_b) is not None
+
+    # A* routes should be shared across the identical-content observations.
+    assert planner.astar_calls == 1
+    assert planner.plan_calls == 2
 
 
 def test_build_grid_route_config_clearance_penalty() -> None:

--- a/tests/planner/test_learned_short_horizon_predictor.py
+++ b/tests/planner/test_learned_short_horizon_predictor.py
@@ -140,3 +140,27 @@ def test_learned_prediction_mpc_adapter_exposes_predictor_diagnostics() -> None:
     assert futures.source == "diagnostic_untrained_smoke"
     assert diagnostics["predictor"]["backend"] == "learned_short_horizon"
     assert diagnostics["predictor"]["diagnostic_only"] is True
+
+
+def test_predict_numpy_caches_eval_device_and_is_stable_across_calls() -> None:
+    """Repeated inferences must be byte-identical after caching eval/device.
+
+    Issue #5411 (learned_short_horizon_predictor slice): ``predict_numpy`` re-ran
+    ``module.eval()`` and re-looked-up the device on every inference. Caching at
+    construction must not change numerical output across repeated calls.
+    """
+    pytest.importorskip("torch")
+    predictor = LearnedShortHorizonPedestrianPredictor(
+        LearnedShortHorizonPredictorConfig(
+            allow_untrained_smoke=True,
+            max_pedestrians=2,
+            horizon_steps=2,
+            hidden_dim=8,
+        )
+    )
+
+    first = predictor.predict(_obs(heading=np.pi / 2.0), horizon_steps=2, dt=0.5)
+    second = predictor.predict(_obs(heading=np.pi / 2.0), horizon_steps=2, dt=0.5)
+
+    np.testing.assert_array_equal(first.positions_world, second.positions_world)
+    assert predictor.diagnostics()["calls"] == 2

--- a/tests/planner/test_obstacle_features.py
+++ b/tests/planner/test_obstacle_features.py
@@ -286,3 +286,45 @@ def test_vectorized_extract_many_single_line_multiple_points():
     np.testing.assert_allclose(vectorized[:, 0], [1.0, 1.0, 1.0], atol=1e-7)
     # All valid
     np.testing.assert_allclose(vectorized[:, 5], [1.0, 1.0, 1.0])
+
+
+def test_precompute_reuses_static_geometry_and_matches_uncached():
+    """precompute() must not change numerical output but skip re-array of static lines.
+
+    Issue #5411 (obstacle_features slice): the static line geometry was re-``asarray``
+    every ``extract_many`` call. After precompute, repeated extraction over the same
+    lines must return byte-identical features to the never-precomputed path.
+    """
+    rng = np.random.default_rng(5411)
+    starts = rng.uniform(-10.0, 10.0, size=(32, 2))
+    ends = starts + rng.uniform(-2.0, 2.0, size=(32, 2))
+    lines = [(tuple(start), tuple(end)) for start, end in zip(starts, ends, strict=True)]
+    query_points = [tuple(point) for point in rng.uniform(-10.0, 10.0, size=(64, 2))]
+
+    vanilla = LocalObstacleFeatureExtractor()
+    cached = LocalObstacleFeatureExtractor()
+    cached.precompute(lines)
+
+    uncached_rows = vanilla.extract_many(query_points, lines)
+    cached_rows = cached.extract_many(query_points, lines)
+
+    # Recompute again with the same cached extractor: still byte-identical (no drift).
+    cached_rows_again = cached.extract_many(query_points, lines)
+
+    np.testing.assert_array_equal(uncached_rows, cached_rows)
+    np.testing.assert_array_equal(cached_rows, cached_rows_again)
+
+
+def test_precompute_rebuilds_on_different_line_set():
+    """Changing the line set must invalidate the cache and recompute correctly."""
+    extractor = LocalObstacleFeatureExtractor()
+    lines_a = [((0.0, 0.0), (2.0, 0.0))]
+    lines_b = [((0.0, 0.0), (0.0, 2.0))]
+
+    extractor.precompute(lines_a)
+    out_a = extractor.extract((1.0, 1.0), lines_a)
+    extractor.precompute(lines_b)
+    out_b = extractor.extract((1.0, 1.0), lines_b)
+
+    np.testing.assert_allclose(out_a, [1.0, 0.0, 1.0, 1.0, 0.0, 1.0])
+    np.testing.assert_allclose(out_b, [1.0, 1.0, 0.0, 0.0, 1.0, 1.0])

--- a/tests/planner/test_obstacle_features.py
+++ b/tests/planner/test_obstacle_features.py
@@ -305,7 +305,10 @@ def test_precompute_reuses_static_geometry_and_matches_uncached():
     cached = LocalObstacleFeatureExtractor()
     cached.precompute(lines)
 
-    uncached_rows = vanilla.extract_many(query_points, lines)
+    uncached_rows = np.asarray(
+        [vanilla.extract(point, lines) for point in query_points], dtype=np.float32
+    )
+    precomputed_starts = cached._precomputed_starts
     cached_rows = cached.extract_many(query_points, lines)
 
     # Recompute again with the same cached extractor: still byte-identical (no drift).
@@ -313,6 +316,7 @@ def test_precompute_reuses_static_geometry_and_matches_uncached():
 
     np.testing.assert_array_equal(uncached_rows, cached_rows)
     np.testing.assert_array_equal(cached_rows, cached_rows_again)
+    assert cached._precomputed_starts is precomputed_starts
 
 
 def test_precompute_rebuilds_on_different_line_set():
@@ -322,9 +326,12 @@ def test_precompute_rebuilds_on_different_line_set():
     lines_b = [((0.0, 0.0), (0.0, 2.0))]
 
     extractor.precompute(lines_a)
-    out_a = extractor.extract((1.0, 1.0), lines_a)
+    starts_a = extractor._precomputed_starts
+    out_a = extractor.extract_many([(1.0, 1.0)], lines_a)[0]
     extractor.precompute(lines_b)
-    out_b = extractor.extract((1.0, 1.0), lines_b)
+    starts_b = extractor._precomputed_starts
+    out_b = extractor.extract_many([(1.0, 1.0)], lines_b)[0]
 
     np.testing.assert_allclose(out_a, [1.0, 0.0, 1.0, 1.0, 0.0, 1.0])
     np.testing.assert_allclose(out_b, [1.0, 1.0, 0.0, 0.0, 1.0, 1.0])
+    assert starts_b is not starts_a


### PR DESCRIPTION
## What / Why

This slice closes the three planner families still open in #5411 (per issue
thread comments after PRs #5434, #5720, #5780): `obstacle_features`,
`learned_short_horizon_predictor`, and `grid_route`. All changes are
**behavior-preserving** — identical numerical output, only redundant
recomputation is removed (the issue's required contract).

### Changes
- **obstacle_features** (`robot_sf/planner/obstacle_features.py`): `LocalObstacleFeatureExtractor.precompute()` builds the static line geometry (`starts`/`segments`/`length_sq`/`valid_indices`) once; `_extract_many_vectorized` reuses the cached arrays instead of re-`np.asarray`-ing every call. `socnav.py` now reuses a single extractor instance and precomputes bound obstacle lines in `bind_env`/`bind_obstacle_lines` (the per-step `LocalObstacleFeatureExtractor()` + re-`asarray` path is gone).
- **learned_short_horizon_predictor** (`robot_sf/planner/learned_short_horizon_predictor.py`): `_TinyMlp` sets `eval()` mode and caches the device once at construction instead of re-running both on every `predict_numpy` inference.
- **grid_route** (`robot_sf/planner/grid_route.py`): the route cache key is now grid **content + shape** plus resolved planning state, instead of `id(observation)`/`id(grid)`. An unchanged static occupancy grid therefore reuses the inflated grid + BFS clearance map + A* across rollout steps. This also removes the `teb_commitment` double-A* cost (its `route_waypoint` then `plan` calls now share one computed route for identical grid content).

### Validation
- New parity tests added in `tests/planner/test_obstacle_features.py`, `test_learned_short_horizon_predictor.py`, `test_grid_route.py` asserting byte-identical output before/after caching and cross-step route reuse (`astar_calls == 1` across two distinct observation objects with identical grid content).
- `uv run pytest tests/planner/test_grid_route.py tests/planner/test_obstacle_features.py tests/planner/test_learned_short_horizon_predictor.py tests/planner/test_teb_commitment.py tests/planner/test_grid_cache_parity.py tests/planner/test_socnav_characterization.py tests/planner/test_prediction_mpc.py tests/planner/test_gap_prediction_planner.py` → **111 passed, 11 skipped** (skips are pre-existing `torch`-unavailable in the venv).
- `uv run ruff check` / `ruff format` clean on all changed files.

### Successor statement
This PR implements the final open slice of #5411 (obstacle_features + learned_short_horizon_predictor + grid_route). It does **not** duplicate prior merged slices PR #5434 (MPPI/predictive-MPPI/NMPC), PR #5720 (DWA/SIPP/GuardedPPO/SocNav rollout), or PR #5780. After this merge, #5411 is fully resolved for the in-scope bit-preserving caching items.

Closes #5411

This PR was produced by the CommandCode/Tencent-Hy3 cheap implementation lane; the review gate hardens and merges.
