### PR TITLE
Issue #5930: extend Torch 2.13.0 CPU safety guard to Python 3.11 (cheap-lane worker)

### DIFF
--- a/robot_sf/common/seed.py
+++ b/robot_sf/common/seed.py
@@ -65,7 +65,7 @@ def _configure_torch_213_runtime() -> bool:
     Returns:
         bool: Whether the compatibility guard was applied.
     """
-    if sys.version_info[:2] >= (3, 12):  # noqa: UP036 - Python 3.11 remains supported.
+    if sys.version_info[:2] >= (3, 11):  # noqa: UP036 - Python 3.11 remains supported.
         try:
             version = package_version("torch")
         except PackageNotFoundError:
@@ -115,7 +115,7 @@ def _set_torch_deterministic_algorithms(torch_module: Any, deterministic: bool) 
         return False
 
     version = str(getattr(torch_module, "__version__", "")).split("+", 1)[0]
-    if sys.version_info[:2] >= (3, 12) and version.startswith("2.13.0"):
+    if sys.version_info[:2] >= (3, 11) and version.startswith("2.13.0"):
         c_module = getattr(torch_module, "_C", None)
         c_setter = getattr(c_module, "_set_deterministic_algorithms", None)
         if c_setter is None:

--- a/robot_sf/common/seed.py
+++ b/robot_sf/common/seed.py
@@ -54,7 +54,7 @@ def _import_torch():
 def _configure_torch_213_runtime() -> bool:
     """Disable Torch's crashing compile wrapper on the supported 2.13/Python path.
 
-    Torch 2.13.0 on Python 3.12+ can segfault when the first optimizer operation
+    Torch 2.13.0 on Python 3.11+ can segfault when the first optimizer operation
     imports its ``torch._dynamo``/Triton wrapper.  Preloading Triton gives its
     native extension a safe import point before that lazy wrapper is entered.
     ``TORCH_COMPILE_DISABLE=1`` is also set for Torch builds that honor the
@@ -94,7 +94,7 @@ _TORCH_213_RUNTIME_GUARD_APPLIED = _configure_torch_213_runtime()
 def _set_torch_deterministic_algorithms(torch_module: Any, deterministic: bool) -> bool:
     """Set torch's deterministic-algorithm flag without the Torch 2.13.0 CI crash path.
 
-    Torch 2.13.0 on Python 3.12 imports ``torch._inductor.config`` from the public
+    Torch 2.13.0 on Python 3.11+ imports ``torch._inductor.config`` from the public
     ``use_deterministic_algorithms`` wrapper.  That import reaches Dynamo/Triton and can
     segfault in the repository's test and smoke workers.  The C-level setter is already
     loaded with torch and preserves the operation-level determinism flag without loading

--- a/tests/test_seed_utils.py
+++ b/tests/test_seed_utils.py
@@ -109,8 +109,8 @@ def test_model_package_preloads_torch_runtime_before_direct_ppo_import():
         version = seed_module.package_version("torch")
     except PackageNotFoundError:
         pytest.skip("Torch is not installed")
-    if sys.version_info[:2] < (3, 12) or not str(version).split("+", 1)[0].startswith("2.13.0"):
-        pytest.skip("the model-import boundary guard only applies to Torch 2.13/Python 3.12+")
+    if sys.version_info[:2] < (3, 11) or not str(version).split("+", 1)[0].startswith("2.13.0"):
+        pytest.skip("the model-import boundary guard only applies to Torch 2.13/Python 3.11+")
     if importlib.util.find_spec("stable_baselines3") is None:
         pytest.skip("Stable-Baselines3 is not installed")
 
@@ -138,7 +138,7 @@ def test_model_package_preloads_torch_runtime_before_direct_ppo_import():
 
 def test_torch_213_runtime_guard_is_limited_to_supported_versions(monkeypatch):
     """Do not disable Torch compilation for unaffected interpreter/version pairs."""
-    monkeypatch.setattr(sys, "version_info", (3, 11))
+    monkeypatch.setattr(sys, "version_info", (3, 10))
     monkeypatch.setattr(seed_module, "package_version", lambda _name: "2.13.0+cpu")
     monkeypatch.setenv("TORCH_COMPILE_DISABLE", "0")
 
@@ -181,14 +181,14 @@ def test_torch_optional_behavior():
 
 
 def test_torch_213_python312_313_uses_c_level_determinism_setter(monkeypatch):
-    """Avoid Torch 2.13.0's Python 3.12/3.13 Dynamo/Triton import path.
+    """Avoid Torch 2.13.0's Python 3.11/3.12/3.13 Dynamo/Triton import path.
 
     The real Torch 2.13.0 ``_C._set_deterministic_algorithms`` builtin takes a
     single positional ``enabled`` flag. The double mirrors that exact arity so
     the test fails if the helper regresses to the 2-arg call that raised
     ``TypeError`` under the actual Torch 2.13.0 graph (issue #5556).
     """
