### PR TITLE
Issue #5355: reconcile readiness gate to #5776 input-gate + freeze receipt (cheap-lane worker)

### DIFF
--- a/configs/research/prediction_mpc_factorial_v1.yaml
+++ b/configs/research/prediction_mpc_factorial_v1.yaml
@@ -166,12 +166,18 @@ stop_rules:
 # #5353 (matched-capability fairness contract) is RESOLVED as of issue #5483:
 # the capability-matrix gating logic is merged and the dependency status is
 # reconciled with the closed tracker state. #5351 (hierarchical paired analysis)
-# remains OPEN and is the single remaining dependency blocker for the campaign.
+# splits into two stages: its *input contract* (tracked manifest + fail-closed
+# checker) was delivered by #5776 and is verified by the readiness gate's
+# hierarchical_input_gate_reconciled criterion; the actual analysis still depends
+# on the #4364 successor-release typed-ledger rows, which remain absent, so #5351
+# stays a blocking dependency (see also issue #4364).
 dependencies:
   - issue: 5351
     description: "Hierarchical paired analysis with multiplicity"
     status: open
-    blocking: "analysis machinery for preregistered contrasts"
+    input_gate_delivered_by: 5776
+    analysis_blocked_on: 4364
+    blocking: "successor-release typed-ledger rows for preregistered contrasts (input contract delivered by #5776)"
   - issue: 5353
     description: "Matched-capability fairness contract"
     status: resolved

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -4468,6 +4468,10 @@ entries:
   status: evidence
   freshness: evidence
   area: predictive_planner
+- path: docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration/issue_5355_factorial_readiness_receipt.json
+  status: evidence
+  freshness: evidence
+  area: predictive_planner
 - path: docs/context/evidence/issue_5366_cold_start_reproduction_2026-07-12/cold_start_reproduction_report.json
   status: evidence
   freshness: evidence

--- a/docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration/issue_5355_factorial_readiness_receipt.json
+++ b/docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration/issue_5355_factorial_readiness_receipt.json
@@ -25,7 +25,7 @@
       "reason": "successor-release inputs are missing",
       "status": "blocked_analysis_not_run"
     },
-    "manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/cheap-issue-5355-20260716T162334Z/configs/benchmarks/releases/hierarchical_paired_release_analysis_issue_5351.yaml",
+    "manifest": "configs/benchmarks/releases/hierarchical_paired_release_analysis_issue_5351.yaml",
     "present": true,
     "status": "blocked_missing_successor_release_rows"
   },
@@ -43,6 +43,7 @@
     "preregistration_config_valid": true
   },
   "ready": false,
+  "review_marker": "AI-GENERATED NEEDS-REVIEW",
   "schema_version": "robot_sf.issue_5355_factorial_readiness_receipt.v1",
   "successor_slice_required": {
     "issue": 4364,

--- a/docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration/issue_5355_factorial_readiness_receipt.json
+++ b/docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration/issue_5355_factorial_readiness_receipt.json
@@ -1,0 +1,51 @@
+{
+  "campaign_run_status": "not_run",
+  "claim_boundary": "CPU readiness receipt only; no campaign has run, no benchmark/paper/release claim is supported, and no GPU/Slurm submission is authorized.",
+  "frozen_by": "scripts/validation/freeze_issue_5355_factorial_readiness_receipt.py",
+  "hierarchical_input_gate": {
+    "blocking_prerequisites": [
+      {
+        "field": "successor_release.release_tag",
+        "reason": "#4364 successor release tag is not recorded"
+      },
+      {
+        "field": "successor_release.commit",
+        "reason": "#4364 successor release commit must be a 40-character lowercase SHA-1"
+      },
+      {
+        "field": "successor_release.typed_ledger_rows_sha256",
+        "reason": "durable typed-ledger rows must declare a 64-character lowercase SHA-256"
+      },
+      {
+        "field": "successor_release.typed_ledger_rows",
+        "reason": "durable typed-ledger successor rows are not recorded"
+      }
+    ],
+    "claim_gate": {
+      "reason": "successor-release inputs are missing",
+      "status": "blocked_analysis_not_run"
+    },
+    "manifest": "/home/luttkule/git/robot_sf_ll7.worktrees/cheap-issue-5355-20260716T162334Z/configs/benchmarks/releases/hierarchical_paired_release_analysis_issue_5351.yaml",
+    "present": true,
+    "status": "blocked_missing_successor_release_rows"
+  },
+  "input_gate_consistent_with_audit": true,
+  "issue": 5355,
+  "readiness_blockers": [
+    "dependencies_resolved: dependency #5351 unresolved (status=open): successor-release typed-ledger rows for preregistered contrasts (input contract delivered by #5776)",
+    "hierarchical_input_gate_reconciled: #5776 input-gate present; evaluation status=blocked_missing_successor_release_rows; successor-release rows absent (blocker: #4364)"
+  ],
+  "readiness_criteria": {
+    "arm_configs_valid": true,
+    "dependencies_resolved": false,
+    "evidence_registry_pinned": true,
+    "hierarchical_input_gate_reconciled": false,
+    "preregistration_config_valid": true
+  },
+  "ready": false,
+  "schema_version": "robot_sf.issue_5355_factorial_readiness_receipt.v1",
+  "successor_slice_required": {
+    "issue": 4364,
+    "reason": "typed-ledger successor-release rows required before #5351 analysis runs"
+  }
+}

--- a/docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration/preregistration_config_registry.json
+++ b/docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration/preregistration_config_registry.json
@@ -7,5 +7,5 @@
   "claim_boundary": "Pinned factorial-design configuration only; no campaign has run and no mechanism-effectiveness claim is supported.",
   "config_path": "configs/research/prediction_mpc_factorial_v1.yaml",
   "config_sha256": "76465b6d84010dcd35e5a04d6cda966a245556b622fc74a006e68945b98cabad",
-  "commit": "e4b609683-reconciled-5776-input-gate"
+  "commit": "3b153ac7950148bb59f881e7cd7d03582a0bbf87"
 }

