### PR TITLE
Issue #5869: dedupe superseded check runs in PR babysitter snapshots (cheap-lane worker)

### DIFF
--- a/scripts/dev/snapshot_pr_queue.py
+++ b/scripts/dev/snapshot_pr_queue.py
@@ -257,7 +257,9 @@ def _checks(pr: dict[str, Any]) -> dict[str, Any]:
     `_latest_check_runs` semantics used by `check_pr_ci_status`.  A current,
     non-superseded cancellation remains fail-closed.
     """
-    raw_rollup = pr.get("statusCheckRollup", []) or []
+    raw_rollup = [
+        check for check in (pr.get("statusCheckRollup", []) or []) if isinstance(check, dict)
+    ]
     rollup, superseded_count = _latest_check_runs(raw_rollup)
     conclusions: dict[str, int] = {}
     statuses: dict[str, int] = {}

--- a/scripts/dev/snapshot_pr_queue.py
+++ b/scripts/dev/snapshot_pr_queue.py
@@ -14,6 +14,7 @@ from scripts.dev._gh_pagination import is_likely_truncated
 from scripts.dev.check_pr_ci_status import (
     FAILURE_CONCLUSIONS,
     PENDING_STATUSES,
+    _latest_check_runs,
     _rollup_conclusion,
     _rollup_name,
     _rollup_status,
@@ -249,8 +250,15 @@ query($owner:String!,$repo:String!,$number:Int!,$threads:Int!,$comments:Int!){
 
 
 def _checks(pr: dict[str, Any]) -> dict[str, Any]:
-    """Return a compact CI check summary from statusCheckRollup."""
-    rollup = pr.get("statusCheckRollup", []) or []
+    """Return a compact CI check summary from statusCheckRollup.
+
+    Superseded GitHub Actions runs (an older run replaced by a newer one on the
+    same workflow/job identity) are dropped first, matching the canonical
+    `_latest_check_runs` semantics used by `check_pr_ci_status`.  A current,
+    non-superseded cancellation remains fail-closed.
+    """
+    raw_rollup = pr.get("statusCheckRollup", []) or []
+    rollup, superseded_count = _latest_check_runs(raw_rollup)
     conclusions: dict[str, int] = {}
     statuses: dict[str, int] = {}
     names: set[str] = set()
@@ -290,6 +298,7 @@ def _checks(pr: dict[str, Any]) -> dict[str, Any]:
     return {
         "overall": overall,
         "total": len(rollup),
+        "superseded": superseded_count,
         "by_conclusion": conclusions,
         "by_status": statuses,
         "names": sorted(names),

--- a/tests/dev/test_pr_babysitter_snapshot.py
+++ b/tests/dev/test_pr_babysitter_snapshot.py
@@ -207,6 +207,64 @@ def test_none_fields_do_not_stringify_to_none_or_crash() -> None:
     assert recommendation["review_feedback"]["issue_comments"] == 0
 
 
+def test_superseded_cancelled_run_recommends_wait_ci_not_diagnose() -> None:
+    """A superseded cancelled run with a newer pending replacement must not diagnose."""
+    pr_payload = {
+        "number": 5869,
+        "title": "superseded cancelled PR",
+        "state": "OPEN",
+        "isDraft": False,
+        "url": "https://github.test/pull/5869",
+        "labels": [],
+        "headRefName": "feature",
+        "headRefOid": "abc111",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [
+            {
+                "__typename": "CheckRun",
+                "name": "ci",
+                "workflowName": "ci",
+                "status": "completed",
+                "conclusion": "cancelled",
+                "startedAt": "2026-07-01T00:00:00Z",
+            },
+            {
+                "__typename": "CheckRun",
+                "name": "ci",
+                "workflowName": "ci",
+                "status": "in_progress",
+                "conclusion": "",
+                "startedAt": "2026-07-01T00:05:00Z",
+            },
+        ],
+        "reviews": [],
+        "comments": [],
+    }
+    thread_payload = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {"totalCount": 0, "nodes": []},
+                }
+            }
+        }
+    }
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps(thread_payload), stderr=""),
+        ]
+        payload = build_babysitter_snapshot(
+            [5869], repo="ll7/robot_sf_ll7", retry_state=load_retry_state(None)
+        )
+
+    pr = payload["prs"][0]
+    assert pr["checks"]["overall"] == "pending"
+    assert pr["recommendation"]["action"] == "wait"
+    assert "ci_pending" in pr["recommendation"]["reasons"]
+    assert pr["recommendation"]["after_diagnosis_action"] is None
+
+
 def test_build_snapshot_wraps_compact_pr_queue_and_records_retry(tmp_path) -> None:  # type: ignore[no-untyped-def]
     """The wrapper should reuse compact queue snapshots and persist retry accounting."""
     state_file = tmp_path / "retry-state.json"

--- a/tests/dev/test_snapshot_pr_queue.py
+++ b/tests/dev/test_snapshot_pr_queue.py
@@ -92,6 +92,171 @@ def test_snapshot_prs_pending_next_action() -> None:
     assert payload["route_health_overview"]["healthy"] == 1
 
 
+def test_snapshot_prs_suppresses_superseded_cancelled_run() -> None:
+    """An older cancelled run must not override a newer pending replacement."""
+    pr_payload = {
+        "number": 5869,
+        "title": "superseded cancelled PR",
+        "state": "OPEN",
+        "isDraft": False,
+        "labels": [],
+        "headRefName": "feature",
+        "headRefOid": "abc111",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [
+            {
+                "__typename": "CheckRun",
+                "name": "ci",
+                "workflowName": "ci",
+                "status": "completed",
+                "conclusion": "cancelled",
+                "startedAt": "2026-07-01T00:00:00Z",
+            },
+            {
+                "__typename": "CheckRun",
+                "name": "ci",
+                "workflowName": "ci",
+                "status": "in_progress",
+                "conclusion": "",
+                "startedAt": "2026-07-01T00:05:00Z",
+            },
+        ],
+        "reviews": [],
+        "comments": [],
+    }
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr="")
+        payload = snapshot_prs([5869], repo="ll7/robot_sf_ll7", expected_head_sha="abc111")
+
+    pr = payload["prs"][0]
+    assert pr["checks"]["overall"] == "pending"
+    assert pr["checks"]["superseded"] == 1
+    assert pr["checks"]["total"] == 1
+
+
+def test_snapshot_prs_suppresses_superseded_cancelled_for_newer_success() -> None:
+    """A newer successful replacement should suppress an older cancellation."""
+    pr_payload = {
+        "number": 5869,
+        "title": "superseded cancelled then success",
+        "state": "OPEN",
+        "isDraft": False,
+        "labels": [],
+        "headRefName": "feature",
+        "headRefOid": "abc222",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [
+            {
+                "__typename": "CheckRun",
+                "name": "ci",
+                "workflowName": "ci",
+                "status": "completed",
+                "conclusion": "cancelled",
+                "startedAt": "2026-07-01T00:00:00Z",
+            },
+            {
+                "__typename": "CheckRun",
+                "name": "ci",
+                "workflowName": "ci",
+                "status": "completed",
+                "conclusion": "success",
+                "startedAt": "2026-07-01T00:05:00Z",
+            },
+        ],
+        "reviews": [],
+        "comments": [],
+    }
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr="")
+        payload = snapshot_prs([5869], repo="ll7/robot_sf_ll7", expected_head_sha="abc222")
+
+    pr = payload["prs"][0]
+    assert pr["checks"]["overall"] == "success"
+    assert pr["checks"]["superseded"] == 1
+    assert pr["checks"]["total"] == 1
+
+
+def test_snapshot_prs_current_cancellation_stays_fail_closed() -> None:
+    """A current, non-superseded cancellation must remain a failure."""
+    pr_payload = {
+        "number": 5869,
+        "title": "current cancellation PR",
+        "state": "OPEN",
+        "isDraft": False,
+        "labels": [],
+        "headRefName": "feature",
+        "headRefOid": "abc333",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [
+            {
+                "__typename": "CheckRun",
+                "name": "ci",
+                "workflowName": "ci",
+                "status": "completed",
+                "conclusion": "cancelled",
+                "startedAt": "2026-07-01T00:00:00Z",
+            }
+        ],
+        "reviews": [],
+        "comments": [],
+    }
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr="")
+        payload = snapshot_prs([5869], repo="ll7/robot_sf_ll7", expected_head_sha="abc333")
+
+    pr = payload["prs"][0]
+    assert pr["checks"]["overall"] == "failure"
+    assert pr["checks"]["superseded"] == 0
+
+
+def test_snapshot_prs_keeps_independent_legacy_status_entries() -> None:
+    """Legacy statuses and timestamp-less runs stay independently classified."""
+    pr_payload = {
+        "number": 5869,
+        "title": "mixed legacy and actions runs",
+        "state": "OPEN",
+        "isDraft": False,
+        "labels": [],
+        "headRefName": "feature",
+        "headRefOid": "abc444",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [
+            {
+                "name": "legacy-status",
+                "status": "completed",
+                "conclusion": "success",
+            },
+            {
+                "__typename": "CheckRun",
+                "name": "ci",
+                "workflowName": "ci",
+                "status": "completed",
+                "conclusion": "cancelled",
+                "startedAt": "2026-07-01T00:00:00Z",
+            },
+            {
+                "__typename": "CheckRun",
+                "name": "ci",
+                "workflowName": "ci",
+                "status": "completed",
+                "conclusion": "success",
+                "startedAt": "2026-07-01T00:05:00Z",
+            },
+        ],
+        "reviews": [],
+        "comments": [],
+    }
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr="")
+        payload = snapshot_prs([5869], repo="ll7/robot_sf_ll7", expected_head_sha="abc444")
+
+    pr = payload["prs"][0]
+    assert pr["checks"]["overall"] == "success"
+    assert pr["checks"]["superseded"] == 1
+    assert pr["checks"]["total"] == 2
+    assert pr["checks"]["names"] == ["ci", "legacy-status"]
+
+
 def test_snapshot_prs_details_url_none_falls_back_without_none_string() -> None:
     """Explicit null detailsUrl should not become the literal string None."""
     pr_payload = {

--- a/tests/dev/test_snapshot_pr_queue.py
+++ b/tests/dev/test_snapshot_pr_queue.py
@@ -209,6 +209,36 @@ def test_snapshot_prs_current_cancellation_stays_fail_closed() -> None:
     assert pr["checks"]["superseded"] == 0
 
 
+def test_snapshot_prs_ignores_non_mapping_rollup_entries_before_deduplication() -> None:
+    """Malformed rollup entries must not crash the latest-run filter."""
+    pr_payload = {
+        "number": 5869,
+        "title": "mixed malformed rollup",
+        "state": "OPEN",
+        "isDraft": False,
+        "labels": [],
+        "headRefName": "feature",
+        "headRefOid": "abc-malformed",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [
+            None,
+            "not-a-check",
+            {"name": "ci", "status": "completed", "conclusion": "success"},
+        ],
+        "reviews": [],
+        "comments": [],
+    }
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr="")
+        payload = snapshot_prs([5869], repo="ll7/robot_sf_ll7", expected_head_sha="abc-malformed")
+
+    checks = payload["prs"][0]["checks"]
+    assert checks["overall"] == "success"
+    assert checks["total"] == 1
+    assert checks["superseded"] == 0
+    assert checks["names"] == ["ci"]
+
+
 def test_snapshot_prs_keeps_independent_legacy_status_entries() -> None:
     """Legacy statuses and timestamp-less runs stay independently classified."""
     pr_payload = {


### PR DESCRIPTION
## What / Why

During the #5843 batch gate a PR body edit retriggered workflows. GitHub retained cancelled older runs while their replacements were pending, and the babysitter snapshot recommended `diagnose_ci_failure` even though the effective latest checks had no failed job. `scripts/dev/check_pr_ci_status.py::_latest_check_runs` already handles newest-run-per-workflow-job semantics, but `scripts/dev/snapshot_pr_queue.py::_checks` consumed the raw rollup directly and inherited the stale cancellation as a failure.

This change reuses the canonical `_latest_check_runs` filter inside `snapshot_pr_queue._checks`, so the queue/babysitter summary applies the same supersession semantics as the canonical CI status helper. A current, non-superseded cancellation still produces a fail-closed failure; timestamp-less and legacy-status entries remain independently classified. The snapshot boundary also filters malformed non-mapping rollup entries before calling the typed helper, preserving the prior defensive behavior instead of crashing on `.get()`.

- `scripts/dev/snapshot_pr_queue.py`: apply `_latest_check_runs` before summarizing, expose the `superseded` count, and retain defensive payload filtering.
- `tests/dev/test_snapshot_pr_queue.py`: cover superseded cancelled→pending, superseded→success, current cancellation fail-closed, independent legacy/CheckRun entries, and malformed mixed rollups.
- `tests/dev/test_pr_babysitter_snapshot.py`: assert the resulting `wait`/`ci_pending` recommendation instead of `diagnose_ci_failure`.

## Validation

```text
uv run ruff check scripts/dev/snapshot_pr_queue.py tests/dev/test_snapshot_pr_queue.py tests/dev/test_pr_babysitter_snapshot.py
uv run ruff format --check scripts/dev/snapshot_pr_queue.py tests/dev/test_snapshot_pr_queue.py tests/dev/test_pr_babysitter_snapshot.py
uv run pytest tests/dev/test_snapshot_pr_queue.py tests/dev/test_pr_babysitter_snapshot.py tests/dev/test_check_pr_ci_status.py -q
74 passed in 1.54s
```

## Scope notes

Read-only snapshot tooling only; no change to GitHub Actions cancellation, retry, or merge policy. No benchmark/research claim or durable `output/` dependency is produced. This PR fully resolves issue #5869.

Closes #5869

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardened it. The deterministic dispatcher is the sole merge owner.
