### PR TITLE
Issue #5870: pagination-safe targeted --issue-number sync (cheap-lane worker)

### DIFF
--- a/scripts/tools/project_priority_score.py
+++ b/scripts/tools/project_priority_score.py
@@ -332,7 +332,14 @@ class GhProjectClient:
         )
 
     def item_list(self, *, owner: str, project_number: int, limit: int) -> list[dict[str, Any]]:
-        """Return project items with their visible field values."""
+        """Return project items with their visible field values.
+
+        Fails closed when the result reaches the ``limit`` cap: because this list
+        drives score write-backs, a page at the cap (indistinguishable from a full
+        page) could silently skip items beyond the limit. Callers that cannot
+        bound the project size should use :meth:`item_list_until_issue` or
+        :meth:`item_list_paginated` instead (issue #5870 / #5048 / #4991).
+        """
 
         payload = self._run_project_command(
             "item-list",
@@ -349,6 +356,105 @@ class GhProjectClient:
         # (indistinguishable from a full page) could silently skip items beyond the
         # limit. Raise instead of writing a partial sync (issue #5048 / #4991).
         assert_not_truncated(items, limit=limit, context="gh project item-list")
+        return items
+
+    def item_list_until_issue(
+        self,
+        *,
+        owner: str,
+        project_number: int,
+        issue_number: int,
+        page_limit: int = 100,
+        max_pages: int | None = 50,
+    ) -> list[dict[str, Any]]:
+        """Return the single issue-backed item without requiring a full untruncated page.
+
+        ``gh project item-list`` has no server-side issue filter, so the targeted
+        ``--issue-number`` sync used to call the full ``item_list`` at the default
+        cap and fail closed before it could apply the filter (issue #5870). This
+        helper walks the project in bounded pages and stops as soon as the matching
+        issue-backed item is found, so a targeted sync stays cheap and bounded no
+        matter how many items the project contains.
+
+        Each page is read at ``page_limit`` rows; because we stop at the first match
+        we never need a complete page, so the per-page truncation guard is not
+        required here. When the issue is not found after ``max_pages`` pages, an
+        empty list is returned (a clear bounded result, not an ambiguous scan).
+        """
+
+        if max_pages is not None and max_pages <= 0:
+            raise ValueError("max_pages must be positive or None")
+        seen: set[int] = set()
+        for page in range(max_pages if max_pages is not None else 1 << 62):
+            payload = self._run_project_command(
+                "item-list",
+                owner=owner,
+                project_number=project_number,
+                extra_args=(
+                    "--limit",
+                    str(page_limit),
+                ),
+                as_json=True,
+            )
+            chunk = list(payload["items"])
+            for item in chunk:
+                content = item.get("content")
+                if not isinstance(content, dict) or content.get("type") != "Issue":
+                    continue
+                number = content.get("number")
+                if not isinstance(number, int) or number < 0 or number in seen:
+                    continue
+                seen.add(number)
+                if number == issue_number:
+                    return [item]
+            # No match in this page; if the page came back shorter than the cap the
+            # project is exhausted, otherwise continue paging.
+            if len(chunk) < page_limit:
+                return []
+        return []
+
+    def item_list_paginated(
+        self,
+        *,
+        owner: str,
+        project_number: int,
+        page_limit: int = 100,
+        max_pages: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return all project items by paging past the truncation cap.
+
+        Unlike :meth:`item_list`, this does not fail closed at the cap: it keeps
+        fetching bounded pages until a short page signals exhaustion (or
+        ``max_pages`` is reached). A ``max_pages`` bound keeps full-project syncs
+        from running unbounded; ``None`` means page until exhaustion with no extra
+        guard beyond the natural short-page stop.
+        """
+
+        items: list[dict[str, Any]] = []
+        seen: set[int] = set()
+        for page in range(max_pages if max_pages is not None else 1 << 62):
+            payload = self._run_project_command(
+                "item-list",
+                owner=owner,
+                project_number=project_number,
+                extra_args=(
+                    "--limit",
+                    str(page_limit),
+                ),
+                as_json=True,
+            )
+            chunk = list(payload["items"])
+            for item in chunk:
+                content = item.get("content")
+                if not isinstance(content, dict) or content.get("type") != "Issue":
+                    continue
+                number = content.get("number")
+                if not isinstance(number, int) or number < 0 or number in seen:
+                    continue
+                seen.add(number)
+                items.append(item)
+            if len(chunk) < page_limit:
+                return items
         return items
 
     def update_number_field(
@@ -499,11 +605,25 @@ def sync_scores(
         )
 
     project_id = client.project_id(owner=options.owner, project_number=options.project_number)
-    items = client.item_list(
-        owner=options.owner,
-        project_number=options.project_number,
-        limit=options.limit,
-    )
+    if options.issue_number is not None:
+        # Targeted sync: locate the single issue-backed item without requiring a
+        # full untruncated project page. Paginate in bounded chunks and stop at the
+        # first match so the lookup stays cheap regardless of project size
+        # (issue #5870). The original fail-closed full-project guard is preserved
+        # for unscoped sync below.
+        items = client.item_list_until_issue(
+            owner=options.owner,
+            project_number=options.project_number,
+            issue_number=options.issue_number,
+        )
+    else:
+        # Unscoped sync keeps the explicit truncation protection: a full project
+        # page at the cap must fail closed rather than silently skip items.
+        items = client.item_list(
+            owner=options.owner,
+            project_number=options.project_number,
+            limit=options.limit,
+        )
     previews = build_previews(
         items,
         alpha=options.alpha,

--- a/scripts/tools/project_priority_score.py
+++ b/scripts/tools/project_priority_score.py
@@ -337,8 +337,8 @@ class GhProjectClient:
         Fails closed when the result reaches the ``limit`` cap: because this list
         drives score write-backs, a page at the cap (indistinguishable from a full
         page) could silently skip items beyond the limit. Callers that cannot
-        bound the project size should use :meth:`item_list_until_issue` or
-        :meth:`item_list_paginated` instead (issue #5870 / #5048 / #4991).
+        bound the project size should use :meth:`item_list_until_issue` instead
+        (issue #5870 / #5048 / #4991).
         """
 
         payload = self._run_project_command(
@@ -364,98 +364,43 @@ class GhProjectClient:
         owner: str,
         project_number: int,
         issue_number: int,
-        page_limit: int = 100,
-        max_pages: int | None = 50,
+        limit: int = 100,
     ) -> list[dict[str, Any]]:
-        """Return the single issue-backed item without requiring a full untruncated page.
+        """Return one issue-backed item through the project query surface.
 
-        ``gh project item-list`` has no server-side issue filter, so the targeted
-        ``--issue-number`` sync used to call the full ``item_list`` at the default
-        cap and fail closed before it could apply the filter (issue #5870). This
-        helper walks the project in bounded pages and stops as soon as the matching
-        issue-backed item is found, so a targeted sync stays cheap and bounded no
-        matter how many items the project contains.
-
-        Each page is read at ``page_limit`` rows; because we stop at the first match
-        we never need a complete page, so the per-page truncation guard is not
-        required here. When the issue is not found after ``max_pages`` pages, an
-        empty list is returned (a clear bounded result, not an ambiguous scan).
+        The numeric query narrows discovery before ``gh`` applies ``--limit``;
+        the exact-number check then rejects textual false positives. If the
+        bounded query reaches its cap without finding the issue, fail closed
+        because the exact match may have been truncated.
         """
 
-        if max_pages is not None and max_pages <= 0:
-            raise ValueError("max_pages must be positive or None")
-        seen: set[int] = set()
-        for page in range(max_pages if max_pages is not None else 1 << 62):
-            payload = self._run_project_command(
-                "item-list",
-                owner=owner,
-                project_number=project_number,
-                extra_args=(
-                    "--limit",
-                    str(page_limit),
-                ),
-                as_json=True,
-            )
-            chunk = list(payload["items"])
-            for item in chunk:
-                content = item.get("content")
-                if not isinstance(content, dict) or content.get("type") != "Issue":
-                    continue
-                number = content.get("number")
-                if not isinstance(number, int) or number < 0 or number in seen:
-                    continue
-                seen.add(number)
-                if number == issue_number:
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        payload = self._run_project_command(
+            "item-list",
+            owner=owner,
+            project_number=project_number,
+            extra_args=(
+                "--query",
+                str(issue_number),
+                "--limit",
+                str(limit),
+            ),
+            as_json=True,
+        )
+        items = list(payload["items"])
+        for item in items:
+            content = item.get("content")
+            if isinstance(content, dict) and content.get("type") == "Issue":
+                if content.get("number") == issue_number:
                     return [item]
-            # No match in this page; if the page came back shorter than the cap the
-            # project is exhausted, otherwise continue paging.
-            if len(chunk) < page_limit:
-                return []
+
+        assert_not_truncated(
+            items,
+            limit=limit,
+            context=f"gh project item-list query for issue #{issue_number}",
+        )
         return []
-
-    def item_list_paginated(
-        self,
-        *,
-        owner: str,
-        project_number: int,
-        page_limit: int = 100,
-        max_pages: int | None = None,
-    ) -> list[dict[str, Any]]:
-        """Return all project items by paging past the truncation cap.
-
-        Unlike :meth:`item_list`, this does not fail closed at the cap: it keeps
-        fetching bounded pages until a short page signals exhaustion (or
-        ``max_pages`` is reached). A ``max_pages`` bound keeps full-project syncs
-        from running unbounded; ``None`` means page until exhaustion with no extra
-        guard beyond the natural short-page stop.
-        """
-
-        items: list[dict[str, Any]] = []
-        seen: set[int] = set()
-        for page in range(max_pages if max_pages is not None else 1 << 62):
-            payload = self._run_project_command(
-                "item-list",
-                owner=owner,
-                project_number=project_number,
-                extra_args=(
-                    "--limit",
-                    str(page_limit),
-                ),
-                as_json=True,
-            )
-            chunk = list(payload["items"])
-            for item in chunk:
-                content = item.get("content")
-                if not isinstance(content, dict) or content.get("type") != "Issue":
-                    continue
-                number = content.get("number")
-                if not isinstance(number, int) or number < 0 or number in seen:
-                    continue
-                seen.add(number)
-                items.append(item)
-            if len(chunk) < page_limit:
-                return items
-        return items
 
     def update_number_field(
         self,
@@ -607,8 +552,8 @@ def sync_scores(
     project_id = client.project_id(owner=options.owner, project_number=options.project_number)
     if options.issue_number is not None:
         # Targeted sync: locate the single issue-backed item without requiring a
-        # full untruncated project page. Paginate in bounded chunks and stop at the
-        # first match so the lookup stays cheap regardless of project size
+        # full untruncated project page. Query before applying the cap, then verify
+        # the exact issue number so textual false positives cannot be updated
         # (issue #5870). The original fail-closed full-project guard is preserved
         # for unscoped sync below.
         items = client.item_list_until_issue(

--- a/tests/tools/test_project_priority_score.py
+++ b/tests/tools/test_project_priority_score.py
@@ -13,6 +13,7 @@ from scripts.tools.project_priority_score import (
     DEFAULT_SUCCESS_PROBABILITY,
     EFFORT_FIELD,
     PRIORITY_SCORE_FIELD,
+    REQUIRED_NUMBER_FIELDS,
     ScoreInputs,
     SyncOptions,
     build_previews,
@@ -60,6 +61,27 @@ class FakeGhProjectClient:
         """Return project items up to the requested limit."""
 
         return self._items[:limit]
+
+    def item_list_until_issue(
+        self,
+        *,
+        owner: str,
+        project_number: int,
+        issue_number: int,
+        page_limit: int = 100,
+        max_pages: int | None = 50,
+    ) -> list[dict]:
+        """Simulate bounded pagination that stops at the matching issue."""
+
+        for start in range(0, max(len(self._items), 1), max(page_limit, 1)):
+            chunk = self._items[start : start + page_limit]
+            for item in chunk:
+                content = item.get("content") or {}
+                if content.get("type") == "Issue" and content.get("number") == issue_number:
+                    return [item]
+            if len(chunk) < page_limit:
+                break
+        return []
 
     def update_number_field(
         self,
@@ -287,6 +309,122 @@ def test_sync_scores_skips_malformed_issue_numbers_when_indexing_items() -> None
     assert client.updated_numbers == [
         ("item-699", f"field-{PRIORITY_SCORE_FIELD}", "project-id", previews[0].new_score)
     ]
+
+
+def test_sync_scores_targeted_finds_issue_beyond_default_limit() -> None:
+    """`--issue-number N` locates N past the default 400-item boundary cheaply.
+
+    Issue #5870: the targeted sync must not call the full fail-closed
+    ``item_list`` (which raises at the cap) before applying the issue filter.
+    Here the project holds 2,300+ items; the targeted pass must find issue
+    2299 using bounded pagination without needing a full untruncated page.
+    """
+
+    items = [
+        _item(number, improvement=5, **{lower_first_key(EFFORT_FIELD): 8})
+        for number in range(1, 2301)
+    ]
+    client = FakeGhProjectClient(
+        fields=[
+            _field(name)
+            for name in (
+                EFFORT_FIELD,
+                *REQUIRED_NUMBER_FIELDS,
+            )
+        ],
+        items=items,
+    )
+
+    previews = sync_scores(
+        client,
+        SyncOptions(
+            owner="ll7",
+            project_number=5,
+            ensure_fields=False,
+            limit=400,
+            alpha=DEFAULT_ALPHA,
+            round_digits=6,
+            issue_number=2299,
+            dry_run=False,
+            skip_statuses={"Done"},
+        ),
+    )
+
+    assert [p.issue_number for p in previews] == [2299]
+    assert client.updated_numbers == [
+        ("item-2299", f"field-{PRIORITY_SCORE_FIELD}", "project-id", previews[0].new_score)
+    ]
+
+
+def test_sync_scores_targeted_does_not_update_others() -> None:
+    """Targeted mode updates exactly the requested issue and no other item."""
+
+    client = FakeGhProjectClient(
+        fields=[
+            _field(name)
+            for name in (
+                EFFORT_FIELD,
+                *REQUIRED_NUMBER_FIELDS,
+            )
+        ],
+        items=[
+            _item(1, improvement=5, **{lower_first_key(EFFORT_FIELD): 8}),
+            _item(2, improvement=5, **{lower_first_key(EFFORT_FIELD): 8}),
+            _item(3, improvement=5, **{lower_first_key(EFFORT_FIELD): 8}),
+        ],
+    )
+
+    previews = sync_scores(
+        client,
+        SyncOptions(
+            owner="ll7",
+            project_number=5,
+            ensure_fields=False,
+            limit=400,
+            alpha=DEFAULT_ALPHA,
+            round_digits=6,
+            issue_number=2,
+            dry_run=False,
+            skip_statuses={"Done"},
+        ),
+    )
+
+    assert [p.issue_number for p in previews] == [2]
+    assert len(client.updated_numbers) == 1
+    assert client.updated_numbers[0][0] == "item-2"
+
+
+def test_sync_scores_targeted_missing_issue_returns_no_updates() -> None:
+    """A missing issue number yields a bounded empty result, not an ambiguous scan."""
+
+    client = FakeGhProjectClient(
+        fields=[
+            _field(name)
+            for name in (
+                EFFORT_FIELD,
+                *REQUIRED_NUMBER_FIELDS,
+            )
+        ],
+        items=[_item(1, improvement=5, **{lower_first_key(EFFORT_FIELD): 8})],
+    )
+
+    previews = sync_scores(
+        client,
+        SyncOptions(
+            owner="ll7",
+            project_number=5,
+            ensure_fields=False,
+            limit=400,
+            alpha=DEFAULT_ALPHA,
+            round_digits=6,
+            issue_number=999,
+            dry_run=False,
+            skip_statuses={"Done"},
+        ),
+    )
+
+    assert previews == []
+    assert client.updated_numbers == []
 
 
 def test_write_summary_persists_machine_readable_payload(tmp_path: Path) -> None:

--- a/tests/tools/test_project_priority_score.py
+++ b/tests/tools/test_project_priority_score.py
@@ -68,19 +68,14 @@ class FakeGhProjectClient:
         owner: str,
         project_number: int,
         issue_number: int,
-        page_limit: int = 100,
-        max_pages: int | None = 50,
+        limit: int = 100,
     ) -> list[dict]:
-        """Simulate bounded pagination that stops at the matching issue."""
+        """Simulate an exact issue query over the fake project items."""
 
-        for start in range(0, max(len(self._items), 1), max(page_limit, 1)):
-            chunk = self._items[start : start + page_limit]
-            for item in chunk:
-                content = item.get("content") or {}
-                if content.get("type") == "Issue" and content.get("number") == issue_number:
-                    return [item]
-            if len(chunk) < page_limit:
-                break
+        for item in self._items:
+            content = item.get("content") or {}
+            if content.get("type") == "Issue" and content.get("number") == issue_number:
+                return [item]
         return []
 
     def update_number_field(
@@ -317,7 +312,7 @@ def test_sync_scores_targeted_finds_issue_beyond_default_limit() -> None:
     Issue #5870: the targeted sync must not call the full fail-closed
     ``item_list`` (which raises at the cap) before applying the issue filter.
     Here the project holds 2,300+ items; the targeted pass must find issue
-    2299 using bounded pagination without needing a full untruncated page.
+    2299 using a bounded server-side query without needing a full project list.
     """
 
     items = [

--- a/tests/tools/test_project_priority_score_truncation.py
+++ b/tests/tools/test_project_priority_score_truncation.py
@@ -69,47 +69,29 @@ def test_targeted_lookup_finds_issue_beyond_cap(monkeypatch: pytest.MonkeyPatch)
 
     Issue #5870: a project with more items than the default cap must not force a
     full untruncated page for a targeted ``--issue-number`` lookup. The helper
-    pages in bounded chunks and stops at the first match.
+    uses the bounded project query surface and verifies the exact issue number.
     """
 
-    pages = {
-        0: [
-            {"id": f"item{index}", "content": {"type": "Issue", "number": index}}
-            for index in range(100)
-        ],
-        1: [
-            {"id": f"item{index}", "content": {"type": "Issue", "number": index}}
-            for index in range(100, 200)
-        ],
-        2: [
-            {"id": f"item{index}", "content": {"type": "Issue", "number": index}}
-            for index in range(200, 300)
-        ],
-    }
-    call_index = {"n": 0}
+    calls: list[list[str]] = []
 
     def _fake_run(
         args: list[str], *, check: bool, capture_output: bool, text: bool
     ) -> subprocess.CompletedProcess[str]:
-        # Return each full page in turn, then an empty page to signal exhaustion.
-        if call_index["n"] < len(pages):
-            page = pages[call_index["n"]]
-        else:
-            page = []
-        call_index["n"] += 1
+        calls.append(args)
+        items = [{"id": "item250", "content": {"type": "Issue", "number": 250}}]
         return subprocess.CompletedProcess(
-            args=args, returncode=0, stdout=json.dumps({"items": page}), stderr=""
+            args=args, returncode=0, stdout=json.dumps({"items": items}), stderr=""
         )
 
     monkeypatch.setattr(subprocess, "run", _fake_run)
     client = GhProjectClient()
-    found = client.item_list_until_issue(
-        owner="ll7", project_number=5, issue_number=250, page_limit=100
-    )
+    found = client.item_list_until_issue(owner="ll7", project_number=5, issue_number=250, limit=25)
     assert len(found) == 1
     assert found[0]["content"]["number"] == 250
-    # Stopped at the matching page, not after exhaustively paging a huge project.
-    assert call_index["n"] == 3
+    assert len(calls) == 1
+    assert "--query" in calls[0]
+    assert calls[0][calls[0].index("--query") + 1] == "250"
+    assert calls[0][calls[0].index("--limit") + 1] == "25"
 
 
 def test_targeted_lookup_missing_issue_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -125,11 +107,27 @@ def test_targeted_lookup_missing_issue_returns_empty(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(subprocess, "run", _fake_run)
     client = GhProjectClient()
     assert (
-        client.item_list_until_issue(
-            owner="ll7", project_number=5, issue_number=999, page_limit=100
-        )
+        client.item_list_until_issue(owner="ll7", project_number=5, issue_number=999, limit=100)
         == []
     )
+
+
+def test_targeted_lookup_fails_closed_when_query_is_capped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A capped query cannot claim that a missing exact issue is absent."""
+
+    def _fake_run(
+        args: list[str], *, check: bool, capture_output: bool, text: bool
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout=_items_payload(2), stderr=""
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    client = GhProjectClient()
+    with pytest.raises(GhListTruncated):
+        client.item_list_until_issue(owner="ll7", project_number=5, issue_number=999, limit=2)
 
 
 def test_full_project_sync_still_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/tools/test_project_priority_score_truncation.py
+++ b/tests/tools/test_project_priority_score_truncation.py
@@ -62,3 +62,92 @@ def test_item_list_passes_below_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     client = GhProjectClient()
     items = client.item_list(owner="ll7", project_number=5, limit=20)
     assert len(items) == 2
+
+
+def test_targeted_lookup_finds_issue_beyond_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`item_list_until_issue` finds an issue past the truncation cap cheaply.
+
+    Issue #5870: a project with more items than the default cap must not force a
+    full untruncated page for a targeted ``--issue-number`` lookup. The helper
+    pages in bounded chunks and stops at the first match.
+    """
+
+    pages = {
+        0: [
+            {"id": f"item{index}", "content": {"type": "Issue", "number": index}}
+            for index in range(100)
+        ],
+        1: [
+            {"id": f"item{index}", "content": {"type": "Issue", "number": index}}
+            for index in range(100, 200)
+        ],
+        2: [
+            {"id": f"item{index}", "content": {"type": "Issue", "number": index}}
+            for index in range(200, 300)
+        ],
+    }
+    call_index = {"n": 0}
+
+    def _fake_run(
+        args: list[str], *, check: bool, capture_output: bool, text: bool
+    ) -> subprocess.CompletedProcess[str]:
+        # Return each full page in turn, then an empty page to signal exhaustion.
+        if call_index["n"] < len(pages):
+            page = pages[call_index["n"]]
+        else:
+            page = []
+        call_index["n"] += 1
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout=json.dumps({"items": page}), stderr=""
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    client = GhProjectClient()
+    found = client.item_list_until_issue(
+        owner="ll7", project_number=5, issue_number=250, page_limit=100
+    )
+    assert len(found) == 1
+    assert found[0]["content"]["number"] == 250
+    # Stopped at the matching page, not after exhaustively paging a huge project.
+    assert call_index["n"] == 3
+
+
+def test_targeted_lookup_missing_issue_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing issue yields an empty list, not an ambiguous full scan."""
+
+    def _fake_run(
+        args: list[str], *, check: bool, capture_output: bool, text: bool
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout=json.dumps({"items": []}), stderr=""
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    client = GhProjectClient()
+    assert (
+        client.item_list_until_issue(
+            owner="ll7", project_number=5, issue_number=999, page_limit=100
+        )
+        == []
+    )
+
+
+def test_full_project_sync_still_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unscoped sync retains the explicit truncation guard past the cap.
+
+    This regression guards issue #5870's compatibility constraint: making
+    targeted lookups pagination-safe must not weaken the fail-closed full-sync
+    path. A capped page must still raise GhListTruncated for unscoped sync.
+    """
+
+    def _fake_run(
+        args: list[str], *, check: bool, capture_output: bool, text: bool
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout=_items_payload(400), stderr=""
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    client = GhProjectClient()
+    with pytest.raises(GhListTruncated):
+        client.item_list(owner="ll7", project_number=5, limit=400)


### PR DESCRIPTION
## Issue #5870: make issue-targeted priority score sync pagination-safe (cheap-lane worker)

### What / Why
`scripts/tools/project_priority_score.py sync --issue-number N` failed closed for Project #5
(>2,300 items) because `sync_scores` called the full `gh project item-list` at the default cap
(`item_list(limit=400)`) and hit `GhListTruncated` *before* applying the `--issue-number` filter.

### Change
- Added `GhProjectClient.item_list_until_issue(...)`: uses the supported project query surface to
  narrow discovery before the cap, then verifies the exact issue number so textual false positives
  cannot be updated.
- The targeted query is bounded and fails closed if a capped result cannot prove that an issue is
  absent.
- `sync_scores` now routes `--issue-number` targets through the targeted query and keeps the
  unscoped fail-closed `item_list` path intact.
- CLI unchanged; no score-math or field-definition changes.

### Validation
- `uv run ruff check` and `ruff format --check` pass on changed files.
- `uv run pytest tests/tools/test_project_priority_score.py tests/tools/test_project_priority_score_truncation.py -q` -> **21 passed**.
- Live read-only dry run against Project #5 found Issue #5870 through the targeted query and computed
  exactly one preview.
- Regression coverage verifies one query call, exact-number filtering, no unrelated writes, an
  empty bounded result below the cap, and fail-closed behavior at the query/full-project caps.

### Successor statement
This PR fully resolves Issue #5870 (fix-class): targeted discovery is bounded and query-safe, and
the fail-closed full-project guard is retained. No remaining slices.

Closes #5870

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and the deterministic dispatcher owns merge.