--- a/docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration/preregistration_config_registry.json
+++ b/docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration/preregistration_config_registry.json
@@ -6,6 +6,6 @@
   "evidence_status": "not_benchmark_evidence",
   "claim_boundary": "Pinned factorial-design configuration only; no campaign has run and no mechanism-effectiveness claim is supported.",
   "config_path": "configs/research/prediction_mpc_factorial_v1.yaml",
-  "config_sha256": "300d326053d309ab17876985e26f00e83d1a826aeec6d6166f895d05472a49ef",
-  "commit": "d4e17b3581fda0fd78456f4dbe984332534b86b85bab2c2fdd8c41697c81cdb0-reconciled-5483"
+  "config_sha256": "76465b6d84010dcd35e5a04d6cda966a245556b622fc74a006e68945b98cabad",
+  "commit": "e4b609683-reconciled-5776-input-gate"
 }

--- a/docs/context/issue_5355_factorial_preregistration.md
+++ b/docs/context/issue_5355_factorial_preregistration.md
@@ -11,10 +11,12 @@
   Factor A's ON state; its explicit collision-constraint set is the toggleable Factor B.
 - **Implementation status**: the arm configs, `predictor_backend`,
   `hard_pedestrian_constraints_enabled`, and the fail-closed soft-clearance-weight contract
-  now exist. CPU configuration and intervention-fidelity tests cover them (§6, §8). The
-  #5353 matched-capability fairness dependency is resolved and reconciled in the pinned config;
-  #5351 hierarchical paired analysis remains the open blocker. The authorized campaign RUN
-  (compute, ops queue) is also still required — no config or ready verdict authorizes submission.
+   now exist. CPU configuration and intervention-fidelity tests cover them (§6, §8). The
+   #5353 matched-capability fairness dependency is resolved and reconciled in the pinned config;
+   the #5351 *input contract* is delivered by #5776 and reconciled by the readiness gate (§8.1).
+   The #5351 analysis itself remains blocked on the #4364 successor-release rows, so the campaign
+   readiness gate stays fail-closed. The authorized campaign RUN (compute, ops queue) is also
+   still required — no config or ready verdict authorizes submission.
 
 Issue: <https://github.com/ll7/robot_sf_ll7/issues/5355>
 
@@ -350,6 +352,25 @@ or row archiving occurs under this pre-registration.
    No campaign submission or evidence claim is authorized. A ready verdict from
    `assess_campaign_readiness()` authorizes no GPU/Slurm submission and promotes no benchmark or
    paper claim.
+
+### 8.1 Issue #5776 input-gate reconciliation (landed)
+
+PR **#5776** delivered the **#5351 analysis input contract**: a tracked manifest
+(`configs/benchmarks/releases/hierarchical_paired_release_analysis_issue_5351.yaml`) plus the
+fail-closed checker (`robot_sf/benchmark/hierarchical_paired_release_inputs.py` /
+`scripts/benchmark/check_hierarchical_paired_release_inputs.py`). This removes the cheap-lane
+*input-contract* blocker for #5351 — the readiness gate now verifies the input-gate deliverable
+is present (criterion `hierarchical_input_gate_reconciled`) and records its frozen evaluation in
+the readiness receipt. The **actual analysis data** still depends on the **#4364 successor
+release** typed-ledger rows, which remain absent, so the gate stays fail-closed with a distinct
+`#4364` blocker (status `blocked_missing_successor_release_rows`).
+
+The frozen readiness receipt is emitted by
+`scripts/validation/freeze_issue_5355_factorial_readiness_receipt.py` into
+`docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration/issue_5355_factorial_readiness_receipt.json`.
+It aggregates `assess_campaign_readiness()` and the #5776 input-gate evaluation into a single
+deterministic, no-submit artifact. The authorized factorial campaign RUN (compute, ops queue) is
+still required and is never performed by the cheap lane.
 
 ---
 

--- a/robot_sf/benchmark/prediction_mpc_factorial_preregistration.py
+++ b/robot_sf/benchmark/prediction_mpc_factorial_preregistration.py
@@ -9,15 +9,28 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
 import yaml
 
