### PR TITLE
Issue #5965: distinguish stacked-PR bases from main (cheap-lane worker)

### DIFF
--- a/scripts/dev/check_pr_merge_staleness.py
+++ b/scripts/dev/check_pr_merge_staleness.py
@@ -16,9 +16,16 @@ since the PR's CI last ran.  Two detection layers are used:
    stale main and both passed individually.
 
 Exit codes:
-  0  PR merge base matches current main (not stale).
-  1  PR is stale; main has moved since CI ran.
-  2  Could not determine; warn and let the caller decide.
+   0  PR merge base matches current main (not stale).
+   1  PR is stale; main has moved since CI ran.
+   2  Could not determine; warn and let the caller decide.
+
+Stacked-PR handling (issue #5965):
+   A PR whose declared base is a branch other than ``main`` is only stale when
+   its CI did not test the *current* declared base ref, or when the declared
+   parent branch itself lags ``main``.  Unrelated movement on ``main`` alone
+   never marks a current stacked base as stale.  Use ``--base-ref`` (or let it
+   auto-detect) to enable this.
 """
 
 from __future__ import annotations
@@ -39,6 +46,8 @@ if TYPE_CHECKING:
 GH_RETRY_MAX_ATTEMPTS = 4
 GH_RETRY_BACKOFF_BASE = 1.0
 GH_RETRY_MAX_BACKOFF = 8.0
+
+DEFAULT_BASE_BRANCH = "main"
 
 
 def _gh(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
@@ -223,6 +232,16 @@ def _parse_json(stdout: str) -> tuple[dict[str, Any] | None, str | None]:
     return data, None
 
 
+def _get_ref_sha(repo: str, ref: str) -> str | None:
+    """Return the current HEAD SHA of a branch ref, or None on error."""
+    safe_ref = ref.replace("/", "%2F")
+    result = _gh(["api", f"repos/{repo}/git/refs/heads/{safe_ref}", "--jq", ".object.sha"])
+    if result.returncode != 0:
+        return None
+    sha = result.stdout.strip()
+    return sha if sha else None
+
+
 def _get_main_sha(repo: str) -> str | None:
     """Return current main branch HEAD SHA, or None on error.
 
@@ -231,6 +250,26 @@ def _get_main_sha(repo: str) -> str | None:
     a freshness signal).
     """
     return _fetch_main_sha_with_retry(repo).sha
+
+
+def _fetch_pr_base_ref(pr_number: str, *, repo: str) -> str | None:
+    """Return the PR's declared base branch name (e.g. ``main`` or ``feature/x``).
+
+    Returns ``None`` when the base ref name cannot be determined.
+    """
+    result = _gh(["api", f"repos/{repo}/pulls/{pr_number}"])
+    if result.returncode != 0:
+        return None
+    payload, _ = _parse_json(result.stdout)
+    if not isinstance(payload, dict):
+        return None
+    base = payload.get("base")
+    if not isinstance(base, dict):
+        return None
+    ref = base.get("ref")
+    if isinstance(ref, str) and ref:
+        return ref
+    return None
 
 
 def _fetch_pr_head_metadata(pr_number: str, *, repo: str) -> tuple[str | None, str | None]:
@@ -320,13 +359,23 @@ def check_merge_staleness(
     *,
     base_sha: str,
     repo: str,
+    base_ref: str | None = None,
 ) -> dict[str, Any]:
-    """Check whether a PR's CI ran against a stale main.
+    """Check whether a PR's CI ran against a stale merge base.
+
+    For a PR targeting ``main`` this preserves the existing merge-race check:
+    the CI-tested base (or the PR's declared ``base.sha``) must match current
+    main.  For an explicitly stacked PR (``base_ref`` is a non-main branch), the
+    PR is only stale when its CI did **not** test the *current* declared base
+    ref.  Unrelated movement on ``main`` alone never marks a current stacked
+    base as stale, but if the declared parent branch itself lags ``main`` the
+    PR still fails closed with an actionable parent-refresh reason.
 
     Returns a result dict with at minimum:
       - ``stale``: bool | None (None = unknown / error)
       - ``detection``: ``"workflow_run_base_sha"`` | ``"base_vs_main"``
-      - ``pr``, ``base_sha``, ``main_sha``
+                         | ``"stacked_base"`` | ``"stacked_base_stale_parent"``
+      - ``pr``, ``base_sha``, ``main_sha``, ``base_ref``
     """
     main_result = _fetch_main_sha_with_retry(repo)
     if main_result.sha is None:
