### PR TITLE
Issue #5935: reconcile legacy late_evasive.v1 in scenario-evidence crosswalk (cheap-lane worker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **issue #5935 scenario-evidence crosswalk accepts legacy `safety_predicate.late_evasive.v1`.**
+  The export lane (`trace_predicate_export.py`) already accepted both `late_evasive.v1` and `.v2`
+  to preserve existing campaign provenance, but the crosswalk's schema registry
+  (`scenario_evidence_crosswalk.py`) recognized only `.v2`, so feeding a real legacy export (e.g.
+  the issue4206 trace-capable rerun, which is v1-only: 6291 v1 / 0 v2 records) through
+  `build_scenario_evidence_crosswalk` failed closed with `unknown predicate schema version
+  'safety_predicate.late_evasive.v1'`. The crosswalk now separates `KNOWN_PREDICATE_SCHEMAS`
+  (the current/motivated `.v2` referenced by `motivated_not_exported` records) from
+  `SUPPORTED_PREDICATE_SCHEMAS` (the full accepted provenance set including legacy `.v1`) and
+  validates exported predicate records against the accepted set, retaining the exact source
+  schema version rather than normalizing it away. The v1→v2 bump (#5063) is an additive
+  telemetry-instrumentation change (`latency_unavailable_reason`) with no benchmark metric
+  semantics change, and the crosswalk only records predicate identity + schema provenance +
+  status, so the two versions are compatible for its public contract. Fail-closed behavior on
+  genuinely unknown versions is preserved; no benchmark, metric, or paper-facing claim is
+  upgraded by this compatibility fix.
+
 * **issue #5464 PR Contract Check no longer flags modified evidence files as new.** The
   `pr-contract-check.yml` workflow used `actions/checkout` on `pull_request` without fetching the
   base branch, so `origin/main` was absent in the runner. `pr_contract_check.py`'s `is_file_new`

--- a/docs/context/issue_3483_safety_predicate_producers.md
+++ b/docs/context/issue_3483_safety_predicate_producers.md
@@ -46,6 +46,16 @@ enough, the dominant goal-planner case) or `hazard_never_visible`. A late-evasiv
 never emits a silent-empty latency; downstream consumers can distinguish "never reacted" from a
 data gap. It is `null` exactly when `response_latency_s` is finite.
 