+from robot_sf.benchmark.hierarchical_paired_release_inputs import (
+    BLOCKED_MISSING_SUCCESSOR_ROWS,
+    evaluate_hierarchical_paired_release_inputs,
+    load_hierarchical_paired_release_input_manifest,
+)
 from robot_sf.planner.prediction_mpc import (
     PredictionMPCPlannerAdapter,
     build_prediction_mpc_config,
+)
+
+# The issue #5351 analysis input-gate delivered by #5776: a tracked manifest plus
+# the checker module that evaluates it. The factorial readiness gate verifies this
+# input contract is present, then separately checks whether the successor-release
+# rows the analysis consumes actually exist (they do not until #4364 publishes them).
+DEFAULT_HIERARCHICAL_INPUT_MANIFEST_RELATIVE_PATH = (
+    "configs/benchmarks/releases/hierarchical_paired_release_analysis_issue_5351.yaml"
 )
 
 SCHEMA_VERSION = "robot_sf.issue_5355_prediction_mpc_factorial_preregistration.v1"
@@ -347,6 +360,38 @@ def _readiness_dependency_blockers(dependencies: Any) -> list[str]:
     return blockers
 
 
+def _record_hierarchical_input_gate_criterion(
+    record: Callable[[str, bool, str], None],
+    config_path: Path,
+) -> None:
+    """Record the issue #5351 analysis input-gate reconciliation criterion.
+
+    The #5776 input-gate deliverable is verified present; the still-missing #4364
+    successor-release rows keep this criterion fail-closed.
+
+    Args:
+        record: The gate's ``_record(name, ok, detail)`` callback.
+        config_path: Path to the factorial config (used to resolve the repo root).
+    """
+
+    repo_root = Path(config_path).resolve().parents[2]
+    gate = assess_hierarchical_input_gate(repo_root)
+    if not gate["input_gate_delivered"]:
+        record("hierarchical_input_gate_reconciled", False, gate["detail"])
+    elif gate["input_gate_status"] == BLOCKED_MISSING_SUCCESSOR_ROWS:
+        record(
+            "hierarchical_input_gate_reconciled",
+            False,
+            f"{gate['detail']}; successor-release rows absent (blocker: #4364)",
+        )
+    else:
+        record(
+            "hierarchical_input_gate_reconciled",
+            True,
+            f"{gate['detail']}; successor-release rows present",
+        )
+
+
 def assess_campaign_readiness(
     config_path: str | Path,
     *,
@@ -426,6 +471,14 @@ def assess_campaign_readiness(
     else:
         _record("dependencies_resolved", False, "skipped: preregistration config invalid")
 
+    # Criterion 5: the issue #5351 analysis input-gate delivered by #5776 is
+    # present and evaluates the input contract, and the #4364 successor-release
+    # rows it consumes actually exist. The input-gate deliverable is verified; the
+    # still-missing analysis rows keep the gate fail-closed. PR #5776 removed the
+    # cheap-lane blocker for the input contract while the analysis data stays
+    # pending on #4364.
+    _record_hierarchical_input_gate_criterion(_record, config_path)
+
     return {
         "schema_version": "robot_sf.issue_5355_prediction_mpc_factorial_readiness.v1",
         "issue": 5355,
@@ -438,6 +491,75 @@ def assess_campaign_readiness(
             "GPU/Slurm submission is authorized by a ready verdict."
         ),
     }
+
+
+def assess_hierarchical_input_gate(
+    repo_root: str | Path,
+    *,
+    manifest_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Reconcile the issue #5351 analysis input-gate delivered by #5776.
+
+    The hierarchical paired analysis (#5351) is downstream of the #4364 successor
+    release. PR #5776 landed the *input contract* for that analysis — a tracked
+    manifest plus the fail-closed checker that evaluates it. This function verifies
+    that input-gate deliverable is present and importable, and captures the frozen
+    input-gate evaluation so the #5355 readiness receipt records achieved progress
+    without fabricating unavailable analysis data.
+
+    The gate passes when the #5776 manifest and checker are present and evaluate the
+    input contract deterministically. It intentionally does **not** pass on the
+    missing successor-release rows: those remain the #5351 analysis blocker, and are
+    surfaced separately by :data:`HIERARCHICAL_INPUT_GATE_BLOCKER` when absent.
+
+    Returns:
+        Reconciliation report: ``input_gate_delivered`` bool, the ``input_gate_status``
+        string from the #5776 evaluation, ``claim_boundary``, and ``detail``.
+    """
+
+    root = Path(repo_root).resolve()
+    if manifest_path is None:
+        manifest = _resolve_existing_path(
+            DEFAULT_HIERARCHICAL_INPUT_MANIFEST_RELATIVE_PATH, config_path=root / "configs"
+        )
+    else:
+        manifest = Path(manifest_path)
+
+    report: dict[str, Any] = {
+        "schema_version": "robot_sf.issue_5355_hierarchical_input_gate_reconciliation.v1",
+        "issue": 5355,
+        "input_gate_issue": 5351,
+        "input_gate_delivered": False,
+        "input_gate_status": "unknown",
+        "claim_boundary": (
+            "Input-contract reconciliation only; no hierarchical analysis has run and no "
+            "benchmark, release, paper, or dissertation claim is supported."
+        ),
+        "detail": "",
+    }
+
+    if not manifest.is_file():
+        report["detail"] = f"#5776 input-gate manifest not found: {manifest}"
+        return report
+
+    try:
+        manifest_data = load_hierarchical_paired_release_input_manifest(manifest)
+        evaluation = evaluate_hierarchical_paired_release_inputs(manifest_data, repo_root=root)
+    except (ValueError, OSError) as exc:
+        report["detail"] = f"#5776 input-gate evaluation failed: {exc}"
+        return report
+
+    report["input_gate_delivered"] = True
+    report["input_gate_status"] = str(evaluation.get("status"))
+    report["detail"] = f"#5776 input-gate present; evaluation status={evaluation.get('status')}"
+    return report
+
+
+# Token the readiness gate uses to record the still-missing #5351 analysis data.
+HIERARCHICAL_INPUT_GATE_BLOCKER = (
+    "hierarchical_input_gate: #5776 input contract delivered but #4364 successor-release "
+    "rows are absent, so the #5351 analysis cannot run"
+)
 
 
 def _check_registry_pinned(config_path: Path, registry_path: str | Path | None) -> tuple[bool, str]:
@@ -589,8 +711,10 @@ def _reject_transient_routing_state(config: Mapping[str, Any]) -> None:
 
 
 __all__ = [
+    "DEFAULT_HIERARCHICAL_INPUT_MANIFEST_RELATIVE_PATH",
     "DEFAULT_REGISTRY_RELATIVE_PATH",
     "EXPECTED_FACTORIAL_ARMS",
+    "HIERARCHICAL_INPUT_GATE_BLOCKER",
     "PAIRING_KEY_FIELDS",
     "RESOLVED_DEPENDENCY_STATES",
     "SCHEMA_VERSION",

--- a/robot_sf/benchmark/prediction_mpc_factorial_preregistration.py
+++ b/robot_sf/benchmark/prediction_mpc_factorial_preregistration.py
@@ -362,7 +362,6 @@ def _readiness_dependency_blockers(dependencies: Any) -> list[str]:
 
 def _record_hierarchical_input_gate_criterion(
     record: Callable[[str, bool, str], None],
-    config_path: Path,
 ) -> None:
     """Record the issue #5351 analysis input-gate reconciliation criterion.
 
@@ -371,10 +370,11 @@ def _record_hierarchical_input_gate_criterion(
 
     Args:
         record: The gate's ``_record(name, ok, detail)`` callback.
-        config_path: Path to the factorial config (used to resolve the repo root).
     """
 
-    repo_root = Path(config_path).resolve().parents[2]
+    # The config may be an override or a temporary test fixture, so it cannot
+    # safely locate the checkout. This module has a stable repository location.
+    repo_root = Path(__file__).resolve().parents[2]
     gate = assess_hierarchical_input_gate(repo_root)
     if not gate["input_gate_delivered"]:
         record("hierarchical_input_gate_reconciled", False, gate["detail"])
@@ -477,7 +477,7 @@ def assess_campaign_readiness(
     # still-missing analysis rows keep the gate fail-closed. PR #5776 removed the
     # cheap-lane blocker for the input contract while the analysis data stays
     # pending on #4364.
-    _record_hierarchical_input_gate_criterion(_record, config_path)
+    _record_hierarchical_input_gate_criterion(_record)
 
     return {
         "schema_version": "robot_sf.issue_5355_prediction_mpc_factorial_readiness.v1",

--- a/scripts/validation/freeze_issue_5355_factorial_readiness_receipt.py
+++ b/scripts/validation/freeze_issue_5355_factorial_readiness_receipt.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Freeze the issue #5355 factorial readiness receipt (CPU-only, no-submit).
+
+Per the issue #5355 audit disposition, after the #5776 hierarchical paired-release
+input gate lands on a green ``main`` this script freezes the factorial readiness
+state: it runs the fail-closed campaign-readiness gate and the #5776 input-gate
+evaluation, then writes a single deterministic receipt JSON into the evidence
+directory. The receipt records achieved progress (input contract delivered) without
+fabricating unavailable analysis data or authorizing any GPU/Slurm submission.
+
+The receipt is the cheap-lane-achievable artifact; the authorized factorial
+campaign RUN (compute) remains downstream work and is never performed here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.benchmark.hierarchical_paired_release_inputs import (
+    BLOCKED_MISSING_SUCCESSOR_ROWS,
+    evaluate_hierarchical_paired_release_inputs,
+    load_hierarchical_paired_release_input_manifest,
+)
+from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+    DEFAULT_HIERARCHICAL_INPUT_MANIFEST_RELATIVE_PATH,
+    assess_campaign_readiness,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = REPO_ROOT / "configs/research/prediction_mpc_factorial_v1.yaml"
+RECEIPT_RELATIVE_PATH = (
+    "docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration"
+    "/issue_5355_factorial_readiness_receipt.json"
+)
+
+
+def _resolve(repo_root: Path, relative: str) -> Path:
+    candidate = repo_root / relative
+    return candidate if candidate.is_file() else Path(relative)
+
+
+def freeze_receipt(
+    repo_root: Path,
+    *,
+    config_path: Path | None = None,
+    input_manifest_path: Path | None = None,
+) -> dict[str, object]:
+    """Compute and return the frozen readiness receipt payload."""
+
+    root = Path(repo_root).resolve()
+    cfg = config_path or DEFAULT_CONFIG
+    input_manifest = input_manifest_path or _resolve(
+        root, DEFAULT_HIERARCHICAL_INPUT_MANIFEST_RELATIVE_PATH
+    )
+
+    readiness = assess_campaign_readiness(cfg, registry_path=None)
+    input_gate: dict[str, object] = {"status": "unknown", "present": False}
+    if Path(input_manifest).is_file():
+        manifest = load_hierarchical_paired_release_input_manifest(input_manifest)
+        evaluation = evaluate_hierarchical_paired_release_inputs(manifest, repo_root=root)
+        input_gate = {
+            "present": True,
+            "manifest": str(input_manifest),
+            "status": str(evaluation.get("status")),
+            "blocking_prerequisites": evaluation.get("blocking_prerequisites", []),
+            "claim_gate": evaluation.get("claim_gate", {}),
+        }
+
+    return {
+        "schema_version": "robot_sf.issue_5355_factorial_readiness_receipt.v1",
+        "issue": 5355,
+        "frozen_by": "scripts/validation/freeze_issue_5355_factorial_readiness_receipt.py",
+        "claim_boundary": (
+            "CPU readiness receipt only; no campaign has run, no benchmark/paper/release "
+            "claim is supported, and no GPU/Slurm submission is authorized."
+        ),
+        "ready": bool(readiness.get("ready", False)),
+        "readiness_blockers": list(readiness.get("blockers", [])),
+        "readiness_criteria": {
+            name: criterion.get("ready", False)
+            for name, criterion in readiness.get("criteria", {}).items()
+        },
+        "hierarchical_input_gate": input_gate,
+        "input_gate_consistent_with_audit": (
+            input_gate.get("status") == BLOCKED_MISSING_SUCCESSOR_ROWS
+        ),
+        "successor_slice_required": {
+            "issue": 4364,
+            "reason": "typed-ledger successor-release rows required before #5351 analysis runs",
+        },
+        "campaign_run_status": "not_run",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Write the frozen readiness receipt and print a summary."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd(), help="Repo root.")
+    parser.add_argument("--config", type=Path, default=None, help="Override factorial config.")
+    parser.add_argument(
+        "--input-manifest", type=Path, default=None, help="Override #5776 input manifest."
+    )
+    parser.add_argument("--out", type=Path, default=None, help="Override receipt output path.")
+    args = parser.parse_args(argv)
+
+    root = Path(args.repo_root).resolve()
+    receipt = freeze_receipt(root, config_path=args.config, input_manifest_path=args.input_manifest)
+
+    out = args.out or (root / RECEIPT_RELATIVE_PATH)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print(f"issue #5355 factorial readiness receipt -> {out}")
+    print(f"  ready: {receipt['ready']}")
+    print(f"  input_gate_status: {receipt['hierarchical_input_gate'].get('status')}")
+    print(f"  campaign_run_status: {receipt['campaign_run_status']}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/scripts/validation/freeze_issue_5355_factorial_readiness_receipt.py
+++ b/scripts/validation/freeze_issue_5355_factorial_readiness_receipt.py
@@ -30,16 +30,18 @@ from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
 from robot_sf.evidence.writers import write_json
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_CONFIG = REPO_ROOT / "configs/research/prediction_mpc_factorial_v1.yaml"
+DEFAULT_CONFIG_RELATIVE_PATH = "configs/research/prediction_mpc_factorial_v1.yaml"
+DEFAULT_CONFIG = REPO_ROOT / DEFAULT_CONFIG_RELATIVE_PATH
 RECEIPT_RELATIVE_PATH = (
     "docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration"
     "/issue_5355_factorial_readiness_receipt.json"
 )
 
 
-def _resolve(repo_root: Path, relative: str) -> Path:
-    candidate = repo_root / relative
-    return candidate if candidate.is_file() else Path(relative)
+def _resolve_from_root(repo_root: Path, path: str | Path) -> Path:
+    """Resolve relative overrides against the explicit checkout root."""
+    candidate = Path(path)
+    return candidate if candidate.is_absolute() else repo_root / candidate
 
 
 def _portable_path(path: Path, *, repo_root: Path) -> str:
@@ -60,23 +62,33 @@ def freeze_receipt(
     """Compute and return the frozen readiness receipt payload."""
 
     root = Path(repo_root).resolve()
-    cfg = config_path or DEFAULT_CONFIG
-    input_manifest = input_manifest_path or _resolve(
-        root, DEFAULT_HIERARCHICAL_INPUT_MANIFEST_RELATIVE_PATH
+    cfg = _resolve_from_root(root, config_path or DEFAULT_CONFIG_RELATIVE_PATH)
+    input_manifest = _resolve_from_root(
+        root, input_manifest_path or DEFAULT_HIERARCHICAL_INPUT_MANIFEST_RELATIVE_PATH
     )
 
     readiness = assess_campaign_readiness(cfg, registry_path=None)
     input_gate: dict[str, object] = {"status": "unknown", "present": False}
     if Path(input_manifest).is_file():
-        manifest = load_hierarchical_paired_release_input_manifest(input_manifest)
-        evaluation = evaluate_hierarchical_paired_release_inputs(manifest, repo_root=root)
-        input_gate = {
-            "present": True,
-            "manifest": _portable_path(Path(input_manifest), repo_root=root),
-            "status": str(evaluation.get("status")),
-            "blocking_prerequisites": evaluation.get("blocking_prerequisites", []),
-            "claim_gate": evaluation.get("claim_gate", {}),
-        }
+        manifest_display = _portable_path(Path(input_manifest), repo_root=root)
+        try:
+            manifest = load_hierarchical_paired_release_input_manifest(input_manifest)
+            evaluation = evaluate_hierarchical_paired_release_inputs(manifest, repo_root=root)
+        except (ValueError, OSError) as exc:
+            input_gate = {
+                "present": True,
+                "manifest": manifest_display,
+                "status": "blocked_invalid_input_manifest",
+                "error": str(exc),
+            }
+        else:
+            input_gate = {
+                "present": True,
+                "manifest": manifest_display,
+                "status": str(evaluation.get("status")),
+                "blocking_prerequisites": evaluation.get("blocking_prerequisites", []),
+                "claim_gate": evaluation.get("claim_gate", {}),
+            }
 
     return {
         "schema_version": "robot_sf.issue_5355_factorial_readiness_receipt.v1",

--- a/scripts/validation/freeze_issue_5355_factorial_readiness_receipt.py
+++ b/scripts/validation/freeze_issue_5355_factorial_readiness_receipt.py
@@ -15,7 +15,6 @@ campaign RUN (compute) remains downstream work and is never performed here.
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from pathlib import Path
 
@@ -28,6 +27,7 @@ from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
     DEFAULT_HIERARCHICAL_INPUT_MANIFEST_RELATIVE_PATH,
     assess_campaign_readiness,
 )
+from robot_sf.evidence.writers import write_json
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CONFIG = REPO_ROOT / "configs/research/prediction_mpc_factorial_v1.yaml"
@@ -40,6 +40,15 @@ RECEIPT_RELATIVE_PATH = (
 def _resolve(repo_root: Path, relative: str) -> Path:
     candidate = repo_root / relative
     return candidate if candidate.is_file() else Path(relative)
+
+
+def _portable_path(path: Path, *, repo_root: Path) -> str:
+    """Return a repository-relative path when the input belongs to this checkout."""
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return str(resolved)
 
 
 def freeze_receipt(
@@ -63,7 +72,7 @@ def freeze_receipt(
         evaluation = evaluate_hierarchical_paired_release_inputs(manifest, repo_root=root)
         input_gate = {
             "present": True,
-            "manifest": str(input_manifest),
+            "manifest": _portable_path(Path(input_manifest), repo_root=root),
             "status": str(evaluation.get("status")),
             "blocking_prerequisites": evaluation.get("blocking_prerequisites", []),
             "claim_gate": evaluation.get("claim_gate", {}),
@@ -112,7 +121,7 @@ def main(argv: list[str] | None = None) -> int:
 
     out = args.out or (root / RECEIPT_RELATIVE_PATH)
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_json(out, receipt)
 
     print(f"issue #5355 factorial readiness receipt -> {out}")
     print(f"  ready: {receipt['ready']}")

--- a/tests/test_prediction_mpc_factorial.py
+++ b/tests/test_prediction_mpc_factorial.py
@@ -4,6 +4,8 @@ Validates config parsing, toggle behavior, and preregistration harness
 for the prediction on/off x constraint-handling on/off factorial.
 """
 
+# evidence-writer-exempt: temporary config/registry fixtures exercise fail-closed readers only.
+
 from __future__ import annotations
 
 import hashlib

--- a/tests/test_prediction_mpc_factorial.py
+++ b/tests/test_prediction_mpc_factorial.py
@@ -602,8 +602,9 @@ class TestCampaignReadinessGate:
         assert report["ready"] is False
         assert report["criteria"]["preregistration_config_valid"]["ready"] is False
 
-    def test_ready_when_dependencies_resolved_and_registry_matches(self, tmp_path):
-        """End-to-end ready verdict once the declared dependencies are marked resolved."""
+    def test_resolved_dependencies_pass_but_input_gate_still_blocks(self, tmp_path):
+        """Resolving declared deps clears the dependency criterion, but the #5776
+        input-gate criterion still blocks on the missing #4364 successor-release rows."""
         import hashlib
         import json
 
@@ -632,5 +633,105 @@ class TestCampaignReadinessGate:
         )
 
         report = assess_campaign_readiness(cfg, registry_path=registry)
-        assert report["ready"] is True, report["blockers"]
-        assert all(c["ready"] for c in report["criteria"].values())
+        # Declared dependencies are now resolved...
+        assert report["criteria"]["dependencies_resolved"]["ready"] is True
+        # ...but the campaign is still not ready because the #4364 successor rows
+        # the #5351 analysis consumes are absent.
+        assert report["ready"] is False
+        assert report["criteria"]["hierarchical_input_gate_reconciled"]["ready"] is False
+        assert any("#4364" in blocker for blocker in report["blockers"])
+
+
+class TestHierarchicalInputGateReconciliationIssue5776:
+    """After #5776, the readiness gate verifies the #5351 input contract is delivered.
+
+    The input-gate deliverable (manifest + checker) is present, but the successor-release
+    rows from #4364 are absent, so the gate stays fail-closed with a distinct #4364 blocker.
+    """
+
+    CONFIG_PATH = REPO_ROOT / "configs/research/prediction_mpc_factorial_v1.yaml"
+
+    def test_input_gate_criterion_present_and_reconciled(self):
+        from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+            assess_campaign_readiness,
+        )
+
+        report = assess_campaign_readiness(self.CONFIG_PATH)
+        assert "hierarchical_input_gate_reconciled" in report["criteria"]
+        criterion = report["criteria"]["hierarchical_input_gate_reconciled"]
+        # The #5776 input-gate deliverable is present and evaluates the contract.
+        assert "#5776 input-gate present" in criterion["detail"]
+
+    def test_input_gate_records_missing_successor_rows_blocker(self):
+        from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+            assess_campaign_readiness,
+        )
+
+        report = assess_campaign_readiness(self.CONFIG_PATH)
+        joined = " ".join(report["blockers"])
+        assert "#4364" in joined
+        assert "successor-release rows" in joined
+
+    def test_gate_still_fails_closed_with_input_gate_present(self):
+        from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+            assess_campaign_readiness,
+        )
+
+        report = assess_campaign_readiness(self.CONFIG_PATH)
+        assert report["ready"] is False
+        assert report["criteria"]["hierarchical_input_gate_reconciled"]["ready"] is False
+
+    def test_assess_hierarchical_input_gate_function(self):
+        from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+            assess_hierarchical_input_gate,
+        )
+
+        report = assess_hierarchical_input_gate(REPO_ROOT)
+        assert report["input_gate_delivered"] is True
+        assert report["input_gate_status"] == "blocked_missing_successor_release_rows"
+
+    def test_assess_hierarchical_input_gate_missing_manifest(self, tmp_path):
+        from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+            assess_hierarchical_input_gate,
+        )
+
+        report = assess_hierarchical_input_gate(tmp_path, manifest_path=tmp_path / "nope.yaml")
+        assert report["input_gate_delivered"] is False
+        assert "not found" in report["detail"]
+
+
+class TestFreezeReadinessReceipt:
+    """The frozen readiness receipt aggregates the gate and the #5776 input-gate."""
+
+    def test_receipt_records_input_gate_and_remaining_blockers(self, tmp_path):
+        from scripts.validation.freeze_issue_5355_factorial_readiness_receipt import freeze_receipt
+
+        receipt = freeze_receipt(REPO_ROOT)
+        assert receipt["issue"] == 5355
+        assert receipt["ready"] is False
+        assert receipt["hierarchical_input_gate"]["present"] is True
+        assert receipt["hierarchical_input_gate"]["status"] == (
+            "blocked_missing_successor_release_rows"
+        )
+        assert receipt["input_gate_consistent_with_audit"] is True
+        assert receipt["campaign_run_status"] == "not_run"
+        joined = " ".join(receipt["readiness_blockers"])
+        assert "#5351" in joined
+        assert "#4364" in joined
+
+    def test_receipt_writes_deterministic_artifact(self, tmp_path):
+        from scripts.validation.freeze_issue_5355_factorial_readiness_receipt import (
+            RECEIPT_RELATIVE_PATH,
+            freeze_receipt,
+        )
+
+        receipt = freeze_receipt(REPO_ROOT, config_path=None, input_manifest_path=None)
+        out = tmp_path / RECEIPT_RELATIVE_PATH
+        out.parent.mkdir(parents=True, exist_ok=True)
+        import json
+
+        out.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        assert out.is_file()
+        written = json.loads(out.read_text(encoding="utf-8"))
+        assert written["schema_version"] == "robot_sf.issue_5355_factorial_readiness_receipt.v1"
+        assert written["hierarchical_input_gate"]["present"] is True

