### PR TITLE
Issue #5948: register doorway butterfly trace re-export provenance (cheap-lane worker)

### DIFF
--- a/configs/benchmarks/doorway_butterfly_trace_reexport.yaml
+++ b/configs/benchmarks/doorway_butterfly_trace_reexport.yaml
@@ -1,0 +1,75 @@
+# Reconstructed 2026-07-17 per issue #5948 from job-13483 run_summary.yaml
+# Original ad-hoc config was lost when worktree doorway-a307 was cleaned.
+# This reconstruction matches config_hash 846e99aaba7dff51 from the actual run.
+#
+# Provenance:
+#   - Slurm job: 13483
+#   - Execution commit: a307ef276d701f8d14dead1aa0513f44ee97c0b0
+#   - Output tree: output/benchmarks/doorway_butterfly_trace_reexport/job-13483/
+#   - Durable bundle: durable-evidence/job-13483-doorway-provenance.tar.gz
+#   - Bundle sha256: 1a434946d774a5550ec3791ec6a829768fab5ce058c7a9ec4db9d43711780dff
+#
+# Note: The spec's minimal variant listed seeds [113, 114]; the run actually used
+# the recommended 30-seed set (111-140). This artifact is authoritative about what ran.
+
+name: doorway_butterfly_trace_reexport
+paper_facing: false
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+scenario_candidates: [classic_doorway_medium]
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+
+seed_policy:
+  mode: fixed-list
+  seeds: [111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140]
+
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+
+amv_contract:
+  enabled: true
+  status: pass
+  profile: amv-paper-v1
+
+workers: 1
+horizon: 600
+dt: 0.1
+record_forces: true
+record_planner_decision_trace: true
+record_simulation_step_trace: true
+resume: false
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix: [differential_drive]
+export_publication_bundle: false
+include_videos_in_publication: false
+overwrite_publication_bundle: false
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: "{release_tag}"
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: diagnostic-trace-reexport-only
+
+# Observation noise disabled per reconstruction (issue #5948)
+observation_noise:
+  enabled: false
+
+planners:
+  - key: ppo
+    algo: ppo
+    planner_group: experimental
+    algo_config: configs/baselines/ppo_15m_grid_socnav.yaml
+    benchmark_profile: experimental
+    adapter_impact_eval: true

--- a/configs/benchmarks/doorway_butterfly_trace_reexport.yaml
+++ b/configs/benchmarks/doorway_butterfly_trace_reexport.yaml
@@ -59,7 +59,7 @@ include_videos_in_publication: false
 overwrite_publication_bundle: false
 repository_url: https://github.com/ll7/robot_sf_ll7
 release_tag: "{release_tag}"
-doi: 10.5281/zenodo.<record-id>
+doi: null
 paper_interpretation_profile: diagnostic-trace-reexport-only
 
 # Observation noise disabled per reconstruction (issue #5948)

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -20,6 +20,22 @@ freshness_values:
   policy: Durable policy boundary; update only when the policy changes.
   evidence: Evidence pointer or manifest; preserve provenance and checksums when applicable.
 entries:
+- path: docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/README.md
+  status: evidence
+  freshness: dated
+  area: reproducibility
+- path: docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/config_sha256.txt
+  status: evidence
+  freshness: dated
+  area: reproducibility
+- path: docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/provenance_manifest.json
+  status: evidence
+  freshness: dated
+  area: reproducibility
+- path: docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/run_summary_reconstruction.yaml
+  status: evidence
+  freshness: dated
+  area: reproducibility
 - path: docs/context/issue_5936_result_job_durability_gate.md
   status: current
   freshness: policy

