### PR TITLE
test(validation): guard TODO-docstring baseline against cleanup drift

### DIFF
--- a/tests/validation/test_check_docstring_todos.py
+++ b/tests/validation/test_check_docstring_todos.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import textwrap
+from pathlib import Path
 
 from scripts.validation import check_docstring_todos
 
@@ -223,3 +224,28 @@ def test_committed_baseline_matches_base_ref_no_phantom_keys():
 
     assert drift == [], f"baseline is stale vs base ref: {drift}"
     assert reverse == [], f"baseline exceeds base ref (phantom keys): {reverse}"
+
+
+def test_committed_baseline_matches_working_tree_backlog(monkeypatch):
+    """The tracked baseline must equal a fresh working-tree backlog.
+
+    Reproduces issue #5894: after a cleanup PR removes placeholder docstrings,
+    the committed ``docstring_todo_baseline.json`` must be regenerated so the
+    ``verify-baseline`` freshness gate stays green. This guards against the
+    baseline drifting from the actual file tree when such removals merge.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    baseline_path = repo_root / "scripts" / "validation" / "docstring_todo_baseline.json"
+    monkeypatch.chdir(repo_root)
+
+    baseline = check_docstring_todos._read_backlog_baseline(baseline_path, repo_root)
+    assert baseline is not None
+
+    report = check_docstring_todos.build_backlog_report(
+        repo_root,
+        roots=check_docstring_todos.DEFAULT_BACKLOG_ROOTS,
+    )
+    drift, reverse = check_docstring_todos.compare_baseline_drift(report, baseline)
+
+    assert drift == []
+    assert reverse == []


### PR DESCRIPTION
## What / Why

Issue #5894 is a friction defect: the tracked `scripts/validation/docstring_todo_baseline.json`
can drift after cleanup PRs remove placeholder docstrings, breaking the `verify-baseline`
freshness gate for unrelated PRs.

The stale-entry reconciliation described by this issue is already present on current `main`:
PR #5864 removed the historical `tests/benchmark_full/test_integration_performance_smoke.py`
entry, and PR #5915 reconciled the remaining
`tests/validation/test_pr_contract_check.py` entry. After rebasing, this PR intentionally
contributes the regression guard; it no longer modifies the baseline JSON.

- PR #5879 removed two placeholders from `tests/benchmark_full/test_integration_performance_smoke.py`;
  PR #5864 reconciled that historical recurrence on the current base.
- PR #5897 removed one placeholder from `tests/validation/test_pr_contract_check.py`;
  PR #5915 reconciled that remaining recurrence on the current base.
- This PR adds a fail-closed test that compares the committed baseline with a fresh working-tree
  backlog, guarding against the next cleanup merge causing the same drift.

This is a regression-guard slice for #5894; it does not claim sole completion of the baseline
refresh, which is already represented on current `main`.

Refs #5894

## Changes

- `scripts/validation/docstring_todo_baseline.json`: unchanged by this rebased head; current
  `main` reports 205 files and 1841 occurrences.
- `tests/validation/test_check_docstring_todos.py`: added
  `test_committed_baseline_matches_working_tree_backlog`, a fail-closed regression test that
  asserts the committed baseline equals a fresh working-tree backlog.

## Validation (CPU only)

```
uv run python scripts/validation/check_docstring_todos.py --mode verify-baseline
# TODO-docstring baseline matches base 'origin/main': 205 files, 1841 occurrences.
python -m pytest tests/validation/test_check_docstring_todos.py -q
# 10 passed
uv run ruff check tests/validation/test_check_docstring_todos.py
# All checks passed
```

No runtime or benchmark semantics change.

This PR was produced by the CommandCode/Tencent-Hy3 cheap implementation lane; the review gate
rebases and hardens the regression guard for the dispatcher-owned merge sweep.