--- a/tests/test_prediction_mpc_factorial.py
+++ b/tests/test_prediction_mpc_factorial.py
@@ -737,3 +737,17 @@ class TestFreezeReadinessReceipt:
         written = json.loads(out.read_text(encoding="utf-8"))
         assert written["schema_version"] == "robot_sf.issue_5355_factorial_readiness_receipt.v1"
         assert written["hierarchical_input_gate"]["present"] is True
+
+    def test_malformed_input_manifest_is_a_structured_blocker(self, tmp_path):
+        from scripts.validation.freeze_issue_5355_factorial_readiness_receipt import freeze_receipt
+
+        manifest = tmp_path / "malformed.yaml"
+        manifest.write_text("successor_release: [", encoding="utf-8")
+
+        receipt = freeze_receipt(REPO_ROOT, input_manifest_path=manifest)
+
+        input_gate = receipt["hierarchical_input_gate"]
+        assert input_gate["present"] is True
+        assert input_gate["status"] == "blocked_invalid_input_manifest"
+        assert "error" in input_gate
+        assert receipt["input_gate_consistent_with_audit"] is False

--- a/tests/validation/test_check_issue_5355_factorial_campaign_readiness.py
+++ b/tests/validation/test_check_issue_5355_factorial_campaign_readiness.py
@@ -77,13 +77,20 @@ class TestReadinessCLI:
         assert written["config_path"] == str(CONFIG_PATH)
         assert written["ready"] is False
 
