### PR TITLE
Issue #1496: fix BC loader ragged expert_traj_v1 schema (cheap-lane worker)

### DIFF
--- a/robot_sf/training/oracle_imitation_bc_smoke.py
+++ b/robot_sf/training/oracle_imitation_bc_smoke.py
@@ -197,9 +197,9 @@ def _per_episode_steps(array: np.ndarray, *, name: str) -> list[np.ndarray]:
         )
     if data.ndim == 1:
         # Ragged layout: each element is already a per-episode step array.
-        return [data[index] for index in range(data.shape[0])]
+        return list(data)
     # Rectangular 2-D (or 3-D for actions): each leading-axis slice is one episode.
-    return [data[index] for index in range(data.shape[0])]
+    return list(data)
 
 
 def _episode_identity(array: np.ndarray, *, name: str) -> list[str]:
@@ -324,10 +324,12 @@ def _validate_dataset_arrays(arrays: dict[str, np.ndarray]) -> int:
             f"{len(actions)} vs {len(observations)}"
         )
     for episode_index, (obs_steps, act_steps) in enumerate(zip(observations, actions, strict=True)):
-        if _step_count(obs_steps) != _step_count(act_steps):
+        obs_len = _step_count(obs_steps)
+        act_len = _step_count(act_steps)
+        if obs_len != act_len:
             raise OracleImitationBcSmokeError(
                 f"episode {episode_index} observations and actions disagree on step count: "
-                f"{_step_count(obs_steps)} vs {_step_count(act_steps)}"
+                f"{obs_len} vs {act_len}"
             )
 
     episode_count = len(observations)

--- a/robot_sf/training/oracle_imitation_bc_smoke.py
+++ b/robot_sf/training/oracle_imitation_bc_smoke.py
@@ -168,33 +168,38 @@ def _require_array(npz: np.lib.npyio.NpzFile, name: str) -> np.ndarray:
     return npz[name]
 
 
-def _observations_array(array: np.ndarray) -> np.ndarray:
-    """Return the per-step observation array, validated as 2-D (episodes, steps).
+def _per_episode_steps(array: np.ndarray, *, name: str) -> list[np.ndarray]:
+    """Return one per-episode step container for each episode, layout-agnostic.
 
-    The expert_traj_v1 schema pads episodes to a common max-step width, so observations are
-    stored as a 2-D object array of structured observation dicts (or ``None`` padding).
+    The ``expert_traj_v1`` collection spec writes per-step fields via
+    ``np.asarray(list_of_per_episode_arrays, dtype=object)``. When episodes share a step count
+    numpy stores a rectangular 2-D ``(episodes, steps)`` object array (each row a step slice);
+    when episode lengths differ numpy stores a ragged 1-D ``(episodes,)`` object array whose
+    elements are the per-episode step arrays. Both are valid outputs of the same writer, so the
+    loader must accept both.
+
+    Args:
+        array: A raw observations/actions (or other per-step) NPZ array.
+        name: Field name used in fail-closed error messages.
+
+    Returns:
+        A list with one entry per episode. For observations each entry is a 1-D object array of
+        observation dicts (possibly containing ``None`` padding on the rectangular layout); for
+        actions each entry is a ``(steps, action_dim)`` array.
+
+    Raises:
+        OracleImitationBcSmokeError: If the array is scalar or otherwise not episode-major.
     """
     data = np.asarray(array)
-    if data.ndim != 2:
+    if data.ndim == 0:
         raise OracleImitationBcSmokeError(
-            f"NPZ array 'observations' expected 2-D (episodes, steps), got shape {data.shape}"
+            f"NPZ array {name!r} expected episode-major per-step data, got scalar shape"
         )
-    return data
-
-
-def _actions_array(array: np.ndarray) -> np.ndarray:
-    """Return the per-step action array, validated as 2-D or 3-D.
-
-    Actions are stored as ``(episodes, steps)`` of action vectors (object dtype) or as
-    ``(episodes, steps, action_dim)``. Both layouts index identically as ``actions[e, s]``.
-    """
-    data = np.asarray(array)
-    if data.ndim not in (2, 3):
-        raise OracleImitationBcSmokeError(
-            f"NPZ array 'actions' expected 2-D or 3-D (episodes, steps[, action_dim]), "
-            f"got shape {data.shape}"
-        )
-    return data
+    if data.ndim == 1:
+        # Ragged layout: each element is already a per-episode step array.
+        return [data[index] for index in range(data.shape[0])]
+    # Rectangular 2-D (or 3-D for actions): each leading-axis slice is one episode.
+    return [data[index] for index in range(data.shape[0])]
 
 
 def _episode_identity(array: np.ndarray, *, name: str) -> list[str]:
@@ -291,26 +296,41 @@ def _splits_from_metadata(npz: np.lib.npyio.NpzFile) -> dict[str, list[str]]:
     return out
 
 
+def _step_count(per_episode: np.ndarray) -> int:
+    """Return the step count of one per-episode step container (non-padded length)."""
+    try:
+        return len(per_episode)
+    except TypeError as exc:  # pragma: no cover - defensive: a non-iterable slipped through
+        raise OracleImitationBcSmokeError(
+            f"per-episode step container is not iterable: {type(per_episode).__name__}"
+        ) from exc
+
+
 def _validate_dataset_arrays(arrays: dict[str, np.ndarray]) -> int:
     """Validate array alignment and provenance fields.
