### PR TITLE
Issue #5592: implement constraints_first_structural_rank metric (cheap-lane worker)

### DIFF
--- a/scripts/validation/compute_issue_5592_structural_ranking.py
+++ b/scripts/validation/compute_issue_5592_structural_ranking.py
@@ -27,6 +27,7 @@ import argparse
 import csv
 import hashlib
 import json
+import math
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -118,9 +119,10 @@ def _to_float(value: Any) -> float | None:
     if value is None or value == "":
         return None
     try:
-        return float(value)
+        parsed = float(value)
     except (TypeError, ValueError):
         return None
+    return parsed if math.isfinite(parsed) else None
 
 
 def _is_fallback_or_degraded(row: Mapping[str, Any]) -> bool:
@@ -163,6 +165,26 @@ def _score(
     )
 
 
+def _parse_metric_aggregate(row: Mapping[str, Any], planner_key: str) -> dict[str, float | None]:
+    """Parse one planner's metrics and reject malformed or non-finite values."""
+    parsed_metrics: dict[str, float | None] = {}
+    for field in REQUIRED_METRIC_FIELDS:
+        parsed = _to_float(row[field])
+        if parsed is None:
+            raise RankingMetricError(
+                f"invalid or non-finite metric field {field!r} for {planner_key!r}"
+            )
+        parsed_metrics[field] = parsed
+
+    raw_snqi = row.get("snqi_mean")
+    parsed_snqi = _to_float(raw_snqi)
+    if raw_snqi not in (None, "") and parsed_snqi is None:
+        raise RankingMetricError(
+            f"invalid or non-finite metric field 'snqi_mean' for {planner_key!r}"
+        )
+    return {**parsed_metrics, "snqi_mean": parsed_snqi}
+
+
 def compute_structural_ranking(
     episode_rows: Sequence[Mapping[str, Any]],
     *,
@@ -203,17 +225,7 @@ def compute_structural_ranking(
         klass = planner_to_class.get(str(planner_key).strip())
         if klass is None:
             raise RankingMetricError(f"planner not in preregistered roster: {planner_key!r}")
-        try:
-            aggregate = {
-                "success_rate": float(row["success_rate"]),
-                "collision_event_rate": float(row["collision_event_rate"]),
-                "near_miss_event_rate": float(row["near_miss_event_rate"]),
-                "timeout_rate": float(row["timeout_rate"]),
-                "snqi_mean": row.get("snqi_mean"),
-            }
-        except (TypeError, ValueError) as exc:
-            raise RankingMetricError(f"invalid metric row for {planner_key!r}: {exc}") from exc
-        by_class[klass].append(aggregate)
+        by_class[klass].append(_parse_metric_aggregate(row, str(planner_key).strip()))
 
     missing_classes = [klass for klass, rows in by_class.items() if not rows]
     if missing_classes:

--- a/scripts/validation/compute_issue_5592_structural_ranking.py
+++ b/scripts/validation/compute_issue_5592_structural_ranking.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Issue #5592 structural-class ranking metric: ``constraints_first_structural_rank``.
+
+This module implements the metric named but never defined in the pre-registration
+packet (`configs/benchmarks/issue_5592_cross_matrix_preregistration.yaml`,
+``comparison_contract.metric: constraints_first_structural_rank``). It converts
+per-planner episode aggregates (the output of the frozen-contract paid campaign once
+it exists) into an independent ``1..4`` ranking of the four structural planner
+classes, one ranking per matrix. The ranking CSV it writes carries the preregistered
+12-planner roster signature and is consumed directly by
+``scripts/validation/build_issue_5592_cross_matrix_agreement.py``.
+
+The metric is pure CPU aggregation: it never runs a campaign, Slurm job, or training
+run. It is the artifact-first gap-filler between campaign episode rows and the
+cross-matrix agreement table.
+
+Scoring semantics (constraints-first ordering): a structural class is ranked better
+when its planners complete routes more often (higher success rate), collide less
+(lower collision event rate), cause fewer near-miss events, time out less, and
+achieve higher social-navigation quality (SNQI). The score tuple orders classes so
+that rank 1 is the best-performing structural class for the matrix under test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_PACKET = REPO_ROOT / "configs/benchmarks/issue_5592_cross_matrix_preregistration.yaml"
+SCHEMA_VERSION = "issue_5592_cross_matrix_preregistration.v1"
+
+STRUCTURAL_CLASS_ORDER = [
+    "constraint_first_hybrid",
+    "learned_policy",
+    "predictive",
+    "baseline_reactive",
+]
+
+RANKING_COLUMNS = ["structural_class", "rank", "roster_signature"]
+ROSTER_SIGNATURE_COLUMN = "roster_signature"
+
+
+class RankingMetricError(ValueError):
+    """Raised when issue #5592 ranking inputs or the pre-registration are malformed."""
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise RankingMetricError(f"{path} must contain a YAML mapping")
+    return payload
+
+
+def _roster_signature(packet: Mapping[str, Any]) -> str:
+    """Return the deterministic SHA-256 signature of the preregistered planner roster."""
+    roster = packet.get("planner_roster")
+    if not isinstance(roster, dict):
+        raise RankingMetricError("packet.planner_roster must be a mapping")
+    structural_classes = roster.get("structural_classes")
+    if not isinstance(structural_classes, dict):
+        raise RankingMetricError("packet.planner_roster.structural_classes must be a mapping")
+    if set(structural_classes) != set(STRUCTURAL_CLASS_ORDER):
+        raise RankingMetricError("packet planner roster structural classes mismatch")
+
+    canonical: dict[str, list[str]] = {}
+    planners: list[str] = []
+    for structural_class in STRUCTURAL_CLASS_ORDER:
+        class_planners = structural_classes.get(structural_class)
+        if not isinstance(class_planners, list) or not class_planners:
+            raise RankingMetricError(
+                f"planner roster for {structural_class!r} must be a non-empty list"
+            )
+        normalized = [str(planner).strip() for planner in class_planners]
+        if any(not planner for planner in normalized):
+            raise RankingMetricError(
+                f"planner roster for {structural_class!r} contains an empty planner"
+            )
+        canonical[structural_class] = normalized
+        planners.extend(normalized)
+    if len(planners) != len(set(planners)):
+        raise RankingMetricError("packet planner roster contains duplicate planner keys")
+    serialized = json.dumps(canonical, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _load_packet(packet_path: Path) -> dict[str, Any]:
+    packet = _load_yaml(packet_path)
+    if packet.get("schema_version") != SCHEMA_VERSION:
+        raise RankingMetricError("packet schema_version mismatch")
+    if packet.get("issue") != 5592:
+        raise RankingMetricError("packet.issue must be 5592")
+    if packet.get("status") != "pre_registered":
+        raise RankingMetricError("packet.status must be pre_registered")
+    return packet
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_fallback_or_degraded(row: Mapping[str, Any]) -> bool:
+    """Reject fallback/degraded/unavailable planner rows so they cannot enter the ranking."""
+    fallback_statuses = {"fallback", "degraded", "unavailable", "not_available", "unavailable_mode"}
+    for key in ("status", "run_status", "planner_status", "availability_status", "execution_mode"):
+        value = row.get(key)
+        if value is not None and str(value).strip().lower() in fallback_statuses:
+            return True
+    return False
+
+
+def _score(
+    class_aggregates: Sequence[Mapping[str, Any]],
+) -> tuple[float, float, float, float, float]:
+    """Aggregate a structural class across its planners into a comparable score tuple.
+
+    Lower collision/near-miss/timeout and higher success/SNQI rank better. Returns a
+    5-tuple ordered for descending-quality sort:
+        (-success_rate, collision_event_rate, near_miss_event_rate, timeout_rate, -snqi_mean).
+    """
+    success = [float(a["success_rate"]) for a in class_aggregates]
+    collision = [float(a["collision_event_rate"]) for a in class_aggregates]
+    near_miss = [float(a["near_miss_event_rate"]) for a in class_aggregates]
+    timeout = [float(a["timeout_rate"]) for a in class_aggregates]
+    snqi = [_to_float(a.get("snqi_mean")) for a in class_aggregates]
+    snqi_mean = sum(v for v in snqi if v is not None) / max(
+        1, sum(1 for v in snqi if v is not None)
+    )
+
+    def _mean(values: Sequence[float]) -> float:
+        return sum(values) / max(1, len(values))
+
+    return (
+        -_mean(success),
+        _mean(collision),
+        _mean(near_miss),
+        _mean(timeout),
+        -snqi_mean,
+    )
+
+
+def compute_structural_ranking(
+    episode_rows: Sequence[Mapping[str, Any]],
+    *,
+    planner_to_class: Mapping[str, str],
+) -> dict[str, int]:
+    """Compute a ``1..4`` structural-class ranking for one matrix from episode rows.
+
+    Args:
+        episode_rows: Iterable of per-planner aggregate records, each carrying
+            ``planner_key`` (or ``planner``), ``success_rate``,
+            ``collision_event_rate``, ``near_miss_event_rate``, ``timeout_rate``,
+            and optional ``snqi_mean``.
+        planner_to_class: Mapping from planner key to one of the four structural
+            class names.
+
+    Returns:
+        Mapping from structural class to a unique integer rank in ``1..4`` (1 = best).
+
+    Raises:
+        RankingMetricError: If a row is a fallback/degraded execution, a planner key
+            is unknown, or a structural class has no eligible rows.
+    """
+    by_class: dict[str, list[dict[str, Any]]] = {klass: [] for klass in STRUCTURAL_CLASS_ORDER}
+    for row in episode_rows:
+        if _is_fallback_or_degraded(row):
+            label = row.get("planner_key") or row.get("planner") or "<unknown>"
+            raise RankingMetricError(f"fallback/degraded row excluded from ranking: {label}")
+        planner_key = row.get("planner_key") or row.get("planner")
+        if planner_key is None:
+            raise RankingMetricError("episode row missing planner_key/planner")
+        klass = planner_to_class.get(str(planner_key).strip())
+        if klass is None:
+            raise RankingMetricError(f"planner not in preregistered roster: {planner_key!r}")
+        try:
+            aggregate = {
+                "success_rate": float(row.get("success_rate", 0.0)),
+                "collision_event_rate": float(row.get("collision_event_rate", 0.0)),
+                "near_miss_event_rate": float(row.get("near_miss_event_rate", 0.0)),
+                "timeout_rate": float(row.get("timeout_rate", 0.0)),
+                "snqi_mean": row.get("snqi_mean"),
+            }
+        except (TypeError, ValueError) as exc:
+            raise RankingMetricError(f"invalid metric row for {planner_key!r}: {exc}") from exc
+        by_class[klass].append(aggregate)
+
+    missing_classes = [klass for klass, rows in by_class.items() if not rows]
+    if missing_classes:
+        raise RankingMetricError(
+            f"structural class(es) have no eligible rows: {sorted(missing_classes)}"
+        )
+
+    class_scores: dict[str, tuple[float, float, float, float, float]] = {}
+    for klass, rows in by_class.items():
+        class_scores[klass] = _score(rows)
+
+    ranked = sorted(STRUCTURAL_CLASS_ORDER, key=lambda klass: class_scores[klass])
+    return {klass: rank for rank, klass in enumerate(ranked, start=1)}
+
+
+def _planner_to_class(packet: Mapping[str, Any]) -> dict[str, str]:
+    roster = packet.get("planner_roster", {})
+    structural_classes = roster.get("structural_classes", {})
+    mapping: dict[str, str] = {}
+    for klass, planners in structural_classes.items():
+        for planner in planners:
+            mapping[str(planner).strip()] = str(klass)
+    return mapping
+
+
+def _read_episode_rows(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        return [dict(row) for row in reader]
+
+
+def _write_ranking_csv(path: Path, ranking: Mapping[str, int], *, roster_signature: str) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=RANKING_COLUMNS, lineterminator="\n")
+        writer.writeheader()
+        for klass in STRUCTURAL_CLASS_ORDER:
+            writer.writerow(
+                {
+                    "structural_class": klass,
+                    "rank": ranking[klass],
+                    ROSTER_SIGNATURE_COLUMN: roster_signature,
+                }
+            )
+
+
+def build_ranking_for_matrix(
+    *,
+    packet_path: Path,
+    episode_rows_path: Path,
+    output_path: Path,
+) -> dict[str, int]:
+    """Compute and write the structural-class ranking CSV for one matrix.
+
+    Reads the per-planner episode aggregates, derives the constraints-first
+    structural ranking, and writes it to ``output_path`` with the frozen roster
+    signature. Returns the ranking mapping.
+    """
+    packet = _load_packet(packet_path)
+    roster_signature = _roster_signature(packet)
+    planner_to_class = _planner_to_class(packet)
+    rows = _read_episode_rows(episode_rows_path)
+    ranking = compute_structural_ranking(rows, planner_to_class=planner_to_class)
+    _write_ranking_csv(output_path, ranking, roster_signature=roster_signature)
+    return ranking
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--packet", type=Path, default=DEFAULT_PACKET)
+    parser.add_argument(
+        "--episode-rows",
+        type=Path,
+        required=True,
+        help="Per-planner episode aggregate CSV for one matrix",
+    )
+    parser.add_argument(
+        "--output", type=Path, required=True, help="Output structural-class ranking CSV path"
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point for the issue #5592 structural ranking metric."""
+    args = _parse_args(argv or sys.argv[1:])
+    try:
+        ranking = build_ranking_for_matrix(
+            packet_path=args.packet,
+            episode_rows_path=args.episode_rows,
+            output_path=args.output,
+        )
+    except RankingMetricError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(f"matrix_ranking: {args.output}")
+    for klass in STRUCTURAL_CLASS_ORDER:
+        print(f"  {klass}: rank {ranking[klass]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/compute_issue_5592_structural_ranking.py
+++ b/scripts/validation/compute_issue_5592_structural_ranking.py
@@ -49,6 +49,15 @@ STRUCTURAL_CLASS_ORDER = [
 
 RANKING_COLUMNS = ["structural_class", "rank", "roster_signature"]
 ROSTER_SIGNATURE_COLUMN = "roster_signature"
+# Core per-planner metric fields every episode-aggregate row must carry so the
+# ranking cannot silently impute a best-case (0.0 collision/timeout) value for a
+# missing safety metric. ``snqi_mean`` remains optional (handled in ``_score``).
+REQUIRED_METRIC_FIELDS = (
+    "success_rate",
+    "collision_event_rate",
+    "near_miss_event_rate",
+    "timeout_rate",
+)
 
 
 class RankingMetricError(ValueError):
@@ -174,7 +183,8 @@ def compute_structural_ranking(
 
     Raises:
         RankingMetricError: If a row is a fallback/degraded execution, a planner key
-            is unknown, or a structural class has no eligible rows.
+            is unknown, a required metric field is missing, or a structural class has
+            no eligible rows.
     """
     by_class: dict[str, list[dict[str, Any]]] = {klass: [] for klass in STRUCTURAL_CLASS_ORDER}
     for row in episode_rows:
@@ -184,15 +194,21 @@ def compute_structural_ranking(
         planner_key = row.get("planner_key") or row.get("planner")
         if planner_key is None:
             raise RankingMetricError("episode row missing planner_key/planner")
+        missing_fields = [field for field in REQUIRED_METRIC_FIELDS if row.get(field) in (None, "")]
+        if missing_fields:
+            raise RankingMetricError(
+                f"episode row for {planner_key!r} missing required metric field(s): "
+                f"{missing_fields}"
+            )
         klass = planner_to_class.get(str(planner_key).strip())
         if klass is None:
             raise RankingMetricError(f"planner not in preregistered roster: {planner_key!r}")
         try:
             aggregate = {
-                "success_rate": float(row.get("success_rate", 0.0)),
-                "collision_event_rate": float(row.get("collision_event_rate", 0.0)),
-                "near_miss_event_rate": float(row.get("near_miss_event_rate", 0.0)),
-                "timeout_rate": float(row.get("timeout_rate", 0.0)),
+                "success_rate": float(row["success_rate"]),
+                "collision_event_rate": float(row["collision_event_rate"]),
+                "near_miss_event_rate": float(row["near_miss_event_rate"]),
+                "timeout_rate": float(row["timeout_rate"]),
                 "snqi_mean": row.get("snqi_mean"),
             }
         except (TypeError, ValueError) as exc:

--- a/tests/validation/test_compute_issue_5592_structural_ranking.py
+++ b/tests/validation/test_compute_issue_5592_structural_ranking.py
@@ -1,0 +1,231 @@
+"""Contract tests for the issue #5592 ``constraints_first_structural_rank`` metric."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.validation import compute_issue_5592_structural_ranking as metric
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKET = REPO_ROOT / "configs/benchmarks/issue_5592_cross_matrix_preregistration.yaml"
+ROSTER_SIGNATURE = metric._roster_signature(metric._load_packet(PACKET))
+
+PLANNERS_BY_CLASS = {
+    "constraint_first_hybrid": [
+        "scenario_adaptive_hybrid_orca_v1",
+        "hybrid_rule_v3_fast_progress_static_escape",
+    ],
+    "learned_policy": ["ppo", "guarded_ppo"],
+    "predictive": ["prediction_planner", "prediction_mpc", "prediction_mpc_cbf"],
+    "baseline_reactive": ["goal", "social_force", "orca", "socnav_sampling", "sacadrl"],
+}
+
+
+def _rows_with_success(success_by_planner: dict[str, float]) -> list[dict[str, str]]:
+    """Build a per-planner episode-aggregate row set from success-rate overrides."""
+    rows = []
+    for planners in PLANNERS_BY_CLASS.values():
+        for planner in planners:
+            success = success_by_planner.get(planner, 0.5)
+            rows.append(
+                {
+                    "planner_key": planner,
+                    "success_rate": str(success),
+                    "collision_event_rate": str(round(1.0 - success, 3)),
+                    "near_miss_event_rate": "0.1",
+                    "timeout_rate": "0.05",
+                    "snqi_mean": str(round(0.4 + success * 0.5, 3)),
+                }
+            )
+    return rows
+
+
+def _write_rows(tmp_path: Path, name: str, rows: list[dict[str, str]]) -> Path:
+    path = tmp_path / name
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        import csv
+
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "planner_key",
+                "success_rate",
+                "collision_event_rate",
+                "near_miss_event_rate",
+                "timeout_rate",
+                "snqi_mean",
+                "execution_mode",
+                "availability_status",
+            ],
+            lineterminator="\n",
+            extrasaction="ignore",
+        )
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+    return path
+
+
+def test_metric_is_defined_and_exports_name() -> None:
+    """The pre-registration names this metric; it now resolves to a real implementation."""
+    packet = metric._load_packet(PACKET)
+    assert packet["comparison_contract"]["metric"] == "constraints_first_structural_rank"
+
+
+def test_reference_ranking_is_valid_permutation(tmp_path: Path) -> None:
+    """A realistic reference matrix produces a complete 1..4 permutation with roster signature."""
+    # constraint-first hybrids are best, then learned, predictive, baseline reactive.
+    success = {
+        "scenario_adaptive_hybrid_orca_v1": 0.95,
+        "hybrid_rule_v3_fast_progress_static_escape": 0.92,
+        "ppo": 0.80,
+        "guarded_ppo": 0.78,
+        "prediction_planner": 0.70,
+        "prediction_mpc": 0.72,
+        "prediction_mpc_cbf": 0.71,
+        "goal": 0.40,
+        "social_force": 0.45,
+        "orca": 0.50,
+        "socnav_sampling": 0.42,
+        "sacadrl": 0.48,
+    }
+    rows = _rows_with_success(success)
+    out = tmp_path / "reference_ranking.csv"
+    ranking = metric.build_ranking_for_matrix(
+        packet_path=PACKET,
+        episode_rows_path=_write_rows(tmp_path, "ref_rows.csv", rows),
+        output_path=out,
+    )
+    assert set(ranking.keys()) == set(metric.STRUCTURAL_CLASS_ORDER)
+    assert set(ranking.values()) == {1, 2, 3, 4}
+    assert ranking["constraint_first_hybrid"] == 1
+    assert ranking["baseline_reactive"] == 4
+
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert lines[0].split(",") == metric.RANKING_COLUMNS
+    for line in lines[1:]:
+        assert line.split(",")[2] == ROSTER_SIGNATURE
+
+
+def test_candidate_ranking_flips_order_when_predictive_improves(tmp_path: Path) -> None:
+    """A geometry where predictive beats learned_policy shows a rank flip, not a fixed order."""
+    success = {
+        "scenario_adaptive_hybrid_orca_v1": 0.95,
+        "hybrid_rule_v3_fast_progress_static_escape": 0.90,
+        "ppo": 0.55,
+        "guarded_ppo": 0.52,
+        "prediction_planner": 0.88,
+        "prediction_mpc": 0.89,
+        "prediction_mpc_cbf": 0.87,
+        "goal": 0.40,
+        "social_force": 0.43,
+        "orca": 0.46,
+        "socnav_sampling": 0.41,
+        "sacadrl": 0.44,
+    }
+    rows = _rows_with_success(success)
+    out = tmp_path / "candidate_ranking.csv"
+    ranking = metric.build_ranking_for_matrix(
+        packet_path=PACKET,
+        episode_rows_path=_write_rows(tmp_path, "cand_rows.csv", rows),
+        output_path=out,
+    )
+    assert ranking["predictive"] < ranking["learned_policy"]
+
+
+def test_rejects_fallback_or_degraded_rows(tmp_path: Path) -> None:
+    """Fallback/degraded planner rows must not enter the structural ranking."""
+    rows = _rows_with_success({})
+    rows[0]["execution_mode"] = "fallback"
+    out = tmp_path / "out.csv"
+    try:
+        metric.build_ranking_for_matrix(
+            packet_path=PACKET,
+            episode_rows_path=_write_rows(tmp_path, "rows.csv", rows),
+            output_path=out,
+        )
+    except metric.RankingMetricError as exc:
+        assert "fallback" in str(exc).lower()
+    else:
+        raise AssertionError("fallback row must fail closed")
+
+
+def test_rejects_unknown_planner(tmp_path: Path) -> None:
+    """A planner outside the preregistered roster cannot be ranked."""
+    rows = _rows_with_success({})
+    rows[0]["planner_key"] = "unknown_planner"
+    out = tmp_path / "out.csv"
+    try:
+        metric.build_ranking_for_matrix(
+            packet_path=PACKET,
+            episode_rows_path=_write_rows(tmp_path, "rows.csv", rows),
+            output_path=out,
+        )
+    except metric.RankingMetricError as exc:
+        assert "not in preregistered roster" in str(exc)
+    else:
+        raise AssertionError("unknown planner must fail closed")
+
+
+def test_rejects_matrix_with_missing_class(tmp_path: Path) -> None:
+    """A matrix whose campaign produced no rows for a structural class fails closed."""
+    rows = _rows_with_success({})
+    rows = [row for row in rows if row["planner_key"] not in ("ppo", "guarded_ppo")]
+    out = tmp_path / "out.csv"
+    try:
+        metric.build_ranking_for_matrix(
+            packet_path=PACKET,
+            episode_rows_path=_write_rows(tmp_path, "rows.csv", rows),
+            output_path=out,
+        )
+    except metric.RankingMetricError as exc:
+        assert "no eligible rows" in str(exc)
+    else:
+        raise AssertionError("missing-class matrix must fail closed")
+
+
+def test_metric_output_feedable_to_agreement_builder(
+    tmp_path: Path,
+) -> None:
+    """The metric output CSV is directly consumable by the #5642 agreement builder."""
+    from scripts.validation import build_issue_5592_cross_matrix_agreement as builder
+
+    ref_rows = _rows_with_success(
+        {
+            "scenario_adaptive_hybrid_orca_v1": 0.95,
+            "ppo": 0.80,
+            "prediction_planner": 0.70,
+            "goal": 0.40,
+        }
+    )
+    cand_rows = _rows_with_success(
+        {
+            "scenario_adaptive_hybrid_orca_v1": 0.93,
+            "ppo": 0.55,
+            "prediction_planner": 0.88,
+            "goal": 0.40,
+        }
+    )
+    ref_ranking = tmp_path / "ref_ranking.csv"
+    cand_ranking = tmp_path / "cand_ranking.csv"
+    metric.build_ranking_for_matrix(
+        packet_path=PACKET,
+        episode_rows_path=_write_rows(tmp_path, "ref.csv", ref_rows),
+        output_path=ref_ranking,
+    )
+    metric.build_ranking_for_matrix(
+        packet_path=PACKET,
+        episode_rows_path=_write_rows(tmp_path, "cand.csv", cand_rows),
+        output_path=cand_ranking,
+    )
+
+    summary = builder.build_packet(
+        packet_path=PACKET,
+        reference_ranking_path=ref_ranking,
+        candidate_ranking_path=cand_ranking,
+        output_dir=tmp_path / "out",
+        generated_at="2026-07-17T00:00:00+00:00",
+    )
+    assert summary["status"] == "ready"
+    # Reference: hybrid best; candidate: predictive improved past learned -> a flip exists.
+    assert summary["disagreement_row_count"] >= 1

--- a/tests/validation/test_compute_issue_5592_structural_ranking.py
+++ b/tests/validation/test_compute_issue_5592_structural_ranking.py
@@ -229,3 +229,25 @@ def test_metric_output_feedable_to_agreement_builder(
     assert summary["status"] == "ready"
     # Reference: hybrid best; candidate: predictive improved past learned -> a flip exists.
     assert summary["disagreement_row_count"] >= 1
+
+
+def test_rejects_row_missing_required_metric_field(tmp_path: Path) -> None:
+    """A row missing a core metric field must fail closed, not impute a best-case value.
+
+    A missing ``collision_event_rate`` must not be silently treated as 0.0 (best), since
+    that would mask a data problem and rank the class as collision-free.
+    """
+    rows = _rows_with_success({})
+    del rows[0]["collision_event_rate"]
+    out = tmp_path / "out.csv"
+    try:
+        metric.build_ranking_for_matrix(
+            packet_path=PACKET,
+            episode_rows_path=_write_rows(tmp_path, "rows.csv", rows),
+            output_path=out,
+        )
+    except metric.RankingMetricError as exc:
+        assert "collision_event_rate" in str(exc)
+        assert "missing required metric field" in str(exc)
+    else:
+        raise AssertionError("missing required metric field must fail closed")

--- a/tests/validation/test_compute_issue_5592_structural_ranking.py
+++ b/tests/validation/test_compute_issue_5592_structural_ranking.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from scripts.validation import compute_issue_5592_structural_ranking as metric
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -23,6 +25,10 @@ PLANNERS_BY_CLASS = {
 
 def _rows_with_success(success_by_planner: dict[str, float]) -> list[dict[str, str]]:
     """Build a per-planner episode-aggregate row set from success-rate overrides."""
+    known_planners = {planner for planners in PLANNERS_BY_CLASS.values() for planner in planners}
+    unknown_planners = set(success_by_planner) - known_planners
+    if unknown_planners:
+        raise KeyError(f"unknown planner override(s): {sorted(unknown_planners)}")
     rows = []
     for planners in PLANNERS_BY_CLASS.values():
         for planner in planners:
@@ -229,6 +235,36 @@ def test_metric_output_feedable_to_agreement_builder(
     assert summary["status"] == "ready"
     # Reference: hybrid best; candidate: predictive improved past learned -> a flip exists.
     assert summary["disagreement_row_count"] >= 1
+
+
+def test_fixture_rejects_unknown_success_override() -> None:
+    """Fixture typos must fail instead of silently changing no planner."""
+    with pytest.raises(KeyError, match="unknown planner override"):
+        _rows_with_success({"typo_planner": 0.9})
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("success_rate", "NaN"),
+        ("collision_event_rate", "Inf"),
+        ("near_miss_event_rate", "-Inf"),
+        ("timeout_rate", "not-a-number"),
+        ("snqi_mean", "NaN"),
+    ],
+)
+def test_rejects_nonfinite_or_malformed_metric_cells(
+    tmp_path: Path, field: str, value: str
+) -> None:
+    """Non-finite or malformed numeric cells must fail closed before ranking."""
+    rows = _rows_with_success({})
+    rows[0][field] = value
+    with pytest.raises(metric.RankingMetricError, match="invalid or non-finite"):
+        metric.build_ranking_for_matrix(
+            packet_path=PACKET,
+            episode_rows_path=_write_rows(tmp_path, "rows.csv", rows),
+            output_path=tmp_path / "out.csv",
+        )
 
 
 def test_rejects_row_missing_required_metric_field(tmp_path: Path) -> None:


### PR DESCRIPTION
## What / Why

Issue #5592 is the cross-matrix generalization check for the structural planner ranking. All previous merged slices (#5622 pre-registration+checker, #5642 agreement builder, #5688 metadata review gate, #5895 row gate) are CPU-contract packets that treat the two structural-class ranking CSVs as *inputs* supplied by a future paid campaign.

The 15th-visit thread identified a genuine unmet input that IS implementable in the cheap-lane: the metric `constraints_first_structural_rank` is **named** in the pre-registration contract (`configs/benchmarks/issue_5592_cross_matrix_preregistration.yaml` → `comparison_contract.metric`) but **nothing computes it**. Episode outcomes could not be turned into the `1..4` structural-class ranking the #5642 generator consumes. This slice closes that gap.

### New capability (does not duplicate prior PRs)
- `scripts/validation/compute_issue_5592_structural_ranking.py`: pure-CPU aggregation that converts per-planner episode aggregates (per matrix) into an independent `1..4` structural-class ranking, bound to the preregistered 12-planner roster signature (`roster_signature` column). Output CSV is directly consumed by the existing #5642 `build_issue_5592_cross_matrix_agreement.py`.
- Scoring semantics follow the constraints-first ordering (higher success / lower collision / lower near-miss / lower timeout / higher SNQI = better), reusing the fail-closed precedent from `build_issue_4206_policy_structure_mechanism_crosscut.py`.
- Fail-closed on: fallback/degraded execution rows, unknown planners (outside roster), malformed or non-finite metric cells, and structural classes with no eligible rows.

### What this is NOT
- It does **not** run the campaign. It is the artifact-first metric between campaign episode rows and the agreement table.
- It does **not** promote any ranking or edit paper/dissertation claims.
- The aggregation formula remains subject to the maintainer decision recorded in [#5982](https://github.com/ll7/robot_sf_ll7/issues/5982); until that contract is approved, this PR is diagnostic implementation work and is not merge-ready benchmark evidence.

## Research Result Guidance

- Target claim / hypothesis / blocker: provide a CPU-only implementation candidate for the missing #5592 ranking transformation without claiming cross-matrix transfer.
- Comparator or baseline: none; no campaign ranking or agreement result is produced here.
- Evidence tier: diagnostic probe
- Result classification: diagnostic-only / blocker-resolution candidate
- Decision or stop rule: stop before benchmark use until #5982 approves the metric semantics; then align this implementation and focused tests to that contract.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #5592 and the existing #5642 agreement builder; no ranking claim is promoted by this PR.
- New analysis tool representative use: synthetic contract fixtures only; no durable campaign input is available in this cheap-lane slice. The follow-up decision and later campaign are tracked by #5982/#5592.

## Domain-Aware Approval

- Required for this PR: yes - the metric defines a ranking used by a benchmark comparison surface.
- Domains reviewed: benchmark interpretation, evidence classification
- Status: blocked pending maintainer decision in [#5982](https://github.com/ll7/robot_sf_ll7/issues/5982)
- Approver/review source or waiver: batch-gate review of the exact-head diff and current #5592 maintainer comments; no semantics approval is inferred from passing tests.
- Validity checklist:
  - Target claim/hypothesis: implementation candidate for `constraints_first_structural_rank`, not a transfer/generalization result.
  - Comparator or split/evidence validity: no native matrix comparison is run or claimed.
  - Fallback/degraded exclusions: fallback/degraded rows and malformed/non-finite metric cells fail closed; no degraded row is success evidence.
  - Claim boundary: no ranking promotion, cross-matrix conclusion, paper claim, or figure eligibility.
  - Implementation integrity vs experimental validity: focused synthetic tests support implementation integrity only; experimental validity remains blocked on the approved metric contract and paired campaign.

## Validation output
- `uv run python -m pytest tests/validation/test_compute_issue_5592_structural_ranking.py` → **14 passed**
- Full issue-5592 validation suite `tests/validation/test_*5592*.py` → **61 passed** (no regression)
- `ruff check` + `ruff format` clean on both new files
- CLI smoke test confirms valid `1..4` permutation CSV with roster signature; feeding two such CSVs into the #5642 builder yields `status: ready` with a real disagreement row (rank flip), exercised by `test_metric_output_feedable_to_agreement_builder`.

## Remaining (successor lane — campaign-capable, not cheap)
0. Resolve the metric-semantics decision in [#5982](https://github.com/ll7/robot_sf_ll7/issues/5982) before treating this implementation as the frozen #5592 contract.
1. Run the pre-registered paired campaign (5 seeds `[20..24]`, h600, dt=0.1, 12-planner roster) for both `classic_interactions` (reference) and `atomic_topology` (candidate) matrices.
2. Feed each matrix's per-planner episode aggregates through `compute_issue_5592_structural_ranking.py` to produce the two ranking CSVs.
3. Run `build_issue_5592_cross_matrix_agreement.py` with both ranking CSVs to materialize the durable `cross_matrix_agreement.csv` + `metadata.json` + `README.md` + `integration_report.md` + `SHA256SUMS` under `docs/context/evidence/issue_5592_cross_matrix`.

Refs #5592 (this slice resolves the missing metric candidate; the semantics decision, campaign, and agreement-artifact step remain in the decision/campaign-capable lanes).

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and evaluates it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to compute and export constraints-first structural performance rankings as a CSV (structural class, rank, and a roster signature).
  * Rankings combine success, collision/near-miss/timeout signals, and SNQI (when available) and enforce a preregistered structural-class roster.
  * Strict input validation rejects fallback/degraded/unavailable rows, unknown planners, non-finite/malformed metrics, and missing required fields.
* **Tests**
  * Added contract tests for correct 1–4 rankings, ordering changes for candidate data, failure-closed behavior on invalid inputs, and compatibility with cross-matrix agreement generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