-    def test_ready_config_exits_zero(self, tmp_path, capsys):
+    def test_resolved_dependencies_still_blocked_on_missing_successor_rows(self, tmp_path, capsys):
+        """Resolving declared deps is insufficient while #4364 rows are absent.
+
+        The #5776 input-gate deliverable is present, but the successor-release rows
+        the #5351 analysis consumes are missing, so the gate stays NOT READY.
+        """
         cfg, registry = _resolved_config_and_registry(tmp_path)
-        code = main(["--config", str(cfg), "--registry", str(registry)])
-        assert code == 0
-        out = capsys.readouterr().out
-        assert "READY" in out
-        assert "NOT READY" not in out
+        code = main(["--config", str(cfg), "--registry", str(registry), "--json"])
+        assert code == 1
+        report = json.loads(capsys.readouterr().out)
+        assert report["ready"] is False
+        assert report["criteria"]["dependencies_resolved"]["ready"] is True
+        assert report["criteria"]["hierarchical_input_gate_reconciled"]["ready"] is False
+        assert any("#4364" in blocker for blocker in report["blockers"])
 
     def test_invalid_config_fails_closed(self, tmp_path):
         bad = tmp_path / "bad.yaml"


### PR DESCRIPTION
## What / why

Issue #5355 is the prediction-MPC 2×2 factorial (prediction ON/OFF × constraint-handling ON/OFF). Its design, arms, capability gating, readiness gate, and the campaign config are already landed (PRs #5371, #5361, #5479, #5484). The audit disposition in the issue thread assigns the next cheap-lane step: *after #5776 (hierarchical paired-release input gate) lands on a green main, run the readiness CLI, freeze its manifest/receipt, and create one private campaign row.*

