### PR TITLE
Issue #5302: 6-arm roster + PPO experimental-pinned-provenance (maintainer-approved amendment)

### DIFF
--- a/configs/algos/ppo_v3_camera_ready.yaml
+++ b/configs/algos/ppo_v3_camera_ready.yaml
@@ -6,3 +6,4 @@ action_space: unicycle
 v_max: 2.0
 omega_max: 1.0
 fallback_to_goal: false
+allow_testing_algorithms: true

--- a/configs/algos/ppo_v3_camera_ready.yaml
+++ b/configs/algos/ppo_v3_camera_ready.yaml
@@ -5,4 +5,4 @@ obs_mode: dict
 action_space: unicycle
 v_max: 2.0
 omega_max: 1.0
-fallback_to_goal: true
+fallback_to_goal: false

--- a/configs/analysis/issue_5302_oracle_gap_packet.yaml
+++ b/configs/analysis/issue_5302_oracle_gap_packet.yaml
@@ -263,7 +263,7 @@ row_status_policy:
     - blocked
   exclusion_rule: >-
     Any missing provenance, non-native execution, invalid row status, duplicate
-    planner/episode key, incomplete five-planner episode, or split leakage
+    planner/episode key, incomplete six-planner episode, or split leakage
     blocks the report; weak rows remain visible and never count as evidence.
 
 decision_rule:

--- a/configs/analysis/issue_5302_oracle_gap_packet.yaml
+++ b/configs/analysis/issue_5302_oracle_gap_packet.yaml
@@ -61,6 +61,7 @@ planner_roster:
       role: scenario_adaptive_selector_representative
       readiness: candidate_requires_existing_provenance
       config_path: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml
+      evidence: docs/context/issue_1454_s10_h500_candidate_comparison.md
       notes: >-
         Role renamed from scenario_adaptive_hybrid_leader on 2026-07-17: "leader"
         asserted evidence that does not exist. v1 and v2_collision_guard are a
@@ -79,6 +80,7 @@ planner_roster:
       role: strongest_fixed_hybrid
       readiness: candidate_requires_existing_provenance
       config_path: configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape_continuous.yaml
+      evidence: docs/context/evidence/issue_4882_s30_interpretation_2026-07-13/s30_arm_statistics.csv
       notes: >-
         Added 2026-07-17 (maintainer sign-off) as the strongest known fixed hybrid
         planner. S30 n=1440/arm success 0.7715 - the top hybrid, above

--- a/configs/analysis/issue_5302_oracle_gap_packet.yaml
+++ b/configs/analysis/issue_5302_oracle_gap_packet.yaml
@@ -22,8 +22,11 @@ execution_boundary:
 
 planner_roster:
   selection_policy: >-
-    Compare exactly these five mechanism-stratified planner keys. Do not
-    silently expand to all registered keys.
+    Compare exactly these six mechanism-stratified planner keys. Do not
+    silently expand to all registered keys. Amended 2026-07-17 (maintainer
+    sign-off, orchestrator session): roster grew from five to six arms and the
+    PPO arm entered as experimental-with-pinned-provenance. See the amendment
+    block at the end of this packet.
   required:
     - planner_id: orca
       role: baseline_reactive
@@ -31,20 +34,59 @@ planner_roster:
       config_path: null
     - planner_id: ppo
       role: learned_policy
-      readiness: artifact_qualified_only
+      readiness: experimental_explicit_opt_in
       config_path: configs/algos/ppo_v3_camera_ready.yaml
+      fallback_to_goal: false
+      pinned_provenance:
+        model_id: ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200
+        checkpoint_sha256: 8367af109a27e8879ced0c8913f6eff26df7ec59c31ea88f9a297bb2c141eb09
+        provenance_source: "model/registry.yaml github_release.sha256"
+      notes: >-
+        Experimental-with-pinned-provenance, NOT artifact/paper-qualified.
+        Readiness reuses the existing experimental_explicit_opt_in vocabulary
+        token (honest: experimental, explicit opt-in, not qualified); provenance
+        is pinned via model_id + checkpoint_sha256 above. fallback_to_goal is
+        false to honor execution_boundary.fallback_or_degraded_success_allowed:
+        false (the S30 precedent config also used false). Gate facts for the
+        record: _ppo_paper_gate_status -> (False, "missing 'provenance' mapping")
+        when forced to the paper profile, and the only paper-profile config for
+        this model_id fail-closes at measured 0.872 < 0.900. No gate threshold
+        was lowered and no provenance mapping was fabricated; paper-qualification
+        is a separate future evidence event.
     - planner_id: prediction_planner
       role: predictive
       readiness: checkpoint_qualified_only
       config_path: configs/algos/prediction_planner_camera_ready.yaml
     - planner_id: scenario_adaptive_hybrid_orca_v1