@@ -343,9 +392,154 @@ def check_merge_staleness(
             "pr": pr_number,
             "base_sha": base_sha,
             "main_sha": None,
+            "base_ref": base_ref,
         }
     main_sha = main_result.sha
 
+    if base_ref is None or base_ref == DEFAULT_BASE_BRANCH:
+        return _check_main_targeting_pr(
+            pr_number, base_sha=base_sha, repo=repo, main_sha=main_sha, base_ref=base_ref
+        )
+
+    # Stacked PR: the relevant merge base is the declared parent branch, not main.
+    parent_sha = _get_ref_sha(repo, base_ref)
+    if parent_sha is None:
+        return {
+            "status": "error",
+            "error": f"Failed to fetch current SHA for base ref {base_ref!r}",
+            "stale": None,
+            "detection": "error",
+            "pr": pr_number,
+            "base_sha": base_sha,
+            "main_sha": main_sha,
+            "base_ref": base_ref,
+        }
+
+    # Layer 1: workflow-run provenance — did CI test the current parent ref?
+    ci_base_sha = _detect_workflow_run_base_sha(repo, pr_number)
+    if ci_base_sha:
+        if ci_base_sha == parent_sha:
+            stale = _parent_branch_lags_main(parent_sha, main_sha)
+            if stale:
+                return {
+                    "status": "ok",
+                    "stale": True,
+                    "detection": "stacked_base_stale_parent",
+                    "reason": (
+                        f"PR is current with its declared base {base_ref!r}, but that "
+                        f"parent branch lags main and must be refreshed (gh pr update-branch "
+                        f"or rebase {base_ref} onto main) before merge."
+                    ),
+                    "pr": pr_number,
+                    "base_sha": base_sha,
+                    "ci_base_sha": ci_base_sha,
+                    "parent_sha": parent_sha,
+                    "main_sha": main_sha,
+                    "base_ref": base_ref,
+                }
+            return {
+                "status": "ok",
+                "stale": False,
+                "detection": "stacked_base",
+                "pr": pr_number,
+                "base_sha": base_sha,
+                "ci_base_sha": ci_base_sha,
+                "parent_sha": parent_sha,
+                "main_sha": main_sha,
+                "base_ref": base_ref,
+            }
+        return {
+            "status": "ok",
+            "stale": True,
+            "detection": "stacked_base",
+            "reason": (
+                f"CI last tested base {ci_base_sha}, but the declared base {base_ref!r} "
+                f"is now at {parent_sha}. Re-run CI against the current base."
+            ),
+            "pr": pr_number,
+            "base_sha": base_sha,
+            "ci_base_sha": ci_base_sha,
+            "parent_sha": parent_sha,
+            "main_sha": main_sha,
+            "base_ref": base_ref,
+        }
+
+    # Fallback: compare the PR's declared base.sha against the current parent ref.
+    if base_sha != parent_sha:
+        return {
+            "status": "ok",
+            "stale": True,
+            "detection": "stacked_base",
+            "reason": (
+                f"PR base {base_sha} differs from current declared base {base_ref!r} "
+                f"({parent_sha}). Re-run CI against the current base."
+            ),
+            "warning": (
+                "Cannot detect the exact workflow-run base SHA CI tested against; "
+                "compared declared base.sha against current parent ref."
+            ),
+            "pr": pr_number,
+            "base_sha": base_sha,
+            "parent_sha": parent_sha,
+            "main_sha": main_sha,
+            "base_ref": base_ref,
+        }
+
+    stale = _parent_branch_lags_main(parent_sha, main_sha)
+    if stale:
+        return {
+            "status": "ok",
+            "stale": True,
+            "detection": "stacked_base_stale_parent",
+            "reason": (
+                f"PR is current with its declared base {base_ref!r}, but that parent "
+                f"branch lags main and must be refreshed before merge."
+            ),
+            "warning": (
+                "Cannot detect the exact workflow-run base SHA CI tested against; "
+                "compared declared base.sha against current parent ref."
+            ),
+            "pr": pr_number,
+            "base_sha": base_sha,
+            "parent_sha": parent_sha,
+            "main_sha": main_sha,
+            "base_ref": base_ref,
+        }
+    return {
+        "status": "ok",
+        "stale": False,
+        "detection": "stacked_base",
+        "warning": (
+            "Cannot detect the exact workflow-run base SHA CI tested against; "
+            "compared declared base.sha against current parent ref."
+        ),
+        "pr": pr_number,
+        "base_sha": base_sha,
+        "parent_sha": parent_sha,
+        "main_sha": main_sha,
+        "base_ref": base_ref,
+    }
+
+
+def _parent_branch_lags_main(parent_sha: str, main_sha: str) -> bool:
+    """True when the declared parent branch is behind current main.
+
+    We conservatively treat any parent SHA that differs from main as lagging:
+    without a full merge-base graph walk we cannot tell whether main is an
+    ancestor of the parent.  Differing SHAs are the safe fail-closed signal.
+    """
+    return parent_sha != main_sha
+
+
+def _check_main_targeting_pr(
+    pr_number: str,
+    *,
+    base_sha: str,
+    repo: str,
+    main_sha: str,
+    base_ref: str | None,
+) -> dict[str, Any]:
+    """Race check for a PR that targets ``main`` (unchanged behaviour)."""
     ci_base_sha = _detect_workflow_run_base_sha(repo, pr_number)
     if ci_base_sha:
         is_stale = ci_base_sha != main_sha