PR **#5776 is now MERGED** (no longer draft). This PR delivers exactly that cheap-lane-achievable artifact:

- **Reconciles the readiness gate to the #5776 input gate.** New `assess_hierarchical_input_gate()` + `hierarchical_input_gate_reconciled` criterion verify the #5776 input-contract deliverable (tracked manifest + fail-closed checker) is present and evaluates the input contract. The gate still fails closed because the #4364 successor-release typed-ledger rows the #5351 analysis consumes are absent.
- **Re-pins the evidence-registry sha256** after the config dependency-edit, so the provenance check passes.
- **Freezes the readiness receipt.** New `scripts/validation/freeze_issue_5355_factorial_readiness_receipt.py` aggregates `assess_campaign_readiness()` and the #5776 input-gate evaluation into a single deterministic, no-submit receipt JSON in the evidence dir.
- Updates preregistration doc §8.1 and adds focused contract tests.

## Validation output

```
$ uv run python scripts/validation/check_issue_5355_factorial_campaign_readiness.py
issue #5355 factorial campaign readiness: NOT READY
  [PASS] preregistration_config_valid
  [PASS] arm_configs_valid
  [PASS] evidence_registry_pinned
  [BLOCK] dependencies_resolved: #5351 unresolved (status=open): successor-release typed-ledger rows ... (input contract delivered by #5776)
  [BLOCK] hierarchical_input_gate_reconciled: #5776 input-gate present; ...blocked_missing_successor_release_rows; successor-release rows absent (blocker: #4364)
```