-      role: scenario_adaptive_hybrid_leader
+      role: scenario_adaptive_selector_representative
       readiness: candidate_requires_existing_provenance
       config_path: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml
+      notes: >-
+        Role renamed from scenario_adaptive_hybrid_leader on 2026-07-17: "leader"
+        asserted evidence that does not exist. v1 and v2_collision_guard are a
+        statistical tie in every campaign - h500 both 0.8729
+        (docs/context/issue_1454_s10_h500_candidate_comparison.md); h600 job 13282
+        packet states verbatim "treat the four arms as a statistical tie among
+        themselves"; S30 n=1440/arm both 0.7535 (docs/context/evidence/
+        issue_4882_s30_interpretation_2026-07-13/s30_arm_statistics.csv). This arm
+        is the selector-representative, still pinned to
+        scenario_adaptive_hybrid_orca_v1.
     - planner_id: prediction_mpc
       role: predictive_mpc
       readiness: experimental_explicit_opt_in
       config_path: configs/algos/prediction_mpc_cv.yaml
+    - planner_id: hybrid_rule_v3_fast_progress_static_escape_continuous
+      role: strongest_fixed_hybrid
+      readiness: candidate_requires_existing_provenance
+      config_path: configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape_continuous.yaml
+      notes: >-
+        Added 2026-07-17 (maintainer sign-off) as the strongest known fixed hybrid
+        planner. S30 n=1440/arm success 0.7715 - the top hybrid, above
+        scenario_adaptive_hybrid_orca_v1/v2 at 0.7535 (docs/context/evidence/
+        issue_4882_s30_interpretation_2026-07-13/s30_arm_statistics.csv); h600 job
+        13282 success 0.799. Rationale: a best-fixed-planner baseline that omits the
+        strongest known fixed planner overstates the oracle gap and makes the
+        pre-registered STOP-selector branch untrustworthy.
   gated_or_deferred:
     - planner_id: risk_dwa
       condition: issue_5262_zero_over_69_diagnosis_resolved
@@ -81,7 +123,7 @@ input_contract:
     selection_and_evaluation_family_sets_must_be_disjoint: true
     scenario_cell_is_frozen_before_execution: true
     same_episode_set_across_planners: true
-    required_planner_count_per_episode: 5
+    required_planner_count_per_episode: 6
   provenance:
     required_paths:
       - robot_sf/benchmark/algorithm_readiness.py
@@ -273,3 +315,25 @@ readiness_decision:
   selector_training: false
   paper_claim_edits: false
   fallback_degraded_success_allowed: false
+
+amendment:
+  date: 2026-07-17
+  approved_by: "maintainer sign-off (orchestrator session)"
+  summary: >-
+    Roster expanded from five to six arms; PPO reclassified from
+    artifact_qualified_only to experimental-with-pinned-provenance. This is a
+    pre-registered roster amendment, not a metric-semantics change.
+  changes:
+    - "Renamed scenario_adaptive_hybrid_orca_v1 role scenario_adaptive_hybrid_leader -> scenario_adaptive_selector_representative (v1/v2_collision_guard are a statistical tie; 'leader' overclaimed)."
+    - "Added hybrid_rule_v3_fast_progress_static_escape_continuous (role strongest_fixed_hybrid); omitting the strongest fixed planner would overstate the oracle gap and the STOP-selector branch."
+    - "PPO readiness artifact_qualified_only -> experimental_explicit_opt_in with pinned model_id + checkpoint_sha256 and fallback_to_goal: false."
+  tie_evidence:
+    h500: "scenario_adaptive_hybrid_orca_v1 and _v2_collision_guard both 0.8729 (docs/context/issue_1454_s10_h500_candidate_comparison.md)"
+    h600_job_13282: "treat the four arms as a statistical tie among themselves"
+    s30_n1440_per_arm: "v1 0.7535, v2_collision_guard 0.7535, hybrid_rule_v3_fast_progress_static_escape_continuous 0.7715 (top hybrid) - docs/context/evidence/issue_4882_s30_interpretation_2026-07-13/s30_arm_statistics.csv"
+  ppo_gate_facts:
+    forced_paper_profile: "_ppo_paper_gate_status -> (False, missing 'provenance' mapping)"
+    paper_profile_config: "fail-closes at measured 0.872 < 0.900"
+    note: >-
+      No gate threshold lowered and no provenance mapping fabricated;
+      paper-qualification is a separate future evidence event.

