### PR TITLE
Issue #5908: reconcile TODO-docstring ratchet baseline after #5897 (cheap-lane worker)

### DIFF
--- a/scripts/validation/docstring_todo_baseline.json
+++ b/scripts/validation/docstring_todo_baseline.json
@@ -13,8 +13,8 @@
       "occurrences": 587
     },
     "tests": {
-      "files": 182,
-      "occurrences": 1255
+      "files": 181,
+      "occurrences": 1254
     }
   },
   "files": {
@@ -208,7 +208,6 @@
     "tests/unit/test_metrics_edge_cases.py": 5,
     "tests/unit/test_resume_manifest.py": 18,
     "tests/unit/test_runner_video.py": 10,
-    "tests/validation/test_pr_contract_check.py": 1,
     "tests/visuals/test_deterministic_selection.py": 6,
     "tests/visuals/test_encode_wrapper.py": 22,
     "tests/visuals/test_encode_write_clip_fallbacks.py": 35,
@@ -233,7 +232,7 @@
   ],
   "schema_version": "docstring-todo-backlog.v1",
   "totals": {
-    "files": 206,
-    "total_occurrences": 1842
+    "files": 205,
+    "total_occurrences": 1841
   }
 }

--- a/tests/validation/test_check_docstring_todos.py
+++ b/tests/validation/test_check_docstring_todos.py
@@ -202,3 +202,24 @@ def test_verify_baseline_docs_only_branch_does_not_fail():
 
     assert drift == []
     assert reverse == []
+
+
+def test_committed_baseline_matches_base_ref_no_phantom_keys():
+    """The tracked baseline must not over-count files the base ref has already cleaned.
+
+    Regression for issue #5908: the baseline recorded a stale phantom key for
+    ``tests/validation/test_pr_contract_check.py`` (baseline 1, base 0) after the
+    placeholder cleanup in #5897, which made ``verify-baseline`` fail unrelated
+    docs-only PRs. The committed baseline must agree with the base ref so no
+    reverse-drift (baseline exceeds base) lines remain.
+    """
+    repo_root = check_docstring_todos._repo_root()
+    baseline = check_docstring_todos._read_backlog_baseline(
+        repo_root / check_docstring_todos.DEFAULT_BASELINE_PATH, repo_root
+    )
+    ref_report = check_docstring_todos.build_backlog_report_for_ref(repo_root, "origin/main")
+
+    drift, reverse = check_docstring_todos.compare_baseline_drift(ref_report, baseline)
+
+    assert drift == [], f"baseline is stale vs base ref: {drift}"
+    assert reverse == [], f"baseline exceeds base ref (phantom keys): {reverse}"


### PR DESCRIPTION
## What / Why

Issue #5908 reports that `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` fails for branches (e.g. PR #5901) whose only PR-owned changes are unrelated files, because the committed `scripts/validation/docstring_todo_baseline.json` still recorded a stale phantom key `tests/validation/test_pr_contract_check.py: 1` after the placeholder cleanup in #5897. The committed baseline over-counted a file that the base ref actually has at 0 placeholder docstrings, so the `verify-baseline` drift guard reported:

```
baseline exceeds base (base has fewer): tests/validation/test_pr_contract_check.py: base has 0, baseline has 1 (exceeds by 1)
```

Fix: regenerate the baseline against current `origin/main` so it no longer contains that phantom key. This is a pure decrease (206->205 files, 1842->1841 occurrences) that matches the already-landed cleanup. The increase-only ratchet is preserved and not weakened.

## Validation

- `uv run python scripts/validation/check_docstring_todos.py --mode verify-baseline --base origin/main` -> `TODO-docstring baseline matches base 'origin/main': 205 files, 1841 occurrences.` (was failing)
- `uv run python scripts/validation/check_docstring_todos.py --mode ratchet` -> `TODO-docstring backlog ratchet passed: 205 files, 1841 occurrences.`
- `uv run pytest tests/validation/test_check_docstring_todos.py -v` -> 9 passed (added `test_committed_baseline_matches_base_ref_no_phantom_keys` regression test that fails closed if any phantom baseline key reappears)
- `uv run ruff check` and `uv run ruff format` -> clean

## Scope

- In scope: reconcile the baseline with the placeholder removal already on main; retain proof the ratchet/drift guard passes.
- Non-goals: changing docstring policy or weakening the increase-only ratchet.

Closes #5908

This PR was produced by the CommandCode/Tencent-Hy3 cheap implementation lane; the review gate hardens and merges.