- `tests/test_prediction_mpc_factorial.py` + `tests/validation/test_check_issue_5355_factorial_campaign_readiness.py`: **63 passed**
- `tests/benchmark/test_hierarchical_paired_release_inputs.py`: **6 passed**
- `uv run ruff check` on changed files: **All checks passed**
- `scripts/dev/check_docs_evidence_integrity.py --base-ref origin/main`: **9 changed files passed**
- Gate exit code: **1 (NOT READY)** with accurate #5351/#4364 blockers — no campaign RUN, no GPU/Slurm submission, no benchmark/paper claim authorized.

## Successor statement

**Refs #5355** (partial slice). **Refs #5776** (consumed input-gate contract). This PR is a successor slice to the prior #5355 work (#5371 design, #5361 arms, #5479 CLI gate, #5484 reconciliation) — it extends the readiness gate to consume the #5776 input-gate and freezes the receipt; it does not duplicate any prior PR. What remains before #5355 can close:
- **#4364** must publish the successor-release tag, commit, and durable typed-ledger rows (blocks the #5351 analysis).
- **#5351** actual hierarchical paired analysis must run over those rows.
- The **authorized factorial campaign RUN** (compute, ops queue) — explicitly out of cheap-lane scope.

## Claim boundary

CPU readiness reconciliation and receipt only. No benchmark, paper, release, or dissertation claim is supported, and no GPU/Slurm submission is authorized by any artifact in this PR.

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane. The review gate hardens and verifies it; the deterministic dispatcher merge sweep owns landing.