@@ -357,6 +551,7 @@ def check_merge_staleness(
             "base_sha": base_sha,
             "ci_base_sha": ci_base_sha,
             "main_sha": main_sha,
+            "base_ref": base_ref,
         }
 
     # Fallback: conservative base-vs-main comparison.
@@ -374,6 +569,7 @@ def check_merge_staleness(
         "pr": pr_number,
         "base_sha": base_sha,
         "main_sha": main_sha,
+        "base_ref": base_ref,
     }
 
 
@@ -396,8 +592,14 @@ def format_human(data: dict[str, Any]) -> str:
     lines = [f"PR #{pr}: {verdict}  (detection: {detection})"]
     lines.append(f"  base_sha:  {data.get('base_sha', '?')}")
     lines.append(f"  main_sha:  {data.get('main_sha', '?')}")
+    if data.get("base_ref") is not None:
+        lines.append(f"  base_ref:  {data['base_ref']}")
     if "ci_base_sha" in data:
         lines.append(f"  ci_base_sha: {data['ci_base_sha']}")
+    if "parent_sha" in data:
+        lines.append(f"  parent_sha: {data['parent_sha']}")
+    if data.get("reason"):
+        lines.append(f"  reason: {data['reason']}")
     if data.get("warning"):
         lines.append(f"  warning: {data['warning']}")
     return "\n".join(lines)
@@ -461,6 +663,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--pr", dest="pr_number_option", help="GitHub PR number alias")
     parser.add_argument("--json", action="store_true", default=False, help="emit JSON output")
     parser.add_argument("--repo", default="", help="owner/repo (default: detect from gh)")
+    parser.add_argument(
+        "--base-ref",
+        default=None,
+        help="PR's declared base branch (default: detect from gh). "
+        "A non-main base enables stacked-PR handling.",
+    )
     args = parser.parse_args(argv)
 
     if args.pr_number and args.pr_number_option and args.pr_number != args.pr_number_option:
@@ -480,7 +688,11 @@ def main(argv: list[str] | None = None) -> int:
             _output({"status": "error", "error": err}, as_json=args.json)
             return 1
 
-        data = check_merge_staleness(pr_number, base_sha=base_sha, repo=repo)
+        base_ref = args.base_ref
+        if base_ref is None:
+            base_ref = _fetch_pr_base_ref(pr_number, repo=repo)
+
+        data = check_merge_staleness(pr_number, base_sha=base_sha, repo=repo, base_ref=base_ref)
     except FileNotFoundError:
         print("gh CLI not found.  Install GitHub CLI: https://cli.github.com/", file=sys.stderr)
         return 1

--- a/scripts/dev/check_pr_merge_staleness.py
+++ b/scripts/dev/check_pr_merge_staleness.py
@@ -419,7 +419,7 @@ def check_merge_staleness(
     ci_base_sha = _detect_workflow_run_base_sha(repo, pr_number)
     if ci_base_sha:
         if ci_base_sha == parent_sha:
-            stale = _parent_branch_lags_main(parent_sha, main_sha)
+            stale = _parent_branch_lags_main(repo, parent_sha, main_sha)
             if stale:
                 return {
                     "status": "ok",
@@ -485,7 +485,7 @@ def check_merge_staleness(
             "base_ref": base_ref,
         }
 
-    stale = _parent_branch_lags_main(parent_sha, main_sha)
+    stale = _parent_branch_lags_main(repo, parent_sha, main_sha)
     if stale:
         return {
             "status": "ok",
@@ -521,14 +521,19 @@ def check_merge_staleness(
     }
 
 
-def _parent_branch_lags_main(parent_sha: str, main_sha: str) -> bool:
-    """True when the declared parent branch is behind current main.
+def _parent_branch_lags_main(repo: str, parent_sha: str, main_sha: str) -> bool:
+    """Return whether the parent ref is behind or diverged from current main.
 
-    We conservatively treat any parent SHA that differs from main as lagging:
-    without a full merge-base graph walk we cannot tell whether main is an
-    ancestor of the parent.  Differing SHAs are the safe fail-closed signal.
+    A healthy stacked parent can be ahead of main, so SHA inequality alone is
+    not sufficient. GitHub's compare endpoint reports the ancestry relation;
+    an unavailable or malformed response fails closed as lagging.
     """
-    return parent_sha != main_sha
+    if parent_sha == main_sha:
+        return False
+    result = _gh(["api", f"repos/{repo}/compare/{main_sha}...{parent_sha}", "--jq", ".status"])
+    if result.returncode != 0:
+        return True
+    return result.stdout.strip() not in {"ahead", "identical"}
 
 
 def _check_main_targeting_pr(

--- a/tests/dev/test_check_pr_merge_staleness.py
+++ b/tests/dev/test_check_pr_merge_staleness.py
@@ -9,12 +9,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from scripts.dev.check_pr_merge_staleness import (
+    DEFAULT_BASE_BRANCH,
     _detect_workflow_run_base_sha,
     _fetch_main_sha_with_retry,
+    _fetch_pr_base_ref,
     _fetch_pr_base_sha,
     _fetch_workflow_runs_with_retry,
     _gh_with_retry,
     _is_transient_gh_failure,
+    _parent_branch_lags_main,
     _PermanentApiError,
     check_merge_staleness,
     format_human,
@@ -243,6 +246,150 @@ def test_fallback_when_detect_returns_none() -> None:
     assert data["stale"] is False
 
 
+# ── stacked PR handling (issue #5965) ────────────────────────────────────────
+
+
+def test_stacked_pr_fresh_when_current_with_declared_base() -> None:
+    """A PR current with its stacked base is not stale just because main moved."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch(
+            "scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha",
+            return_value="parent_sha",
+        ),
+    ):
+        # main sha + parent ref sha both fetched via _gh; parent equals ci base
+        # and parent equals main, so the PR is genuinely fresh.
+        mock_gh.side_effect = [
+            _gh_response(stdout="parent_sha"),
+            _gh_response(stdout="parent_sha"),
+        ]
+        data = check_merge_staleness(
+            "5953",
+            base_sha="parent_sha",
+            repo="owner/repo",
+            base_ref="proto-butterfly-video",
+        )
+
+    assert data["detection"] == "stacked_base"
+    assert data["stale"] is False
+    assert data["parent_sha"] == "parent_sha"
+    assert data["main_sha"] == "parent_sha"
+
+
+def test_stacked_pr_stale_when_ci_base_older_than_current_parent() -> None:
+    """A stacked PR whose declared base moved since CI ran is stale."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch(
+            "scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha",
+            return_value="old_parent",
+        ),
+    ):
+        mock_gh.side_effect = [
+            _gh_response(stdout="main_head"),
+            _gh_response(stdout="current_parent"),
+        ]
+        data = check_merge_staleness(
+            "5953",
+            base_sha="current_parent",
+            repo="owner/repo",
+            base_ref="proto-butterfly-video",
+        )
+
+    assert data["detection"] == "stacked_base"
+    assert data["stale"] is True
+    assert data["ci_base_sha"] == "old_parent"
+    assert data["parent_sha"] == "current_parent"
+
+
+def test_stacked_pr_stale_when_parent_lags_main_fallback() -> None:
+    """A stale parent branch fails closed even without workflow provenance."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch(
+            "scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha", return_value=None
+        ),
+    ):
+        # base_sha == parent_sha, but parent_sha != main -> stale parent.
+        mock_gh.side_effect = [
+            _gh_response(stdout="main_head"),
+            _gh_response(stdout="parent_sha"),
+        ]
+        data = check_merge_staleness(
+            "5953",
+            base_sha="parent_sha",
+            repo="owner/repo",
+            base_ref="proto-butterfly-video",
+        )
+
+    assert data["detection"] == "stacked_base_stale_parent"
+    assert data["stale"] is True
+    assert "parent" in data["reason"].lower()
+
+
+def test_stacked_pr_stale_when_declared_base_sha_older_fallback() -> None:
+    """Fallback path flags a stacked PR when declared base.sha lags parent."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch(
+            "scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha", return_value=None
+        ),
+    ):
+        mock_gh.side_effect = [
+            _gh_response(stdout="main_head"),
+            _gh_response(stdout="current_parent"),
+        ]
+        data = check_merge_staleness(
+            "5953",
+            base_sha="old_parent",
+            repo="owner/repo",
+            base_ref="proto-butterfly-video",
+        )
+
+    assert data["detection"] == "stacked_base"
+    assert data["stale"] is True
+    assert data["parent_sha"] == "current_parent"
+
+
+def test_main_targeting_pr_preserves_race_check() -> None:
+    """A PR targeting main keeps the original base-vs-main race protection."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch(
+            "scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha", return_value=None
+        ),
+    ):
+        mock_gh.side_effect = [_gh_response(stdout="new_main")]
+        data = check_merge_staleness("42", base_sha="old_base", repo="owner/repo", base_ref="main")
+
+    assert data["detection"] == "base_vs_main"
+    assert data["stale"] is True
+
+
+def test_parent_branch_lags_main_helper() -> None:
+    """Helper reports lag when parent SHA differs from main."""
+    assert _parent_branch_lags_main("abc", "abc") is False
+    assert _parent_branch_lags_main("abc", "def") is True
+
+
+def test_fetch_pr_base_ref_reads_ref_field() -> None:
+    """The PR's declared base ref name is read from the REST payload."""
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        mock_gh.return_value = _gh_response(
+            stdout=json.dumps({"base": {"sha": "s", "ref": "proto-x"}})
+        )
+        ref = _fetch_pr_base_ref("42", repo="owner/repo")
+
+    assert ref == "proto-x"
+    assert "pulls/42" in " ".join(mock_gh.call_args.args[0])
+
+
+def test_default_base_branch_constant_is_main() -> None:
+    """The default base branch used for race checks is main."""
+    assert DEFAULT_BASE_BRANCH == "main"
+
+
 # ── format_human ─────────────────────────────────────────────────────────────
 
 
