### PR TITLE
Issue #5960: ci_driver lint enumerates all failures (cheap-lane worker)

### DIFF
--- a/scripts/dev/ci_driver.sh
+++ b/scripts/dev/ci_driver.sh
@@ -94,34 +94,35 @@ is_strict_smoke_mode() {
   [[ "$github_ref" == "refs/heads/main" || "$event_name" == "workflow_dispatch" ]]
 }
 
+_run_lint_check() {
+  local step_failed=0
+  echo "==> lint step: $*"
+  if "$@"; then
+    echo "    lint step passed"
+  else
+    step_failed=$?
+    echo "    lint step FAILED (status $step_failed); continuing to surface remaining checks" >&2
+    lint_status=1
+  fi
+}
+
 run_lint_phase() {
   # The lint phase ENUMERATES problems; it must NOT short-circuit on the first
   # failure (set -e in the outer script would otherwise kill the phase after the
   # first finding, hiding subsequent independent errors — see issue #5960). We
   # collect every check's status and exit non-zero once, reporting all findings.
   local lint_status=0
-  local step_failed=0
-  run_lint_check() {
-    echo "==> lint step: $*"
-    if "$@"; then
-      echo "    lint step passed"
-    else
-      step_failed=$?
-      echo "    lint step FAILED (status $step_failed); continuing to surface remaining checks" >&2
-      lint_status=1
-    fi
-  }
 
-  run_lint_check uv run ruff check .
-  run_lint_check uv run ruff format --check .
+  _run_lint_check uv run ruff check .
+  _run_lint_check uv run ruff format --check .
   # Ratchet: fail if broad (Exception/BaseException/bare) catches increase on
   # benchmark/script surfaces beyond the approved baseline (issue #3478).
-  run_lint_check uv run python scripts/validation/check_broad_exceptions.py
+  _run_lint_check uv run python scripts/validation/check_broad_exceptions.py
   # Advisory (non-gating) version-drift guard: the git tag/release line is the
   # single source of truth for the package and CITATION.cff versions. Surfaced
   # here on every CI run; enforced (gating) on tag pushes by
   # .github/workflows/release-functional-badge.yml.
-  run_lint_check uv run python scripts/dev/check_version_alignment.py --advisory
+  _run_lint_check uv run python scripts/dev/check_version_alignment.py --advisory
 
   if [[ "$lint_status" -ne 0 ]]; then
     echo "lint phase FAILED: one or more checks reported errors (see above)." >&2

--- a/scripts/dev/ci_driver.sh
+++ b/scripts/dev/ci_driver.sh
@@ -94,6 +94,41 @@ is_strict_smoke_mode() {
   [[ "$github_ref" == "refs/heads/main" || "$event_name" == "workflow_dispatch" ]]
 }
 
+run_lint_phase() {
+  # The lint phase ENUMERATES problems; it must NOT short-circuit on the first
+  # failure (set -e in the outer script would otherwise kill the phase after the
+  # first finding, hiding subsequent independent errors — see issue #5960). We
+  # collect every check's status and exit non-zero once, reporting all findings.
+  local lint_status=0
+  local step_failed=0
+  run_lint_check() {
+    echo "==> lint step: $*"
+    if "$@"; then
+      echo "    lint step passed"
+    else
+      step_failed=$?
+      echo "    lint step FAILED (status $step_failed); continuing to surface remaining checks" >&2
+      lint_status=1
+    fi
+  }
+
+  run_lint_check uv run ruff check .
+  run_lint_check uv run ruff format --check .
+  # Ratchet: fail if broad (Exception/BaseException/bare) catches increase on
+  # benchmark/script surfaces beyond the approved baseline (issue #3478).
+  run_lint_check uv run python scripts/validation/check_broad_exceptions.py
+  # Advisory (non-gating) version-drift guard: the git tag/release line is the
+  # single source of truth for the package and CITATION.cff versions. Surfaced
+  # here on every CI run; enforced (gating) on tag pushes by
+  # .github/workflows/release-functional-badge.yml.
+  run_lint_check uv run python scripts/dev/check_version_alignment.py --advisory
+
+  if [[ "$lint_status" -ne 0 ]]; then
+    echo "lint phase FAILED: one or more checks reported errors (see above)." >&2
+    return 1
+  fi
+}
+
 run_smoke_phase() {
   local event_name="$1"
   local github_ref="$2"
@@ -240,16 +275,7 @@ run_phase() {
 
   case "$phase" in
     lint)
-      uv run ruff check .
-      uv run ruff format --check .
-      # Ratchet: fail if broad (Exception/BaseException/bare) catches increase on
-      # benchmark/script surfaces beyond the approved baseline (issue #3478).
-      uv run python scripts/validation/check_broad_exceptions.py
-      # Advisory (non-gating) version-drift guard: the git tag/release line is the
-      # single source of truth for the package and CITATION.cff versions. Surfaced
-      # here on every CI run; enforced (gating) on tag pushes by
-      # .github/workflows/release-functional-badge.yml.
-      uv run python scripts/dev/check_version_alignment.py --advisory
+      run_lint_phase
       ;;
     typecheck)
       echo "Running ty in advisory mode (--exit-zero); findings are reported but do not fail this phase."

--- a/tests/test_ci_driver_contract.py
+++ b/tests/test_ci_driver_contract.py
@@ -493,7 +493,7 @@ def test_ci_driver_artifact_policy_uses_no_sync() -> None:
     assert "uv run --no-sync python scripts/tools/check_artifact_root.py" in driver_text
 
 
-def test_ci_driver_lint_reports_all_failures_without_short_circuiting() -> None:
+def test_ci_driver_lint_reports_all_failures_without_short_circuiting(tmp_path: Path) -> None:
     """The lint phase must enumerate every failure, not stop at the first (issue #5960).
 
     Reproduces the exact bug class from the issue: a branch with BOTH a format
@@ -506,11 +506,10 @@ def test_ci_driver_lint_reports_all_failures_without_short_circuiting() -> None:
     # Stub `uv` so `uv run <tool> <args>` proxies to the local interpreter (or a
     # failing stub). We map each known lint check to a deterministic pass/fail so we
     # can force BOTH ruff format AND broad-exception failures simultaneously.
-    stub_dir = ROOT / "output" / "ci_driver_lint_stub"
+    stub_dir = tmp_path / "ci_driver_lint_stub"
     stub_dir.mkdir(parents=True, exist_ok=True)
     uv_stub = stub_dir / "uv"
     python_stub = stub_dir / "python"
-    check_broad = stub_dir / "check_broad.py"
 
     # `uv run` forwards to our python stub. We detect which check is running via the
     # args so we can make the broad-exception check fail.
@@ -533,7 +532,6 @@ def test_ci_driver_lint_reports_all_failures_without_short_circuiting() -> None:
         "sys.exit(0)\n",
         encoding="utf-8",
     )
-    check_broad.write_text("", encoding="utf-8")
     uv_stub.chmod(0o755)
     python_stub.chmod(0o755)
 
@@ -562,10 +560,10 @@ def test_ci_driver_lint_reports_all_failures_without_short_circuiting() -> None:
     assert result.returncode != 0, f"lint phase exited zero despite failures:\n{combined}"
 
 
-def test_ci_driver_lint_passes_when_all_checks_pass() -> None:
+def test_ci_driver_lint_passes_when_all_checks_pass(tmp_path: Path) -> None:
     """The lint phase must exit zero when every check passes (issue #5960)."""
 
-    stub_dir = ROOT / "output" / "ci_driver_lint_stub_pass"
+    stub_dir = tmp_path / "ci_driver_lint_stub_pass"
     stub_dir.mkdir(parents=True, exist_ok=True)
     uv_stub = stub_dir / "uv"
     python_stub = stub_dir / "python"

--- a/tests/test_ci_driver_contract.py
+++ b/tests/test_ci_driver_contract.py
@@ -515,10 +515,7 @@ def test_ci_driver_lint_reports_all_failures_without_short_circuiting() -> None:
     # `uv run` forwards to our python stub. We detect which check is running via the
     # args so we can make the broad-exception check fail.
     uv_stub.write_text(
-        "#!/usr/bin/env bash\nset -- \"${@:3}\"\n"
-        "exec \""
-        + str(python_stub)
-        + "\" \"$@\"\n",
+        '#!/usr/bin/env bash\nset -- "${@:3}"\nexec "' + str(python_stub) + '" "$@"\n',
         encoding="utf-8",
     )
     python_stub.write_text(
@@ -558,9 +555,9 @@ def test_ci_driver_lint_reports_all_failures_without_short_circuiting() -> None:
     combined = result.stdout + result.stderr
     # Both independent failures must appear in a single run.
     assert "would reformat" in combined, f"format failure not surfaced:\n{combined}"
-    assert (
-        "broad exception ratchet increased" in combined
-    ), f"broad-exception failure not surfaced:\n{combined}"
+    assert "broad exception ratchet increased" in combined, (
+        f"broad-exception failure not surfaced:\n{combined}"
+    )
     # The phase must still fail overall.
     assert result.returncode != 0, f"lint phase exited zero despite failures:\n{combined}"
 
@@ -574,15 +571,10 @@ def test_ci_driver_lint_passes_when_all_checks_pass() -> None:
     python_stub = stub_dir / "python"
 
     uv_stub.write_text(
-        "#!/usr/bin/env bash\nset -- \"${@:3}\"\n"
-        "exec \""
-        + str(python_stub)
-        + "\" \"$@\"\n",
+        '#!/usr/bin/env bash\nset -- "${@:3}"\nexec "' + str(python_stub) + '" "$@"\n',
         encoding="utf-8",
     )
-    python_stub.write_text(
-        "#!/usr/bin/env python3\nimport sys\nsys.exit(0)\n", encoding="utf-8"
-    )
+    python_stub.write_text("#!/usr/bin/env python3\nimport sys\nsys.exit(0)\n", encoding="utf-8")
     uv_stub.chmod(0o755)
     python_stub.chmod(0o755)
 

--- a/tests/test_ci_driver_contract.py
+++ b/tests/test_ci_driver_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import shlex
 import subprocess
@@ -490,3 +491,113 @@ def test_ci_driver_artifact_policy_uses_no_sync() -> None:
     """
     driver_text = CI_DRIVER.read_text(encoding="utf-8")
     assert "uv run --no-sync python scripts/tools/check_artifact_root.py" in driver_text
+
+
+def test_ci_driver_lint_reports_all_failures_without_short_circuiting() -> None:
+    """The lint phase must enumerate every failure, not stop at the first (issue #5960).
+
+    Reproduces the exact bug class from the issue: a branch with BOTH a format
+    violation (ruff format) and a new broad exception must report BOTH in one run.
+    We stub ``uv``/``python`` so the real ``run_lint_phase`` logic in ci_driver.sh
+    executes without a Python environment, then assert that all failing checks ran
+    and the phase still exits non-zero.
+    """
+
+    # Stub `uv` so `uv run <tool> <args>` proxies to the local interpreter (or a
+    # failing stub). We map each known lint check to a deterministic pass/fail so we
+    # can force BOTH ruff format AND broad-exception failures simultaneously.
+    stub_dir = ROOT / "output" / "ci_driver_lint_stub"
+    stub_dir.mkdir(parents=True, exist_ok=True)
+    uv_stub = stub_dir / "uv"
+    python_stub = stub_dir / "python"
+    check_broad = stub_dir / "check_broad.py"
+
+    # `uv run` forwards to our python stub. We detect which check is running via the
+    # args so we can make the broad-exception check fail.
+    uv_stub.write_text(
+        "#!/usr/bin/env bash\nset -- \"${@:3}\"\n"
+        "exec \""
+        + str(python_stub)
+        + "\" \"$@\"\n",
+        encoding="utf-8",
+    )
+    python_stub.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "# ruff format --check -> fail (format violation)\n"
+        "if 'format' in sys.argv and '--check' in sys.argv:\n"
+        "    sys.stderr.write('would reformat file.py\\n')\n"
+        "    sys.exit(1)\n"
+        "# check_broad_exceptions -> fail (new broad exception)\n"
+        "if 'check_broad_exceptions' in sys.argv[0] or sys.argv[-1].endswith('check_broad_exceptions.py'):\n"
+        "    sys.stderr.write('broad exception ratchet increased\\n')\n"
+        "    sys.exit(1)\n"
+        "# ruff check -> pass; version alignment -> pass\n"
+        "sys.exit(0)\n",
+        encoding="utf-8",
+    )
+    check_broad.write_text("", encoding="utf-8")
+    uv_stub.chmod(0o755)
+    python_stub.chmod(0o755)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{stub_dir}:{env.get('PATH', '')}"
+    env["CI_DRIVER_GITHUB_REF"] = "refs/heads/feature"
+    env["CI_DRIVER_EVENT_NAME"] = "pull_request"
+
+    result = subprocess.run(
+        [str(CI_DRIVER), "lint"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=ROOT,
+        env=env,
+    )
+
+    combined = result.stdout + result.stderr
+    # Both independent failures must appear in a single run.
+    assert "would reformat" in combined, f"format failure not surfaced:\n{combined}"
+    assert (
+        "broad exception ratchet increased" in combined
+    ), f"broad-exception failure not surfaced:\n{combined}"
+    # The phase must still fail overall.
+    assert result.returncode != 0, f"lint phase exited zero despite failures:\n{combined}"
+
+
+def test_ci_driver_lint_passes_when_all_checks_pass() -> None:
+    """The lint phase must exit zero when every check passes (issue #5960)."""
+
+    stub_dir = ROOT / "output" / "ci_driver_lint_stub_pass"
+    stub_dir.mkdir(parents=True, exist_ok=True)
+    uv_stub = stub_dir / "uv"
+    python_stub = stub_dir / "python"
+
+    uv_stub.write_text(
+        "#!/usr/bin/env bash\nset -- \"${@:3}\"\n"
+        "exec \""
+        + str(python_stub)
+        + "\" \"$@\"\n",
+        encoding="utf-8",
+    )
+    python_stub.write_text(
+        "#!/usr/bin/env python3\nimport sys\nsys.exit(0)\n", encoding="utf-8"
+    )
+    uv_stub.chmod(0o755)
+    python_stub.chmod(0o755)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{stub_dir}:{env.get('PATH', '')}"
+    env["CI_DRIVER_GITHUB_REF"] = "refs/heads/main"
+    env["CI_DRIVER_EVENT_NAME"] = "push"
+
+    result = subprocess.run(
+        [str(CI_DRIVER), "lint"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=ROOT,
+        env=env,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## What / Why
`scripts/dev/ci_driver.sh` ran its `lint` phase (ruff check, ruff format --check, broad-exception ratchet, version-alignment advisory) directly under `set -e`. The first failing check short-circuited the phase, so a second independent failure stayed invisible until the first was fixed and pushed — exactly the bug in PRs #5826 and #5848 that aged 33h/23h and exhausted the cheap fix lane's attempt budget.

The `lint` phase now collects every check's status via a `run_lint_check` helper and exits non-zero once, reporting **all** findings. `set -e` is preserved for genuinely fatal setup steps; only the check phase is made non-short-circuiting.

## Changes
- `scripts/dev/ci_driver.sh`: extracted `run_lint_phase()` (top-level, reusable) that runs all lint checks and accumulates failures.
- `tests/test_ci_driver_contract.py`: two new tests proving the acceptance criteria by stubbing `uv`/`python` so the real `run_lint_phase` logic runs:
  - `test_ci_driver_lint_reports_all_failures_without_short_circuiting`: forces BOTH a `ruff format --check` violation AND a `check_broad_exceptions` failure, asserts both surface in one run and the phase exits non-zero.
  - `test_ci_driver_lint_passes_when_all_checks_pass`: asserts exit zero when all checks pass.

## Validation
- `bash -n scripts/dev/ci_driver.sh` → syntax OK.
- `uv run pytest tests/test_ci_driver_contract.py -q` → 24 passed.
- `uv run ruff check tests/test_ci_driver_contract.py` → All checks passed!

Both failure modes (format + broad exception) are verified by deliberately introducing both, not by reading the script, per the acceptance criteria.

## Successor statement
This PR FULLY resolves issue #5960: it implements the required fix (collect lint failures, exit non-zero once) and adds tests proving both-independent-failures surface in a single run. No remaining slices.

Closes #5960

## Gate follow-up

No deferred acceptance item remains for Issue #5960. The earlier #5972 baseline-drift blocker is obsolete because merged PR #5974 repaired the current-main evidence-registry gate; this branch is being refreshed only because its prior CI ran against a stale main tip.

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lint validation so all checks run even when one fails.
  * Reports every lint failure together and returns an accurate overall status.
  * Ensures successful lint runs complete with a passing result.

* **Tests**
  * Added coverage for multiple simultaneous lint failures and fully passing lint checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->