--- a/docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/README.md
+++ b/docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/README.md
@@ -1,0 +1,60 @@
+# Issue #5948: Doorway Butterfly Trace Re-export Provenance
+
+## Summary
+
+This directory registers the durable provenance pointer for job 13483 (doorway butterfly trace re-export), whose run config was lost when the ad-hoc worktree was cleaned.
+
+## Incident
+
+- **Date discovered:** 2026-07-17
+- **Root cause:** Campaign config `configs/benchmarks/doorway_butterfly_trace_reexport.yaml` was created ad-hoc inside worktree `doorway-a307`, used to drive job 13483, and left uncommitted. The worktree was subsequently cleaned, and the original file is gone.
+- **Impact:** The only record of what actually ran was job 13483's output tree (7.2 MB: `run_summary.yaml`, `campaign_manifest.json`, `PER_SEED_DIFF.md`, per-seed reports) — gitignored, untracked, one `git clean` from permanent loss.
+
+## Durable Preservation
+
+The output tree was preserved as a checksummed bundle before this fix:
+- **Bundle:** `job-13483-doorway-provenance.tar.gz`
+- **SHA-256:** `1a434946d774a5550ec3791ec6a829768fab5ce058c7a9ec4db9d43711780dff`
+- **Files:** 46 individually hashed
+- **Location:** Copied off the originating disk to a second host under `durable-evidence/`
+
+## Reconstruction
+
+The config was reconstructed from two independent sources that agree:
+1. The spec's inline YAML
+2. Job 13483's own `run_summary.yaml` (config_hash `846e99aaba7dff51`)
+
+Reconstruction parameters:
+- Scenario matrix: `classic_interactions_francis2023.yaml`
+- Scenario candidate: `classic_doorway_medium`
+- Planner: `ppo` @ `ppo_15m_grid_socnav.yaml`
+- Seed set: `paper_eval_s30` = 111–140 (30 seeds)
+- Horizon: 600
+- dt: 0.1
+- Workers: 1
+- SNQI: `camera_ready_v3` enforcement `warn`
+- AMV: `amv-paper-v1` status `pass`
+- Observation noise: disabled
+- `paper_facing: false`
+
+**Note:** The spec's minimal variant lists seeds `[113, 114]`; the run actually used the **recommended** 30-seed set (111–140). The artifact is authoritative about what ran.
+
+## Rule Established
+
+Per the comment in issue #5948, this incident establishes the rule:
+
+> **Anything required to reproduce a shipped artifact — its config, its input, AND the code that produced it — must be durable on main (or registered with a durable pointer) before the artifact is treated as shipped.**
+
+This is the producer-side sibling of #5936 (result-job durability gate): #5936 requires an analysis to have a durable *input*; this requires a recorded run to have a durable *config*.
+
+## Files in This Directory
+
+- `provenance_manifest.json` — Machine-readable provenance pointer
+- `run_summary_reconstruction.yaml` — Key fields from job 13483's run_summary.yaml
+- `config_sha256.txt` — SHA-256 of the reconstructed config file (filled after commit)
+
+## Related Issues
+
+- #5936 — Result-job durability gate (no analysis successor before input is durable)
+- #5893 — Promotion decision for trace-tooling prototypes (#5834/#5839/#5840)
+- #5447 — Trace comparison and figure eligibility promotion

