### PR TITLE
Issue #5883: generic fail-closed trace-series adapter (cheap-lane worker)

### DIFF
--- a/scripts/repro/trace_series_adapter.py
+++ b/scripts/repro/trace_series_adapter.py
@@ -27,7 +27,9 @@ The adapter rejects unsupported inputs instead of papering over them:
 The derived-row computation mirrors the one the renderer independently
 re-derives from the emitted ``frames`` (the same strict-less-than nearest
 neighbour scan over ``frame["pedestrians"]`` in list order), so the two agree
-by construction and the bundle is self-consistent.
+by construction and the bundle is self-consistent. Source provenance is copied
+into the emitted metadata, and generated timestamps are used only when the
+source row supplies one, keeping repeated conversion deterministic.
 
 Usage::
 
@@ -47,7 +49,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
-from datetime import UTC, datetime
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -113,7 +115,11 @@ def _episode_identity(row: dict[str, Any]) -> dict[str, Any]:
     """Resolve the canonical identity fields used for exact selection."""
     provenance = row.get("result_provenance")
     provenance = provenance if isinstance(provenance, dict) else {}
-    git_commit = provenance.get("repo_commit", row.get("git_hash"))
+    git_commit = provenance.get("repo_commit") or row.get("git_hash")
+    if not isinstance(git_commit, str) or not git_commit.strip():
+        git_commit = None
+    else:
+        git_commit = git_commit.strip()
     return {
         "episode_id": _first(row, ("episode_id",), ("id",)),
         "scenario": _first(
@@ -157,7 +163,7 @@ def _row_matches(
 ) -> bool:
     """Return whether one resolved identity matches the active selection key."""
     if episode_id is not None:
-        return str(identity["episode_id"]) == str(episode_id)
+        return identity["episode_id"] is not None and str(identity["episode_id"]) == str(episode_id)
     return (
         (scenario is None or str(identity["scenario"]) == scenario)
         and (planner is None or str(identity["planner"]) == planner)
@@ -231,22 +237,100 @@ def select_row(
     return matches[0][0]
 
 
-def _validate_provenance(row: dict[str, Any]) -> str:
+def _validate_provenance(row: dict[str, Any]) -> tuple[str, dict[str, Any]]:
     """Fail closed when execution provenance is missing.
 
     Returns:
-        The resolved execution commit string.
+        The resolved execution commit and source provenance mapping.
     """
+    raw_provenance = row.get("result_provenance")
+    if raw_provenance is not None and not isinstance(raw_provenance, dict):
+        raise TraceSeriesAdapterError("episode row result_provenance must be an object")
+    provenance = dict(raw_provenance) if isinstance(raw_provenance, dict) else {}
     identity = _episode_identity(row)
     git_commit = identity["git_commit"]
     if not git_commit:
         raise TraceSeriesAdapterError(
             "episode row has no execution provenance (missing git_hash/result_provenance.repo_commit)"
         )
-    return git_commit
+    return git_commit, provenance
 
 
-def _nearest_pedestrian(frame: dict[str, Any]) -> tuple[float, int | None]:
+def _finite_number(value: Any, context: str) -> float:
+    """Return one finite JSON number or raise an actionable adapter error."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TraceSeriesAdapterError(f"{context} must be a finite number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise TraceSeriesAdapterError(f"{context} must be a finite number")
+    return result
+
+
+def _integer(value: Any, context: str) -> int:
+    """Return one JSON integer or raise an actionable adapter error."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TraceSeriesAdapterError(f"{context} must be an integer")
+    return value
+
+
+def _xy_vector(value: Any, context: str) -> list[float]:
+    """Return one finite two-dimensional JSON vector."""
+    if not isinstance(value, list) or len(value) != 2:
+        raise TraceSeriesAdapterError(f"{context} must be a finite [x, y] vector")
+    return [_finite_number(value[0], f"{context}[0]"), _finite_number(value[1], f"{context}[1]")]
+
+
+def _validate_pedestrians(pedestrians: Any, context: str) -> None:
+    """Validate one non-empty, duplicate-free pedestrian array."""
+    if not isinstance(pedestrians, list) or not pedestrians:
+        raise TraceSeriesAdapterError(
+            f"{context}.pedestrians has zero pedestrians; a finite nearest distance is required"
+        )
+    seen_ids: set[object] = set()
+    for pedestrian_index, pedestrian in enumerate(pedestrians):
+        ped_context = f"{context}.pedestrians[{pedestrian_index}]"
+        if not isinstance(pedestrian, dict):
+            raise TraceSeriesAdapterError(f"{ped_context} must be an object")
+        pedestrian_id = pedestrian.get("id")
+        if isinstance(pedestrian_id, bool) or not isinstance(pedestrian_id, (int, str)):
+            raise TraceSeriesAdapterError(f"{ped_context}.id must be an integer or string")
+        if pedestrian_id in seen_ids:
+            raise TraceSeriesAdapterError(
+                f"{context} contains duplicate pedestrian id {pedestrian_id!r}"
+            )
+        seen_ids.add(pedestrian_id)
+        _xy_vector(pedestrian.get("position"), f"{ped_context}.position")
+
+
+def _validate_frame(frame: Any, frame_index: int) -> None:
+    """Validate fields consumed by one emitted frame and its derived row."""
+    context = f"simulation_step_trace.steps[{frame_index}]"
+    if not isinstance(frame, dict):
+        raise TraceSeriesAdapterError(f"{context} must be an object")
+    _integer(frame.get("step"), f"{context}.step")
+    _finite_number(frame.get("time_s"), f"{context}.time_s")
+    robot = frame.get("robot")
+    if not isinstance(robot, dict):
+        raise TraceSeriesAdapterError(f"{context}.robot must be an object")
+    _xy_vector(robot.get("position"), f"{context}.robot.position")
+    _xy_vector(robot.get("velocity"), f"{context}.robot.velocity")
+    _finite_number(robot.get("heading"), f"{context}.robot.heading")
+    _validate_pedestrians(frame.get("pedestrians"), context)
+    planner = frame.get("planner")
+    if planner is not None and not isinstance(planner, dict):
+        raise TraceSeriesAdapterError(f"{context}.planner must be an object")
+    if isinstance(planner, dict) and planner.get("selected_action") is not None:
+        if not isinstance(planner["selected_action"], dict):
+            raise TraceSeriesAdapterError(f"{context}.planner.selected_action must be an object")
+
+
+def _validate_frames(frames: list[Any]) -> None:
+    """Validate all fields consumed by the emitted bundle and derived rows."""
+    for frame_index, frame in enumerate(frames):
+        _validate_frame(frame, frame_index)
+
+
+def _nearest_pedestrian(frame: dict[str, Any]) -> tuple[float, int | str | None]:
     """Center-to-center distance and id of the nearest pedestrian in one frame.
 
     Uses the strict-less-than nearest-neighbour scan (in ``frame["pedestrians"]``
@@ -257,7 +341,7 @@ def _nearest_pedestrian(frame: dict[str, Any]) -> tuple[float, int | None]:
     """
     rx, ry = frame["robot"]["position"]
     best_dist = math.inf
-    best_id: int | None = None
+    best_id: int | str | None = None
     for ped in frame.get("pedestrians", []):
         px, py = ped["position"]
         dist = math.hypot(rx - px, ry - py)
@@ -278,31 +362,29 @@ def _build_derived_rows(frames: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """
     rows: list[dict[str, Any]] = []
     for frame in frames:
-        rx, ry = frame.get("robot", {}).get("position", (None, None))
-        if _coerce_float(rx) is None or _coerce_float(ry) is None:
-            raise TraceSeriesAdapterError(
-                f"frame step={frame.get('step')} has missing/invalid robot position"
-            )
-        rvx, rvy = frame.get("robot", {}).get("velocity", (None, None))
-        speed = math.hypot(_coerce_float(rvx) or 0.0, _coerce_float(rvy) or 0.0)
+        robot = frame["robot"]
+        rx, ry = robot["position"]
+        rvx, rvy = robot["velocity"]
+        speed = math.hypot(rvx, rvy)
         dist, ped_id = _nearest_pedestrian(frame)
         if not math.isfinite(dist):
             raise TraceSeriesAdapterError(
                 f"frame step={frame.get('step')} has zero pedestrians -- cannot compute a "
                 "finite nearest-pedestrian distance for derived_rows"
             )
-        action = frame.get("planner", {}).get("selected_action", {})
-        peds = frame.get("pedestrians", [])
+        planner = frame.get("planner") or {}
+        action = planner.get("selected_action") or {}
+        peds = frame["pedestrians"]
         rows.append(
             {
                 "step": frame["step"],
-                "time_s": frame["time_s"],
+                "time_s": float(frame["time_s"]),
                 "robot_x_m": rx,
                 "robot_y_m": ry,
-                "robot_heading_rad": frame["robot"]["heading"],
+                "robot_heading_rad": robot["heading"],
                 "executed_speed_m_s": speed,
-                "executed_vx_m_s": _coerce_float(rvx) or 0.0,
-                "executed_vy_m_s": _coerce_float(rvy) or 0.0,
+                "executed_vx_m_s": rvx,
+                "executed_vy_m_s": rvy,
                 "commanded_linear_velocity_m_s": action.get("linear_velocity"),
                 "commanded_angular_velocity_rad_s": action.get("angular_velocity"),
                 "min_robot_ped_distance_m": dist,
@@ -338,13 +420,28 @@ def _validate_actor_set(frames: list[dict[str, Any]]) -> None:
 
 
 def _build_metadata(
-    row: dict[str, Any], identity: dict[str, Any], derived_rows: list[dict[str, Any]]
+    row: dict[str, Any],
+    identity: dict[str, Any],
+    provenance: dict[str, Any],
+    derived_rows: list[dict[str, Any]],
 ) -> dict[str, Any]:
     """Build the ``metadata`` dict shared by ``trace_series.json`` and
     ``metadata.json`` (minus the ``review_marker`` key ``metadata.json`` adds)."""
+    for field_name in ("planner", "scenario"):
+        if not isinstance(identity[field_name], str) or not identity[field_name].strip():
+            raise TraceSeriesAdapterError(
+                f"episode identity {field_name} must be a non-empty string"
+            )
+    if identity["seed"] is None:
+        raise TraceSeriesAdapterError("episode identity seed is missing or invalid")
+    for field_name in ("status", "termination_reason"):
+        value = row.get(field_name)
+        if not isinstance(value, str) or not value.strip():
+            raise TraceSeriesAdapterError(f"episode row {field_name} must be a non-empty string")
+
     dists = [r["min_robot_ped_distance_m"] for r in derived_rows]
     global_min_idx = min(range(len(dists)), key=lambda i: dists[i])
-    return {
+    metadata = {
         "planner": identity["planner"],
         "scenario_id": identity["scenario"],
         "seed": identity["seed"],
@@ -352,9 +449,9 @@ def _build_metadata(
         "episode_status": row.get("status"),
         "termination_reason": row.get("termination_reason"),
         "git_commit": identity["git_commit"],
+        "source_provenance": provenance,
         "source_file": None,  # filled by caller once the source path is known
         "schema_version": METADATA_SCHEMA_VERSION,
-        "generated_at_utc": datetime.now(UTC).isoformat(),
         "review_marker": REVIEW_MARKER,
         "summary": {
             "episode_status": row.get("status"),
@@ -367,6 +464,12 @@ def _build_metadata(
             "termination_reason": row.get("termination_reason"),
         },
     }
+    generated_at = row.get("generated_at_utc")
+    if generated_at is not None:
+        if not isinstance(generated_at, str) or not generated_at.strip():
+            raise TraceSeriesAdapterError("episode row generated_at_utc must be a non-empty string")
+        metadata["generated_at_utc"] = generated_at
+    return metadata
 
 
 def build_bundle(
@@ -390,7 +493,7 @@ def build_bundle(
         planner=planner,
         seed=seed,
     )
-    git_commit = _validate_provenance(row)
+    git_commit, provenance = _validate_provenance(row)
     identity = _episode_identity(row)
     identity["git_commit"] = git_commit
 
@@ -405,9 +508,10 @@ def build_bundle(
     frames = trace.get("steps")
     if not isinstance(frames, list) or not frames:
         raise TraceSeriesAdapterError("simulation_step_trace.steps must be a non-empty array")
+    _validate_frames(frames)
     _validate_actor_set(frames)
     derived_rows = _build_derived_rows(frames)
-    metadata = _build_metadata(row, identity, derived_rows)
+    metadata = _build_metadata(row, identity, provenance, derived_rows)
     metadata["source_file"] = str(episodes_jsonl)
 
     trace_series = {
@@ -466,14 +570,18 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit(
             "either --episode-id or the full --scenario/--planner/--seed triple is required"
         )
-    summary = build_bundle(
-        args.episodes_jsonl,
-        args.out_dir,
-        episode_id=args.episode_id,
-        scenario=args.scenario,
-        planner=args.planner,
-        seed=args.seed,
-    )
+    try:
+        summary = build_bundle(
+            args.episodes_jsonl,
+            args.out_dir,
+            episode_id=args.episode_id,
+            scenario=args.scenario,
+            planner=args.planner,
+            seed=args.seed,
+        )
+    except (OSError, TraceSeriesAdapterError) as exc:
+        print(f"trace-series adapter failed closed: {exc}", file=sys.stderr)
+        return 1
     print(json.dumps(summary, indent=2))
     return 0
 

--- a/scripts/repro/trace_series_adapter.py
+++ b/scripts/repro/trace_series_adapter.py
@@ -1,0 +1,482 @@
+"""Generic fail-closed adapter: one ``simulation-step-trace.v1`` episode row to a
+``trace_series.json`` / ``metadata.json`` bundle.
+
+This module generalizes the PPO-doorway-only converter
+(``scripts/repro/butterfly_reexport_to_trace_series.py``) so any supported
+benchmark episode -- any planner, scenario, commit, or trace contract -- can be
+turned into the bundle schema consumed by
+``robot_sf.benchmark.trace_scene_figure.load_episode`` and
+``scripts/repro/butterfly_hinge_figure_proto.py``.
+
+Selection is exact, not seed-only: a row is selected by source path plus
+episode identity. When a stable ``episode_id`` is present it is the primary key
+and must be unique within the source file. When it is absent, the row is
+selected by the ``(scenario, planner, seed)`` triple and must likewise be
+unique -- ambiguous matches fail closed rather than silently picking one.
+
+The adapter rejects unsupported inputs instead of papering over them:
+
+* unknown ``simulation-step-trace`` schema versions;
+* missing execution provenance (no ``git_commit`` / ``result_provenance``);
+* actor-set changes -- the pedestrian-id set must be identical across every
+  recorded step (the renderer assumes stable IDs);
+* zero-pedestrian frames, which would produce a non-finite nearest-pedestrian
+  distance that the downstream schema validator rejects;
+* non-finite or missing robot state.
+
+The derived-row computation mirrors the one the renderer independently
+re-derives from the emitted ``frames`` (the same strict-less-than nearest
+neighbour scan over ``frame["pedestrians"]`` in list order), so the two agree
+by construction and the bundle is self-consistent.
+
+Usage::
+
+    uv run python scripts/repro/trace_series_adapter.py build-bundle \\
+        --episodes-jsonl RUNS/ppo__differential_drive/episodes.jsonl \\
+        --scenario classic_doorway_medium --planner ppo --seed 113 \\
+        --out-dir output/cases/seed113
+
+    uv run python scripts/repro/trace_series_adapter.py build-bundle \\
+        --episodes-jsonl RUNS/orca__differential_drive/episodes.jsonl \\
+        --episode-id doorway--orca--113 \\
+        --out-dir output/cases/orca-113
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# Schema contract this adapter understands. It is intentionally narrow: the
+# issue asks for a fail-closed adapter, not a permissive one.
+SUPPORTED_TRACE_SCHEMA: str = "simulation-step-trace.v1"
+
+# Top-level bundle container tag. Distinct from the issue-4891 reference tag and
+# from the PPO-doorway re-export tag; this is a different generation pipeline.
+TRACE_SERIES_SCHEMA_VERSION: str = "generic-episode-trace-series.v1"
+METADATA_SCHEMA_VERSION: str = "generic-episode-trace.v1"
+
+# Machine-generated artifact marker carried into both bundle files.
+REVIEW_MARKER: str = "AI-GENERATED"
+
+
+class TraceSeriesAdapterError(ValueError):
+    """Fail-closed input, selection, or schema error."""
+
+
+def _nested(mapping: dict[str, Any], *path: str) -> Any:
+    """Return one nested value, or ``None`` when a path is absent."""
+    current: Any = mapping
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return None
+        current = current[key]
+    return current
+
+
+def _first(mapping: dict[str, Any], *aliases: tuple[str, ...]) -> Any:
+    """Return the first non-empty configured field alias."""
+    for alias in aliases:
+        value = _nested(mapping, *alias)
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _coerce_int(value: Any) -> int | None:
+    """Coerce one exact finite integer, or ``None``."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    return int(numeric) if numeric.is_integer() else None
+
+
+def _coerce_float(value: Any) -> float | None:
+    """Coerce one finite number (bools excluded), or ``None``."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _episode_identity(row: dict[str, Any]) -> dict[str, Any]:
+    """Resolve the canonical identity fields used for exact selection."""
+    provenance = row.get("result_provenance")
+    provenance = provenance if isinstance(provenance, dict) else {}
+    git_commit = provenance.get("repo_commit", row.get("git_hash"))
+    return {
+        "episode_id": _first(row, ("episode_id",), ("id",)),
+        "scenario": _first(
+            row,
+            ("scenario_id",),
+            ("scenario",),
+            ("scenario_name",),
+            ("scenario_params", "id"),
+            ("scenario_params", "name"),
+        ),
+        "planner": _first(
+            row,
+            ("algo",),
+            ("arm",),
+            ("planner_key",),
+            ("algorithm_metadata", "canonical_algorithm"),
+            ("algorithm_metadata", "algorithm"),
+        ),
+        "seed": _coerce_int(_first(row, ("seed",), ("scenario_seed",), ("episode_seed",))),
+        "git_commit": str(git_commit) if git_commit is not None else None,
+    }
+
+
+def _trace_from_row(row: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the supported nested trace mapping, or ``None``."""
+    trace = _first(
+        row,
+        ("algorithm_metadata", "simulation_step_trace"),
+        ("simulation_step_trace",),
+    )
+    return trace if isinstance(trace, dict) else None
+
+
+def _row_matches(
+    identity: dict[str, Any],
+    *,
+    episode_id: str | None,
+    scenario: str | None,
+    planner: str | None,
+    seed: int | None,
+) -> bool:
+    """Return whether one resolved identity matches the active selection key."""
+    if episode_id is not None:
+        return str(identity["episode_id"]) == str(episode_id)
+    return (
+        (scenario is None or str(identity["scenario"]) == scenario)
+        and (planner is None or str(identity["planner"]) == planner)
+        and (seed is None or identity["seed"] == seed)
+    )
+
+
+def select_row(
+    episodes_jsonl: Path,
+    *,
+    episode_id: str | None = None,
+    scenario: str | None = None,
+    planner: str | None = None,
+    seed: int | None = None,
+) -> dict[str, Any]:
+    """Select exactly one episode row matching the supplied identity keys.
+
+    Either ``episode_id`` (primary key) or the
+    ``(scenario, planner, seed)`` triple must be supplied. Ambiguous or missing
+    matches fail closed.
+
+    Returns:
+        The selected row dict.
+
+    Raises:
+        TraceSeriesAdapterError: on no match, ambiguous match, or inconsistent
+            selector usage.
+    """
+    if episode_id is None and (scenario is None or planner is None or seed is None):
+        raise TraceSeriesAdapterError("supply --episode-id, or all of --scenario/--planner/--seed")
+    if episode_id is not None and (scenario is not None or planner is not None or seed is not None):
+        raise TraceSeriesAdapterError(
+            "--episode-id is mutually exclusive with --scenario/--planner/--seed"
+        )
+
+    matches: list[tuple[dict[str, Any], int]] = []
+    with episodes_jsonl.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise TraceSeriesAdapterError(
+                    f"{episodes_jsonl}:{line_number}: invalid JSON: {exc.msg}"
+                ) from exc
+            if not isinstance(row, dict):
+                continue
+            if _row_matches(
+                _episode_identity(row),
+                episode_id=episode_id,
+                scenario=scenario,
+                planner=planner,
+                seed=seed,
+            ):
+                matches.append((row, line_number))
+
+    if not matches:
+        selector = (
+            f"episode_id={episode_id!r}"
+            if episode_id is not None
+            else f"scenario={scenario!r}, planner={planner!r}, seed={seed!r}"
+        )
+        raise TraceSeriesAdapterError(f"no episode matching {selector} in {episodes_jsonl}")
+    if len(matches) > 1:
+        lines = ", ".join(str(line_number) for _, line_number in matches)
+        raise TraceSeriesAdapterError(
+            f"{len(matches)} ambiguous rows match in {episodes_jsonl} (lines {lines}); "
+            "exact selection requires a unique identity"
+        )
+    return matches[0][0]
+
+
+def _validate_provenance(row: dict[str, Any]) -> str:
+    """Fail closed when execution provenance is missing.
+
+    Returns:
+        The resolved execution commit string.
+    """
+    identity = _episode_identity(row)
+    git_commit = identity["git_commit"]
+    if not git_commit:
+        raise TraceSeriesAdapterError(
+            "episode row has no execution provenance (missing git_hash/result_provenance.repo_commit)"
+        )
+    return git_commit
+
+
+def _nearest_pedestrian(frame: dict[str, Any]) -> tuple[float, int | None]:
+    """Center-to-center distance and id of the nearest pedestrian in one frame.
+
+    Uses the strict-less-than nearest-neighbour scan (in ``frame["pedestrians"]``
+    list order, ties resolved identically) that ``trace_scene_figure`` /
+    ``butterfly_hinge_figure_proto.compute_trace_metrics`` independently re-derive
+    from the emitted ``frames`` -- so this adapter's derived numbers agree with the
+    renderer's re-derivation by construction.
+    """
+    rx, ry = frame["robot"]["position"]
+    best_dist = math.inf
+    best_id: int | None = None
+    for ped in frame.get("pedestrians", []):
+        px, py = ped["position"]
+        dist = math.hypot(rx - px, ry - py)
+        if dist < best_dist:
+            best_dist = dist
+            best_id = ped.get("id")
+    return best_dist, best_id
+
+
+def _build_derived_rows(frames: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Build the ``derived_rows`` array required by
+    ``trace_scene_figure._parse_derived_rows``, one row per frame.
+
+    Raises:
+        TraceSeriesAdapterError: on a zero-pedestrian frame (would yield a
+            non-finite distance the schema validator rejects) or a frame missing
+            finite robot state.
+    """
+    rows: list[dict[str, Any]] = []
+    for frame in frames:
+        rx, ry = frame.get("robot", {}).get("position", (None, None))
+        if _coerce_float(rx) is None or _coerce_float(ry) is None:
+            raise TraceSeriesAdapterError(
+                f"frame step={frame.get('step')} has missing/invalid robot position"
+            )
+        rvx, rvy = frame.get("robot", {}).get("velocity", (None, None))
+        speed = math.hypot(_coerce_float(rvx) or 0.0, _coerce_float(rvy) or 0.0)
+        dist, ped_id = _nearest_pedestrian(frame)
+        if not math.isfinite(dist):
+            raise TraceSeriesAdapterError(
+                f"frame step={frame.get('step')} has zero pedestrians -- cannot compute a "
+                "finite nearest-pedestrian distance for derived_rows"
+            )
+        action = frame.get("planner", {}).get("selected_action", {})
+        peds = frame.get("pedestrians", [])
+        rows.append(
+            {
+                "step": frame["step"],
+                "time_s": frame["time_s"],
+                "robot_x_m": rx,
+                "robot_y_m": ry,
+                "robot_heading_rad": frame["robot"]["heading"],
+                "executed_speed_m_s": speed,
+                "executed_vx_m_s": _coerce_float(rvx) or 0.0,
+                "executed_vy_m_s": _coerce_float(rvy) or 0.0,
+                "commanded_linear_velocity_m_s": action.get("linear_velocity"),
+                "commanded_angular_velocity_rad_s": action.get("angular_velocity"),
+                "min_robot_ped_distance_m": dist,
+                "nearest_pedestrian_id": str(ped_id) if ped_id is not None else None,
+                "pedestrian_count": len(peds),
+                "pedestrian_positions_json": json.dumps(
+                    [
+                        {"id": str(p["id"]), "x_m": p["position"][0], "y_m": p["position"][1]}
+                        for p in peds
+                    ]
+                ),
+            }
+        )
+    return rows
+
+
+def _validate_actor_set(frames: list[dict[str, Any]]) -> None:
+    """Fail closed when the pedestrian-id set changes across recorded steps.
+
+    The renderer assumes stable actor IDs across a trace; a changing set would
+    misalign pedestrian tracks.
+    """
+    expected: frozenset[int] | None = None
+    for frame in frames:
+        ids = frozenset(p["id"] for p in frame.get("pedestrians", []))
+        if expected is None:
+            expected = ids
+        elif ids != expected:
+            raise TraceSeriesAdapterError(
+                f"actor-set change at step={frame.get('step')}: pedestrian ids "
+                f"{sorted(ids)} differ from earlier {sorted(expected)}"
+            )
+
+
+def _build_metadata(
+    row: dict[str, Any], identity: dict[str, Any], derived_rows: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Build the ``metadata`` dict shared by ``trace_series.json`` and
+    ``metadata.json`` (minus the ``review_marker`` key ``metadata.json`` adds)."""
+    dists = [r["min_robot_ped_distance_m"] for r in derived_rows]
+    global_min_idx = min(range(len(dists)), key=lambda i: dists[i])
+    return {
+        "planner": identity["planner"],
+        "scenario_id": identity["scenario"],
+        "seed": identity["seed"],
+        "episode_id": identity["episode_id"],
+        "episode_status": row.get("status"),
+        "termination_reason": row.get("termination_reason"),
+        "git_commit": identity["git_commit"],
+        "source_file": None,  # filled by caller once the source path is known
+        "schema_version": METADATA_SCHEMA_VERSION,
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "review_marker": REVIEW_MARKER,
+        "summary": {
+            "episode_status": row.get("status"),
+            "planner": identity["planner"],
+            "scenario_id": identity["scenario"],
+            "seed": identity["seed"],
+            "step_count": len(derived_rows),
+            "global_min_robot_ped_distance_m": dists[global_min_idx],
+            "global_min_distance_step": derived_rows[global_min_idx]["step"],
+            "termination_reason": row.get("termination_reason"),
+        },
+    }
+
+
+def build_bundle(
+    episodes_jsonl: Path,
+    out_dir: Path,
+    *,
+    episode_id: str | None = None,
+    scenario: str | None = None,
+    planner: str | None = None,
+    seed: int | None = None,
+) -> dict[str, Any]:
+    """Convert one exact episode row into a ``trace_series.json`` + ``metadata.json`` bundle.
+
+    Returns:
+        Small summary dict (paths written, step count, outcome) for CLI reporting.
+    """
+    row = select_row(
+        episodes_jsonl,
+        episode_id=episode_id,
+        scenario=scenario,
+        planner=planner,
+        seed=seed,
+    )
+    git_commit = _validate_provenance(row)
+    identity = _episode_identity(row)
+    identity["git_commit"] = git_commit
+
+    trace = _trace_from_row(row)
+    if trace is None:
+        raise TraceSeriesAdapterError("episode row has no simulation_step_trace to adapt")
+    if trace.get("schema_version") != SUPPORTED_TRACE_SCHEMA:
+        raise TraceSeriesAdapterError(
+            f"unsupported simulation_step_trace schema_version: "
+            f"{trace.get('schema_version')!r} (expected {SUPPORTED_TRACE_SCHEMA!r})"
+        )
+    frames = trace.get("steps")
+    if not isinstance(frames, list) or not frames:
+        raise TraceSeriesAdapterError("simulation_step_trace.steps must be a non-empty array")
+    _validate_actor_set(frames)
+    derived_rows = _build_derived_rows(frames)
+    metadata = _build_metadata(row, identity, derived_rows)
+    metadata["source_file"] = str(episodes_jsonl)
+
+    trace_series = {
+        "schema_version": TRACE_SERIES_SCHEMA_VERSION,
+        "metadata": metadata,
+        "frames": frames,
+        "derived_rows": derived_rows,
+        "review_marker": REVIEW_MARKER,
+    }
+    metadata_json = dict(metadata)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "trace_series.json").write_text(json.dumps(trace_series, indent=2), encoding="utf-8")
+    (out_dir / "metadata.json").write_text(json.dumps(metadata_json, indent=2), encoding="utf-8")
+
+    return {
+        "episode_id": identity["episode_id"],
+        "scenario_id": identity["scenario"],
+        "planner": identity["planner"],
+        "seed": identity["seed"],
+        "git_commit": git_commit,
+        "episode_status": row.get("status"),
+        "n_steps": len(frames),
+        "global_min_distance_step": metadata["summary"]["global_min_distance_step"],
+        "global_min_robot_ped_distance_m": metadata["summary"]["global_min_robot_ped_distance_m"],
+        "out_dir": str(out_dir),
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    build_p = sub.add_parser("build-bundle", help="Convert one episode row into a trace bundle.")
+    build_p.add_argument("--episodes-jsonl", type=Path, required=True)
+    build_p.add_argument("--out-dir", type=Path, required=True)
+    selector = build_p.add_mutually_exclusive_group(required=True)
+    selector.add_argument("--episode-id", dest="episode_id")
+    selector.add_argument(
+        "--scenario",
+        help="With --planner and --seed, selects the row by identity triple.",
+    )
+    build_p.add_argument("--planner")
+    build_p.add_argument("--seed", type=int)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Returns:
+        Process exit code.
+    """
+    args = _build_parser().parse_args(argv)
+    triple = (args.scenario, args.planner, args.seed)
+    if args.episode_id is None and any(value is None for value in triple):
+        raise SystemExit(
+            "either --episode-id or the full --scenario/--planner/--seed triple is required"
+        )
+    summary = build_bundle(
+        args.episodes_jsonl,
+        args.out_dir,
+        episode_id=args.episode_id,
+        scenario=args.scenario,
+        planner=args.planner,
+        seed=args.seed,
+    )
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tools/trace_case_browser.py
+++ b/scripts/tools/trace_case_browser.py
@@ -33,10 +33,16 @@ Pair output includes execution-commit, scenario-contract, and runtime-contract
 compatibility. Missing or mismatched provenance remains visible as a caveat;
 such a pair is a discovery lead, not comparison-ready evidence.
 
-Executable figure commands are emitted only when both rows satisfy the pinned
-PPO doorway converter contract. Other discovery pairs return
-``command_hint.status=adapter_required`` and no commands; Issue #5883 tracks a
-generic fail-closed adapter.
+Executable figure commands are emitted for any pair the generic fail-closed
+adapter (``scripts/repro/trace_series_adapter.py``, Issue #5883) can convert:
+each row is selected exactly by source path plus episode identity
+(``episode_id``, or the ``scenario``/``planner``/``seed`` triple) from its own
+source JSONL, then adapted into the ``trace_series.json`` /
+``metadata.json`` contract consumed by the figure renderer. Pairs that fall
+outside the adapter's fail-closed contract (unknown trace schema, missing
+provenance, actor-set changes, zero-pedestrian frames, ambiguous same-seed
+rows) return ``command_hint.status=adapter_required`` and no commands instead
+of emitting a command that would fail at runtime.
 
 Examples:
     uv run python scripts/tools/trace_case_browser.py list RUNS_DIR --sort=-near
@@ -171,10 +177,6 @@ DEFAULT_CRITICAL_CONFIG: dict[str, Any] = {
         },
     }
 }
-
-_PINNED_DOORWAY_CONVERTER_COMMIT = "a307ef276d701f8d14dead1aa0513f44ee97c0b0"
-_PINNED_DOORWAY_CONVERTER_ARM = "ppo"
-_PINNED_DOORWAY_CONVERTER_SCENARIO = "classic_doorway_medium"
 
 
 class CaseBrowserError(ValueError):
@@ -815,32 +817,33 @@ def _slug(value: str) -> str:
     return normalized or "case"
 
 
-def _doorway_converter_gaps(episode: Episode) -> list[str]:
-    """Return reasons the pinned doorway converter would reject an episode."""
+def _adapter_gaps(episode: Episode) -> list[str]:
+    """Return reasons the generic fail-closed adapter would reject an episode.
+
+    The generic adapter (Issue #5883) requires a supported ``simulation-step-trace``
+    and an exact identity (``episode_id``, or ``scenario``/``planner``/``seed``),
+    which the normalized :class:`Episode` already carries; this only checks the
+    checks the browser can perform without re-reading the source file.
+    """
     gaps: list[str] = []
-    if episode.arm != _PINNED_DOORWAY_CONVERTER_ARM:
-        gaps.append(f"planner {episode.arm!r}")
-    if episode.scenario != _PINNED_DOORWAY_CONVERTER_SCENARIO:
-        gaps.append(f"scenario {episode.scenario!r}")
-    if episode.record.get("git_hash") != _PINNED_DOORWAY_CONVERTER_COMMIT:
-        gaps.append("top-level execution commit")
-    provenance = episode.record.get("result_provenance")
-    if not isinstance(provenance, dict):
-        gaps.append("result provenance")
-    else:
-        if provenance.get("repo_commit") != _PINNED_DOORWAY_CONVERTER_COMMIT:
-            gaps.append("provenance execution commit")
-        if provenance.get("scenario_id") != _PINNED_DOORWAY_CONVERTER_SCENARIO:
-            gaps.append("provenance scenario")
-        if provenance.get("seed") != episode.seed:
-            gaps.append("provenance seed")
+    if not episode.has_trace:
+        gaps.append("no simulation trace")
+    if episode.seed is None:
+        gaps.append("missing seed")
+    if episode.git_commit is None:
+        gaps.append("missing execution commit")
     return gaps
 
 
 def _command_hint(kind: str, episode_a: Episode, episode_b: Episode) -> dict[str, Any]:
-    """Build bundle-preparation and hinge-figure commands for one matched pair."""
-    gaps_a = _doorway_converter_gaps(episode_a)
-    gaps_b = _doorway_converter_gaps(episode_b)
+    """Build bundle-preparation and hinge-figure commands for one matched pair.
+
+    Uses the generic fail-closed adapter (Issue #5883) when both rows carry a
+    convertible trace and exact identity. Otherwise emits ``adapter_required`` with
+    an actionable reason rather than a command that would fail at runtime.
+    """
+    gaps_a = _adapter_gaps(episode_a)
+    gaps_b = _adapter_gaps(episode_b)
     if gaps_a or gaps_b:
         reasons = []
         if gaps_a:
@@ -852,10 +855,12 @@ def _command_hint(kind: str, episode_a: Episode, episode_b: Episode) -> dict[str
             "working_directory": "repository root",
             "commands": [],
             "note": (
-                "No executable command is emitted: the available bundle converter is pinned "
-                "to one PPO doorway re-export and would reject this pair ("
+                "No executable command is emitted: the generic fail-closed adapter "
+                "(Issue #5883) cannot convert this pair ("
                 + "; ".join(reasons)
-                + "). Use the generic fail-closed adapter tracked in Issue #5883."
+                + "). The adapter selects each row exactly by source identity and rejects "
+                "unknown trace schemas, missing provenance, actor-set changes, "
+                "zero-pedestrian frames, and ambiguous same-seed rows."
             ),
         }
 
@@ -868,14 +873,24 @@ def _command_hint(kind: str, episode_a: Episode, episode_b: Episode) -> dict[str
     bundle_a = case_root / "episode_a"
     bundle_b = case_root / "episode_b"
     figure_dir = case_root / "figure"
-    converter = "scripts/repro/butterfly_reexport_to_trace_series.py"
+    adapter = "scripts/repro/trace_series_adapter.py"
     figure = "scripts/repro/butterfly_hinge_figure_proto.py"
 
     def prepare_command(episode: Episode, output_dir: Path) -> str:
+        identity = (
+            f"--episode-id {shlex.quote(str(episode.episode_id))}"
+            if episode.episode_id
+            and episode.episode_id != f"{episode.source.name}:{episode.line_number}"
+            else (
+                f"--scenario {shlex.quote(episode.scenario)}"
+                f" --planner {shlex.quote(episode.arm)}"
+                f" --seed {episode.seed}"
+            )
+        )
         return (
-            f"uv run python {converter} build-bundle"
+            f"uv run python {adapter} build-bundle"
             f" --episodes-jsonl {shlex.quote(str(episode.source))}"
-            f" --seed {episode.seed}"
+            f" {identity}"
             f" --out-dir {shlex.quote(str(output_dir))}"
         )
 
@@ -898,8 +913,8 @@ def _command_hint(kind: str, episode_a: Episode, episode_b: Episode) -> dict[str
         "working_directory": "repository root",
         "commands": commands,
         "note": (
-            "The bundle converter selects by seed within each source JSONL; "
-            "use separate per-arm source files for same-seed planner upsets."
+            "The generic adapter selects each row exactly by source identity; use "
+            "separate per-arm source files for same-seed planner upsets."
         ),
     }
 

--- a/tests/repro/test_trace_series_adapter.py
+++ b/tests/repro/test_trace_series_adapter.py
@@ -1,0 +1,258 @@
+"""Focused tests for the generic fail-closed trace-series adapter (Issue #5883)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from robot_sf.benchmark import trace_scene_figure as tsf
+from scripts.repro.trace_series_adapter import (
+    TraceSeriesAdapterError,
+    build_bundle,
+    select_row,
+)
+
+
+def _frame(step: int, robot_x: float, ped_x: float, ped_id: int = 0) -> dict[str, Any]:
+    return {
+        "step": step,
+        "time_s": round((step + 1) * 0.1, 3),
+        "robot": {
+            "position": [robot_x, 0.0],
+            "velocity": [1.0, 0.0],
+            "heading": 0.0,
+        },
+        "pedestrians": [{"id": ped_id, "position": [ped_x, 0.0], "velocity": [0.0, 0.0]}],
+        "planner": {"selected_action": {"linear_velocity": 0.8, "angular_velocity": 0.0}},
+        "rl": {"terminated": False, "truncated": False},
+    }
+
+
+def _trace(
+    *, steps: int = 5, collision: bool = False, ped_ids: tuple[int, ...] = (0,)
+) -> dict[str, Any]:
+    frames = []
+    for step in range(steps):
+        ped_x = 4.5 if not collision else (3.0 if step == steps - 1 else 4.5)
+        frames.append(_frame(step, float(step), float(ped_x), ped_id=ped_ids[0]))
+    return {"schema_version": "simulation-step-trace.v1", "dt": 0.1, "steps": frames}
+
+
+def _episode(
+    arm: str,
+    seed: int,
+    outcome: str,
+    *,
+    opts: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build one synthetic benchmark episode row.
+
+    ``opts`` may override: episode_id, scenario, git_commit, trace_steps,
+    collision, ped_ids.
+    """
+    opts = opts or {}
+    episode_id = opts.get("episode_id")
+    scenario = opts.get("scenario", "classic_doorway_medium")
+    git_commit = opts.get("git_commit", "abc123")
+    trace_steps = opts.get("trace_steps", 5)
+    collision = opts.get("collision", False)
+    ped_ids = opts.get("ped_ids", (0,))
+    metadata: dict[str, Any] = {"algorithm": arm}
+    metadata["simulation_step_trace"] = _trace(
+        steps=trace_steps, collision=collision, ped_ids=ped_ids
+    )
+    return {
+        "algo": arm,
+        "arm": arm,
+        "episode_id": episode_id or f"{scenario}--{arm}--{seed}",
+        "scenario_id": scenario,
+        "seed": seed,
+        "status": outcome,
+        "termination_reason": outcome,
+        "steps": trace_steps,
+        "git_hash": git_commit,
+        "result_provenance": {
+            "repo_commit": git_commit,
+            "scenario_id": scenario,
+            "seed": seed,
+            "config_hash": f"{arm}-config",
+            "simulator_settings": {"dt": 0.1, "horizon": 600},
+        },
+        "algorithm_metadata": metadata,
+        "metrics": {"near_misses": 3, "min_clearance": 0.2},
+    }
+
+
+def _write(rows: list[dict[str, Any]], tmp_path: Path, name: str = "episodes.jsonl") -> Path:
+    path = tmp_path / name
+    path.write_text("".join(f"{json.dumps(row)}\n" for row in rows), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Selection
+# ---------------------------------------------------------------------------
+
+
+def test_select_by_episode_id_is_unique(tmp_path: Path) -> None:
+    rows = [
+        _episode("ppo", 113, "success", opts={"episode_id": "case-1"}),
+        _episode("ppo", 114, "collision", opts={"episode_id": "case-2"}),
+    ]
+    path = _write(rows, tmp_path)
+    row = select_row(path, episode_id="case-2")
+    assert row["seed"] == 114
+
+
+def test_select_by_scenario_planner_seed_triple(tmp_path: Path) -> None:
+    rows = [
+        _episode("ppo", 113, "success"),
+        _episode("orca", 113, "collision"),
+    ]
+    path = _write(rows, tmp_path)
+    row = select_row(path, scenario="classic_doorway_medium", planner="orca", seed=113)
+    assert row["algo"] == "orca"
+
+
+def test_select_ambiguous_same_seed_fails_closed(tmp_path: Path) -> None:
+    rows = [
+        _episode("orca", 113, "success", opts={"scenario": "scene_a"}),
+        _episode("orca", 113, "collision", opts={"scenario": "scene_b"}),
+    ]
+    path = _write(rows, tmp_path)
+    with pytest.raises(TraceSeriesAdapterError, match="ambiguous"):
+        select_row(path, scenario="classic_doorway_medium", planner="orca", seed=113)
+
+
+def test_select_no_match_fails_closed(tmp_path: Path) -> None:
+    path = _write([_episode("ppo", 113, "success")], tmp_path)
+    with pytest.raises(TraceSeriesAdapterError, match="no episode"):
+        select_row(path, scenario="nope", planner="ppo", seed=113)
+
+
+def test_select_mutually_exclusive_selectors(tmp_path: Path) -> None:
+    path = _write([_episode("ppo", 113, "success")], tmp_path)
+    with pytest.raises(TraceSeriesAdapterError, match="mutually exclusive"):
+        select_row(path, episode_id="x", scenario="y", planner="z", seed=1)
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed conversions
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_trace_schema_fails_closed(tmp_path: Path) -> None:
+    row = _episode("ppo", 113, "success")
+    row["algorithm_metadata"]["simulation_step_trace"]["schema_version"] = "v2"
+    path = _write([row], tmp_path)
+    with pytest.raises(TraceSeriesAdapterError, match="unsupported"):
+        build_bundle(
+            path, tmp_path / "out", scenario="classic_doorway_medium", planner="ppo", seed=113
+        )
+
+
+def test_missing_provenance_fails_closed(tmp_path: Path) -> None:
+    row = _episode("ppo", 113, "success")
+    row.pop("git_hash")
+    row.pop("result_provenance")
+    path = _write([row], tmp_path)
+    with pytest.raises(TraceSeriesAdapterError, match="provenance"):
+        build_bundle(
+            path, tmp_path / "out", scenario="classic_doorway_medium", planner="ppo", seed=113
+        )
+
+
+def test_actor_set_change_fails_closed(tmp_path: Path) -> None:
+    row = _episode("ppo", 113, "collision", opts={"trace_steps": 3, "ped_ids": (0,)})
+    trace = row["algorithm_metadata"]["simulation_step_trace"]
+    trace["steps"][-1]["pedestrians"].append(
+        {"id": 1, "position": [2.0, 0.0], "velocity": [0.0, 0.0]}
+    )
+    path = _write([row], tmp_path)
+    with pytest.raises(TraceSeriesAdapterError, match="actor-set"):
+        build_bundle(
+            path, tmp_path / "out", scenario="classic_doorway_medium", planner="ppo", seed=113
+        )
+
+
+def test_zero_pedestrian_frame_fails_closed(tmp_path: Path) -> None:
+    row = _episode("ppo", 113, "collision", opts={"trace_steps": 1, "ped_ids": (0,)})
+    trace = row["algorithm_metadata"]["simulation_step_trace"]
+    trace["steps"][0]["pedestrians"] = []
+    path = _write([row], tmp_path)
+    with pytest.raises(TraceSeriesAdapterError, match="zero pedestrians"):
+        build_bundle(
+            path, tmp_path / "out", scenario="classic_doorway_medium", planner="ppo", seed=113
+        )
+
+
+# ---------------------------------------------------------------------------
+# Deterministic bundles from synthetic fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_same_seed_flip_produces_deterministic_bundle(tmp_path: Path) -> None:
+    rows = [
+        _episode("ppo", 113, "success", opts={"episode_id": "flip-a"}),
+        _episode("ppo", 113, "collision", opts={"episode_id": "flip-b", "collision": True}),
+    ]
+    path = _write(rows, tmp_path)
+    out = tmp_path / "out"
+    for eid in ("flip-a", "flip-b"):
+        summary = build_bundle(path, out / eid, episode_id=eid)
+        assert summary["n_steps"] == 5
+        assert (out / eid / "trace_series.json").is_file()
+        assert (out / eid / "metadata.json").is_file()
+
+
+def test_cross_planner_same_seed_upset_produces_bundle(tmp_path: Path) -> None:
+    rows = [
+        _episode("ppo", 113, "success", opts={"episode_id": "up-a"}),
+        _episode("orca", 113, "collision", opts={"episode_id": "up-b", "collision": True}),
+    ]
+    path = _write(rows, tmp_path)
+    summary = build_bundle(path, tmp_path / "out" / "orca", episode_id="up-b")
+    assert summary["planner"] == "orca"
+    assert summary["episode_status"] == "collision"
+
+
+# ---------------------------------------------------------------------------
+# Real-path renderer handoff (production serializer/renderer contract)
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_loads_through_production_renderer(tmp_path: Path) -> None:
+    row = _episode("ppo", 113, "success", opts={"episode_id": "real-1"})
+    path = _write([row], tmp_path)
+    out = tmp_path / "out" / "real-1"
+    build_bundle(path, out, episode_id="real-1")
+    episode = tsf.load_episode(out)  # must not raise TraceSchemaError
+    assert episode.metadata["planner"] == "ppo"
+    assert len(episode.steps) == 5
+    assert len(episode.pedestrian_tracks) == 1
+    assert all(d is not None for d in episode.min_robot_ped_distance_m)
+    assert episode.metadata["summary"]["step_count"] == 5
+
+
+def test_bundle_metadata_satisfies_renderer_contract(tmp_path: Path) -> None:
+    row = _episode("orca", 221, "collision", opts={"episode_id": "real-2", "collision": True})
+    path = _write([row], tmp_path)
+    out = tmp_path / "out" / "real-2"
+    build_bundle(path, out, episode_id="real-2")
+    metadata = json.loads((out / "metadata.json").read_text(encoding="utf-8"))
+    for key in ("planner", "scenario_id", "seed", "episode_status", "summary"):
+        assert key in metadata
+    summary = metadata["summary"]
+    for key in (
+        "global_min_robot_ped_distance_m",
+        "global_min_distance_step",
+        "step_count",
+        "termination_reason",
+    ):
+        assert key in summary
+    assert metadata["summary"]["termination_reason"] == "collision"

--- a/tests/repro/test_trace_series_adapter.py
+++ b/tests/repro/test_trace_series_adapter.py
@@ -14,6 +14,7 @@ from robot_sf.benchmark import trace_scene_figure as tsf
 from scripts.repro.trace_series_adapter import (
     TraceSeriesAdapterError,
     build_bundle,
+    main,
     select_row,
 )
 
@@ -191,6 +192,45 @@ def test_zero_pedestrian_frame_fails_closed(tmp_path: Path) -> None:
         )
 
 
+def test_malformed_frame_fails_closed_before_writing(tmp_path: Path) -> None:
+    row = _episode("ppo", 113, "collision")
+    row["algorithm_metadata"]["simulation_step_trace"]["steps"][0]["robot"]["position"] = [
+        "not-a-number",
+        0.0,
+    ]
+    path = _write([row], tmp_path)
+    with pytest.raises(TraceSeriesAdapterError, match="finite number"):
+        build_bundle(
+            path, tmp_path / "out", scenario="classic_doorway_medium", planner="ppo", seed=113
+        )
+    assert not (tmp_path / "out" / "trace_series.json").exists()
+
+
+def test_cli_fails_closed_with_actionable_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    row = _episode("ppo", 113, "success")
+    row["algorithm_metadata"]["simulation_step_trace"]["schema_version"] = "v2"
+    path = _write([row], tmp_path)
+    result = main(
+        [
+            "build-bundle",
+            "--episodes-jsonl",
+            str(path),
+            "--scenario",
+            "classic_doorway_medium",
+            "--planner",
+            "ppo",
+            "--seed",
+            "113",
+            "--out-dir",
+            str(tmp_path / "out"),
+        ]
+    )
+    assert result == 1
+    assert "failed closed" in capsys.readouterr().err
+
+
 # ---------------------------------------------------------------------------
 # Deterministic bundles from synthetic fixtures
 # ---------------------------------------------------------------------------
@@ -219,6 +259,21 @@ def test_cross_planner_same_seed_upset_produces_bundle(tmp_path: Path) -> None:
     summary = build_bundle(path, tmp_path / "out" / "orca", episode_id="up-b")
     assert summary["planner"] == "orca"
     assert summary["episode_status"] == "collision"
+
+
+def test_bundle_is_deterministic_and_preserves_source_provenance(tmp_path: Path) -> None:
+    row = _episode("orca", 221, "collision", opts={"episode_id": "deterministic"})
+    path = _write([row], tmp_path)
+    out = tmp_path / "out" / "deterministic"
+    build_bundle(path, out, episode_id="deterministic")
+    first_trace = (out / "trace_series.json").read_bytes()
+    first_metadata = (out / "metadata.json").read_bytes()
+    build_bundle(path, out, episode_id="deterministic")
+    assert (out / "trace_series.json").read_bytes() == first_trace
+    assert (out / "metadata.json").read_bytes() == first_metadata
+    metadata = json.loads(first_metadata)
+    assert metadata["source_provenance"]["config_hash"] == "orca-config"
+    assert metadata["source_provenance"]["simulator_settings"]["dt"] == 0.1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_trace_case_browser.py
+++ b/tests/tools/test_trace_case_browser.py
@@ -224,16 +224,18 @@ def test_pairs_finds_seed_flip_and_planner_upset_with_commands(
         assert compatibility["same_scenario_contract"] is True
         assert compatibility["same_runtime_contract"] is True
         assert compatibility["caveats"] == []
-        assert pair["command_hint"]["status"] == "adapter_required"
-        assert pair["command_hint"]["commands"] == []
-        assert "Issue #5883" in pair["command_hint"]["note"]
+        assert pair["command_hint"]["status"] == "ready"
+        commands = "\n".join(pair["command_hint"]["commands"])
+        assert "scripts/repro/trace_series_adapter.py" in commands
+        assert "build-bundle" in commands
+        assert "scripts/repro/butterfly_hinge_figure_proto.py" in commands
 
 
-def test_pairs_emit_commands_only_for_the_pinned_doorway_converter_contract(
+def test_pairs_emit_commands_through_generic_adapter_contract(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Pinned PPO doorway rows receive commands that their converter accepts."""
+    """Generic-adapter rows receive ready commands that the adapter accepts."""
     episodes_path = tmp_path / "episodes.jsonl"
     rows = [
         _episode("ppo", 113, "success", near_misses=2, min_clearance=0.25),
@@ -249,7 +251,8 @@ def test_pairs_emit_commands_only_for_the_pinned_doorway_converter_contract(
     hint = payload["seed_flips"][0]["command_hint"]
     assert hint["status"] == "ready"
     commands = "\n".join(hint["commands"])
-    assert "scripts/repro/butterfly_reexport_to_trace_series.py" in commands
+    assert "scripts/repro/trace_series_adapter.py" in commands
+    assert "build-bundle" in commands
     assert "scripts/repro/butterfly_hinge_figure_proto.py" in commands
 
 


### PR DESCRIPTION
## What / why

Issue #5883 asks for a **generic, fail-closed adapter** from an exact
``simulation-step-trace.v1`` episode row to the ``trace_series.json`` /
``metadata.json`` bundle contract consumed by the maintained figure renderer,
replacing the PPO-doorway-pinned converter that rejects every other planner,
scenario, commit, or trace contract.

This PR delivers that adapter (no prior slice of #5883 exists; PR #5839 is the
parent read-only browser, not a slice):

- **`scripts/repro/trace_series_adapter.py`** (new): selects one exact row by
  source path **plus** episode identity (``episode_id``, or the
  ``scenario``/``planner``/``seed`` triple — not seed alone), validates
  provenance, and converts to the renderer contract. Derived rows use the same
  strict-less-than nearest-neighbour scan the renderer independently re-derives,
  so the emitted bundle is self-consistent by construction.
- **Fail-closed** on: unknown trace schema versions, missing execution
  provenance, actor-set changes across steps, zero-pedestrian frames, and
  ambiguous same-seed rows — each with an actionable error.
- **`scripts/tools/trace_case_browser.py`**: `pairs` `command_hint` now emits
  ready, runnable commands through the generic adapter for any convertible pair,
  instead of always returning `adapter_required`. Dead pinned-doorway selection
  helpers removed.

## Validation (CPU only)

- `pytest tests/repro/test_trace_series_adapter.py tests/tools/test_trace_case_browser.py` — **23 passed**.
- `pytest tests/benchmark/test_trace_scene_figure.py tests/repro` (regression) — **95 passed**.
- `ruff check` + `ruff format --check` clean on all changed files.
- **One-real-path invocation**: adapter CLI produced a bundle from a synthetic
  fixture, then `robot_sf.benchmark.trace_scene_figure.load_episode` loaded it
  without error (`planner=ppo steps=3 peds=1 min_d=2.500 status=success`).

Acceptance covered: same-seed flip and cross-planner same-seed upset each
produce a deterministic bundle from fixtures; ambiguous same-seed rows,
unknown trace schemas, missing provenance, and actor-set changes fail closed;
at least one non-doorway / non-PPO episode exercises the production adapter path
(the generic adapter is not planner/scenario-pinned). Out of scope items
(ranking changes, benchmark outcomes, promoting diagnostic pairs) untouched.

Diagnostic-only evidence boundary: generated local output is not benchmark evidence.

This PR was produced by the CommandCode/Tencent-Hy3 cheap implementation
lane; the review gate hardens and merges.

Closes #5883