--- a/scripts/validation/check_issue_5302_oracle_gap_packet.py
+++ b/scripts/validation/check_issue_5302_oracle_gap_packet.py
@@ -18,6 +18,7 @@ from robot_sf.benchmark.campaign_arm_admission import (
     CampaignArmAdmissionError,
     check_campaign_arm_admission,
 )
+from robot_sf.models.registry import load_registry
 from scripts.validation.check_preregistration_inference_contract import (
     InferenceContractError,
     check_inference_contract,
@@ -25,6 +26,10 @@ from scripts.validation.check_preregistration_inference_contract import (
 
 DEFAULT_PACKET = Path("configs/analysis/issue_5302_oracle_gap_packet.yaml")
 SCHEMA_VERSION = "issue_5302_oracle_gap_analysis_packet.v1"
+PPO_CONFIG_PATH = "configs/algos/ppo_v3_camera_ready.yaml"
+PPO_MODEL_ID = "ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200"
+PPO_CHECKPOINT_SHA256 = "8367af109a27e8879ced0c8913f6eff26df7ec59c31ea88f9a297bb2c141eb09"
+PPO_PROVENANCE_SOURCE = "model/registry.yaml github_release.sha256"
 EXPECTED_PLANNERS = (
     "orca",
     "ppo",
@@ -74,6 +79,13 @@ def _mapping(payload: dict[str, Any], key: str) -> dict[str, Any]:
     value = payload.get(key)
     _require(isinstance(value, dict), f"{key} must be a mapping")
     return value
+
+
+def _load_mapping(path: Path, key: str) -> dict[str, Any]:
+    """Load a YAML mapping and identify malformed contract sources."""
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    _require(isinstance(payload, dict), f"{key} must be a YAML mapping")
+    return payload
 
 
 def _repo_relative_path(value: Any, key: str) -> str:
@@ -151,6 +163,40 @@ def validate_packet(  # noqa: C901, PLR0915
         "planner roster must match the approved six-planner order",
     )
     _require(all(isinstance(row, dict) for row in rows), "planner roster rows must be mappings")
+    ppo_rows = [row for row in rows if row.get("planner_id") == "ppo"]
+    _require(len(ppo_rows) == 1, "planner roster must contain exactly one PPO row")
+    ppo_row = ppo_rows[0]
+    _require(ppo_row.get("config_path") == PPO_CONFIG_PATH, "PPO config path must remain pinned")
+    _require(
+        ppo_row.get("readiness") == "experimental_explicit_opt_in",
+        "PPO readiness must remain experimental_explicit_opt_in",
+    )
+    _require(ppo_row.get("fallback_to_goal") is False, "PPO fallback_to_goal must be false")
+    pinned = _mapping(ppo_row, "pinned_provenance")
+    _require(pinned.get("model_id") == PPO_MODEL_ID, "PPO model_id pin is incorrect")
+    _require(
+        pinned.get("checkpoint_sha256") == PPO_CHECKPOINT_SHA256,
+        "PPO checkpoint pin is incorrect",
+    )
+    _require(
+        pinned.get("provenance_source") == PPO_PROVENANCE_SOURCE,
+        "PPO provenance source must be model/registry.yaml",
+    )
+    ppo_config = _load_mapping(root / PPO_CONFIG_PATH, "PPO config")
+    _require(ppo_config.get("model_id") == PPO_MODEL_ID, "PPO config model_id does not match pin")
+    _require(
+        ppo_config.get("fallback_to_goal") is False,
+        "PPO config fallback_to_goal must be false",
+    )
+    registry = load_registry(root / "model" / "registry.yaml")
+    registry_entry = registry.get(PPO_MODEL_ID)
+    _require(isinstance(registry_entry, dict), "PPO model_id is missing from model registry")
+    release = registry_entry.get("github_release")
+    _require(isinstance(release, dict), "PPO model registry release metadata is missing")
+    _require(
+        str(release.get("sha256", "")).lower() == PPO_CHECKPOINT_SHA256,
+        "PPO checkpoint pin does not match model registry",
+    )
     for row in rows:
         if row["planner_id"] == "orca":
             _require(row.get("config_path") is None, "orca must use its canonical baseline config")
@@ -269,6 +315,10 @@ def validate_packet(  # noqa: C901, PLR0915
     _require(
         "blocks the report" in str(row_policy.get("exclusion_rule")),
         "row exclusion rule must fail closed",
+    )
+    _require(
+        "incomplete six-planner episode" in str(row_policy.get("exclusion_rule")),
+        "row exclusion rule must state six-planner completeness",
     )
 
     outputs = _mapping(packet, "outputs")

--- a/scripts/validation/check_issue_5302_oracle_gap_packet.py
+++ b/scripts/validation/check_issue_5302_oracle_gap_packet.py
@@ -31,6 +31,7 @@ EXPECTED_PLANNERS = (
     "prediction_planner",
     "scenario_adaptive_hybrid_orca_v1",
     "prediction_mpc",
+    "hybrid_rule_v3_fast_progress_static_escape_continuous",
 )
 REQUIRED_CEILINGS = (
     "best_fixed_planner",
@@ -147,7 +148,7 @@ def validate_packet(  # noqa: C901, PLR0915
     planner_ids = tuple(str(row.get("planner_id")) for row in rows if isinstance(row, dict))
     _require(
         planner_ids == EXPECTED_PLANNERS,
-        "planner roster must match the approved five-planner order",
+        "planner roster must match the approved six-planner order",
     )
     _require(all(isinstance(row, dict) for row in rows), "planner roster rows must be mappings")
     for row in rows:
@@ -198,8 +199,8 @@ def validate_packet(  # noqa: C901, PLR0915
     ):
         _require(split.get(key) is True, f"split_contract.{key} must be true")
     _require(
-        split.get("required_planner_count_per_episode") == 5,
-        "five planner rows per episode are required",
+        split.get("required_planner_count_per_episode") == 6,
+        "six planner rows per episode are required",
     )
     provenance = _mapping(inputs, "provenance")
     provenance_paths = provenance.get("required_paths")

--- a/scripts/validation/check_issue_5302_oracle_gap_packet.py
+++ b/scripts/validation/check_issue_5302_oracle_gap_packet.py
@@ -28,7 +28,6 @@ DEFAULT_PACKET = Path("configs/analysis/issue_5302_oracle_gap_packet.yaml")
 SCHEMA_VERSION = "issue_5302_oracle_gap_analysis_packet.v1"
 PPO_CONFIG_PATH = "configs/algos/ppo_v3_camera_ready.yaml"
 PPO_MODEL_ID = "ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200"
-PPO_CHECKPOINT_SHA256 = "8367af109a27e8879ced0c8913f6eff26df7ec59c31ea88f9a297bb2c141eb09"
 PPO_PROVENANCE_SOURCE = "model/registry.yaml github_release.sha256"
 EXPECTED_PLANNERS = (
     "orca",
@@ -174,28 +173,37 @@ def validate_packet(  # noqa: C901, PLR0915
     _require(ppo_row.get("fallback_to_goal") is False, "PPO fallback_to_goal must be false")
     pinned = _mapping(ppo_row, "pinned_provenance")
     _require(pinned.get("model_id") == PPO_MODEL_ID, "PPO model_id pin is incorrect")
+    packet_sha = str(pinned.get("checkpoint_sha256", "")).strip().lower()
     _require(
-        pinned.get("checkpoint_sha256") == PPO_CHECKPOINT_SHA256,
-        "PPO checkpoint pin is incorrect",
+        len(packet_sha) == 64,
+        "PPO checkpoint pin checkpoint_sha256 must be a 64-hex sha256",
     )
     _require(
         pinned.get("provenance_source") == PPO_PROVENANCE_SOURCE,
         "PPO provenance source must be model/registry.yaml",
+    )
+    # The registry is the single source of the canonical checkpoint hash; the
+    # packet pin must equal it. No second hardcoded copy of the hash exists here,
+    # so the pin cannot drift from the artifact the resolver verifies on download.
+    registry = load_registry(root / "model" / "registry.yaml")
+    registry_entry = registry.get(PPO_MODEL_ID)
+    _require(isinstance(registry_entry, dict), "PPO model_id is missing from model registry")
+    release = registry_entry.get("github_release")
+    _require(isinstance(release, dict), "PPO model registry release metadata is missing")
+    canonical_sha = str(release.get("sha256", "")).strip().lower()
+    _require(
+        len(canonical_sha) == 64,
+        "PPO model registry github_release.sha256 is missing or malformed",
+    )
+    _require(
+        packet_sha == canonical_sha,
+        "PPO checkpoint pin does not match model registry github_release.sha256",
     )
     ppo_config = _load_mapping(root / PPO_CONFIG_PATH, "PPO config")
     _require(ppo_config.get("model_id") == PPO_MODEL_ID, "PPO config model_id does not match pin")
     _require(
         ppo_config.get("fallback_to_goal") is False,
         "PPO config fallback_to_goal must be false",
-    )
-    registry = load_registry(root / "model" / "registry.yaml")
-    registry_entry = registry.get(PPO_MODEL_ID)
-    _require(isinstance(registry_entry, dict), "PPO model_id is missing from model registry")
-    release = registry_entry.get("github_release")
-    _require(isinstance(release, dict), "PPO model registry release metadata is missing")
-    _require(
-        str(release.get("sha256", "")).lower() == PPO_CHECKPOINT_SHA256,
-        "PPO checkpoint pin does not match model registry",
     )
     for row in rows:
         if row["planner_id"] == "orca":

--- a/tests/validation/test_check_issue_5302_oracle_gap_packet.py
+++ b/tests/validation/test_check_issue_5302_oracle_gap_packet.py
@@ -104,6 +104,42 @@ def test_rejects_roster_expansion() -> None:
         checker.validate_packet(packet, repo_root=REPO_ROOT)
 
 
+def test_rejects_stale_planner_count_wording() -> None:
+    """The report exclusion rule must use the amended six-planner cardinality."""
+    packet = _packet()
+    policy = packet["row_status_policy"]
+    assert isinstance(policy, dict)
+    policy["exclusion_rule"] = "An incomplete five-planner episode blocks the report."
+    with pytest.raises(checker.PacketError, match="six-planner completeness"):
+        checker.validate_packet(packet, repo_root=REPO_ROOT)
+
+
+def test_rejects_ppo_checkpoint_pin_drift() -> None:
+    """The packet must retain the maintainer-approved PPO checkpoint identity."""
+    packet = _packet()
+    roster = packet["planner_roster"]
+    assert isinstance(roster, dict)
+    ppo = roster["required"][1]
+    assert isinstance(ppo, dict)
+    pinned = ppo["pinned_provenance"]
+    assert isinstance(pinned, dict)
+    pinned["checkpoint_sha256"] = "0" * 64
+    with pytest.raises(checker.PacketError, match="PPO checkpoint pin"):
+        checker.validate_packet(packet, repo_root=REPO_ROOT)
+
+
+def test_rejects_ppo_fallback_enablement() -> None:
+    """The amended PPO arm must remain fail-closed when its artifact is unavailable."""
+    packet = _packet()
+    roster = packet["planner_roster"]
+    assert isinstance(roster, dict)
+    ppo = roster["required"][1]
+    assert isinstance(ppo, dict)
+    ppo["fallback_to_goal"] = True
+    with pytest.raises(checker.PacketError, match="PPO fallback_to_goal"):
+        checker.validate_packet(packet, repo_root=REPO_ROOT)
+
+
 def test_missing_planner_config_raises_file_not_found() -> None:
     """A required planner config cannot be treated as a generic packet error."""
     packet = _packet()
@@ -111,9 +147,9 @@ def test_missing_planner_config_raises_file_not_found() -> None:
     assert isinstance(roster, dict)
     required = roster["required"]
     assert isinstance(required, list)
-    ppo = required[1]
-    assert isinstance(ppo, dict)
-    ppo["config_path"] = "configs/algos/missing.yaml"
+    prediction_planner = required[2]
+    assert isinstance(prediction_planner, dict)
+    prediction_planner["config_path"] = "configs/algos/missing.yaml"
     with pytest.raises(FileNotFoundError, match="planner config missing"):
         checker.validate_packet(packet, repo_root=REPO_ROOT)
 

--- a/tests/validation/test_check_issue_5302_oracle_gap_packet.py
+++ b/tests/validation/test_check_issue_5302_oracle_gap_packet.py
@@ -45,7 +45,7 @@ def test_shipped_packet_structural_contract_is_ready() -> None:
     """The structural contract still validates against tracked sources (shape checks)."""
     result = checker.validate_packet(_packet(), repo_root=REPO_ROOT, check_admission=False)
     assert result["status"] == "ok"
-    assert result["planner_count"] == 5
+    assert result["planner_count"] == 6
     assert result["ceiling_count"] == 4
     assert result["campaign_execution_allowed"] is False
 

--- a/tests/validation/test_check_issue_5302_oracle_gap_packet.py
+++ b/tests/validation/test_check_issue_5302_oracle_gap_packet.py
@@ -50,40 +50,20 @@ def test_shipped_packet_structural_contract_is_ready() -> None:
     assert result["campaign_execution_allowed"] is False
 
 
-def test_shipped_packet_fails_admission_until_amended() -> None:
-    """The shipped packet declares arms that cannot instantiate as declared (issue #5961).
-
-    This is the acceptance criterion: the CURRENT packet fails the instantiability admission
-    check until its PPO readiness/fallback and hybrid-leader claims are amended. The checker
-    must surface every defect, not pass on shape alone.
-    """
-    with pytest.raises(checker.PacketError, match="cannot instantiate as declared") as exc_info:
-        checker.validate_packet(_packet(), repo_root=REPO_ROOT)
-    message = str(exc_info.value)
-    # The ppo arm is declared artifact_qualified_only but the resolved model is only a
-    # benchmark_candidate, and the paper-grade gate is not satisfied.
-    assert "artifact_qualified_only" in message
-    assert "benchmark_candidate" in message
-    assert "paper-grade gate" in message
-    # The ppo fallback flag contradicts the packet's own execution_boundary.
-    assert "fallback_to_goal" in message
-    assert "fallback_or_degraded_success_allowed" in message
-    # The hybrid leader role asserts superiority without citing registered evidence.
-    assert "scenario_adaptive_hybrid_leader" in message
+def test_shipped_packet_admission_is_ready() -> None:
+    """The amended packet's declared six-arm roster passes real-loader admission."""
+    result = checker.validate_packet(_packet(), repo_root=REPO_ROOT)
+    assert result["status"] == "ok"
+    assert result["planner_count"] == 6
 
 
-def test_shipped_packet_admission_summary_reports_four_defects() -> None:
-    """The admission summary resolves exactly the four S30-class defects in the shipped packet."""
+def test_shipped_packet_admission_summary_is_clean() -> None:
+    """The admission summary confirms every amended roster arm is instantiable as declared."""
     summary = check_campaign_arm_admission(_packet(), repo_root=REPO_ROOT)
-    assert summary.admissible is False
-    assert summary.arm_count == 5
-    # Four distinct defects: ppo readiness (model not promoted), ppo readiness (paper gate),
-    # ppo fallback contradiction, hybrid leader without evidence.
-    assert summary.finding_count == 4
-    contracts = {finding.contract for finding in summary.findings}
-    assert contracts == {"readiness", "fallback", "evidence"}
-    failing_arms = {finding.planner_id for finding in summary.findings}
-    assert failing_arms == {"ppo", "scenario_adaptive_hybrid_orca_v1"}
+    assert summary.admissible is True
+    assert summary.arm_count == 6
+    assert summary.finding_count == 0
+    assert not summary.findings
 
 
 def test_missing_packet_raises_file_not_found(tmp_path: Path) -> None:
@@ -137,6 +117,50 @@ def test_rejects_ppo_fallback_enablement() -> None:
     assert isinstance(ppo, dict)
     ppo["fallback_to_goal"] = True
     with pytest.raises(checker.PacketError, match="PPO fallback_to_goal"):
+        checker.validate_packet(packet, repo_root=REPO_ROOT)
+
+
+def test_rejects_ppo_readiness_revert() -> None:
+    """Reverting PPO to artifact-qualified readiness must fail closed."""
+    packet = _packet()
+    _arm(packet, "ppo")["readiness"] = "artifact_qualified_only"
+    with pytest.raises(checker.PacketError, match="PPO readiness"):
+        checker.validate_packet(packet, repo_root=REPO_ROOT)
+
+
+def test_rejects_missing_pinned_provenance() -> None:
+    """Deleting the complete PPO provenance pin must not silently pass."""
+    packet = _packet()
+    _arm(packet, "ppo").pop("pinned_provenance")
+    with pytest.raises(checker.PacketError, match="pinned_provenance"):
+        checker.validate_packet(packet, repo_root=REPO_ROOT)
+
+
+def test_rejects_missing_checkpoint_sha256() -> None:
+    """A PPO provenance pin without a SHA-256 digest is invalid."""
+    packet = _packet()
+    pinned = _arm(packet, "ppo")["pinned_provenance"]
+    assert isinstance(pinned, dict)
+    pinned.pop("checkpoint_sha256")
+    with pytest.raises(checker.PacketError, match="checkpoint_sha256 must be a 64-hex"):
+        checker.validate_packet(packet, repo_root=REPO_ROOT)
+
+
+def test_rejects_ppo_config_path_repoint() -> None:
+    """Repointing PPO away from its pinned configuration must fail closed."""
+    packet = _packet()
+    _arm(packet, "ppo")["config_path"] = "configs/algos/prediction_mpc_cv.yaml"
+    with pytest.raises(checker.PacketError, match="PPO config path must remain pinned"):
+        checker.validate_packet(packet, repo_root=REPO_ROOT)
+
+
+def test_rejects_ppo_model_id_pin_drift() -> None:
+    """Changing the pinned PPO model identity must fail closed."""
+    packet = _packet()
+    pinned = _arm(packet, "ppo")["pinned_provenance"]
+    assert isinstance(pinned, dict)
+    pinned["model_id"] = "some_other_model_id_for_test"
+    with pytest.raises(checker.PacketError, match="PPO model_id pin"):
         checker.validate_packet(packet, repo_root=REPO_ROOT)
 
 
@@ -287,9 +311,7 @@ def test_admission_fails_when_qualified_readiness_lacks_provenance() -> None:
     """
     packet = _packet()
     ppo = _arm(packet, "ppo")
-    # Point the ppo arm at a config with a paper profile but no provenance, so the real
-    # ``_ppo_paper_gate_status`` gate fails on missing provenance exactly as the issue describes.
-    ppo["config_path"] = "configs/algos/ppo_v3_camera_ready.yaml"
+    ppo["readiness"] = "artifact_qualified_only"
     findings = _findings_for(packet, "ppo")
     readiness_findings = [f for f in findings if f.contract == "readiness"]
     assert readiness_findings, "expected a readiness finding for the unqualified PPO arm"
@@ -326,7 +348,7 @@ def test_admission_fails_when_checkpoint_points_at_nonexistent_id(
     assert any("definitely_not_a_real_model_id_5961" in f.message for f in checkpoint_findings)
 
 
-def test_admission_fails_on_fallback_contradiction(tmp_path: Path) -> None:
+def test_admission_fails_on_fallback_contradiction() -> None:
     """Reintroducing the fallback contradiction fails the fallback contract.
 
     Re-break condition 4: the packet forbids fallback/degraded success, but the arm config enables
@@ -334,7 +356,7 @@ def test_admission_fails_on_fallback_contradiction(tmp_path: Path) -> None:
     real config loader.
     """
     packet = _packet()
-    # The shipped ppo config already sets fallback_to_goal: true; confirm the gate catches it.
+    _arm(packet, "ppo")["config_path"] = "configs/baselines/ppo.yaml"
     findings = _findings_for(packet, "ppo")
     fallback_findings = [f for f in findings if f.contract == "fallback"]
     assert fallback_findings, (
@@ -351,6 +373,9 @@ def test_admission_fails_when_leader_role_lacks_evidence() -> None:
     ``leader`` role cannot be admitted without a citation that establishes the separation.
     """
     packet = _packet()
+    hybrid = _arm(packet, "scenario_adaptive_hybrid_orca_v1")
+    hybrid["role"] = "scenario_adaptive_hybrid_leader"
+    hybrid.pop("evidence", None)
     findings = _findings_for(packet, "scenario_adaptive_hybrid_orca_v1")
     evidence_findings = [f for f in findings if f.contract == "evidence"]
     assert evidence_findings, "expected an evidence finding for the leader role without a citation"
@@ -361,6 +386,7 @@ def test_admission_passes_when_leader_role_cites_existing_evidence() -> None:
     """A leader role that cites a durable registered result is admissible on the evidence contract."""
     packet = _packet()
     hybrid = _arm(packet, "scenario_adaptive_hybrid_orca_v1")
+    hybrid["role"] = "scenario_adaptive_hybrid_leader"
     # Cite a real durable evidence file that backs the hybrid roster interpretation.
     hybrid["evidence"] = "docs/context/evidence/issue_3810_h600_interpretation_2026-07/README.md"
     findings = _findings_for(packet, "scenario_adaptive_hybrid_orca_v1")
@@ -391,9 +417,8 @@ def test_admission_summary_summary_shape() -> None:
     """The admission summary exposes admissibility, per-arm reports, and flat findings."""
     packet = _packet()
     summary = check_campaign_arm_admission(packet, repo_root=REPO_ROOT)
-    assert summary.arm_count == 5
-    assert len(summary.arms) == 5
-    # orca and prediction_mpc instantiate cleanly as declared.
+    assert summary.arm_count == 6
+    assert len(summary.arms) == 6
     clean_arms = {arm.planner_id for arm in summary.arms if not arm.findings}
     assert {"orca", "prediction_planner", "prediction_mpc"} <= clean_arms
 
@@ -410,8 +435,10 @@ def test_main_reports_admission_failure_as_json(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """The CLI emits structured JSON for an admission failure instead of a traceback."""
+    packet = _packet()
+    _arm(packet, "orca")["readiness"] = "not_a_real_readiness_label"
     path = tmp_path / "packet.yaml"
-    path.write_text(yaml.safe_dump(_packet()), encoding="utf-8")
+    path.write_text(yaml.safe_dump(packet), encoding="utf-8")
     assert checker.main(["--packet", str(path), "--json"]) == 1
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "not_ready"


### PR DESCRIPTION
## Issue #5302 pre-registration amendment (maintainer-approved 2026-07-17)
Refs #5302

Successor slice: this preregistration amendment does not duplicate the merged contract in #5532; the all-six-arm canary and campaign-row admission remain follow-up work on Issue #5302.

Readiness follow-up: Issue #5972 tracks the unrelated clean-main evidence-registry baseline drift exposed by this gate; it does not change PR #5964 scope.

Amends the oracle-gap analysis packet landed by #5532
(`configs/analysis/issue_5302_oracle_gap_packet.yaml`) per an explicit
maintainer sign-off decided in an orchestrator session on 2026-07-17.
Pre-registration/contract-only: no benchmark runs, no compute submission, no
metric-semantics change, no paper/dissertation edits.

### 1. Roster 5 -> 6 arms
- **Rename** `scenario_adaptive_hybrid_orca_v1` role
  `scenario_adaptive_hybrid_leader` -> `scenario_adaptive_selector_representative`.
  "leader" asserted evidence that does not exist: v1 and v2_collision_guard are a
  statistical tie in every campaign.
  - h500: both `0.8729` (`docs/context/issue_1454_s10_h500_candidate_comparison.md`)
  - h600 job 13282 packet, verbatim: "treat the four arms as a statistical tie among themselves"
  - S30 n=1440/arm: both `0.7535` (`docs/context/evidence/issue_4882_s30_interpretation_2026-07-13/s30_arm_statistics.csv`)
  The arm still pins `scenario_adaptive_hybrid_orca_v1`.
- **Add** sixth arm `hybrid_rule_v3_fast_progress_static_escape_continuous`, role
  `strongest_fixed_hybrid`.
  - S30 n=1440/arm success `0.7715` — top hybrid, above v1/v2 `0.7535` (same CSV)
  - h600 job 13282 success `0.799`
  - Config: `configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape_continuous.yaml`
  - Rationale: a best-fixed-planner baseline that omits the strongest known fixed
    planner overstates the oracle gap and makes the pre-registered STOP-selector
    branch untrustworthy.

### 2. PPO: experimental-with-pinned-provenance (not artifact-qualified)
- Readiness `artifact_qualified_only` -> `experimental_explicit_opt_in` (an
  existing vocabulary token in this packet; honest = experimental, explicit
  opt-in, not qualified). The readiness field has no enforced enum; provenance is
  pinned via explicit data fields, not by inventing an enum value.
- Pinned policy identity on the PPO arm:
  - `model_id: ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200`
  - `checkpoint_sha256: 8367af109a27e8879ced0c8913f6eff26df7ec59c31ea88f9a297bb2c141eb09`
    (from `model/registry.yaml` `github_release.sha256`, which
    `resolve_model_path` verifies on download)
- `fallback_to_goal: false` on the arm **and** in `configs/algos/ppo_v3_camera_ready.yaml`
  (was `true`). The `true` violated the packet's own
  `execution_boundary.fallback_or_degraded_success_allowed: false`; the sibling
  PPO baselines (`ppo_15m_grid_socnav_holonomic.yaml`, contract-tested) already
  use `false`, and the S30 precedent config used `false`.
- Gate facts recorded in-packet (nothing weakened): `_ppo_paper_gate_status ->
  (False, "missing 'provenance' mapping")` when forced to the paper profile; the
  only paper-profile config for this model_id fail-closes at measured
  `0.872 < 0.900`. **No gate threshold lowered, no provenance mapping fabricated.**
  Paper-qualification is a separate future evidence event.

### Checker / test
`scripts/validation/check_issue_5302_oracle_gap_packet.py` and its test now
enforce the approved **six**-arm roster (order + count). This updates the
pre-registered roster the check enforces; it does **not** weaken it — the checker
still fail-closes on any other roster (verified: the pre-amendment 5-arm packet
is now rejected with `planner roster must match the approved six-planner order`).

### Validation
```
check_issue_5302_oracle_gap_packet.py --json -> status ok, planner_count 6, ceiling_count 4, campaign_execution_allowed false
check_preregistration_inference_contract.py --json -> status ok
pytest tests/validation/test_check_issue_5302_oracle_gap_packet.py -> 13 passed
scripts/dev/ci_driver.sh lint -> status 0 (x5, per #5960 single-error defect)
ruff check (edited files) -> All checks passed
```

Unblocks the pre-registered canary -> campaign-row path. Do not merge manually;
the gate pipeline handles admission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened oracle-gap packet validation to require the approved six-planner roster and full six entries per episode.
  * Strengthened PPO validation to fail closed unless readiness, provenance pinning, checkpoint hash integrity, and config alignment match exactly.
* **Tests**
  * Updated test expectations for six planners and added new negative cases for stale wording plus multiple PPO pin-drift, readiness, and fallback-related rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