--- a/docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/README.md
+++ b/docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/README.md
@@ -1,3 +1,5 @@
+<!-- AI-GENERATED (robot_sf#5948, 2026-07-17) - NEEDS-REVIEW -->
+
 # Issue #5948: Doorway Butterfly Trace Re-export Provenance
 
 ## Summary
@@ -51,7 +53,7 @@ This is the producer-side sibling of #5936 (result-job durability gate): #5936 r
 
 - `provenance_manifest.json` — Machine-readable provenance pointer
 - `run_summary_reconstruction.yaml` — Key fields from job 13483's run_summary.yaml
-- `config_sha256.txt` — SHA-256 of the reconstructed config file (filled after commit)
+- `config_sha256.txt` — SHA-256 of the committed reconstructed config file
 
 ## Related Issues
 

--- a/docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/config_sha256.txt
+++ b/docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/config_sha256.txt
@@ -1,0 +1,2 @@
+# AI-GENERATED NEEDS-REVIEW
+527c2c6f262cf5011cab381b6ffd4248da5e86f34bb090687ba989d86c360844  configs/benchmarks/doorway_butterfly_trace_reexport.yaml

--- a/docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/provenance_manifest.json
+++ b/docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/provenance_manifest.json
@@ -1,0 +1,59 @@
+{
+  "schema": "robot_sf_run_config_provenance.v1",
+  "issue": 5948,
+  "incident_date": "2026-07-17",
+  "run_identification": {
+    "slurm_job_id": 13483,
+    "execution_commit": "a307ef276d701f8d14dead1aa0513f44ee97c0b0",
+    "config_hash_from_run": "846e99aaba7dff51",
+    "output_tree_path": "output/benchmarks/doorway_butterfly_trace_reexport/job-13483/"
+  },
+  "config_reconstruction": {
+    "reconstructed_file": "configs/benchmarks/doorway_butterfly_trace_reexport.yaml",
+    "reconstruction_date": "2026-07-17",
+    "sources": [
+      "job-13483 run_summary.yaml",
+      "spec inline YAML reconstruction"
+    ],
+    "key_parameters": {
+      "scenario_matrix": "configs/scenarios/classic_interactions_francis2023.yaml",
+      "scenario_candidate": "classic_doorway_medium",
+      "planner_algo": "ppo",
+      "planner_config": "configs/baselines/ppo_15m_grid_socnav.yaml",
+      "seed_set": "paper_eval_s30",
+      "seeds": [111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140],
+      "horizon": 600,
+      "dt": 0.1,
+      "workers": 1,
+      "snqi_weights": "configs/benchmarks/snqi_weights_camera_ready_v3.json",
+      "snqi_enforcement": "warn",
+      "amv_profile": "amv-paper-v1",
+      "amv_status": "pass",
+      "observation_noise_enabled": false,
+      "paper_facing": false
+    }
+  },
+  "durable_bundle": {
+    "filename": "job-13483-doorway-provenance.tar.gz",
+    "sha256": "1a434946d774a5550ec3791ec6a829768fab5ce058c7a9ec4db9d43711780dff",
+    "file_count": 46,
+    "location": "durable-evidence/",
+    "contents": [
+      "run_summary.yaml",
+      "campaign_manifest.json",
+      "PER_SEED_DIFF.md",
+      "per-seed reports"
+    ]
+  },
+  "rule_established": {
+    "title": "Producer-side durability gate",
+    "statement": "Anything required to reproduce a shipped artifact — its config, its input, AND the code that produced it — must be durable on main (or registered with a durable pointer) before the artifact is treated as shipped.",
+    "related_issues": [5936, 5893, 5447]
+  },
+  "resolution": {
+    "config_committed": true,
+    "provenance_registered": true,
+    "bundle_preserved": true,
+    "documentation_added": true
+  }
+}

--- a/docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/provenance_manifest.json
+++ b/docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/provenance_manifest.json
@@ -1,4 +1,5 @@
 {
+  "review_marker": "AI-GENERATED NEEDS-REVIEW",
   "schema": "robot_sf_run_config_provenance.v1",
   "issue": 5948,
   "incident_date": "2026-07-17",

--- a/docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/run_summary_reconstruction.yaml
+++ b/docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/run_summary_reconstruction.yaml
@@ -7,42 +7,42 @@ run_summary_reconstruction:
   slurm_job_id: 13483
   execution_commit: a307ef276d701f8d14dead1aa0513f44ee97c0b0
   config_hash: 846e99aaba7dff51
-  
+
   scenario:
     matrix: configs/scenarios/classic_interactions_francis2023.yaml
     candidate: classic_doorway_medium
-    
+
   planner:
     key: ppo
     algo: ppo
     config: configs/baselines/ppo_15m_grid_socnav.yaml
-    
+
   seed_policy:
     set_name: paper_eval_s30
     seeds: [111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140]
     count: 30
-    
+
   runtime:
     horizon: 600
     dt: 0.1
     workers: 1
-    
+
   snqi_contract:
     enabled: true
     enforcement: warn
     weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
     baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
-    
+
   amv_contract:
     enabled: true
     status: pass
     profile: amv-paper-v1
-    
+
   observation_noise:
     enabled: false
-    
+
   paper_facing: false
-  
+
   output_tree:
     path: output/benchmarks/doorway_butterfly_trace_reexport/job-13483/
     size_mb: 7.2
@@ -51,7 +51,7 @@ run_summary_reconstruction:
       - campaign_manifest.json
       - PER_SEED_DIFF.md
       - episodes.jsonl (per-seed trace exports)
-      
+
   durable_preservation:
     bundle: job-13483-doorway-provenance.tar.gz
     sha256: 1a434946d774a5550ec3791ec6a829768fab5ce058c7a9ec4db9d43711780dff

--- a/docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/run_summary_reconstruction.yaml
+++ b/docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/run_summary_reconstruction.yaml
@@ -1,3 +1,4 @@
+# AI-GENERATED NEEDS-REVIEW
 # Reconstructed from job-13483 run_summary.yaml (authoritative record of actual run)
 # Source: output/benchmarks/doorway_butterfly_trace_reexport/job-13483/run_summary.yaml
 # Preserved in: durable-evidence/job-13483-doorway-provenance.tar.gz

--- a/docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/run_summary_reconstruction.yaml
+++ b/docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/run_summary_reconstruction.yaml
@@ -1,0 +1,61 @@
+# Reconstructed from job-13483 run_summary.yaml (authoritative record of actual run)
+# Source: output/benchmarks/doorway_butterfly_trace_reexport/job-13483/run_summary.yaml
+# Preserved in: durable-evidence/job-13483-doorway-provenance.tar.gz
+
+run_summary_reconstruction:
+  slurm_job_id: 13483
+  execution_commit: a307ef276d701f8d14dead1aa0513f44ee97c0b0
+  config_hash: 846e99aaba7dff51
+  
+  scenario:
+    matrix: configs/scenarios/classic_interactions_francis2023.yaml
+    candidate: classic_doorway_medium
+    
+  planner:
+    key: ppo
+    algo: ppo
+    config: configs/baselines/ppo_15m_grid_socnav.yaml
+    
+  seed_policy:
+    set_name: paper_eval_s30
+    seeds: [111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140]
+    count: 30
+    
+  runtime:
+    horizon: 600
+    dt: 0.1
+    workers: 1
+    
+  snqi_contract:
+    enabled: true
+    enforcement: warn
+    weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+    baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+    
+  amv_contract:
+    enabled: true
+    status: pass
+    profile: amv-paper-v1
+    
+  observation_noise:
+    enabled: false
+    
+  paper_facing: false
+  
+  output_tree:
+    path: output/benchmarks/doorway_butterfly_trace_reexport/job-13483/
+    size_mb: 7.2
+    key_artifacts:
+      - run_summary.yaml
+      - campaign_manifest.json
+      - PER_SEED_DIFF.md
+      - episodes.jsonl (per-seed trace exports)
+      
+  durable_preservation:
+    bundle: job-13483-doorway-provenance.tar.gz
+    sha256: 1a434946d774a5550ec3791ec6a829768fab5ce058c7a9ec4db9d43711780dff
+    location: durable-evidence/
+    files_hashed: 46
+
+# Note: This reconstruction is from the actual run output, not the spec.
+# The spec's minimal variant listed seeds [113, 114]; the run used 111-140.

--- a/tests/benchmark/test_issue_5948_doorway_provenance.py
+++ b/tests/benchmark/test_issue_5948_doorway_provenance.py
@@ -1,0 +1,125 @@
+"""Test for issue #5948 doorway butterfly trace re-export config provenance."""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class TestDoorwayButterflyReexportConfig:
+    """Test the reconstructed config for job 13483 (issue #5948)."""
+
+    @pytest.fixture
+    def config_path(self) -> Path:
+        return REPO_ROOT / "configs" / "benchmarks" / "doorway_butterfly_trace_reexport.yaml"
+
+    @pytest.fixture
+    def provenance_path(self) -> Path:
+        return (
+            REPO_ROOT
+            / "docs"
+            / "context"
+            / "evidence"
+            / "issue_5948_doorway_provenance_2026-07-17"
+            / "provenance_manifest.json"
+        )
+
+    def test_config_file_exists(self, config_path: Path) -> None:
+        """Verify the reconstructed config file exists."""
+        assert config_path.exists(), f"Config file not found: {config_path}"
+
+    def test_config_valid_yaml(self, config_path: Path) -> None:
+        """Verify the config is valid YAML."""
+        with config_path.open() as f:
+            config = yaml.safe_load(f)
+        assert isinstance(config, dict)
+
+    def test_config_has_required_fields(self, config_path: Path) -> None:
+        """Verify the config has the key reconstruction fields."""
+        with config_path.open() as f:
+            config = yaml.safe_load(f)
+
+        # Core identification
+        assert config["name"] == "doorway_butterfly_trace_reexport"
+        assert config["paper_facing"] is False
+
+        # Scenario
+        assert (
+            config["scenario_matrix"] == "configs/scenarios/classic_interactions_francis2023.yaml"
+        )
+        assert config["scenario_candidates"] == ["classic_doorway_medium"]
+
+        # Seeds (30-seed set 111-140, not the minimal [113, 114])
+        assert config["seed_policy"]["mode"] == "fixed-list"
+        expected_seeds = list(range(111, 141))
+        assert config["seed_policy"]["seeds"] == expected_seeds
+
+        # Runtime
+        assert config["horizon"] == 600
+        assert config["dt"] == 0.1
+        assert config["workers"] == 1
+
+        # SNQI
+        assert "snqi_weights" in config
+        assert "snqi_baseline" in config
+        assert config["snqi_contract"]["enabled"] is True
+        assert config["snqi_contract"]["enforcement"] == "warn"
+
+        # AMV
+        assert config["amv_contract"]["enabled"] is True
+        assert config["amv_contract"]["status"] == "pass"
+        assert config["amv_contract"]["profile"] == "amv-paper-v1"
+
+        # Observation noise disabled
+        assert config["observation_noise"]["enabled"] is False
+
+        # Planner
+        assert len(config["planners"]) == 1
+        assert config["planners"][0]["key"] == "ppo"
+        assert config["planners"][0]["algo"] == "ppo"
+        assert config["planners"][0]["algo_config"] == "configs/baselines/ppo_15m_grid_socnav.yaml"
+
+    def test_provenance_manifest_exists(self, provenance_path: Path) -> None:
+        """Verify the provenance manifest file exists."""
+        assert provenance_path.exists(), f"Provenance manifest not found: {provenance_path}"
+
+    def test_provenance_manifest_valid_json(self, provenance_path: Path) -> None:
+        """Verify the provenance manifest is valid JSON."""
+        with provenance_path.open() as f:
+            manifest = json.load(f)
+        assert isinstance(manifest, dict)
+
+    def test_provenance_manifest_has_required_fields(self, provenance_path: Path) -> None:
+        """Verify the provenance manifest has the key fields."""
+        with provenance_path.open() as f:
+            manifest = json.load(f)
+
+        assert manifest["schema"] == "robot_sf_run_config_provenance.v1"
+        assert manifest["issue"] == 5948
+        assert manifest["run_identification"]["slurm_job_id"] == 13483
+        assert manifest["run_identification"]["config_hash_from_run"] == "846e99aaba7dff51"
+        assert (
+            manifest["durable_bundle"]["sha256"]
+            == "1a434946d774a5550ec3791ec6a829768fab5ce058c7a9ec4db9d43711780dff"
+        )
+        assert "rule_established" in manifest
+
+    def test_config_matches_provenance(self, config_path: Path, provenance_path: Path) -> None:
+        """Verify the config matches the provenance manifest reconstruction."""
+        with config_path.open() as f:
+            config = yaml.safe_load(f)
+        with provenance_path.open() as f:
+            manifest = json.load(f)
+
+        # Check key parameters match
+        recon = manifest["config_reconstruction"]["key_parameters"]
+        assert config["scenario_matrix"] == recon["scenario_matrix"]
+        assert config["scenario_candidates"] == [recon["scenario_candidate"]]
+        assert config["planners"][0]["algo_config"] == recon["planner_config"]
+        assert config["seed_policy"]["seeds"] == recon["seeds"]
+        assert config["horizon"] == recon["horizon"]
+        assert config["dt"] == recon["dt"]
+        assert config["workers"] == recon["workers"]

--- a/tests/benchmark/test_issue_5948_doorway_provenance.py
+++ b/tests/benchmark/test_issue_5948_doorway_provenance.py
@@ -1,5 +1,6 @@
 """Test for issue #5948 doorway butterfly trace re-export config provenance."""
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -25,6 +26,18 @@ class TestDoorwayButterflyReexportConfig:
             / "evidence"
             / "issue_5948_doorway_provenance_2026-07-17"
             / "provenance_manifest.json"
+        )
+
+    @pytest.fixture
+    def config_hash_path(self) -> Path:
+        """Return the committed SHA-256 record for the reconstructed config."""
+        return (
+            REPO_ROOT
+            / "docs"
+            / "context"
+            / "evidence"
+            / "issue_5948_doorway_provenance_2026-07-17"
+            / "config_sha256.txt"
         )
 
     def test_config_file_exists(self, config_path: Path) -> None:
@@ -75,6 +88,7 @@ class TestDoorwayButterflyReexportConfig:
 
         # Observation noise disabled
         assert config["observation_noise"]["enabled"] is False
+        assert config["doi"] is None
 
         # Planner
         assert len(config["planners"]) == 1
@@ -101,6 +115,7 @@ class TestDoorwayButterflyReexportConfig:
         assert manifest["issue"] == 5948
         assert manifest["run_identification"]["slurm_job_id"] == 13483
         assert manifest["run_identification"]["config_hash_from_run"] == "846e99aaba7dff51"
+        assert manifest["review_marker"] == "AI-GENERATED NEEDS-REVIEW"
         assert (
             manifest["durable_bundle"]["sha256"]
             == "1a434946d774a5550ec3791ec6a829768fab5ce058c7a9ec4db9d43711780dff"
@@ -123,3 +138,21 @@ class TestDoorwayButterflyReexportConfig:
         assert config["horizon"] == recon["horizon"]
         assert config["dt"] == recon["dt"]
         assert config["workers"] == recon["workers"]
+        assert config["snqi_weights"] == recon["snqi_weights"]
+        assert config["snqi_contract"]["enforcement"] == recon["snqi_enforcement"]
+        assert config["amv_contract"]["profile"] == recon["amv_profile"]
+        assert config["amv_contract"]["status"] == recon["amv_status"]
+        assert config["observation_noise"]["enabled"] == recon["observation_noise_enabled"]
+        assert config["paper_facing"] == recon["paper_facing"]
+
+    def test_config_hash_record_matches_config(
+        self, config_path: Path, config_hash_path: Path
+    ) -> None:
+        """Verify the README-listed config hash is bound to the committed bytes."""
+        assert config_hash_path.exists()
+        lines = config_hash_path.read_text(encoding="utf-8").splitlines()
+        assert lines[0] == "# AI-GENERATED NEEDS-REVIEW"
+        recorded_hash, recorded_path = lines[1].split(maxsplit=1)
+        assert recorded_path == "configs/benchmarks/doorway_butterfly_trace_reexport.yaml"
+        actual_hash = hashlib.sha256(config_path.read_bytes()).hexdigest()
+        assert recorded_hash == actual_hash


### PR DESCRIPTION
## What/Why

This PR reconstructs and commits the lost campaign config from job 13483 (doorway butterfly trace re-export), registers durable provenance through the external-data-plane convention, and records the producer-side durability rule established by issue #5948.

## Changes

- Adds `configs/benchmarks/doorway_butterfly_trace_reexport.yaml`, reconstructed from the authoritative job summary and the actual 30-seed run.
- Adds the reviewed provenance README, manifest, run-summary reconstruction, and bound config SHA-256 record under `docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/`.
- Registers every evidence artifact in `docs/context/catalog.yaml` and carries the required AI-GENERATED/NEEDS-REVIEW markers.
- Removes the unavailable DOI placeholder (`doi: null`) and tests every reconstructed SNQI, AMV, observation-noise, and paper-facing parameter.

## Validation

The focused provenance tests and the named docs-evidence/PR-contract mechanical checks pass on the refreshed head.

## Scope and successor statement

This is the config/provenance slice of issue #5948. The broader producer-code durability decision remains tracked by #5893, so this PR references rather than closes #5948.

This PR was produced by the SAIA/Qwen3.5-397B-A17B cheap implementation lane; the review gate hardens and hands off the merge-ready result.

Refs #5948
Refs #5893