@@ -334,7 +481,7 @@ def test_main_exit_0_when_fresh(capsys: pytest.CaptureFixture) -> None:
             # main sha
             _gh_response(stdout="same_sha"),
         ]
-        rc = main(["42"])
+        rc = main(["42", "--base-ref", "main"])
 
     assert rc == 0
     captured = capsys.readouterr()
@@ -354,7 +501,7 @@ def test_main_exit_1_when_stale(capsys: pytest.CaptureFixture) -> None:
             _gh_response(stdout=json.dumps({"base": {"sha": "old_base"}})),
             _gh_response(stdout="new_main"),
         ]
-        rc = main(["42"])
+        rc = main(["42", "--base-ref", "main"])
 
     assert rc == 1
     captured = capsys.readouterr()
@@ -379,7 +526,7 @@ def test_main_exit_2_on_error(capsys: pytest.CaptureFixture) -> None:
             _gh_response(returncode=1, stderr="network error"),
             _gh_response(returncode=1, stderr="network error"),
         ]
-        rc = main(["1"])
+        rc = main(["1", "--base-ref", "main"])
 
     assert rc == 2
     assert mock_sleep.call_count == 3
@@ -400,7 +547,7 @@ def test_main_json_output(capsys: pytest.CaptureFixture) -> None:
             _gh_response(stdout=json.dumps({"base": {"sha": "abc"}})),
             _gh_response(stdout="abc"),
         ]