+**Legacy `v1` compatibility (issue #5935).** Existing durable campaign bundles carry the
+legacy `safety_predicate.late_evasive.v1` record (the issue4206 trace-capable rerun is
+v1-only: 6291 v1 / 0 v2 records). The v1→v2 bump was an *additive* telemetry change with
+`no benchmark metric semantics change`, so both versions are accepted as valid provenance by
+the export lane (`robot_sf/benchmark/trace_predicate_export.py`) and by the scenario-evidence
+crosswalk (`robot_sf/benchmark/scenario_evidence_crosswalk.py`). The crosswalk records the
+exact source schema version rather than normalizing it away: it separates
+`KNOWN_PREDICATE_SCHEMAS` (the current/motivated `v2` referenced by `motivated_not_exported`
+records) from `SUPPORTED_PREDICATE_SCHEMAS` (the full accepted set including legacy `v1`).
+
 ## Producer 3 — `safety_predicate.occlusion_near_miss.v1`
 
 `occlusion_near_miss_predicate(hazard_distances, visible, track_confidence, speeds, *, dt,

--- a/robot_sf/benchmark/scenario_evidence_crosswalk.py
+++ b/robot_sf/benchmark/scenario_evidence_crosswalk.py
@@ -91,12 +91,6 @@ SUPPORTED_PREDICATE_SCHEMAS: dict[str, frozenset[str]] = {
     "occlusion_near_miss": frozenset({OCCLUSION_NEAR_MISS_PREDICATE_SCHEMA}),
 }
 
-#: Flat set of every accepted predicate schema version, used for fail-closed
-#: provenance validation (unknown versions are rejected).
-_ACCEPTED_PREDICATE_SCHEMA_VERSIONS: frozenset[str] = frozenset().union(
-    *SUPPORTED_PREDICATE_SCHEMAS.values()
-)
-
 PREDICATE_EXPORT_SCHEMA_VERSION = "trace_predicate_export.v1"
 
 EXCLUSION_REASON_PREDICATE_UNAVAILABLE = "predicate_export_unavailable"
@@ -300,6 +294,17 @@ def _absorb_predicate_row(row: Mapping[str, Any], entry: dict[str, Any]) -> None
         entry["predicate_status"][name] = pred.get("status", "ok")
 
 
+def _is_supported_predicate_schema(name: object, version: object) -> bool:
+    """Return whether a predicate name and schema version form a supported pair."""
+    if version is None:
+        return True
+    return (
+        isinstance(name, str)
+        and isinstance(version, str)
+        and version in SUPPORTED_PREDICATE_SCHEMAS.get(name, frozenset())
+    )
+
+
 def _predicate_section(
     scenario_id: str,
     export: Mapping[str, dict[str, Any]],
@@ -337,7 +342,7 @@ def _predicate_section(
         }
 
     for name, version in entry["exported"].items():
-        if version is not None and version not in _ACCEPTED_PREDICATE_SCHEMA_VERSIONS:
+        if not _is_supported_predicate_schema(name, version):
             raise ScenarioEvidenceCrosswalkError(
                 f"scenario {scenario_id}: unknown predicate schema version {version!r} for "
                 f"predicate {name!r}"
@@ -705,10 +710,12 @@ def _validate_crosswalk_row(
     pred = row.get("predicate_availability")
     if isinstance(pred, Mapping):
         for rec in pred.get("exported_predicates", []) or []:
+            name = rec.get("predicate")
             version = rec.get("schema_version")
-            if version is not None and version not in _ACCEPTED_PREDICATE_SCHEMA_VERSIONS:
+            if not _is_supported_predicate_schema(name, version):
                 errors.append(
-                    f"rows[{index}] ({sid}): unknown predicate schema_version {version!r}"
+                    f"rows[{index}] ({sid}): unknown predicate schema_version {version!r} for "
+                    f"predicate {name!r}"
                 )
 
     evidence = row.get("evidence")

--- a/robot_sf/benchmark/scenario_evidence_crosswalk.py
+++ b/robot_sf/benchmark/scenario_evidence_crosswalk.py
@@ -20,6 +20,21 @@ geometry alone. Two contract rules from the issue are load-bearing:
 The builder is fail-closed: duplicate scenario ids, empty/stale config hashes,
 unknown predicate schema versions, broken artifact references, and
 provenance-incomplete eligibility are all rejected rather than silently patched.
+
+**Legacy schema compatibility (issue #5935).** The crosswalk accepts the legacy
+``safety_predicate.late_evasive.v1`` schema carried by existing durable campaign
+bundles (e.g. the issue4206 trace-capable rerun) and retains the exact source
+schema version as provenance rather than normalizing it away. The v1->v2 bump
+(PR #5063) is documented as an *additive* telemetry-instrumentation change
+(``latency_unavailable_reason`` plus a seconds-valued latency) with ``no
+benchmark metric semantics change``; the crosswalk only records predicate
+identity + schema provenance + status, so v1 and v2 are compatible for this
+public contract. The current/motivated version referenced by
+``motivated_not_exported`` records remains ``v2`` (see
+:data:`KNOWN_PREDICATE_SCHEMAS`), and the full accepted set is
+:data:`SUPPORTED_PREDICATE_SCHEMAS`. This mirrors the producer
+(:mod:`robot_sf.benchmark.trace_predicate_export`), which already accepts both
+versions and preserves exact source provenance.
 """
 
 from __future__ import annotations
@@ -35,19 +50,52 @@ from typing import Any
 
 from jsonschema import Draft202012Validator
 
+from robot_sf.benchmark.safety_predicates import (
+    LATE_EVASIVE_PREDICATE_SCHEMA,
+    OCCLUSION_NEAR_MISS_PREDICATE_SCHEMA,
+    OSCILLATORY_PREDICATE_SCHEMA,
+)
 from robot_sf.benchmark.utils import _config_hash
 from robot_sf.common.json_pointer import json_pointer as _render_json_pointer
 
 SCHEMA_VERSION = "scenario_evidence_crosswalk.v1"
 
-#: Predicate schema tags motivated by the failure taxonomy (#5593 lane). These
-#: are the only predicate versions the crosswalk recognizes; any other version
-#: in a supplied export is rejected as an unknown predicate version.
+#: The legacy late-evasive schema carried by existing durable campaign bundles
+#: (e.g. the issue4206 trace-capable rerun). The producer (`trace_predicate_export`)
+#: accepts both v1 and v2; the v1->v2 bump (#5063) is documented as an *additive*
+#: telemetry-instrumentation change (``latency_unavailable_reason`` and a
+#: seconds-valued latency) with ``no benchmark metric semantics change``. The
+#: crosswalk only records predicate identity + schema provenance + status, so v1
+#: and v2 are compatible for this public contract; we retain the exact source
+#: version rather than normalizing, to preserve provenance (issue #5935).
+LEGACY_LATE_EVASIVE_PREDICATE_SCHEMA = "safety_predicate.late_evasive.v1"
+
+#: Predicate schema tags motivated by the failure taxonomy (#5593 lane). Each
+#: entry maps a predicate name to its *current/motivated* schema version, which
+#: is the version referenced by ``motivated_not_exported`` records.
 KNOWN_PREDICATE_SCHEMAS: dict[str, str] = {
-    "oscillatory_control": "safety_predicate.oscillatory_control.v1",
-    "late_evasive": "safety_predicate.late_evasive.v2",
-    "occlusion_near_miss": "safety_predicate.occlusion_near_miss.v1",
+    "oscillatory_control": OSCILLATORY_PREDICATE_SCHEMA,
+    "late_evasive": LATE_EVASIVE_PREDICATE_SCHEMA,
+    "occlusion_near_miss": OCCLUSION_NEAR_MISS_PREDICATE_SCHEMA,
 }
+
+#: Every predicate schema version the crosswalk accepts as valid provenance.
+#: This is a superset of :data:`KNOWN_PREDICATE_SCHEMAS` values: it also retains
+#: legacy versions that durable campaign bundles carry (issue #5935). Any other
+#: version in a supplied export is rejected as an unknown predicate version.
+SUPPORTED_PREDICATE_SCHEMAS: dict[str, frozenset[str]] = {
+    "oscillatory_control": frozenset({OSCILLATORY_PREDICATE_SCHEMA}),
+    "late_evasive": frozenset(
+        {LEGACY_LATE_EVASIVE_PREDICATE_SCHEMA, LATE_EVASIVE_PREDICATE_SCHEMA}
+    ),
+    "occlusion_near_miss": frozenset({OCCLUSION_NEAR_MISS_PREDICATE_SCHEMA}),
+}
+
+#: Flat set of every accepted predicate schema version, used for fail-closed
+#: provenance validation (unknown versions are rejected).
+_ACCEPTED_PREDICATE_SCHEMA_VERSIONS: frozenset[str] = frozenset().union(
+    *SUPPORTED_PREDICATE_SCHEMAS.values()
+)
 
 PREDICATE_EXPORT_SCHEMA_VERSION = "trace_predicate_export.v1"
 
@@ -289,7 +337,7 @@ def _predicate_section(
         }
 
     for name, version in entry["exported"].items():
-        if version is not None and version not in KNOWN_PREDICATE_SCHEMAS.values():
+        if version is not None and version not in _ACCEPTED_PREDICATE_SCHEMA_VERSIONS:
             raise ScenarioEvidenceCrosswalkError(
                 f"scenario {scenario_id}: unknown predicate schema version {version!r} for "
                 f"predicate {name!r}"
@@ -658,7 +706,7 @@ def _validate_crosswalk_row(
     if isinstance(pred, Mapping):
         for rec in pred.get("exported_predicates", []) or []:
             version = rec.get("schema_version")
-            if version is not None and version not in KNOWN_PREDICATE_SCHEMAS.values():
+            if version is not None and version not in _ACCEPTED_PREDICATE_SCHEMA_VERSIONS:
                 errors.append(
                     f"rows[{index}] ({sid}): unknown predicate schema_version {version!r}"
                 )
@@ -792,8 +840,10 @@ def write_scenario_evidence_crosswalk(
 
 __all__ = [
     "KNOWN_PREDICATE_SCHEMAS",
+    "LEGACY_LATE_EVASIVE_PREDICATE_SCHEMA",
     "PREDICATE_EXPORT_SCHEMA_VERSION",
     "SCHEMA_VERSION",
+    "SUPPORTED_PREDICATE_SCHEMAS",
     "ScenarioEvidenceCrosswalkError",
     "build_scenario_evidence_crosswalk",
     "crosswalk_markdown",

--- a/tests/benchmark/test_scenario_evidence_crosswalk.py
+++ b/tests/benchmark/test_scenario_evidence_crosswalk.py
@@ -259,6 +259,57 @@ def test_unknown_predicate_schema_version_fails_validation() -> None:
         build_scenario_evidence_crosswalk(scenarios, source="fixture.yaml", predicate_export=export)
 
 
+def test_predicate_schema_version_must_match_predicate_name() -> None:
+    """A schema accepted for one predicate must not validate under another name."""
+    scenarios = [_scenario("doorway_low")]
+    export = {
+        "schema_version": PREDICATE_EXPORT_SCHEMA_VERSION,
+        "rows": [
+            {
+                "scenario_id": "doorway_low",
+                "predicates": [
+                    {
+                        "predicate": "oscillatory_control",
+                        "schema_version": LEGACY_LATE_EVASIVE_PREDICATE_SCHEMA,
+                    }
+                ],
+            }
+        ],
+    }
+
+    with pytest.raises(ScenarioEvidenceCrosswalkError, match="unknown predicate schema version"):
+        build_scenario_evidence_crosswalk(scenarios, source="fixture.yaml", predicate_export=export)
+
+
+def test_semantic_validation_rejects_mismatched_predicate_schema_version() -> None:
+    """Semantic validation applies the same predicate-name/schema-version boundary."""
+    scenarios = [_scenario("doorway_low")]
+    export = {
+        "schema_version": PREDICATE_EXPORT_SCHEMA_VERSION,
+        "rows": [
+            {
+                "scenario_id": "doorway_low",
+                "predicates": [
+                    {
+                        "predicate": "late_evasive",
+                        "schema_version": LEGACY_LATE_EVASIVE_PREDICATE_SCHEMA,
+                    }
+                ],
+            }
+        ],
+    }
+    crosswalk = build_scenario_evidence_crosswalk(
+        scenarios, source="fixture.yaml", predicate_export=export
+    )
+    crosswalk["rows"][0]["predicate_availability"]["exported_predicates"][0]["predicate"] = (
+        "oscillatory_control"
+    )
+
+    errors = validate_scenario_evidence_crosswalk(crosswalk)
+
+    assert any("unknown predicate schema_version" in error for error in errors)
+
+
 def test_legacy_late_evasive_v1_flows_through_with_exact_provenance() -> None:
     """Legacy late_evasive.v1 (issue #5935) is accepted and retained as v1, not normalized.
 

--- a/tests/benchmark/test_scenario_evidence_crosswalk.py
+++ b/tests/benchmark/test_scenario_evidence_crosswalk.py
@@ -9,18 +9,28 @@ from pathlib import Path
 
 import pytest
 
+from robot_sf.benchmark.identity.hash_utils import read_jsonl as _read_jsonl
 from robot_sf.benchmark.scenario_evidence_crosswalk import (
     KNOWN_PREDICATE_SCHEMAS,
+    LEGACY_LATE_EVASIVE_PREDICATE_SCHEMA,
     PREDICATE_EXPORT_SCHEMA_VERSION,
     SCHEMA_VERSION,
+    SUPPORTED_PREDICATE_SCHEMAS,
     ScenarioEvidenceCrosswalkError,
     build_scenario_evidence_crosswalk,
     crosswalk_markdown,
     validate_scenario_evidence_crosswalk,
     write_scenario_evidence_crosswalk,
 )
+from robot_sf.benchmark.trace_predicate_export import (
+    EXPORT_STATUS_DEGRADED,
+    EXPORT_STATUS_MISSING,
+    build_trace_predicate_export,
+)
 from scripts.tools.export_scenario_evidence_crosswalk import load_scenario_matrix
 from scripts.tools.export_scenario_evidence_crosswalk import main as export_main
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _scenario(
@@ -249,6 +259,147 @@ def test_unknown_predicate_schema_version_fails_validation() -> None:
         build_scenario_evidence_crosswalk(scenarios, source="fixture.yaml", predicate_export=export)
 
 
+def test_legacy_late_evasive_v1_flows_through_with_exact_provenance() -> None:
+    """Legacy late_evasive.v1 (issue #5935) is accepted and retained as v1, not normalized.
+
+    The real issue4206 trace-capable bundle carries v1 late-evasive records (0 v2 records).
+    The producer accepts both; the crosswalk must also accept v1 and preserve the exact source
+    schema version as provenance rather than silently rewriting it to v2.
+    """
+    scenarios = [_scenario("doorway_low")]
+    export = {
+        "schema_version": PREDICATE_EXPORT_SCHEMA_VERSION,
+        "rows": [
+            {
+                "scenario_id": "doorway_low",
+                "predicates": [
+                    {
+                        "predicate": "late_evasive",
+                        "schema_version": LEGACY_LATE_EVASIVE_PREDICATE_SCHEMA,
+                        "status": "ok",
+                    }
+                ],
+            }
+        ],
+    }
+
+    crosswalk = build_scenario_evidence_crosswalk(
+        scenarios, source="fixture.yaml", predicate_export=export
+    )
+    exported = crosswalk["rows"][0]["predicate_availability"]["exported_predicates"]
+    assert len(exported) == 1
+    assert exported[0]["predicate"] == "late_evasive"
+    # Exact source provenance preserved (NOT normalized to v2).
+    assert exported[0]["schema_version"] == LEGACY_LATE_EVASIVE_PREDICATE_SCHEMA
+    # The v1 record passes full schema + semantic validation.
+    assert validate_scenario_evidence_crosswalk(crosswalk) == []
+
+
+def test_late_evasive_v1_and_v2_coexist_with_distinct_provenance() -> None:
+    """A bundle carrying v1 in one scenario and v2 in another preserves each version distinctly."""
+    scenarios = [_scenario("legacy_scenario"), _scenario("current_scenario")]
+    export = {
+        "schema_version": PREDICATE_EXPORT_SCHEMA_VERSION,
+        "rows": [
+            {
+                "scenario_id": "legacy_scenario",
+                "predicates": [
+                    {
+                        "predicate": "late_evasive",
+                        "schema_version": LEGACY_LATE_EVASIVE_PREDICATE_SCHEMA,
+                        "status": "ok",
+                    }
+                ],
+            },
+            {
+                "scenario_id": "current_scenario",
+                "predicates": [
+                    {
+                        "predicate": "late_evasive",
+                        "schema_version": KNOWN_PREDICATE_SCHEMAS["late_evasive"],
+                        "status": "ok",
+                    }
+                ],
+            },
+        ],
+    }
+
+    crosswalk = build_scenario_evidence_crosswalk(
+        scenarios, source="fixture.yaml", predicate_export=export
+    )
+    by_id = {r["scenario_id"]: r for r in crosswalk["rows"]}
+    legacy = by_id["legacy_scenario"]["predicate_availability"]["exported_predicates"][0]
+    current = by_id["current_scenario"]["predicate_availability"]["exported_predicates"][0]
+    assert legacy["schema_version"] == LEGACY_LATE_EVASIVE_PREDICATE_SCHEMA
+    assert current["schema_version"] == KNOWN_PREDICATE_SCHEMAS["late_evasive"]
+    assert validate_scenario_evidence_crosswalk(crosswalk) == []
+
+
+def test_supported_predicate_schemas_is_superset_of_known_motivated() -> None:
+    """The accepted provenance set is a superset of the motivated/current versions."""
+    motivated = set(KNOWN_PREDICATE_SCHEMAS.values())
+    accepted = set().union(*SUPPORTED_PREDICATE_SCHEMAS.values())
+    assert motivated.issubset(accepted)
+    # v1 is accepted for late_evasive specifically (issue #5935).
+    assert LEGACY_LATE_EVASIVE_PREDICATE_SCHEMA in SUPPORTED_PREDICATE_SCHEMAS["late_evasive"]
+    assert KNOWN_PREDICATE_SCHEMAS["late_evasive"] in SUPPORTED_PREDICATE_SCHEMAS["late_evasive"]
+
+
+def test_motivated_not_exported_still_references_current_v2() -> None:
+    """Accepting v1 provenance does not change the motivated/current schema reference (v2)."""
+    scenarios = [_scenario("doorway_low")]
+    export = {
+        "schema_version": PREDICATE_EXPORT_SCHEMA_VERSION,
+        "rows": [
+            {
+                "scenario_id": "doorway_low",
+                "predicates": [
+                    {
+                        "predicate": "late_evasive",
+                        "schema_version": LEGACY_LATE_EVASIVE_PREDICATE_SCHEMA,
+                        "status": "ok",
+                    }
+                ],
+            }
+        ],
+    }
+
+    crosswalk = build_scenario_evidence_crosswalk(
+        scenarios, source="fixture.yaml", predicate_export=export
+    )
+    motivated = {
+        m["predicate"]: m["schema_version"]
+        for m in crosswalk["rows"][0]["predicate_availability"]["motivated_not_exported_predicates"]
+    }
+    # late_evasive is exported, so it is NOT in motivated_not_exported; the other two remain v1.
+    assert "late_evasive" not in motivated
+    assert motivated["oscillatory_control"] == KNOWN_PREDICATE_SCHEMAS["oscillatory_control"]
+    assert motivated["occlusion_near_miss"] == KNOWN_PREDICATE_SCHEMAS["occlusion_near_miss"]
+
+
+def test_unknown_late_evasive_version_still_fails_closed() -> None:
+    """Accepting v1 must not widen to an arbitrary late_evasive version (fail-closed boundary)."""
+    scenarios = [_scenario("doorway_low")]
+    export = {
+        "schema_version": PREDICATE_EXPORT_SCHEMA_VERSION,
+        "rows": [
+            {
+                "scenario_id": "doorway_low",
+                "predicates": [
+                    {
+                        "predicate": "late_evasive",
+                        "schema_version": "safety_predicate.late_evasive.v9",
+                        "status": "ok",
+                    }
+                ],
+            }
+        ],
+    }
+
+    with pytest.raises(ScenarioEvidenceCrosswalkError, match="unknown predicate schema version"):
+        build_scenario_evidence_crosswalk(scenarios, source="fixture.yaml", predicate_export=export)
+
+
 def test_output_is_deterministic_checksum_identical() -> None:
     """Same inputs produce checksum-identical content JSON."""
     scenarios = [_scenario("doorway_low"), _scenario("bottleneck_low")]
@@ -327,3 +478,108 @@ def test_markdown_labels_geometry_as_descriptive_not_causal() -> None:
     assert "Geometry (descriptive)" in md
     assert "Evidence" in md
     assert "doorway_low" in md
+
+
+class TestRealLegacyLateEvasiveSmoke:
+    """Real-campaign smoke exercising the legacy late_evasive.v1 boundary (issue #5935).
+
+    The real issue4206 trace-capable bundle carries v1 late-evasive records (6291 v1,
+    0 v2 records). This feeds the actual producer export through the crosswalk's
+    consumer contract, asserting the legacy v1 provenance flows end-to-end with exact
+    provenance and passes validation. ``output/`` is gitignored, so the test skips
+    cleanly in fresh worktrees that lack the bundle.
+    """
+
+    RELATIVE_BUNDLE = Path(
+        "output/benchmarks/camera_ready/issue4206_trace_capable_h600_rerun_20260704/"
+        "runs/goal__differential_drive/episodes.jsonl"
+    )
+
+    @classmethod
+    def _bundle_path(cls) -> Path | None:
+        """Resolve the real campaign bundle, checking the current repo and parent checkout."""
+        for root in (REPO_ROOT,):
+            bundle = root / cls.RELATIVE_BUNDLE
+            if bundle.is_file():
+                return bundle
+        # Sibling main checkout. The worktree container here is
+        # ``.../robot_sf_ll7.worktrees/<branch>/``; the main checkout is ``.../robot_sf_ll7``.
+        container = REPO_ROOT.parent
+        if container.name.endswith(".worktrees"):
+            main_root = container.with_name(container.name[: -len(".worktrees")])
+            alt = main_root / cls.RELATIVE_BUNDLE
+            if alt.is_file():
+                return alt
+        return None
+
+    def test_real_legacy_v1_export_flows_through_crosswalk(self) -> None:
+        """The real v1 issue4206 bundle reaches the crosswalk and validates with v1 provenance."""
+        bundle = self._bundle_path()
+        if bundle is None:
+            pytest.skip("real campaign bundle not present")
+        episodes = _read_jsonl(bundle)
+        assert episodes, "bundle must contain episode records"
+
+        # Produce the per-episode export (the producer accepts both v1 and v2 and
+        # preserves the exact source schema_version, including legacy v1).
+        export_rows = build_trace_predicate_export(episodes, run_id="goal__differential_drive")
+        assert export_rows, "producer must emit export rows"
+
+        # The bundle is legacy v1; at least one late_evasive block must carry v1.
+        v1_seen = any(
+            row["predicates"]["late_evasive"]["schema_version"]
+            == LEGACY_LATE_EVASIVE_PREDICATE_SCHEMA
+            for row in export_rows
+            if row["predicates"]["late_evasive"]["export_status"] != EXPORT_STATUS_MISSING
+        )
+        assert v1_seen, "real bundle must carry legacy v1 late_evasive records"
+
+        # Build the crosswalk-consumable envelope (one row per scenario, predicates as a
+        # list of {predicate, schema_version, status} records) from the real producer rows.
+        # Status is derived from the producer's export_status so a missing/degraded predicate
+        # is never misrepresented as a clean measurement (fail-closed surfacing).
+        per_scenario: dict[str, list[dict[str, str]]] = {}
+        for row in export_rows:
+            sid = row["scenario_id"]
+            records = per_scenario.setdefault(sid, [])
+            for predicate, block in row["predicates"].items():
+                if block["export_status"] == EXPORT_STATUS_MISSING:
+                    status = "missing"
+                elif block["export_status"] == EXPORT_STATUS_DEGRADED:
+                    status = "degraded"
+                else:
+                    status = "ok"
+                records.append(
+                    {
+                        "predicate": predicate,
+                        "schema_version": block["schema_version"],
+                        "status": status,
+                    }
+                )
+        predicate_export = {
+            "schema_version": PREDICATE_EXPORT_SCHEMA_VERSION,
+            "rows": [
+                {"scenario_id": sid, "predicates": preds}
+                for sid, preds in sorted(per_scenario.items())
+            ],
+        }
+
+        scenarios = [
+            {"name": sid, "map_id": "m", "metadata": {"scenario_family": "f", "archetype": "g"}}
+            for sid in sorted(per_scenario)
+        ]
+        crosswalk = build_scenario_evidence_crosswalk(
+            scenarios, source="issue4206_real_smoke", predicate_export=predicate_export
+        )
+
+        # Exact v1 source provenance is preserved end-to-end, not normalized away.
+        exported_versions = {
+            rec["schema_version"]
+            for row in crosswalk["rows"]
+            for rec in row["predicate_availability"]["exported_predicates"]
+            if rec["predicate"] == "late_evasive"
+        }
+        assert LEGACY_LATE_EVASIVE_PREDICATE_SCHEMA in exported_versions
+        # No real v2 records exist in this bundle; none should be fabricated.
+        assert KNOWN_PREDICATE_SCHEMAS["late_evasive"] not in exported_versions
+        assert validate_scenario_evidence_crosswalk(crosswalk) == []


### PR DESCRIPTION
## What / Why

Issue #5935 (parent #5593, related closed #5602), discovered while gating PR #5931.

The canonical trace-predicate export lane (`robot_sf/benchmark/trace_predicate_export.py`) already accepts **both** `safety_predicate.late_evasive.v1` and `.v2` (it explicitly retains legacy provenance: `_SUPPORTED_PREDICATE_SCHEMAS["late_evasive"] = (v1, v2)`). But the scenario-evidence crosswalk (`robot_sf/benchmark/scenario_evidence_crosswalk.py`) registry recognized **only `.v2`**, so feeding a real legacy export through `build_scenario_evidence_crosswalk` failed closed with:

```
unknown predicate schema version 'safety_predicate.late_evasive.v1' for predicate 'late_evasive'
```

This blocked the documented downstream consumer (the crosswalk) from reading real, versioned, durable campaign artifacts.

### The decision (recorded, per DoD item 1)

**`safety_predicate.late_evasive.v1` is a supported crosswalk schema, retained as v1 (exact source provenance preserved, not normalized to v2).**

Evidence grounding the decision:
- The v1→v2 bump (PR #5063) is documented as an **additive** telemetry-instrumentation change — it adds `latency_unavailable_reason` and a seconds-valued latency — with explicit **"no benchmark metric semantics change"** and **"Existing consumers read `fields` via `.get(...)` and are unaffected."**
- The crosswalk's public contract records only **predicate identity + schema provenance + status**. It does **not** interpret `latency_unavailable_reason` or any field-level difference; the `late_evasive` boolean and predicate identity are identical between v1 and v2.
- The real durable issue4206 trace-capable bundle is **v1-only**: **6291 v1 records, 0 v2 records** across all 11 planner runs. The v2 schema currently exists only in code; no durable artifact uses it.
- This mirrors the producer's own philosophy ("retain its provenance") and the issue's expected behavior / risk mitigation, both of which say **"preserve exact source schema provenance."**

## Implementation

- **`KNOWN_PREDICATE_SCHEMAS`** — unchanged in role: predicate name → **current/motivated** schema version (`.v2` for `late_evasive`), referenced by `motivated_not_exported` records. Now sourced from `safety_predicates` constants (single source of truth, no drift).
- **`SUPPORTED_PREDICATE_SCHEMAS`** (new) — the full accepted provenance set, a superset of the motivated versions, including legacy `late_evasive.v1`.
- **`_ACCEPTED_PREDICATE_SCHEMA_VERSIONS`** (new) — flattened set used by both fail-closed validation paths.
- The two membership checks (`_predicate_section` build-time + `_validate_crosswalk_row` semantic validation) now validate against the accepted set instead of `KNOWN_PREDICATE_SCHEMAS.values()`, so v1 flows through with exact provenance.
- Durable documentation: module docstring decision block + `docs/context/issue_3483_safety_predicate_producers.md` note + `CHANGELOG.md` `### Fixed` entry.

Fail-closed behavior on **genuinely unknown** versions is preserved (regression-tested).

## Validation

CPU-only; no campaigns, Slurm, training, or benchmark runs.

```
uv run pytest tests/benchmark/test_scenario_evidence_crosswalk.py tests/benchmark/test_trace_predicate_export.py -p no:xdist -q
# 39 passed (existing) → now 45 passed after adding 6 new crosswalk tests
```

New focused regression coverage:
- `test_legacy_late_evasive_v1_flows_through_with_exact_provenance` — the exact issue reproduction now succeeds; v1 is retained, not normalized to v2.
- `test_late_evasive_v1_and_v2_coexist_with_distinct_provenance` — mixed bundle preserves each version distinctly.
- `test_supported_predicate_schemas_is_superset_of_known_motivated` — locks the motivated-vs-accepted invariant.
- `test_motivated_not_exported_still_references_current_v2` — accepting v1 does not change the motivated/current reference (still v2).
- `test_unknown_late_evasive_version_still_fails_closed` — accepting v1 does not widen to arbitrary versions (`late_evasive.v9` still rejected).
- `TestRealLegacyLateEvasiveSmoke::test_real_legacy_v1_export_flows_through_crosswalk` — **real-export smoke**: feeds the actual issue4206 `goal__differential_drive` bundle (233 v1 records) through the producer → crosswalk-consumable envelope → `build_scenario_evidence_crosswalk`, asserting exact v1 provenance survives end-to-end and the crosswalk validates clean. (Skips cleanly in fresh worktrees without the gitignored bundle; passed here against the real bundle.)

```
uv run ruff check <changed files>        # All checks passed!
uv run ruff format --check <changed files> # clean
git diff --check                            # no whitespace errors
```

**Result classification: smoke.** This is a localized schema-registry/provenance fix with targeted regression and real-data smoke coverage. It does **not** upgrade any benchmark, metric, or paper-facing claim (DoD item 5 satisfied).

## Successor statement

Successor slice: this PR adds **new capability** — crosswalk acceptance of legacy `late_evasive.v1` provenance and the motivated-vs-accepted schema-registry split — and **does not duplicate** PR #5931 (the export-lane→crosswalk adapter, still open), which deliberately left this schema-registry decision to this issue. PR #5931's fixtures use recognized versions; once #5931 merges, its real-bundle end-to-end path will now reach the crosswalk instead of failing closed on v1.

## Evidence / artifact handling

No campaigns, Slurm, training, or benchmark runs. No `output/` artifacts produced or depended on — the real-data smoke **reads** a gitignored, worktree-local bundle (`output/benchmarks/camera_ready/issue4206_trace_capable_h600_rerun_20260704/...`) and makes no durable claim. Change is benchmark-schema/tooling-layer only; evidence tier: smoke.

Closes #5935

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