+
+    Both the rectangular (2-D) and ragged (1-D) writer layouts are accepted; observations and
+    actions are normalized to per-episode step containers and aligned episode-by-episode so a
+    step-count mismatch on any single episode fails closed.
 
     Returns:
         Number of episodes represented by the aligned observation/action arrays.
     """
-    observations = _observations_array(arrays["observations"])
-    actions = _actions_array(arrays["actions"])
-    if actions.shape[0] != observations.shape[0]:
+    observations = _per_episode_steps(arrays["observations"], name="observations")
+    actions = _per_episode_steps(arrays["actions"], name="actions")
+    if len(actions) != len(observations):
         raise OracleImitationBcSmokeError(
             "actions and observations disagree on episode count: "
-            f"{actions.shape[0]} vs {observations.shape[0]}"
+            f"{len(actions)} vs {len(observations)}"
         )
-    if actions.shape[1] != observations.shape[1]:
-        raise OracleImitationBcSmokeError(
-            "actions and observations disagree on padded step width: "
-            f"{actions.shape[1]} vs {observations.shape[1]}"
-        )
+    for episode_index, (obs_steps, act_steps) in enumerate(zip(observations, actions, strict=True)):
+        if _step_count(obs_steps) != _step_count(act_steps):
+            raise OracleImitationBcSmokeError(
+                f"episode {episode_index} observations and actions disagree on step count: "
+                f"{_step_count(obs_steps)} vs {_step_count(act_steps)}"
+            )
 
-    episode_count = observations.shape[0]
+    episode_count = len(observations)
     for name in _REQUIRED_ARRAYS:
         array = np.asarray(arrays[name])
         if array.ndim == 0 or len(array) != episode_count:
@@ -523,8 +543,8 @@ def flatten_observation_action_pairs(
         records per-split step counts.
     """
     arrays = dataset["arrays"]
-    observations = _observations_array(arrays["observations"])
-    actions = _actions_array(arrays["actions"])
+    observations = _per_episode_steps(arrays["observations"], name="observations")
+    actions = _per_episode_steps(arrays["actions"], name="actions")
     episode_ids = _episode_identity(arrays["episode_ids"], name="episode_ids")
     split_tags = _episode_identity(arrays["splits"], name="splits")
     wanted = set(splits)
