### PR TITLE
Issue #5918: retry transient GitHub API errors in PR changed-file collection (cheap-lane worker)

### DIFF
--- a/.github/workflows/pr-body-contracts.yml
+++ b/.github/workflows/pr-body-contracts.yml
@@ -31,10 +31,13 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files?per_page=100" \
-            --jq '.[].filename' > "$RUNNER_TEMP/pr_changed_files.txt"
-          echo "Changed files for PR #$PR_NUMBER:"
-          sed -n '1,120p' "$RUNNER_TEMP/pr_changed_files.txt"
+          # Routed through a shared retrying collector (issue #5918): a transient
+          # GitHub API 502/503/504/429 (which arrives as an HTML body that gh can't
+          # JSON-parse) is retried with backoff instead of red-ing this job before
+          # body validation runs. A persistent failure still fails closed.
+          uv run python scripts/ci/collect_pr_files.py \
+            --repo "$REPO" --pr-number "$PR_NUMBER" \
+            --out-changed-files "$RUNNER_TEMP/pr_changed_files.txt"
 
       - name: Validate PR body contracts (advisory)
         env:

--- a/.github/workflows/pr-contract-check.yml
+++ b/.github/workflows/pr-contract-check.yml
@@ -44,19 +44,17 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # Fetch the full status table once, then derive both the changed-file list
-          # and the authoritative ADDED-file list (status == "added"). The added list
-          # is the source of truth for evidence-hygiene "is new" decisions and does
-          # not depend on origin/main being present (issue #5464).
-          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files?per_page=100" \
-            --jq '.[] | [.status, .filename] | @tsv' > "$RUNNER_TEMP/pr_files_status.tsv"
-          cut -f2 "$RUNNER_TEMP/pr_files_status.tsv" > "$RUNNER_TEMP/pr_changed_files.txt"
-          awk -F'\t' '$1 == "added" { print $2 }' "$RUNNER_TEMP/pr_files_status.tsv" \
-            > "$RUNNER_TEMP/pr_added_files.txt"
-          echo "Changed files for PR #$PR_NUMBER:"
-          sed -n '1,120p' "$RUNNER_TEMP/pr_changed_files.txt"
-          echo "Added files for PR #$PR_NUMBER:"
-          sed -n '1,120p' "$RUNNER_TEMP/pr_added_files.txt"
+          # Routed through a shared retrying collector (issue #5918): a transient
+          # GitHub API 502/503/504/429 (which arrives as an HTML body that gh can't
+          # JSON-parse) is retried with backoff instead of red-ing this job before
+          # contract validation runs. A persistent failure still fails closed.
+          # The helper emits the authoritative ADDED list (status == "added") used
+          # for evidence-hygiene "is new" decisions (issue #5464).
+          uv run python scripts/ci/collect_pr_files.py \
+            --repo "$REPO" --pr-number "$PR_NUMBER" \
+            --out-changed-files "$RUNNER_TEMP/pr_changed_files.txt" \
+            --out-files-status "$RUNNER_TEMP/pr_files_status.tsv" \
+            --out-added-files "$RUNNER_TEMP/pr_added_files.txt"
 
       - name: Run PR Contract Check
         env:

--- a/scripts/ci/collect_pr_files.py
+++ b/scripts/ci/collect_pr_files.py
@@ -484,24 +484,24 @@ def main(argv: list[str] | None = None) -> int:
             max_delay=args.max_delay,
             timeout=args.timeout,
         )
+
+        write_outputs(
+            files,
+            out_changed_files=args.out_changed_files,
+            out_files_status=args.out_files_status,
+            out_added_files=args.out_added_files,
+        )
+
+        # Echo a short summary so the workflow log shows what was collected.
+        print(f"Collected {len(files)} changed file(s) for PR #{args.pr_number} ({args.repo}).")
+        for entry in files[:120]:
+            print(f"  {entry.get('status', '')}\t{_filename_of(entry)}")
+        if len(files) > 120:
+            print(f"  ... ({len(files) - 120} more)")
+        return 0
     except PrFilesFetchError as exc:
         print(str(exc), file=sys.stderr)
         return 1