-        rc = main(["7", "--json"])
+        rc = main(["7", "--json", "--base-ref", "main"])
 
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
@@ -421,7 +568,7 @@ def test_main_repo_flag(capsys: pytest.CaptureFixture) -> None:
             _gh_response(stdout=json.dumps({"base": {"sha": "sha"}})),
             _gh_response(stdout="sha"),
         ]
-        rc = main(["1", "--repo", "ll7/robot_sf_ll7"])
+        rc = main(["1", "--repo", "ll7/robot_sf_ll7", "--base-ref", "main"])
 
     assert rc == 0
     # Should have made exactly 2 gh calls (pr view, main sha), not 3.
@@ -440,7 +587,7 @@ def test_main_pr_flag_alias(capsys: pytest.CaptureFixture) -> None:
             _gh_response(stdout=json.dumps({"base": {"sha": "sha"}})),
             _gh_response(stdout="sha"),
         ]
-        rc = main(["--pr", "99", "--repo", "ll7/robot_sf_ll7"])
+        rc = main(["--pr", "99", "--repo", "ll7/robot_sf_ll7", "--base-ref", "main"])
 
     assert rc == 0
 
@@ -489,7 +636,7 @@ def test_main_repo_detect_failure(capsys: pytest.CaptureFixture) -> None:
     """Repository detection failure should exit 1."""
     with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
         mock_gh.return_value = _gh_response(returncode=1, stderr="auth error")
-        rc = main(["42"])
+        rc = main(["42", "--base-ref", "main"])
 
     assert rc == 1
     assert "Failed to detect repository" in capsys.readouterr().err

--- a/tests/dev/test_check_pr_merge_staleness.py
+++ b/tests/dev/test_check_pr_merge_staleness.py
@@ -258,11 +258,12 @@ def test_stacked_pr_fresh_when_current_with_declared_base() -> None:
             return_value="parent_sha",
         ),
     ):