-    for py_ver in [(3, 12), (3, 13)]:
+    for py_ver in [(3, 11), (3, 12), (3, 13)]:
         monkeypatch.setattr(sys, "version_info", py_ver)
 
         calls: list[bool] = []

--- a/tests/test_seed_utils.py
+++ b/tests/test_seed_utils.py
@@ -180,7 +180,7 @@ def test_torch_optional_behavior():
         assert rep.has_torch is False
 
 
-def test_torch_213_python312_313_uses_c_level_determinism_setter(monkeypatch):
+def test_torch_213_python311_plus_uses_c_level_determinism_setter(monkeypatch):
     """Avoid Torch 2.13.0's Python 3.11/3.12/3.13 Dynamo/Triton import path.
 
     The real Torch 2.13.0 ``_C._set_deterministic_algorithms`` builtin takes a


### PR DESCRIPTION
## What/Why

When running tests or scripts that load `stable_baselines3` under Python 3.11 with `torch==2.13.0`, the subsequent call to `torch.use_deterministic_algorithms(True)` imports `torch._inductor.config` (reaching Dynamo/Triton) and causes a segmentation fault (`signal 11`, exit code 139) on CPU-only/stub CUDA configurations. This happens because TensorFlow/Tensorboard and Triton load conflicting CUDA/stub library symbols when TensorFlow/Tensorboard is initialized first.

This was previously fixed for Python 3.12+ in #5739 (for #5724) by skipping Triton preloading and setting `TORCH_COMPILE_DISABLE=1`. However, Python 3.11 is also vulnerable under the same conditions. We extended the runtime safety guard in `robot_sf/common/seed.py` to target Python 3.11+ as well (i.e. changing `sys.version_info[:2] >= (3, 12)` to `sys.version_info[:2] >= (3, 11)`).

## Validation Output

### Pytest Execution (Python 3.11)

```text
$ uv run --python 3.11 pytest tests/training/test_train_ppo_mamba_config_issue_4014.py -v
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
...
tests/training/test_train_ppo_mamba_config_issue_4014.py::test_ppo_mamba_smoke_config_loads_cpu_safe_extractor_contract PASSED [ 33%]
tests/training/test_train_ppo_mamba_config_issue_4014.py::test_ppo_policy_selection_routes_mamba_extractor PASSED [ 66%]
tests/training/test_train_ppo_mamba_config_issue_4014.py::test_ppo_mamba_dry_run_emits_parameter_summary_placeholder PASSED [100%]
============================== 3 passed in 8.30s ===============================
```

### Pytest Seed Utils (Python 3.11)

```text
$ uv run --python 3.11 pytest tests/test_seed_utils.py -v
...
============================== 14 passed in 5.75s ==============================
```

### Ruff Validation

```text
$ uv run ruff check robot_sf/common/seed.py tests/test_seed_utils.py
All checks passed!

$ uv run ruff format --check robot_sf/common/seed.py tests/test_seed_utils.py
2 files already formatted
```

## Successor Statement

This PR is a successor slice that does not duplicate prior work and fully resolves issue #5930 by extending the safety check for conflicting modules to Python 3.11.

This PR was produced by the agy/Gemini-3.5-Flash cheap implementation lane; the review gate hardens and merges.

Closes #5930


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for Torch 2.13.0 on Python 3.11 and newer.
  * Prevented deterministic execution and runtime initialization issues on supported Python versions.

* **Tests**
  * Expanded compatibility coverage for Python 3.11, 3.12, and 3.13.
  * Verified that older Python versions remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->