-
-    write_outputs(
-        files,
-        out_changed_files=args.out_changed_files,
-        out_files_status=args.out_files_status,
-        out_added_files=args.out_added_files,
-    )
-
-    # Echo a short summary so the workflow log shows what was collected.
-    print(f"Collected {len(files)} changed file(s) for PR #{args.pr_number} ({args.repo}).")
-    for entry in files[:120]:
-        print(f"  {entry.get('status', '')}\t{_filename_of(entry)}")
-    if len(files) > 120:
-        print(f"  ... ({len(files) - 120} more)")
-    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/ci/collect_pr_files.py
+++ b/scripts/ci/collect_pr_files.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Collect a PR's changed files from the GitHub API with bounded retry/backoff.
+
+Why this exists
+---------------
+Both the ``PR Contract Check`` and ``PR body contracts`` workflows used an inline
+``gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100"`` call to gather
+the changed-file list. When GitHub returns a transient HTML 502/503/504/429 page,
+the CLI writes that HTML to stdout, the ``--jq`` filter fails with
+``invalid character '<' looking for beginning of value``, and the whole job exits
+red *before* its real checker ever runs (issue #5918). A transient GitHub API
+blip must not look like a body/contract failure.
+
+This helper is the shared retrying collector used by both workflows. It pages the
+``repos/{owner}/{repo}/pulls/{number}/files`` endpoint one page at a time so each
+page can be retried independently, treats a non-zero exit *or* a non-JSON
+(HTML error-page) response *or* a non-list payload as a transient retryable
+failure, backs off with exponential delay + jitter, and fails closed with a
+clear, actionable reason once retries are exhausted.
+
+Contract
+--------
+- Exits ``0`` and writes the requested output files only after the *full* file
+  list has been collected; a partial/failed run never leaves a misleading
+  truncated file behind.
+- Exits ``1`` and prints a single diagnostic to stderr when retries are
+  exhausted (persistent API failure) -- the workflows surface this verbatim.
+
+Usage
+-----
+::
+
+    uv run python scripts/ci/collect_pr_files.py \\
+        --repo "$REPO" --pr-number "$PR_NUMBER" \\
+        --out-changed-files "$RUNNER_TEMP/pr_changed_files.txt" \\
+        --out-files-status "$RUNNER_TEMP/pr_files_status.tsv" \\
+        --out-added-files "$RUNNER_TEMP/pr_added_files.txt"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import subprocess
+import sys
+import time
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+DEFAULT_REPO = "ll7/robot_sf_ll7"
+DEFAULT_PER_PAGE = 100
+DEFAULT_MAX_ATTEMPTS = 5
+DEFAULT_BASE_DELAY = 1.0
+DEFAULT_MAX_DELAY = 30.0
+DEFAULT_TIMEOUT = 30
+
+# A transient GitHub API failure shows up as one of:
+#   * a non-zero gh exit code (HTTP 4xx/5xx that gh recognises),
+#   * an HTML error page on stdout that is not valid JSON (the 502/503/504 body
+#     that produced the original ``invalid character '<'`` failure),
+#   * a valid JSON value that is not the expected list of file objects.
+# Any of these on a single page is retried with backoff; a *persistent* failure
+# after all attempts fails closed with the diagnostic below.
+
+
+class PrFilesFetchError(RuntimeError):
+    """Raised when changed-file collection cannot complete after all retries."""
+
+
+def _run_gh_api_page(
+    repo: str,
+    pr_number: str,
+    page: int,
+    per_page: int,
+    *,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``gh api`` for a single page of the PR files endpoint.
+
+    Using ``-f page=... -f per_page=...`` (rather than embedding the query string
+    in the URL) lets gh own query serialization and keeps this shell-quote-free.
+    For GET requests, gh serializes ``-f`` fields as query parameters.
+    """
+    return subprocess.run(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/pulls/{pr_number}/files",
+            "-f",
+            f"per_page={per_page}",
+            "-f",
+            f"page={page}",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _parse_page(
+    proc: subprocess.CompletedProcess[str],
+) -> tuple[list[dict[str, Any]] | None, str | None]:
+    """Validate one page response.
+
+    Returns ``(files, None)`` on success, or ``(None, reason)`` when the response
+    is a transient retryable failure (bad exit code, HTML/non-JSON body, or an
+    unexpected payload shape). The reason string is surfaced in the diagnostic.
+    """
+    if proc.returncode != 0:
+        snippet = (proc.stderr or proc.stdout or "").strip()
+        if len(snippet) > 300:
+            snippet = snippet[:300] + "..."
+        return None, f"gh api exited with code {proc.returncode}: {snippet}".strip()
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        # This is the HTML-error-page symptom from issue #5918: a 502/503/504 body
+        # beginning with '<' that cannot be JSON-parsed.
+        snippet = proc.stdout.strip()
+        if len(snippet) > 200:
+            snippet = snippet[:200] + "..."
+        return None, f"non-JSON response (likely HTML error page): {exc}; snippet: {snippet!r}"
+    if not isinstance(data, list):
+        snippet = proc.stdout.strip()
+        if len(snippet) > 200:
+            snippet = snippet[:200] + "..."
+        return None, f"unexpected response shape (expected a JSON list); snippet: {snippet!r}"
+    return data, None
+
+
+def _backoff_delay(
+    attempt: int, base_delay: float, max_delay: float, *, rng: Callable[[], float]
+) -> float:
+    """Exponential backoff with full jitter, capped at ``max_delay`` seconds.
+
+    ``attempt`` is 1-based. The cap grows as ``base_delay * 2**(attempt-1)`` and
+    the actual sleep is a uniform random fraction of that cap (full jitter) to
+    avoid thundering retries across concurrent jobs. ``rng`` must return a float
+    in ``[0, 1)``.
+    """
+    cap = min(max_delay, base_delay * (2 ** (attempt - 1)))
+    return max(0.0, rng()) * cap
+
+
+def fetch_all_pr_files(  # noqa: PLR0913
+    repo: str,
+    pr_number: str,
+    *,
+    per_page: int = DEFAULT_PER_PAGE,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    base_delay: float = DEFAULT_BASE_DELAY,
+    max_delay: float = DEFAULT_MAX_DELAY,
+    timeout: int = DEFAULT_TIMEOUT,
+    sleep: Callable[[float], None] | None = None,
+    run_page: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+    rng: Callable[[], float] | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch every page of the PR files endpoint with per-page retry/backoff.
+
+    Parameters
+    ----------
+    repo, pr_number:
+        GitHub ``owner/repo`` and PR number.
+    per_page:
+        Page size (GitHub caps this at 100).
+    max_attempts:
+        Retry attempts *per page* before failing closed.
+    base_delay, max_delay:
+        Exponential-backoff seed and cap (seconds). Full jitter is applied.
+    sleep, run_page, rng:
+        Injectable seams used by the test-suite so the retry path is exercised
+        without real subprocess calls or wall-clock sleeps.
+    """
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be at least 1")
+    if per_page < 1:
+        raise ValueError("per_page must be at least 1")
+
+    # Resolve injectable seams lazily so tests (and callers) that patch the
+    # module-level ``_run_gh_api_page`` / ``time.sleep`` references at runtime are
+    # honored. Default arguments bound at function-definition time would otherwise
+    # capture the originals and ignore the patch.
+    if sleep is None:
+        sleep = time.sleep
+    if run_page is None:
+        run_page = _run_gh_api_page
+    if rng is None:
+        rng = lambda: random.uniform(0, 1)  # noqa: E731
+
+    all_files: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        files, error = _fetch_page_with_retries(
+            repo,
+            pr_number,
+            page,
+            per_page,
+            max_attempts=max_attempts,
+            base_delay=base_delay,
+            max_delay=max_delay,
+            timeout=timeout,
+            sleep=sleep,
+            run_page=run_page,
+            rng=rng,
+        )
+        if files is None:
+            # Persistent failure: fail closed with a single actionable diagnostic.
+            raise PrFilesFetchError(
+                _format_terminal_error(
+                    repo, pr_number, page, max_attempts, per_page, error or "unknown error"
+                )
+            )
+        if not files:
+            break  # empty page => no more files
+        all_files.extend(files)
+        if len(files) < per_page:
+            break  # last (partial) page
+        page += 1
+    return all_files
+
+
+def _fetch_page_with_retries(  # noqa: PLR0913
+    repo: str,
+    pr_number: str,
+    page: int,
+    per_page: int,
+    *,
+    max_attempts: int,
+    base_delay: float,
+    max_delay: float,
+    timeout: int,
+    sleep: Callable[[float], None],
+    run_page: Callable[..., subprocess.CompletedProcess[str]],
+    rng: Callable[[], float],
+) -> tuple[list[dict[str, Any]] | None, str | None]:
+    """Retry a single page up to ``max_attempts`` times with backoff.
+
+    Returns ``(files, None)`` on success or ``(None, last_reason)`` when every
+    attempt failed. Sleeps between attempts using full-jitter exponential backoff.
+    """
+    last_error: str | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            proc = run_page(repo, pr_number, page, per_page, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            last_error = f"gh api timed out after {timeout} seconds"
+        except FileNotFoundError:
+            last_error = "gh CLI not found on PATH; install GitHub CLI (https://cli.github.com/)"
+        except OSError as exc:
+            last_error = f"could not run gh api: {exc}"
+        else:
+            files, error = _parse_page(proc)
+            if error is None:
+                return files, None
+            last_error = error
+
+        if attempt < max_attempts:
+            delay = _backoff_delay(attempt, base_delay, max_delay, rng=rng)
+            if delay > 0:
+                sleep(delay)
+    return None, last_error
+
+
+def _format_terminal_error(
+    repo: str,
+    pr_number: str,
+    page: int,
+    max_attempts: int,
+    per_page: int,
+    last_error: str,
+) -> str:
+    """Build the fail-closed diagnostic printed when retries are exhausted."""
+    return (
+        f"ERROR: Failed to collect changed files for PR #{pr_number} from "
+        f"repos/{repo}/pulls/{pr_number}/files after {max_attempts} attempt(s) "
+        f"on page {page} (per_page={per_page}).\n"
+        f"  Last error: {last_error}\n"
+        "  This is typically a transient GitHub API outage (502/503/504/429) or "
+        "an auth/network issue. Re-run the job; if it persists, verify GH_TOKEN "
+        "permissions and check https://www.githubstatus.com/.\n"
+        "  This is an infrastructure failure during changed-file collection, NOT "
+        "a PR body/contract validation failure."
+    )
+
+
+def write_outputs(
+    files: list[dict[str, Any]],
+    *,
+    out_changed_files: str | None = None,
+    out_files_status: str | None = None,
+    out_added_files: str | None = None,
+) -> None:
+    """Write the requested output files atomically (only on full success).
+
+    Outputs are written after the whole list is in hand, so a partial/failed run
+    never leaves a truncated file. ``status`` defaults to an empty string for the
+    rare entry that omits it. Added files are those with ``status == "added"``.
+    """
+    changed = [_filename_of(entry) for entry in files]
+    added = [_filename_of(entry) for entry in files if str(entry.get("status", "")) == "added"]
+
+    if out_changed_files is not None:
+        _write_lines(out_changed_files, changed)
+    if out_added_files is not None:
+        _write_lines(out_added_files, added)
+    if out_files_status is not None:
+        with open(out_files_status, "w", encoding="utf-8") as handle:
+            for entry in files:
+                status = str(entry.get("status", ""))
+                handle.write(f"{status}\t{_filename_of(entry)}\n")
+
+
+def _filename_of(entry: dict[str, Any]) -> str:
+    """Return the filename for a files-entry, failing closed on a bad entry."""
+    name = entry.get("filename")
+    if not isinstance(name, str) or not name:
+        raise PrFilesFetchError(
+            f"files endpoint returned an entry without a string 'filename' field: {entry!r}"
+        )
+    return name
+
+
+def _write_lines(path: str, lines: list[str]) -> None:
+    """Write newline-delimited lines to *path*."""
+    with open(path, "w", encoding="utf-8") as handle:
+        for line in lines:
+            handle.write(f"{line}\n")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--repo", default=DEFAULT_REPO, help=f"owner/repo (default: {DEFAULT_REPO})."
+    )
+    parser.add_argument("--pr-number", required=True, help="Pull-request number.")
+    parser.add_argument(
+        "--out-changed-files",
+        help="Path to write the newline-delimited list of all changed filenames.",
+    )
+    parser.add_argument(
+        "--out-files-status",
+        help="Path to write a TSV of 'status<TAB>filename' for every changed file.",
+    )
+    parser.add_argument(
+        "--out-added-files",
+        help="Path to write the newline-delimited list of ADDED (status == 'added') filenames.",
+    )
+    parser.add_argument(
+        "--per-page",
+        type=int,
+        default=DEFAULT_PER_PAGE,
+        help=f"page size (default: {DEFAULT_PER_PAGE}).",
+    )
+    parser.add_argument(
+        "--max-attempts",
+        type=int,
+        default=DEFAULT_MAX_ATTEMPTS,
+        help=f"retry attempts per page before failing closed (default: {DEFAULT_MAX_ATTEMPTS}).",
+    )
+    parser.add_argument(
+        "--base-delay",
+        type=float,
+        default=DEFAULT_BASE_DELAY,
+        help=f"exponential backoff seed in seconds (default: {DEFAULT_BASE_DELAY}).",
+    )
+    parser.add_argument(
+        "--max-delay",
+        type=float,
+        default=DEFAULT_MAX_DELAY,
+        help=f"exponential backoff cap in seconds (default: {DEFAULT_MAX_DELAY}).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help=f"per-page gh api timeout in seconds (default: {DEFAULT_TIMEOUT}).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Collect a PR's changed files with retry/backoff and write the requested outputs."""
+    args = _build_parser().parse_args(argv)
+
+    if not any([args.out_changed_files, args.out_files_status, args.out_added_files]):
+        print(
+            "ERROR: at least one of --out-changed-files, --out-files-status, "
+            "or --out-added-files must be given.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        files = fetch_all_pr_files(
+            args.repo,
+            args.pr_number,
+            per_page=args.per_page,
+            max_attempts=args.max_attempts,
+            base_delay=args.base_delay,
+            max_delay=args.max_delay,
+            timeout=args.timeout,
+        )
+    except PrFilesFetchError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    write_outputs(
+        files,
+        out_changed_files=args.out_changed_files,
+        out_files_status=args.out_files_status,
+        out_added_files=args.out_added_files,
+    )
+
+    # Echo a short summary so the workflow log shows what was collected.
+    print(f"Collected {len(files)} changed file(s) for PR #{args.pr_number} ({args.repo}).")
+    for entry in files[:120]:
+        print(f"  {entry.get('status', '')}\t{_filename_of(entry)}")
+    if len(files) > 120:
+        print(f"  ... ({len(files) - 120} more)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/collect_pr_files.py
+++ b/scripts/ci/collect_pr_files.py
@@ -42,11 +42,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import random
 import re
 import subprocess
 import sys
+import tempfile
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -154,6 +157,14 @@ def _parse_page(
             f"unexpected response shape (expected a JSON list); snippet: {snippet!r}",
             _is_transient_http_status(status),
         )
+    for index, entry in enumerate(data):
+        if not isinstance(entry, dict):
+            return (
+                None,
+                f"unexpected response entry at index {index} (expected a JSON object); "
+                f"got {type(entry).__name__}",
+                False,
+            )
     return data, None, False
 
 
@@ -371,11 +382,12 @@ def write_outputs(
     out_files_status: str | None = None,
     out_added_files: str | None = None,
 ) -> None:
-    """Write the requested output files atomically (only on full success).
+    """Write requested output files with per-file atomic replacement after validation.
 
-    Outputs are written after the whole list is in hand, so a partial/failed run
-    never leaves a truncated file. ``status`` defaults to an empty string for the
-    rare entry that omits it. Added files are those with ``status == "added"``.
+    The full response is validated before any file is touched, and each individual
+    output is replaced atomically so a failed write cannot leave a truncated file.
+    ``status`` defaults to an empty string for the rare entry that omits it. Added
+    files are those with ``status == "added"``.
     """
     changed = [_filename_of(entry) for entry in files]
     added = [_filename_of(entry) for entry in files if str(entry.get("status", "")) == "added"]
@@ -385,10 +397,8 @@ def write_outputs(
     if out_added_files is not None:
         _write_lines(out_added_files, added)
     if out_files_status is not None:
-        with open(out_files_status, "w", encoding="utf-8") as handle:
-            for entry in files:
-                status = str(entry.get("status", ""))
-                handle.write(f"{status}\t{_filename_of(entry)}\n")
+        status_lines = [f"{entry.get('status', '')!s}\t{_filename_of(entry)}\n" for entry in files]
+        _write_text_atomically(out_files_status, "".join(status_lines))
 
 
 def _filename_of(entry: dict[str, Any]) -> str:
@@ -403,9 +413,28 @@ def _filename_of(entry: dict[str, Any]) -> str:
 
 def _write_lines(path: str, lines: list[str]) -> None:
     """Write newline-delimited lines to *path*."""
-    with open(path, "w", encoding="utf-8") as handle:
-        for line in lines:
-            handle.write(f"{line}\n")
+    _write_text_atomically(path, "".join(f"{line}\n" for line in lines))
+
+
+def _write_text_atomically(path: str, text: str) -> None:
+    """Replace one text file atomically, cleaning up a failed temporary write."""
+    destination = Path(path)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+            delete=False,
+        ) as handle:
+            temporary_path = Path(handle.name)
+            handle.write(text)
+        os.replace(temporary_path, destination)
+    except OSError:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+        raise
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/scripts/ci/collect_pr_files.py
+++ b/scripts/ci/collect_pr_files.py
@@ -13,18 +13,19 @@ blip must not look like a body/contract failure.
 
 This helper is the shared retrying collector used by both workflows. It pages the
 ``repos/{owner}/{repo}/pulls/{number}/files`` endpoint one page at a time so each
-page can be retried independently, treats a non-zero exit *or* a non-JSON
-(HTML error-page) response *or* a non-list payload as a transient retryable
-failure, backs off with exponential delay + jitter, and fails closed with a
-clear, actionable reason once retries are exhausted.
+page can be retried independently. HTTP 429/5xx responses, connection failures,
+and non-JSON HTML error pages are retried with exponential delay + jitter;
+permanent failures such as HTTP 401/403/404 fail immediately. Every failure
+fails closed with a clear, actionable reason.
 
 Contract
 --------
 - Exits ``0`` and writes the requested output files only after the *full* file
   list has been collected; a partial/failed run never leaves a misleading
   truncated file behind.
-- Exits ``1`` and prints a single diagnostic to stderr when retries are
-  exhausted (persistent API failure) -- the workflows surface this verbatim.
+- Exits ``1`` and prints a single diagnostic to stderr on an immediate permanent
+  failure or after transient retries are exhausted -- the workflows surface
+  this verbatim.
 
 Usage
 -----
@@ -42,6 +43,7 @@ from __future__ import annotations
 import argparse
 import json
 import random
+import re
 import subprocess
 import sys
 import time
@@ -57,17 +59,23 @@ DEFAULT_BASE_DELAY = 1.0
 DEFAULT_MAX_DELAY = 30.0
 DEFAULT_TIMEOUT = 30
 
-# A transient GitHub API failure shows up as one of:
-#   * a non-zero gh exit code (HTTP 4xx/5xx that gh recognises),
-#   * an HTML error page on stdout that is not valid JSON (the 502/503/504 body
-#     that produced the original ``invalid character '<'`` failure),
-#   * a valid JSON value that is not the expected list of file objects.
-# Any of these on a single page is retried with backoff; a *persistent* failure
-# after all attempts fails closed with the diagnostic below.
+# Retry only failures that are genuinely transient: HTTP 429/5xx, timeouts or
+# connection resets, and the HTML error-page response from issue #5918. In
+# particular, authentication/authorization/not-found responses are permanent
+# and must fail immediately rather than consuming the retry budget.
+
+_CONNECTION_FAILURE_MARKERS = (
+    "connection reset",
+    "connection aborted",
+    "connection refused",
+    "unexpected eof",
+    "tls handshake timeout",
+    "i/o timeout",
+)
 
 
 class PrFilesFetchError(RuntimeError):
-    """Raised when changed-file collection cannot complete after all retries."""
+    """Raised when changed-file collection fails permanently or exhausts retries."""
 
 
 def _run_gh_api_page(
@@ -80,14 +88,16 @@ def _run_gh_api_page(
 ) -> subprocess.CompletedProcess[str]:
     """Run ``gh api`` for a single page of the PR files endpoint.
 
-    Using ``-f page=... -f per_page=...`` (rather than embedding the query string
-    in the URL) lets gh own query serialization and keeps this shell-quote-free.
-    For GET requests, gh serializes ``-f`` fields as query parameters.
+    Adding ``-f`` fields makes ``gh api`` default to POST, so ``--method GET``
+    is required. With that explicit method, gh serializes the fields as query
+    parameters without embedding a query string in the endpoint.
     """
     return subprocess.run(
         [
             "gh",
             "api",
+            "--method",
+            "GET",
             f"repos/{repo}/pulls/{pr_number}/files",
             "-f",
             f"per_page={per_page}",
@@ -103,18 +113,24 @@ def _run_gh_api_page(
 
 def _parse_page(
     proc: subprocess.CompletedProcess[str],
-) -> tuple[list[dict[str, Any]] | None, str | None]:
+) -> tuple[list[dict[str, Any]] | None, str | None, bool]:
     """Validate one page response.
 
-    Returns ``(files, None)`` on success, or ``(None, reason)`` when the response
-    is a transient retryable failure (bad exit code, HTML/non-JSON body, or an
-    unexpected payload shape). The reason string is surfaced in the diagnostic.
+    Returns ``(files, None, False)`` on success, or
+    ``(None, reason, retryable)`` on failure. The reason and retryability are
+    surfaced by the retry loop and terminal diagnostic.
     """
+    status = _http_status(proc)
+    response_text = "\n".join(part for part in (proc.stderr, proc.stdout) if part)
+    is_html = proc.stdout.lstrip().startswith("<")
+    connection_failure = _is_connection_failure(response_text)
+
     if proc.returncode != 0:
         snippet = (proc.stderr or proc.stdout or "").strip()
         if len(snippet) > 300:
             snippet = snippet[:300] + "..."
-        return None, f"gh api exited with code {proc.returncode}: {snippet}".strip()
+        retryable = _is_transient_http_status(status) or is_html or connection_failure
+        return None, f"gh api exited with code {proc.returncode}: {snippet}".strip(), retryable
     try:
         data = json.loads(proc.stdout)
     except json.JSONDecodeError as exc:
@@ -123,13 +139,50 @@ def _parse_page(
         snippet = proc.stdout.strip()
         if len(snippet) > 200:
             snippet = snippet[:200] + "..."
-        return None, f"non-JSON response (likely HTML error page): {exc}; snippet: {snippet!r}"
+        retryable = is_html or connection_failure
+        return (
+            None,
+            f"non-JSON response (likely HTML error page): {exc}; snippet: {snippet!r}",
+            retryable,
+        )
     if not isinstance(data, list):
         snippet = proc.stdout.strip()
         if len(snippet) > 200:
             snippet = snippet[:200] + "..."
-        return None, f"unexpected response shape (expected a JSON list); snippet: {snippet!r}"
-    return data, None
+        return (
+            None,
+            f"unexpected response shape (expected a JSON list); snippet: {snippet!r}",
+            _is_transient_http_status(status),
+        )
+    return data, None, False
+
+
+def _http_status(proc: subprocess.CompletedProcess[str]) -> int | None:
+    """Extract an HTTP status from gh's JSON body or stderr diagnostic."""
+    try:
+        data = json.loads(proc.stdout)
+    except (json.JSONDecodeError, TypeError):
+        data = None
+    if isinstance(data, dict):
+        raw_status = data.get("status")
+        try:
+            return int(raw_status)
+        except (TypeError, ValueError):
+            pass
+
+    match = re.search(r"\bHTTP\s+(\d{3})\b", proc.stderr or "", flags=re.IGNORECASE)
+    return int(match.group(1)) if match else None
+
+
+def _is_transient_http_status(status: int | None) -> bool:
+    """Return whether an HTTP status is safe to retry."""
+    return status == 429 or (status is not None and 500 <= status <= 599)
+
+
+def _is_connection_failure(message: str) -> bool:
+    """Recognize gh diagnostics for transient connection failures."""
+    lowered = message.lower()
+    return any(marker in lowered for marker in _CONNECTION_FAILURE_MARKERS)
 
 
 def _backoff_delay(
@@ -194,7 +247,7 @@ def fetch_all_pr_files(  # noqa: PLR0913
     all_files: list[dict[str, Any]] = []
     page = 1
     while True:
-        files, error = _fetch_page_with_retries(
+        files, error, attempts_used, retryable = _fetch_page_with_retries(
             repo,
             pr_number,
             page,
@@ -211,7 +264,13 @@ def fetch_all_pr_files(  # noqa: PLR0913
             # Persistent failure: fail closed with a single actionable diagnostic.
             raise PrFilesFetchError(
                 _format_terminal_error(
-                    repo, pr_number, page, max_attempts, per_page, error or "unknown error"
+                    repo,
+                    pr_number,
+                    page,
+                    attempts_used,
+                    per_page,
+                    error or "unknown error",
+                    retryable=retryable,
                 )
             )
         if not files:
@@ -236,11 +295,13 @@ def _fetch_page_with_retries(  # noqa: PLR0913
     sleep: Callable[[float], None],
     run_page: Callable[..., subprocess.CompletedProcess[str]],
     rng: Callable[[], float],
-) -> tuple[list[dict[str, Any]] | None, str | None]:
+) -> tuple[list[dict[str, Any]] | None, str | None, int, bool]:
     """Retry a single page up to ``max_attempts`` times with backoff.
 
-    Returns ``(files, None)`` on success or ``(None, last_reason)`` when every
-    attempt failed. Sleeps between attempts using full-jitter exponential backoff.
+    Returns ``(files, None, attempts_used, False)`` on success or
+    ``(None, last_reason, attempts_used, retryable)`` on failure. Permanent
+    failures return immediately; transient failures sleep between attempts using
+    full-jitter exponential backoff.
     """
     last_error: str | None = None
     for attempt in range(1, max_attempts + 1):
@@ -248,40 +309,56 @@ def _fetch_page_with_retries(  # noqa: PLR0913
             proc = run_page(repo, pr_number, page, per_page, timeout=timeout)
         except subprocess.TimeoutExpired:
             last_error = f"gh api timed out after {timeout} seconds"
+            retryable = True
         except FileNotFoundError:
             last_error = "gh CLI not found on PATH; install GitHub CLI (https://cli.github.com/)"
+            retryable = False
         except OSError as exc:
             last_error = f"could not run gh api: {exc}"
+            retryable = isinstance(exc, ConnectionError) or _is_connection_failure(str(exc))
         else:
-            files, error = _parse_page(proc)
+            files, error, retryable = _parse_page(proc)
             if error is None:
-                return files, None
+                return files, None, attempt, False
             last_error = error
 
+        if not retryable:
+            return None, last_error, attempt, False
         if attempt < max_attempts:
             delay = _backoff_delay(attempt, base_delay, max_delay, rng=rng)
             if delay > 0:
                 sleep(delay)
-    return None, last_error
+    return None, last_error, max_attempts, True
 
 
 def _format_terminal_error(
     repo: str,
     pr_number: str,
     page: int,
-    max_attempts: int,
+    attempts_used: int,
     per_page: int,
     last_error: str,
+    *,
+    retryable: bool,
 ) -> str:
-    """Build the fail-closed diagnostic printed when retries are exhausted."""
+    """Build the fail-closed diagnostic for permanent or exhausted failures."""
+    if retryable:
+        guidance = (
+            "  This is typically a transient GitHub API outage (502/503/504/429) or "
+            "connection failure. Re-run the job; if it persists, check "
+            "https://www.githubstatus.com/.\n"
+        )
+    else:
+        guidance = (
+            "  The failure is non-retryable (for example HTTP 401/403/404 or an "
+            "invalid response). Verify the endpoint and GH_TOKEN permissions.\n"
+        )
     return (
         f"ERROR: Failed to collect changed files for PR #{pr_number} from "
-        f"repos/{repo}/pulls/{pr_number}/files after {max_attempts} attempt(s) "
+        f"repos/{repo}/pulls/{pr_number}/files after {attempts_used} attempt(s) "
         f"on page {page} (per_page={per_page}).\n"
         f"  Last error: {last_error}\n"
-        "  This is typically a transient GitHub API outage (502/503/504/429) or "
-        "an auth/network issue. Re-run the job; if it persists, verify GH_TOKEN "
-        "permissions and check https://www.githubstatus.com/.\n"
+        f"{guidance}"
         "  This is an infrastructure failure during changed-file collection, NOT "
         "a PR body/contract validation failure."
     )

--- a/tests/ci/test_collect_pr_files.py
+++ b/tests/ci/test_collect_pr_files.py
@@ -111,6 +111,14 @@ def test_nonzero_exit_is_retried_then_succeeds() -> None:
     assert [e["filename"] for e in files] == ["x.py"]
 
 
+def test_non_object_file_entry_fails_closed() -> None:
+    """A JSON list containing a scalar must fail closed before output handling."""
+    run_page = _scripted_runner({(1, 1): _proc(stdout=json.dumps(["not-a-file-entry"]))})
+
+    with pytest.raises(PrFilesFetchError, match="unexpected response entry"):
+        fetch_all_pr_files("owner/repo", "1", run_page=run_page, sleep=lambda _d: None)
+
+
 @pytest.mark.parametrize("status", [401, 403, 404])
 def test_permanent_http_errors_are_not_retried(status: int) -> None:
     """Authentication, authorization, and not-found errors fail immediately."""

--- a/tests/ci/test_collect_pr_files.py
+++ b/tests/ci/test_collect_pr_files.py
@@ -24,6 +24,7 @@ import pytest
 from scripts.ci.collect_pr_files import (
     PrFilesFetchError,
     _backoff_delay,
+    _run_gh_api_page,
     fetch_all_pr_files,
     main,
     write_outputs,
@@ -108,6 +109,66 @@ def test_nonzero_exit_is_retried_then_succeeds() -> None:
         "owner/repo", "1", run_page=run_page, sleep=lambda _d: None, rng=lambda: 0.0
     )
     assert [e["filename"] for e in files] == ["x.py"]
+
+
+@pytest.mark.parametrize("status", [401, 403, 404])
+def test_permanent_http_errors_are_not_retried(status: int) -> None:
+    """Authentication, authorization, and not-found errors fail immediately."""
+    attempts = {"n": 0}
+
+    def run_page(*args, **kwargs):
+        attempts["n"] += 1
+        return _proc(
+            returncode=1,
+            stdout=json.dumps({"message": "permanent failure", "status": str(status)}),
+            stderr=f"gh: permanent failure (HTTP {status})",
+        )
+
+    with pytest.raises(PrFilesFetchError, match="non-retryable"):
+        fetch_all_pr_files(
+            "owner/repo",
+            "5920",
+            max_attempts=5,
+            run_page=run_page,
+            sleep=lambda _d: pytest.fail("permanent errors must not back off"),
+        )
+
+    assert attempts["n"] == 1
+
+
+@pytest.mark.parametrize(
+    ("stdout", "stderr"),
+    [
+        (json.dumps({"message": "rate limited", "status": "429"}), "gh: HTTP 429"),
+        ("", "read: connection reset by peer"),
+    ],
+)
+def test_transient_rate_limit_and_connection_reset_are_retried(stdout: str, stderr: str) -> None:
+    """Rate limits and connection resets retain bounded retry behavior."""
+    run_page = _scripted_runner(
+        {
+            (1, 1): _proc(returncode=1, stdout=stdout, stderr=stderr),
+            (1, 2): _proc(stdout=json.dumps([_entry("ok.py")])),
+            (2, 1): _proc(stdout="[]"),
+        }
+    )
+
+    files = fetch_all_pr_files(
+        "owner/repo", "5920", run_page=run_page, sleep=lambda _d: None, rng=lambda: 0.0
+    )
+
+    assert [entry["filename"] for entry in files] == ["ok.py"]
+
+
+def test_gh_api_page_explicitly_uses_get(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Raw fields must not silently turn the files endpoint request into POST."""
+    run = MagicMock(return_value=_proc(stdout="[]"))
+    monkeypatch.setattr(subprocess, "run", run)
+
+    _run_gh_api_page("owner/repo", "5920", 2, 100)
+
+    argv = run.call_args.args[0]
+    assert argv[:4] == ["gh", "api", "--method", "GET"]
 
 
 def test_timeout_is_treated_as_transient_and_retried() -> None:

--- a/tests/ci/test_collect_pr_files.py
+++ b/tests/ci/test_collect_pr_files.py
@@ -369,3 +369,23 @@ def test_cli_fails_closed_on_persistent_failure(tmp_path: Path, capsys) -> None:
     assert "NOT a PR body/contract validation failure" in err
     # No partial output file is written on failure.
     assert not changed.exists()
+
+
+def test_cli_fails_closed_on_malformed_file_entry(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A malformed API entry exits cleanly instead of leaking a traceback."""
+    changed = tmp_path / "changed.txt"
+    import scripts.ci.collect_pr_files as mod
+
+    monkeypatch.setattr(
+        mod,
+        "_run_gh_api_page",
+        _scripted_runner({(1, 1): _proc(stdout=json.dumps([{"status": "modified"}]))}),
+    )
+
+    rc = main(["--repo", "o/r", "--pr-number", "5", "--out-changed-files", str(changed)])
+
+    assert rc == 1
+    assert "without a string 'filename' field" in capsys.readouterr().err
+    assert not changed.exists()

--- a/tests/ci/test_collect_pr_files.py
+++ b/tests/ci/test_collect_pr_files.py
@@ -1,0 +1,310 @@
+"""Offline tests for the retrying PR changed-files collector (issue #5918).
+
+These tests pin the two behaviors the issue requires:
+
+* a transient GitHub API 502/503/504/429 (which arrives as an HTML body that
+  cannot be JSON-parsed -- the original ``invalid character '<'`` failure) must
+  be retried rather than red the job; and
+* a *persistent* API failure must still fail closed with a single actionable
+  reason that is clearly distinguishable from a body/contract validation failure.
+
+No real ``gh`` subprocess or wall-clock sleep runs: the page fetcher and the
+sleep seam are injected.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.ci.collect_pr_files import (
+    PrFilesFetchError,
+    _backoff_delay,
+    fetch_all_pr_files,
+    main,
+    write_outputs,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+
+def _proc(*, stdout: str = "", stderr: str = "", returncode: int = 0) -> MagicMock:
+    """Build a fake ``subprocess.CompletedProcess`` for a single ``gh api`` page."""
+    return MagicMock(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+def _entry(filename: str, status: str = "modified") -> dict[str, str]:
+    """One files-endpoint entry as gh would return it."""
+    return {"filename": filename, "status": status, "sha": "abc"}
+
+
+def _scripted_runner(
+    responses: dict[tuple[int, int], MagicMock | Exception],
+) -> Callable[..., MagicMock]:
+    """Return a run_page callable keyed by ``(page, attempt_within_page)``.
+
+    ``attempt_within_page`` resets to 1 for each new page (the retry loop counts
+    attempts per page). An ``Exception`` value is raised to model timeouts / OS
+    errors; a ``MagicMock`` (CompletedProcess) is returned as-is.
+    """
+    seen: dict[int, int] = {}
+
+    def run_page(repo, pr_number, page, per_page, *, timeout):
+        attempt = seen.get(page, 0) + 1
+        seen[page] = attempt
+        value = responses[(page, attempt)]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    return run_page
+
+
+HTML_503 = (
+    "<html><head><title>503 Server Error</title></head><body>Server Error for GH API</body></html>"
+)
+
+
+# ── retry-then-success (the core acceptance) ─────────────────────────────────
+
+
+def test_transient_html_503_is_retried_then_succeeds() -> None:
+    """The exact issue #5918 symptom (HTML 503 body) must be retried, not red."""
+    good_page1 = json.dumps([_entry("a.py", "added"), _entry("b.md", "modified")])
+    run_page = _scripted_runner(
+        {
+            (1, 1): _proc(stdout=HTML_503, returncode=0),  # HTML body, rc 0
+            (1, 2): _proc(stdout=good_page1),  # success on retry
+            (2, 1): _proc(stdout="[]"),  # empty page ends pagination
+        }
+    )
+    sleeps: list[float] = []
+
+    files = fetch_all_pr_files(
+        "owner/repo", "123", run_page=run_page, sleep=sleeps.append, rng=lambda: 0.5
+    )
+
+    assert [e["filename"] for e in files] == ["a.py", "b.md"]
+    # A backoff sleep happened between the failed attempt and the successful retry.
+    assert sleeps == [pytest.approx(1.0 * 0.5)]  # base_delay(1.0) * 2**0 * jitter(0.5)
+
+
+def test_nonzero_exit_is_retried_then_succeeds() -> None:
+    """A non-zero gh exit (recognised HTTP error) is also retryable."""
+    run_page = _scripted_runner(
+        {
+            (1, 1): _proc(returncode=1, stderr="HTTP 503: Service Unavailable"),
+            (1, 2): _proc(stdout=json.dumps([_entry("x.py", "modified")])),
+            (2, 1): _proc(stdout="[]"),
+        }
+    )
+    files = fetch_all_pr_files(
+        "owner/repo", "1", run_page=run_page, sleep=lambda _d: None, rng=lambda: 0.0
+    )
+    assert [e["filename"] for e in files] == ["x.py"]
+
+
+def test_timeout_is_treated_as_transient_and_retried() -> None:
+    """A per-page timeout is a transient failure that is retried, then can succeed."""
+    run_page = _scripted_runner(
+        {
+            (1, 1): subprocess.TimeoutExpired(cmd=["gh", "api"], timeout=30),
+            (1, 2): _proc(stdout=json.dumps([_entry("ok.py", "modified")])),
+            (2, 1): _proc(stdout="[]"),
+        }
+    )
+    files = fetch_all_pr_files(
+        "o/r", "7", run_page=run_page, sleep=lambda _d: None, rng=lambda: 0.0
+    )
+    assert [e["filename"] for e in files] == ["ok.py"]
+
+
+# ── persistent failure fails closed (the core acceptance) ────────────────────
+
+
+def test_persistent_html_failure_raises_with_actionable_diagnostic() -> None:
+    """Exhausting retries on HTML error pages must fail closed with a clear reason."""
+    run_page = _scripted_runner(
+        {
+            (1, 1): _proc(stdout=HTML_503),
+            (1, 2): _proc(stdout=HTML_503),
+            (1, 3): _proc(stdout=HTML_503),
+        }
+    )
+
+    with pytest.raises(PrFilesFetchError) as exc_info:
+        fetch_all_pr_files(
+            "owner/repo",
+            "5918",
+            max_attempts=3,
+            run_page=run_page,
+            sleep=lambda _d: None,
+            rng=lambda: 0.0,
+        )
+
+    message = str(exc_info.value)
+    assert "repos/owner/repo/pulls/5918/files" in message
+    assert "after 3 attempt(s)" in message
+    assert "transient GitHub API outage" in message
+    assert "NOT a PR body/contract validation failure" in message
+    assert "non-JSON response" in message  # correlates with logs
+
+
+def test_persistent_nonzero_exit_fails_closed() -> None:
+    """A persistent non-zero exit also fails closed after retries are spent."""
+    attempts = {"n": 0}
+
+    def run_page(*args, **kwargs):
+        attempts["n"] += 1
+        return _proc(returncode=42, stderr="HTTP 502: Bad Gateway")
+
+    with pytest.raises(PrFilesFetchError) as exc_info:
+        fetch_all_pr_files(
+            "o/r", "9", max_attempts=2, run_page=run_page, sleep=lambda _d: None, rng=lambda: 0.0
+        )
+    assert "gh api exited with code 42" in str(exc_info.value)
+    assert attempts["n"] == 2  # did not exceed the per-page attempt budget
+
+
+def test_no_sleep_after_final_attempt() -> None:
+    """Backoff must not sleep after the last permitted attempt."""
+    sleeps: list[float] = []
+    run_page = _scripted_runner(
+        {
+            (1, 1): _proc(stdout=HTML_503),
+            (1, 2): _proc(stdout=HTML_503),
+            (1, 3): _proc(stdout=HTML_503),
+        }
+    )
+
+    with pytest.raises(PrFilesFetchError):
+        fetch_all_pr_files(
+            "o/r", "1", max_attempts=3, run_page=run_page, sleep=sleeps.append, rng=lambda: 1.0
+        )
+    # 3 attempts => exactly 2 inter-attempt sleeps (none after the final attempt).
+    assert len(sleeps) == 2
+
+
+# ── pagination ───────────────────────────────────────────────────────────────
+
+
+def test_pagination_collects_all_pages() -> None:
+    """Full pages continue until a partial/empty page ends collection."""
+    full_page = [_entry(f"a{i}.py", "modified") for i in range(100)]
+    last_page = [_entry("b.py", "added"), _entry("c.py", "modified")]
+    run_page = _scripted_runner(
+        {
+            (1, 1): _proc(stdout=json.dumps(full_page)),
+            (2, 1): _proc(stdout=json.dumps(last_page)),
+            (3, 1): _proc(stdout="[]"),
+        }
+    )
+    files = fetch_all_pr_files(
+        "o/r", "1", per_page=100, run_page=run_page, sleep=lambda _d: None, rng=lambda: 0.0
+    )
+    assert len(files) == 102
+    assert files[-1]["filename"] == "c.py"
+
+
+# ── outputs: changed / status TSV / added ────────────────────────────────────
+
+
+def test_write_outputs_separates_changed_added_and_status(tmp_path: Path) -> None:
+    """The three output files carry changed names, status TSV, and added names."""
+    files = [
+        _entry("new.py", "added"),
+        _entry("touched.py", "modified"),
+        _entry("gone.py", "removed"),
+    ]
+    changed = tmp_path / "changed.txt"
+    status = tmp_path / "status.tsv"
+    added = tmp_path / "added.txt"
+
+    write_outputs(
+        files,
+        out_changed_files=str(changed),
+        out_files_status=str(status),
+        out_added_files=str(added),
+    )
+
+    assert changed.read_text(encoding="utf-8").splitlines() == ["new.py", "touched.py", "gone.py"]
+    assert added.read_text(encoding="utf-8").splitlines() == ["new.py"]
+    assert status.read_text(encoding="utf-8").splitlines() == [
+        "added\tnew.py",
+        "modified\ttouched.py",
+        "removed\tgone.py",
+    ]
+
+
+# ── backoff math ─────────────────────────────────────────────────────────────
+
+
+def test_backoff_delay_grows_and_is_jittered_and_capped() -> None:
+    """Backoff cap doubles per attempt, is jittered in [0, cap], and capped."""
+    max_rng = lambda: 1.0  # noqa: E731  delay == cap
+    zero_rng = lambda: 0.0  # noqa: E731  delay == 0 (full jitter lower bound)
+    assert _backoff_delay(1, base_delay=1.0, max_delay=30.0, rng=max_rng) == 1.0
+    assert _backoff_delay(2, base_delay=1.0, max_delay=30.0, rng=max_rng) == 2.0
+    assert _backoff_delay(3, base_delay=1.0, max_delay=30.0, rng=max_rng) == 4.0
+    # Capped at max_delay rather than growing without bound.
+    assert _backoff_delay(10, base_delay=1.0, max_delay=30.0, rng=max_rng) == 30.0
+    # Full jitter: rng=0 => zero sleep.
+    assert _backoff_delay(5, base_delay=1.0, max_delay=30.0, rng=zero_rng) == 0.0
+
+
+# ── CLI entry point ──────────────────────────────────────────────────────────
+
+
+def test_cli_writes_outputs_and_exits_zero(tmp_path: Path) -> None:
+    """A successful collection writes the requested files and exits 0."""
+    changed = tmp_path / "changed.txt"
+    import scripts.ci.collect_pr_files as mod
+
+    orig_run, orig_sleep = mod._run_gh_api_page, mod.time.sleep
+    mod._run_gh_api_page = _scripted_runner(
+        {  # type: ignore[assignment]
+            (1, 1): _proc(stdout=json.dumps([_entry("z.py", "added")])),
+            (2, 1): _proc(stdout="[]"),
+        }
+    )
+    mod.time.sleep = lambda _d: None  # type: ignore[assignment,method-assign]
+    try:
+        rc = main(["--repo", "o/r", "--pr-number", "5", "--out-changed-files", str(changed)])
+    finally:
+        mod._run_gh_api_page, mod.time.sleep = orig_run, orig_sleep  # type: ignore[assignment,method-assign]
+
+    assert rc == 0
+    assert changed.read_text(encoding="utf-8").splitlines() == ["z.py"]
+
+
+def test_cli_requires_at_least_one_output() -> None:
+    """Without any --out-* the helper refuses to do work (fail-closed contract)."""
+    rc = main(["--repo", "o/r", "--pr-number", "5"])
+    assert rc == 2
+
+
+def test_cli_fails_closed_on_persistent_failure(tmp_path: Path, capsys) -> None:
+    """Persistent failure exits 1, the diagnostic goes to stderr, no partial file."""
+    changed = tmp_path / "changed.txt"
+    import scripts.ci.collect_pr_files as mod
+
+    orig_run, orig_sleep = mod._run_gh_api_page, mod.time.sleep
+    mod._run_gh_api_page = lambda *a, **k: _proc(stdout=HTML_503)  # type: ignore[assignment]
+    mod.time.sleep = lambda _d: None  # type: ignore[assignment,method-assign]
+    try:
+        rc = main(["--repo", "o/r", "--pr-number", "5", "--out-changed-files", str(changed)])
+    finally:
+        mod._run_gh_api_page, mod.time.sleep = orig_run, orig_sleep  # type: ignore[assignment,method-assign]
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "Failed to collect changed files" in err
+    assert "NOT a PR body/contract validation failure" in err
+    # No partial output file is written on failure.
+    assert not changed.exists()

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -571,7 +571,9 @@ def test_pr_body_contracts_workflow_runs_strict_pr_body_checker() -> None:
     workflow_text = PR_BODY_CONTRACTS_WORKFLOW.read_text(encoding="utf-8")
 
     assert "pull_request:" in workflow_text
-    assert "gh api --paginate" in workflow_text
+    assert "scripts/ci/collect_pr_files.py" in workflow_text
+    assert "--out-changed-files" in workflow_text
+    assert "gh api --paginate" not in workflow_text
     assert "pr_changed_files.txt" in workflow_text
     assert "scripts/dev/check_pr_followups.py" in workflow_text
     for flag in (


### PR DESCRIPTION
## What & why

**Issue #5918** (friction): the `PR body contracts` and `PR Contract Check` workflows both collected the changed-file list with an inline `gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files?per_page=100"`. When GitHub returns a transient HTML 502/503/504/429, `gh` writes that HTML to stdout, the `--jq` filter fails with `invalid character '<' looking for beginning of value`, and the whole job exits red **before** its real body/contract checker ever runs. A transient API blip thus looked like a contract failure (two occurrences recorded in the issue: #5834 and #5878).

This factors the request into a shared **retrying collector**, `scripts/ci/collect_pr_files.py`, used by both workflows:

- Pages `repos/{owner}/{repo}/pulls/{n}/files` **one page at a time** so each page is independently retryable (`gh api --paginate` gives no hook to retry a single page).
- Treats a transient failure as **retryable**: non-zero `gh` exit, a non-JSON (HTML error-page) body — the exact issue symptom — or a non-list payload. Covers 502/503/504/429 plus timeouts/OS errors.
- Backs off with **full-jitter exponential delay** (cap 30s) up to a bounded attempt budget (default 5/page).
- **Fails closed** with a single, actionable diagnostic once retries are exhausted, explicitly stating it is an infrastructure failure during changed-file collection, **NOT a PR body/contract validation failure** — so operators don't confuse a GitHub outage with a contract violation.
- Writes outputs **only after full success**, so a partial/failed run never leaves a misleading truncated file.

## Changes

- `scripts/ci/collect_pr_files.py` (new): the shared retrying collector. Emits `--out-changed-files`, `--out-files-status` (TSV `status<TAB>filename`), and `--out-added-files`; CLI exits 0 on success, 1 on persistent failure, 2 on misuse.
- `.github/workflows/pr-body-contracts.yml`: route `Collect changed files` through the helper.
- `.github/workflows/pr-contract-check.yml`: route `Collect changed files` through the helper; the helper now emits changed/status-TSV/added directly (drops the `cut`/`awk` post-processing) while preserving the authoritative added-files signal for evidence hygiene (#5464).
- `tests/ci/test_collect_pr_files.py` (new, 12 tests): retry-then-success (incl. the exact HTML-503 symptom), non-zero-exit retry, per-page timeout retry, persistent-failure fail-closed diagnostic, no-sleep-after-final-attempt, pagination across pages, output splitting (changed/added/status), backoff math, CLI success, CLI no-output-required-arg (exit 2), and the **no-partial-output-on-failure** contract.

This satisfies the issue's acceptance: *a transient GitHub API 503 does not produce a false red result, while a persistent API failure still fails closed with an actionable reason*. It also addresses the first maintainer comment asking to *broaden the scope to both workflows and factor the request into a retrying helper used by both* — done.

## Validation (CPU/local only; no campaigns/training/Slurm)

```
$ uv run python -m pytest tests/ci/test_collect_pr_files.py -q
12 passed in 0.70s

$ uv run python -m pytest tests/validation/test_pr_contract_check.py tests/ci/ -q
62 passed in 23.38s

$ uv run ruff check scripts/ci/collect_pr_files.py tests/ci/test_collect_pr_files.py
All checks passed!

$ uv run ruff format --check scripts/ci/collect_pr_files.py tests/ci/test_collect_pr_files.py
# clean after format applied
```

End-to-end smoke against a **fake `gh`** on `PATH` confirmed the real CLI wiring (argparse → `gh api -f page=… -f per_page=…` → JSON parse → write):
- fake `gh` returned an HTML 503 body on page 1 attempt 1 → the helper **retried** (state showed `p1=1` then `p1=2`), then collected all 102 files across 2 pages and wrote correct `changed.txt` (102 lines), `added.txt` (`new.py` only), and `status.tsv`. Exit 0.
- fake `gh` always returning HTML 503 → exit **1** with the fail-closed diagnostic naming the endpoint, attempt budget, non-JSON symptom (with HTML snippet), and "NOT a PR body/contract validation failure"; **no partial output file** written.

## Scope / what remains

This is a **complete** resolution of issue #5918's stated acceptance for the changed-file collection path in both workflows. Not in scope (not blocking):
- The second maintainer comment also notes `scripts/dev/check_pr_merge_staleness.py` hit a similar `Failed to fetch current main SHA` during #5878. That script uses several different endpoints and a distinct error model; routing its `_get_main_sha`/`_fetch_workflow_runs` through the same retry primitive is a clean follow-up but out of scope here (it did not produce a false result — local verification independently confirmed freshness).

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.

Closes #5918


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request validation reliability by switching changed-files collection to a shared collector that retries transient GitHub API failures (e.g., HTML error pages, rate limits, connection hiccups).
  * Ensured fail-closed behavior: validation won’t proceed with partial or inconsistent file lists when collection cannot complete.
* **Tests**
  * Added offline test coverage for retry/backoff logic, pagination, output generation, CLI exit codes, and fail-closed vs non-retryable error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Gate follow-up

The deferred retry hardening for `scripts/dev/check_pr_merge_staleness.py` is tracked in #5958.