-        # main sha + parent ref sha both fetched via _gh; parent equals ci base
-        # and parent equals main, so the PR is genuinely fresh.
+        # main sha + parent ref sha + compare status are fetched via _gh; the
+        # parent is ahead of main, so the stacked PR is genuinely fresh.
         mock_gh.side_effect = [
+            _gh_response(stdout="main_sha"),
             _gh_response(stdout="parent_sha"),
-            _gh_response(stdout="parent_sha"),
+            _gh_response(stdout="ahead"),
         ]
         data = check_merge_staleness(
             "5953",
@@ -274,7 +275,7 @@ def test_stacked_pr_fresh_when_current_with_declared_base() -> None:
     assert data["detection"] == "stacked_base"
     assert data["stale"] is False
     assert data["parent_sha"] == "parent_sha"
-    assert data["main_sha"] == "parent_sha"
+    assert data["main_sha"] == "main_sha"
 
 
 def test_stacked_pr_stale_when_ci_base_older_than_current_parent() -> None:
@@ -315,6 +316,7 @@ def test_stacked_pr_stale_when_parent_lags_main_fallback() -> None:
         mock_gh.side_effect = [
             _gh_response(stdout="main_head"),
             _gh_response(stdout="parent_sha"),
+            _gh_response(stdout="behind"),
         ]
         data = check_merge_staleness(
             "5953",
@@ -368,9 +370,20 @@ def test_main_targeting_pr_preserves_race_check() -> None:
 
 
 def test_parent_branch_lags_main_helper() -> None:
-    """Helper reports lag when parent SHA differs from main."""
-    assert _parent_branch_lags_main("abc", "abc") is False
-    assert _parent_branch_lags_main("abc", "def") is True
+    """Helper uses compare ancestry and fails closed on compare errors."""
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        mock_gh.side_effect = [
+            _gh_response(stdout="ahead"),
+            _gh_response(stdout="behind"),
+            _gh_response(stdout="diverged"),
+            _gh_response(returncode=1, stderr="compare unavailable"),
+        ]
+        assert _parent_branch_lags_main("owner/repo", "same", "same") is False
+        assert _parent_branch_lags_main("owner/repo", "parent", "main") is False
+        assert _parent_branch_lags_main("owner/repo", "parent", "main") is True
+        assert _parent_branch_lags_main("owner/repo", "parent", "main") is True
+
+    assert "compare/main...parent" in " ".join(mock_gh.call_args_list[0].args[0])
 
 
 def test_fetch_pr_base_ref_reads_ref_field() -> None:


### PR DESCRIPTION
## What / Why

`scripts/dev/check_pr_merge_staleness.py` unconditionally compared a PR's completed-workflow `base.sha` against current `main`. For stacked PRs whose declared base is another open branch (e.g. PR #5953 → `proto-butterfly-video`), this reported `STALE` even when the branch was current with its declared base and `gh pr update-branch` was a no-op, simply because unrelated commits were newer on `main`.

This change:
- Detects the PR's declared base ref (via `--base-ref` or auto-detect from the REST payload).
- Preserves the existing merge-race protection **unchanged** for PRs targeting `main`.
- For a stacked PR (non-main base), validates that CI tested the *current* declared base ref:
  - fresh when CI tested the current parent ref and the parent itself is current with main;
  - stale with an actionable reason when CI tested an older base ref, or when the declared parent branch lags `main` (fail-closed `stacked_base_stale_parent`).

## Acceptance criteria

- Focused tests added: fresh stacked base, stale stacked base (CI base older than current parent), stale parent (fallback), and preserved main-targeting race check — all passing.
- A PR current with its declared stacked base is no longer falsely classified as stale solely because unrelated commits are newer on `main`.
- A stacked PR whose parent/base branch needs refresh remains fail-closed with an actionable parent/base refresh reason.
- Existing main-targeting merge-race protection is unchanged.

## Validation

- `pytest tests/dev/test_check_pr_merge_staleness.py` → **36 passed**.
- `ruff check` and `ruff format --check` on both changed files → clean.

## Successor statement

This PR fully resolves issue #5965 (a fix/tooling-debt issue, not a slice). Closes #5965.

This PR was produced by the CommandCode/Tencent-Hy3 cheap implementation lane; the review gate hardens and merges.