@@ -532,15 +552,19 @@ def flatten_observation_action_pairs(
     features: list[np.ndarray] = []
     targets: list[np.ndarray] = []
     per_split_steps: dict[str, int] = dict.fromkeys(splits, 0)
-    for episode in range(observations.shape[0]):
+    for episode in range(len(observations)):
         if split_tags[episode] not in wanted:
             continue
         split = split_tags[episode]
-        for step in range(observations.shape[1]):
-            observation = observations[episode, step]
+        episode_obs = observations[episode]
+        episode_acts = actions[episode]
+        # Per-episode step containers may carry ``None`` observations on the rectangular
+        # (padded) writer layout; skip them. The ragged layout has no padding.
+        for step in range(_step_count(episode_obs)):
+            observation = episode_obs[step]
             if observation is None:
                 continue
-            action = actions[episode, step]
+            action = episode_acts[step]
             features.append(_flatten_observation(observation, feature_fields=_FEATURE_FIELDS))
             targets.append(np.asarray(action, dtype=np.float32).reshape(-1))
             per_split_steps[split] = per_split_steps.get(split, 0) + 1

--- a/tests/training/test_oracle_imitation_bc_smoke_ragged_schema.py
+++ b/tests/training/test_oracle_imitation_bc_smoke_ragged_schema.py
@@ -1,0 +1,310 @@
+"""Real-schema conformance for the issue #1496 BC loader/overfit smoke.
+
+PR #5917 shipped the BC loader/overfit smoke with tests built on a *rectangular* synthetic NPZ
+fixture (every episode padded to a common step width, observations stored as a 2-D
+``(episodes, steps)`` object array). The actual ``expert_traj_v1.npz`` produced by the job 13520
+collection spec is **ragged**: episodes have unequal lengths (job 13520 ran 1..241 steps per
+episode), so the collector's ``np.asarray(per_episode_arrays, dtype=object)`` writes
+observations/actions as a **1-D** ``(episodes,)`` object array of per-episode arrays -- not a
+rectangular 2-D array.
+
+These tests build a fixture with the *exact* writer layout the issue #1496 collection spec uses
+(``np.savez(... observations=np.asarray(list_of_per_episode_arrays, dtype=object), ...)``) and
+assert the loader, the split/leakage gate, the flatten step, and the full overfit smoke run
+against it. They are the regression guard that the loader cannot silently drift away from the
+real collector schema again.
+
+Claim boundary reminder: a passing overfit here is *smoke* evidence that the loader and a BC
+training step execute end to end on the real collector schema and memorize the tiny training
+split. It is NOT evidence that the real warm-start policy is good, that BC beats RL, or anything
+benchmark-facing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from robot_sf.training.oracle_imitation_bc_smoke import (
+    BCSmokeConfig,
+    OracleImitationBcSmokeError,
+    flatten_observation_action_pairs,
+    load_expert_trajectory_dataset,
+    run_bc_overfit_smoke,
+    validate_split_leakage_contract,
+)
+
+_PED_SLOTS = 64
+_FEATURE_OBS_KEYS = (
+    "robot_position",
+    "robot_heading",
+    "robot_speed",
+    "robot_velocity_xy",
+    "robot_angular_velocity",
+    "robot_radius",
+    "goal_current",
+    "goal_next",
+    "pedestrians_positions",
+    "pedestrians_velocities",
+    "pedestrians_radius",
+    "pedestrians_count",
+    "map_size",
+    "sim_timestep",
+)
+
+
+def _observation(seed: int, step: int) -> dict[str, Any]:
+    """Build one structured observation dict with the expert_traj_v1 contract keys."""
+    rng = np.random.default_rng(seed * 1000 + step)
+    return {
+        "robot_position": rng.standard_normal(2).astype(np.float32),
+        "robot_heading": np.array([rng.standard_normal()], dtype=np.float32),
+        "robot_speed": rng.standard_normal(2).astype(np.float32),
+        "robot_velocity_xy": rng.standard_normal(2).astype(np.float32),
+        "robot_angular_velocity": np.array([rng.standard_normal()], dtype=np.float32),
+        "robot_radius": np.array([0.3], dtype=np.float32),
+        "goal_current": rng.standard_normal(2).astype(np.float32),
+        "goal_next": rng.standard_normal(2).astype(np.float32),
+        "pedestrians_positions": rng.standard_normal((_PED_SLOTS, 2)).astype(np.float32),
+        "pedestrians_velocities": rng.standard_normal((_PED_SLOTS, 2)).astype(np.float32),
+        "pedestrians_radius": np.array([0.4], dtype=np.float32),
+        "pedestrians_count": np.array([float(_PED_SLOTS)], dtype=np.float32),
+        "map_size": np.array([20.0, 10.0], dtype=np.float32),
+        "sim_timestep": np.array([0.1], dtype=np.float32),
+    }
+
+
+def _action_for(observation: dict[str, Any], bias: int) -> np.ndarray:
+    """Deterministic, learnable action mapping so the overfit probe can succeed."""
+    features = np.concatenate(
+        [
+            np.asarray(observation["robot_position"], dtype=np.float32),
+            np.asarray(observation["robot_heading"], dtype=np.float32),
+            np.asarray(observation["goal_current"], dtype=np.float32),
+        ]
+    ).astype(np.float32)
+    weight = np.array([0.5, -0.3, 0.8, 0.2, -0.4, 0.9], dtype=np.float32)[: features.shape[0]]
+    speed = float(features @ weight) + 0.3 * bias
+    steering = float(features.sum() * 0.1) - 0.1 * bias
+    return np.array([speed, steering], dtype=np.float32)
+
+
+def _write_ragged_npz(
+    path: Path,
+    *,
+    episodes: list[dict[str, Any]],
+    splits_mapping: dict[str, list[str]],
+) -> None:
+    """Serialize ragged episodes with the EXACT writer layout the job 13520 spec uses.
+
+    Mirrors the collection spec: each per-episode array is built independently, then the whole
+    field is written via ``np.asarray(list_of_per_episode_arrays, dtype=object)``. Because
+    episodes have unequal step counts, numpy stores each field as a 1-D ``(episodes,)`` object
+    array of per-episode arrays -- the layout the real 363 MB artifact uses.
+    """
+    episode_count = len(episodes)
+
+    per_episode: dict[str, list[np.ndarray]] = {
+        name: []
+        for name in (
+            "observations",
+            "actions",
+            "positions",
+            "rewards",
+            "return_to_go",
+            "terminated",
+            "truncated",
+        )
+    }
+    episode_ids: list[np.ndarray] = []
+    scenario_ids: list[np.ndarray] = []
+    seeds: list[np.ndarray] = []
+    split_tags: list[np.ndarray] = []
+
+    for episode in episodes:
+        steps = int(episode["steps"])
+        obs_arrays = np.empty(steps, dtype=object)
+        act_arrays = np.empty((steps, 2), dtype=np.float32)
+        for step in range(steps):
+            observation = episode["observations"][step]
+            obs_arrays[step] = observation
+            act_arrays[step] = episode["actions"][step]
+        per_episode["observations"].append(obs_arrays)
+        per_episode["actions"].append(act_arrays)
+        per_episode["positions"].append(np.zeros((steps, 2), dtype=np.float32))
+        per_episode["rewards"].append(np.full(steps, 0.05, dtype=np.float32))
+        per_episode["return_to_go"].append(
+            np.asarray([0.05 * (steps - i) for i in range(steps)], dtype=np.float32)
+        )
+        per_episode["terminated"].append(
+            np.asarray([i == steps - 1 for i in range(steps)], dtype=bool)
+        )
+        per_episode["truncated"].append(np.zeros(steps, dtype=bool))
+        episode_ids.append(np.asarray([episode["episode_id"]], dtype=object))
+        scenario_ids.append(np.asarray([episode["scenario_id"]], dtype=object))
+        seeds.append(np.asarray([episode["seed"]], dtype=np.int64))
+        split_tags.append(np.asarray([episode["split"]], dtype=object))
+
+    metadata = {
+        "dataset_id": "expert_traj_v1",
+        "source_policy_id": "hybrid_rule_v3_static_margin0_waypoint2",
+        "dataset_schema": "trajectory_dataset.v2.decision_transformer_preflight",
+        "splits": {split: {"episode_ids": ids} for split, ids in splits_mapping.items()},
+        "observation_contract": {"keys": sorted(_FEATURE_OBS_KEYS)},
+        "data_collection_only": True,
+        "training_performed": False,
+    }
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(
+        path,
+        observations=np.asarray(per_episode["observations"], dtype=object),
+        actions=np.asarray(per_episode["actions"], dtype=object),
+        positions=np.asarray(per_episode["positions"], dtype=object),
+        rewards=np.asarray(per_episode["rewards"], dtype=object),
+        return_to_go=np.asarray(per_episode["return_to_go"], dtype=object),
+        terminated=np.asarray(per_episode["terminated"], dtype=object),
+        truncated=np.asarray(per_episode["truncated"], dtype=object),
+        episode_ids=np.asarray(episode_ids, dtype=object),
+        scenario_ids=np.asarray(scenario_ids, dtype=object),
+        seeds=np.asarray(seeds, dtype=object),
+        splits=np.asarray(split_tags, dtype=object),
+        episode_count=np.array(episode_count),
+        metadata=np.array(metadata, dtype=object),
+    )
+
+
+def _build_ragged_fixture(tmp_path: Path) -> Path:
+    """Build a ragged NPZ matching the real job 13520 writer (unequal episode lengths)."""
+    episodes: list[dict[str, Any]] = []
+    # Deliberately unequal step counts, including a 1-step episode exactly like job 13520's
+    # minimum (the registration records minimum_episode_steps=1, maximum=241).
+    spec = [
+        ("train__planner_sanity_simple__seed201", "planner_sanity_simple", 201, "train", 12, 1),
+        ("train__classic_head_on__seed202", "classic_head_on", 202, "train", 1, 2),
+        ("validation__classic_crossing__seed101", "classic_crossing", 101, "validation", 8, 3),
+        ("evaluation__classic_doorway__seed111", "classic_doorway", 111, "evaluation", 5, 4),
+    ]
+    for episode_id, scenario_id, seed, split, steps, bias in spec:
+        observations = [_observation(seed, step) for step in range(steps)]
+        actions = np.stack([_action_for(observations[step], bias) for step in range(steps)])
+        episodes.append(
+            {
+                "episode_id": episode_id,
+                "scenario_id": scenario_id,
+                "seed": seed,
+                "split": split,
+                "steps": steps,
+                "observations": observations,
+                "actions": actions,
+            }
+        )
+    splits_mapping = {split: [] for split in ("train", "validation", "evaluation")}
+    for episode in episodes:
+        splits_mapping[episode["split"]].append(episode["episode_id"])
+    dataset_path = tmp_path / "expert_traj_v1.npz"
+    _write_ragged_npz(dataset_path, episodes=episodes, splits_mapping=splits_mapping)
+    return dataset_path
+
+
+def test_ragged_observations_field_is_one_dimensional(tmp_path: Path) -> None:
+    """The real writer stores observations as a 1-D ragged object array, not 2-D rectangular.
+
+    This pins the schema assumption these conformance tests guard: if numpy ever stores equal
+    lengths as 2-D, the fixture would no longer reproduce the real ragged layout.
+    """
+    dataset_path = _build_ragged_fixture(tmp_path)
+    with np.load(dataset_path, allow_pickle=True) as npz:
+        observations = npz["observations"]
+        actions = npz["actions"]
+    assert observations.ndim == 1, observations.shape
+    assert observations.shape == (4,)
+    # actions are also ragged 1-D (each element a (steps, 2) array).
+    assert actions.ndim == 1, actions.shape
+    # Per-episode step counts differ -> this is the ragged layout, not rectangular padding.
+    per_episode_steps = [len(observations[i]) for i in range(observations.shape[0])]
+    assert per_episode_steps == [12, 1, 8, 5]
+
+
+def test_loader_accepts_ragged_real_schema_and_partitions_by_split(tmp_path: Path) -> None:
+    """The loader must load the real ragged collector schema, not only rectangular fixtures."""
+    dataset_path = _build_ragged_fixture(tmp_path)
+    dataset = load_expert_trajectory_dataset(dataset_path)
+
+    assert dataset["episode_count"] == 4
+    assert dataset["splits"]["train"] == [
+        "train__planner_sanity_simple__seed201",
+        "train__classic_head_on__seed202",
+    ]
+    assert dataset["splits"]["evaluation"] == ["evaluation__classic_doorway__seed111"]
+
+
+def test_split_leakage_contract_passes_on_ragged_dataset(tmp_path: Path) -> None:
+    """The split/leakage gate must hold on the real ragged schema before training starts."""
+    dataset_path = _build_ragged_fixture(tmp_path)
+    dataset = load_expert_trajectory_dataset(dataset_path)
+    report = validate_split_leakage_contract(dataset)
+    assert report["episode_counts"] == {"train": 2, "validation": 1, "evaluation": 1}
+    assert report["train_seeds_disjoint_from_holdout"] is True
+    assert report["evaluation_held_out_from_training"] is True
+
+
+def test_flatten_keeps_only_training_steps_on_ragged_dataset(tmp_path: Path) -> None:
+    """The flatten step must walk per-episode arrays on the ragged schema (train only)."""
+    dataset_path = _build_ragged_fixture(tmp_path)
+    dataset = load_expert_trajectory_dataset(dataset_path)
+    features, targets, per_split_steps = flatten_observation_action_pairs(dataset)
+    # 12 + 1 training steps; validation/evaluation held out.
+    assert features.shape[0] == 13
+    assert targets.shape == (13, 2)
+    assert per_split_steps == {"train": 13}
+
+
+def test_overfit_smoke_runs_end_to_end_on_ragged_real_schema(tmp_path: Path) -> None:
+    """The full overfit smoke must run against the real ragged collector schema end to end."""
+    dataset_path = _build_ragged_fixture(tmp_path)
+    output_dir = tmp_path / "smoke_out"
+    result = run_bc_overfit_smoke(
+        BCSmokeConfig(
+            dataset_path=str(dataset_path),
+            output_dir=str(output_dir),
+            epochs=300,
+            learning_rate=5e-3,
+            hidden_dim=64,
+            seed=1496,
+        )
+    )
+
+    assert result.loss_reduction > 0.0
+    assert result.final_loss < result.initial_loss
+    assert result.num_train_steps == 13
+    assert result.episode_counts == {"train": 2, "validation": 1, "evaluation": 1}
+    assert Path(result.checkpoint_path).is_file()
+    assert Path(result.manifest_path).is_file()
+
+    import json
+
+    manifest = json.loads(Path(result.manifest_path).read_text(encoding="utf-8"))
+    assert manifest["smoke_not_quality"] is True
+    assert manifest["not_full_warm_start_comparison"] is True
+    assert manifest["per_split_steps"] == {"train": 13}
+
+
+def test_loader_rejects_per_episode_observation_action_length_mismatch(tmp_path: Path) -> None:
+    """A per-episode observation/action step mismatch must fail closed on the ragged schema."""
+    dataset_path = _build_ragged_fixture(tmp_path)
+    with np.load(dataset_path, allow_pickle=True) as npz:
+        keep = {key: npz[key] for key in npz.files}
+    # Corrupt one episode's actions to a different step count than its observations.
+    observations = keep["observations"]
+    actions = keep["actions"]
+    episode_index = 0
+    obs_steps = len(observations[episode_index])
+    actions[episode_index] = np.zeros((obs_steps + 5, 2), dtype=np.float32)
+    broken = dataset_path.with_name("broken.npz")
+    np.savez(broken, **keep)
+    with pytest.raises(OracleImitationBcSmokeError, match="disagree on step count"):
+        load_expert_trajectory_dataset(broken)

--- a/tests/training/test_oracle_imitation_bc_smoke_ragged_schema.py
+++ b/tests/training/test_oracle_imitation_bc_smoke_ragged_schema.py
@@ -126,12 +126,10 @@ def _write_ragged_npz(
 
     for episode in episodes:
         steps = int(episode["steps"])
-        obs_arrays = np.empty(steps, dtype=object)
-        act_arrays = np.empty((steps, 2), dtype=np.float32)
-        for step in range(steps):
-            observation = episode["observations"][step]
-            obs_arrays[step] = observation
-            act_arrays[step] = episode["actions"][step]
+        obs_arrays = np.asarray(episode["observations"], dtype=object)
+        act_arrays = np.asarray(episode["actions"], dtype=np.float32)
+        assert obs_arrays.shape == (steps,)
+        assert act_arrays.shape == (steps, 2)
         per_episode["observations"].append(obs_arrays)
         per_episode["actions"].append(act_arrays)
         per_episode["positions"].append(np.zeros((steps, 2), dtype=np.float32))


### PR DESCRIPTION
## Summary

**Successor slice to PR #5917; does not duplicate it.** PR #5917 shipped the BC loader/overfit smoke for issue #1496, but its tests used an *equal-length synthetic fixture*, so the loader was never exercised against the real collector schema. This PR fixes a **real correctness bug** in #5917's loader that would have made the authorized BC lane crash when running the smoke against the real materialized `expert_traj_v1.npz`.

### The bug

PR #5917's loader assumed observations/actions are always stored as a rectangular 2-D `(episodes, steps)` object array (`_observations_array` asserted `ndim != 2` → raise; `_actions_array` asserted `ndim in (2,3)`). The actual `expert_traj_v1.npz` produced by the job 13520 collection spec is **ragged**: episodes have unequal lengths (the registration records `minimum_episode_steps=1`, `maximum=241`). When the collector runs `np.asarray(list_of_per_episode_arrays, dtype=object)` over unequal-length episodes, numpy stores each field as a **1-D `(episodes,)` object array of per-episode arrays**, not a rectangular 2-D array.

Reproduced directly against a fixture built with the exact job 13520 writer layout:

```
NPZ array 'observations' expected 2-D (episodes, steps), got shape (4,)
```

So the loader, the split/leakage gate, the flatten step, and the overfit smoke would all fail-closed (crash) on the real dataset. Conformance only appeared to pass because the prior `/tmp` smoke fixtures happened to have equal episode lengths.

### What changed

`robot_sf/training/oracle_imitation_bc_smoke.py` (+59/-35):
- Replaced the rigid `_observations_array`/`_actions_array` (2-D/3-D assertions) with a single layout-agnostic normalizer `_per_episode_steps(...)` that accepts **both** writer layouts: the rectangular 2-D `(episodes, steps)` layout (padded, with `None` padding) **and** the ragged 1-D `(episodes,)` layout (per-episode arrays) that the real collector produces.
- `_validate_dataset_arrays` now aligns observations vs actions **episode-by-episode**, so a per-episode step-count mismatch fails closed with a precise message (`episode N observations and actions disagree on step count: X vs Y`) instead of comparing padded widths.
- `flatten_observation_action_pairs` walks per-episode step containers (still skipping `None` padding on the rectangular layout).

`tests/training/test_oracle_imitation_bc_smoke_ragged_schema.py` (new, 6 tests): a ragged-schema conformance guard that reproduces the **exact job 13520 writer layout** (`np.savez(..., observations=np.asarray(list_of_per_episode_arrays, dtype=object), ...)`, including a 1-step episode just like the real dataset's minimum) and asserts the loader, the split/leakage gate, the flatten step, the full overfit smoke, and the per-episode length-mismatch fail-closed path all behave correctly. This is the regression guard so the loader cannot drift away from the real collector schema again.

The 13 existing rectangular-fixture tests from #5917 continue to pass unchanged.

## Validation

CPU-only (cheap-lane scope; no campaigns, no Slurm, no training runs, no benchmark claims).

```
$ uv run python -m pytest tests/training/test_oracle_imitation_bc_smoke.py \
    tests/training/test_oracle_imitation_bc_smoke_ragged_schema.py -q
19 passed in 4.37s
```

Red→green for the new ragged tests: 5 of 6 failed before the fix (`observations expected 2-D … got shape (4,)`), all 19 pass after.

End-to-end CLI against the real collector schema (both layouts), via `scripts/validation/run_oracle_imitation_bc_smoke.py --dataset-path … --json`:

- Rectangular real-schema fixture (4 equal-length episodes, all splits): `loss 0.6646 → 5.4e-06`, 22 train steps, `status=ok`.
- **Ragged job-13520-layout fixture** (observations stored as 1-D `(4,)`, with a 1-step episode — the real dataset's hardest case): `loss 0.1742 → 1.5e-06`, 8 train steps (7+1), `status=ok`. This is the case that crashed before the fix.

```
$ uv run ruff check <changed files> && uv run ruff format --check <changed files>
All checks passed! / 2 files already formatted
```

```
$ uv run python scripts/validation/check_docstring_todos.py --mode diff --base origin/main
No TODO docstrings found in touched definitions.
```

Adjacent suites unaffected (62 passed): `test_oracle_imitation_trace_uri_registry.py`, `test_oracle_imitation_warm_start_readiness.py`, `test_oracle_imitation_warm_start_readiness_decision_manifest.py`, `test_issue_1496_job_13520_registration.py`.

## Claim boundary (honest)

This is a **loader correctness fix** plus a real-schema conformance test. It makes the #5917 BC smoke actually runnable against the real `expert_traj_v1.npz` instead of crashing. It is **not** benchmark evidence, navigation-quality evidence, warm-start-quality evidence, or a paper/dissertation claim. The smoke checkpoint remains `smoke_not_quality` / `not_full_warm_start_comparison`. The full BC-warm-start-vs-RL comparison still requires the larger balanced collection and SLURM/GPU compute, both out of scope for this cheap CPU lane.

## Scope vs. issue acceptance gates

- [x] #1470 durable dataset pointers — resolved by PR #5914 (unchanged here).
- [x] Split/leakage validation passes before training starts — now actually runs on the real ragged schema (previously crashed); #5917 delivered the gate, this PR makes it work on the real artifact.
- [~] At least one imitation warm-start policy trained — **smoke only** (unchanged boundary; full policy needs SLURM/GPU).
- [ ] Trained checkpoint + manifests with durable pointers — still gated on the full training lane; out of CPU scope.

This PR is **not** the full #1496 resolution. It removes a concrete blocker (loader crash on the real dataset schema) so the next authorized lane can run the #5917 smoke against the real materialized artifact. Use `Refs #1496` (partial slice) — the full comparison and durable-checkpoint acceptance criteria remain open.

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.


## Gate follow-up

The configured optional readiness lane reproduced the existing arm-isolation parity timeout tracked in #5938; this is an unrelated gate-infrastructure failure, not a finding in the two changed loader files.
