### PR TITLE
Issue #5958: retry/backoff + fail-closed diagnostics for PR merge staleness helper (cheap-lane worker)

### DIFF
--- a/scripts/dev/check_pr_merge_staleness.py
+++ b/scripts/dev/check_pr_merge_staleness.py
@@ -27,7 +27,18 @@ import argparse
 import json
 import subprocess
 import sys
-from typing import Any
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Retry budget for transient GitHub API failures (429/5xx, timeout, connection).
+# Permanent failures (auth, not-found) are never retried.
+GH_RETRY_MAX_ATTEMPTS = 4
+GH_RETRY_BACKOFF_BASE = 1.0
+GH_RETRY_MAX_BACKOFF = 8.0
 
 
 def _gh(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
@@ -39,6 +50,165 @@ def _gh(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
         timeout=timeout,
         check=False,
     )
+
+
+class _PermanentApiError(Exception):
+    """A GitHub API request failed for a reason that will not be fixed by retrying."""
+
+    def __init__(self, message: str, *, kind: str) -> None:
+        super().__init__(message)
+        self.message = message
+        self.kind = kind
+
+
+def _is_transient_gh_failure(result: subprocess.CompletedProcess) -> bool:
+    """Return True when a failed gh call is worth retrying.
+
+    Transient conditions: HTTP 429 (rate limit), 5xx (server error), or a
+    generic network/timeout error reported by gh.  Permanent conditions such as
+    authentication or not-found are not transient.
+    """
+    if result.returncode == 0:
+        return False
+    stderr = (result.stderr or "").lower()
+    stdout = (result.stdout or "").lower()
+    combined = f"{stderr} {stdout}"
+    # Permanent conditions: do not retry.
+    if "not found" in combined or "404" in combined:
+        return False
+    if "could not resolve" in combined or "repository" in combined:
+        return False
+    if "authentication" in combined or "unauthorized" in combined or "401" in combined:
+        return False
+    if "403" in combined and "rate" not in combined:
+        return False
+    # Transient conditions.
+    if "rate limit" in combined or "429" in combined:
+        return True
+    if any(code in combined for code in ("500", "502", "503", "504")):
+        return True
+    # gh exited non-zero without an explicit permanent marker: treat network /
+    # timeout style failures as transient.
+    if "timeout" in combined or "timed out" in combined or "connection" in combined:
+        return True
+    # gh exited non-zero with no recognizable message (e.g. killed mid-run).
+    return True
+
+
+def _gh_with_retry(
+    args: list[str],
+    *,
+    timeout: int = 30,
+    max_attempts: int = GH_RETRY_MAX_ATTEMPTS,
+    backoff_base: float = GH_RETRY_BACKOFF_BASE,
+    max_backoff: float = GH_RETRY_MAX_BACKOFF,
+    sleep: Callable[[float], None] | None = None,
+) -> subprocess.CompletedProcess:
+    """Run a ``gh`` command with bounded exponential backoff on transient failure.
+
+    Permanent failures (auth, not-found) raise ``_PermanentApiError`` immediately.
+    Persistent transient failure exhausts the retry budget and also raises
+    ``_PermanentApiError`` (kind ``"unavailable"``) so callers fail closed rather
+    than inferring branch freshness from a missing response.
+    """
+    last_error: Exception | None = None
+    do_sleep = sleep if sleep is not None else time.sleep
+    for attempt in range(1, max_attempts + 1):
+        try:
+            result = _gh(args, timeout=timeout)
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            last_error = exc
+            if attempt >= max_attempts:
+                break
+            do_sleep(min(backoff_base * (2 ** (attempt - 1)), max_backoff))
+            continue
+
+        if result.returncode == 0:
+            return result
+
+        stderr = (result.stderr or "").lower()
+        stdout = (result.stdout or "").lower()
+        combined = f"{stderr} {stdout}"
+        if "not found" in combined or "404" in combined:
+            raise _PermanentApiError(
+                f"GitHub API not found for {args[0]}: {result.stderr.strip() or result.stdout.strip()}",
+                kind="not_found",
+            )
+        if "authentication" in combined or "unauthorized" in combined or "401" in combined:
+            raise _PermanentApiError(
+                f"GitHub API authentication failed for {args[0]}: "
+                f"{result.stderr.strip() or result.stdout.strip()}",
+                kind="auth",
+            )
+
+        last_error = subprocess.CalledProcessError(
+            result.returncode, ["gh", *args], result.stdout, result.stderr
+        )
+        if attempt >= max_attempts:
+            break
+        do_sleep(min(backoff_base * (2 ** (attempt - 1)), max_backoff))
+
+    raise _PermanentApiError(
+        f"GitHub API unavailable after retries (persistent transient failure): {last_error}",
+        kind="unavailable",
+    )
+
+
+@dataclass
+class _MainShaResult:
+    """Result of fetching the current main SHA with retry/backoff."""
+
+    sha: str | None
+    error: str | None = None
+    unavailable: bool = False
+
+
+def _fetch_main_sha_with_retry(repo: str) -> _MainShaResult:
+    """Fetch current main HEAD SHA, retrying transient API failures.
+
+    Returns an explicit ``unavailable`` result on persistent transient failure
+    rather than inferring freshness from a missing response.
+    """
+    try:
+        result = _gh_with_retry(["api", f"repos/{repo}/git/refs/heads/main", "--jq", ".object.sha"])
+    except _PermanentApiError as exc:
+        if exc.kind == "unavailable":
+            return _MainShaResult(sha=None, error=exc.message, unavailable=True)
+        return _MainShaResult(sha=None, error=exc.message)
+    sha = result.stdout.strip()
+    if not sha:
+        return _MainShaResult(sha=None, error="GitHub API returned an empty main SHA")
+    return _MainShaResult(sha=sha)
+
+
+def _fetch_workflow_runs_with_retry(repo: str, head_branch: str) -> list[dict[str, Any]] | None:
+    """Fetch workflow runs for a PR head branch, retrying transient failures.
+
+    Returns ``None`` for permanent failures (auth, not-found) and for persistent
+    transient failure (unavailable), leaving the caller on the documented fallback
+    path without inferring a base SHA.
+    """
+    try:
+        result = _gh_with_retry(
+            [
+                "api",
+                f"repos/{repo}/actions/runs",
+                "--method",
+                "GET",
+                "-f",
+                f"branch={head_branch}",
+                "-f",
+                "event=pull_request",
+                "-f",
+                "per_page=100",
+            ]
+        )
+    except _PermanentApiError:
+        return None
+    payload, _ = _parse_json(result.stdout)
+    if not isinstance(payload, dict) or not isinstance(payload.get("workflow_runs"), list):
+        return None
+    return [run for run in payload["workflow_runs"] if isinstance(run, dict)]
 
 
 def _parse_json(stdout: str) -> tuple[dict[str, Any] | None, str | None]:
@@ -53,12 +223,13 @@ def _parse_json(stdout: str) -> tuple[dict[str, Any] | None, str | None]:
 
 
 def _get_main_sha(repo: str) -> str | None:
-    """Return current main branch HEAD SHA, or None on error."""
-    result = _gh(["api", f"repos/{repo}/git/refs/heads/main", "--jq", ".object.sha"])
-    if result.returncode != 0:
-        return None
-    sha = result.stdout.strip()
-    return sha if sha else None
+    """Return current main branch HEAD SHA, or None on error.
+
+    Retries transient API failures; returns None on permanent or persistent
+    transient failure (the caller treats None as an explicit error, never as
+    a freshness signal).
+    """
+    return _fetch_main_sha_with_retry(repo).sha
 
 
 def _fetch_pr_head_metadata(pr_number: str, *, repo: str) -> tuple[str | None, str | None]:
@@ -79,27 +250,12 @@ def _fetch_pr_head_metadata(pr_number: str, *, repo: str) -> tuple[str | None, s
 
 
 def _fetch_workflow_runs(repo: str, head_branch: str) -> list[dict[str, Any]] | None:
-    """Return workflow-run objects for a PR head branch, or ``None`` on API failure."""
-    result = _gh(
-        [
-            "api",
-            f"repos/{repo}/actions/runs",
-            "--method",
-            "GET",
-            "-f",
-            f"branch={head_branch}",
-            "-f",
-            "event=pull_request",
-            "-f",
-            "per_page=100",
-        ],
-    )
-    if result.returncode != 0:
-        return None
-    payload, _ = _parse_json(result.stdout)
-    if not isinstance(payload, dict) or not isinstance(payload.get("workflow_runs"), list):
-        return None
-    return [run for run in payload["workflow_runs"] if isinstance(run, dict)]
+    """Return workflow-run objects for a PR head branch, or ``None`` on API failure.
+
+    Retries transient failures; returns None on permanent or persistent transient
+    failure so the caller falls back without inferring a base SHA.
+    """
+    return _fetch_workflow_runs_with_retry(repo, head_branch)
 
 
 def _find_workflow_run_base_sha(
@@ -171,17 +327,23 @@ def check_merge_staleness(
       - ``detection``: ``"workflow_run_base_sha"`` | ``"base_vs_main"``
       - ``pr``, ``base_sha``, ``main_sha``
     """
-    main_sha = _get_main_sha(repo)
-    if main_sha is None:
+    main_result = _fetch_main_sha_with_retry(repo)
+    if main_result.sha is None:
+        unavailable = (
+            " (persistent transient API failure; not retried further)"
+            if main_result.unavailable
+            else ""
+        )
         return {
             "status": "error",
-            "error": "Failed to fetch current main SHA",
+            "error": (main_result.error or "Failed to fetch current main SHA") + unavailable,
             "stale": None,
             "detection": "error",
             "pr": pr_number,
             "base_sha": base_sha,
             "main_sha": None,
         }
+    main_sha = main_result.sha
 
     ci_base_sha = _detect_workflow_run_base_sha(repo, pr_number)
     if ci_base_sha:

--- a/scripts/dev/check_pr_merge_staleness.py
+++ b/scripts/dev/check_pr_merge_staleness.py
@@ -129,16 +129,17 @@ def _gh_with_retry(
         stderr = (result.stderr or "").lower()
         stdout = (result.stdout or "").lower()
         combined = f"{stderr} {stdout}"
-        if "not found" in combined or "404" in combined:
+        if not _is_transient_gh_failure(result):
+            if "not found" in combined or "404" in combined:
+                kind = "not_found"
+            elif "authentication" in combined or "unauthorized" in combined or "401" in combined:
+                kind = "auth"
+            else:
+                kind = "permanent"
             raise _PermanentApiError(
-                f"GitHub API not found for {args[0]}: {result.stderr.strip() or result.stdout.strip()}",
-                kind="not_found",
-            )
-        if "authentication" in combined or "unauthorized" in combined or "401" in combined:
-            raise _PermanentApiError(
-                f"GitHub API authentication failed for {args[0]}: "
+                f"GitHub API permanent failure for {args[0]}: "
                 f"{result.stderr.strip() or result.stdout.strip()}",
-                kind="auth",
+                kind=kind,
             )
 
         last_error = subprocess.CalledProcessError(

--- a/tests/dev/test_check_pr_merge_staleness.py
+++ b/tests/dev/test_check_pr_merge_staleness.py
@@ -10,7 +10,12 @@ import pytest
 
 from scripts.dev.check_pr_merge_staleness import (
     _detect_workflow_run_base_sha,
+    _fetch_main_sha_with_retry,
     _fetch_pr_base_sha,
+    _fetch_workflow_runs_with_retry,
+    _gh_with_retry,
+    _is_transient_gh_failure,
+    _PermanentApiError,
     check_merge_staleness,
     format_human,
     main,
@@ -78,7 +83,7 @@ def test_fresh_when_base_matches_main() -> None:
 
 
 def test_error_when_main_sha_fails() -> None:
-    """Error status should propagate when fetching main SHA fails."""
+    """Error status should propagate when fetching main SHA fails (permanent)."""
     with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
         mock_gh.return_value = _gh_response(returncode=1, stderr="not found")
         data = check_merge_staleness("1", base_sha="abc", repo="owner/repo")
@@ -86,7 +91,7 @@ def test_error_when_main_sha_fails() -> None:
     assert data["status"] == "error"
     assert data["stale"] is None
     assert data["detection"] == "error"
-    assert "Failed to fetch current main SHA" in data["error"]
+    assert "Failed to fetch" in data["error"] or "not found" in data["error"]
 
 
 def test_main_sha_empty_string_treated_as_error() -> None:
@@ -160,9 +165,16 @@ def test_detect_workflow_run_base_sha_skips_other_prs() -> None:
 
 def test_detect_workflow_run_base_sha_returns_none_on_api_error() -> None:
     """Actions API failures leave the caller on the documented fallback path."""
-    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch("scripts.dev.check_pr_merge_staleness.time.sleep"),
+    ):
         mock_gh.side_effect = [
             _gh_response(stdout=json.dumps({"headRefName": "feature/x", "headRefOid": "head_sha"})),
+            # Persistent transient failure exhausts the retry budget.
+            _gh_response(returncode=1, stderr="API unavailable"),
+            _gh_response(returncode=1, stderr="API unavailable"),
+            _gh_response(returncode=1, stderr="API unavailable"),
             _gh_response(returncode=1, stderr="API unavailable"),
         ]
         result = _detect_workflow_run_base_sha("owner/repo", "42")
@@ -350,21 +362,27 @@ def test_main_exit_1_when_stale(capsys: pytest.CaptureFixture) -> None:
 
 
 def test_main_exit_2_on_error(capsys: pytest.CaptureFixture) -> None:
-    """main() should return 2 when the check itself errors."""
+    """main() should return 2 when the check itself errors (persistent transient)."""
     with (
         patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
         patch(
             "scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha", return_value=None
         ),
+        patch("scripts.dev.check_pr_merge_staleness.time.sleep") as mock_sleep,
     ):
         mock_gh.side_effect = [
             _gh_response(stdout="ll7/robot_sf_ll7"),
             _gh_response(stdout=json.dumps({"base": {"sha": "abc"}})),
+            # Persistent transient failure: exhausts the retry budget.
+            _gh_response(returncode=1, stderr="network error"),
+            _gh_response(returncode=1, stderr="network error"),
+            _gh_response(returncode=1, stderr="network error"),
             _gh_response(returncode=1, stderr="network error"),
         ]
         rc = main(["1"])
 
     assert rc == 2
+    assert mock_sleep.call_count == 3
     captured = capsys.readouterr()
     assert "ERROR" in captured.out
 
@@ -475,3 +493,160 @@ def test_main_repo_detect_failure(capsys: pytest.CaptureFixture) -> None:
 
     assert rc == 1
     assert "Failed to detect repository" in capsys.readouterr().err
+
+
+# ── retry / backoff (issue #5958) ─────────────────────────────────────────────
+
+
+def test_is_transient_gh_failure_classifies_transient() -> None:
+    """429/5xx/timeout/connection failures are transient and worth retrying."""
+    transient_cases = [
+        _gh_response(returncode=1, stderr="HTTP 429: rate limit"),
+        _gh_response(returncode=1, stderr="HTTP 503 Service Unavailable"),
+        _gh_response(returncode=1, stderr="request timed out"),
+        _gh_response(returncode=1, stderr="connection reset by peer"),
+    ]
+    for resp in transient_cases:
+        assert _is_transient_gh_failure(resp) is True
+
+
+def test_is_transient_gh_failure_classifies_permanent() -> None:
+    """Auth / not-found failures are permanent and must not be retried."""
+    permanent_cases = [
+        _gh_response(returncode=1, stderr="HTTP 404 Not Found"),
+        _gh_response(returncode=1, stderr="graphql: Could not resolve to a Repository"),
+        _gh_response(returncode=1, stderr="HTTP 401 Unauthorized"),
+    ]
+    for resp in permanent_cases:
+        assert _is_transient_gh_failure(resp) is False
+
+
+def test_gh_with_retry_succeeds_after_transient_failure() -> None:
+    """A transient failure followed by success returns the success without sleep."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch("scripts.dev.check_pr_merge_staleness.time.sleep") as mock_sleep,
+    ):
+        mock_gh.side_effect = [
+            _gh_response(returncode=1, stderr="HTTP 503"),
+            _gh_response(stdout="main_head_sha"),
+        ]
+        result = _gh_with_retry(["api", "repos/o/r/git/refs/heads/main", "--jq", ".object.sha"])
+
+    assert result.stdout.strip() == "main_head_sha"
+    assert mock_sleep.call_count == 1
+
+
+def test_gh_with_retry_permanent_failure_raises_immediately() -> None:
+    """A permanent (auth/not-found) failure raises without any retry sleep."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch("scripts.dev.check_pr_merge_staleness.time.sleep") as mock_sleep,
+    ):
+        mock_gh.return_value = _gh_response(returncode=1, stderr="HTTP 404 Not Found")
+        with pytest.raises(_PermanentApiError) as excinfo:
+            _gh_with_retry(["api", "repos/o/r/git/refs/heads/main"])
+
+    assert excinfo.value.kind == "not_found"
+    assert mock_sleep.call_count == 0
+
+
+def test_gh_with_retry_persistent_transient_raises_unavailable() -> None:
+    """Persistent transient failure exhausts the budget and raises unavailable."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch("scripts.dev.check_pr_merge_staleness.time.sleep") as mock_sleep,
+    ):
+        mock_gh.return_value = _gh_response(returncode=1, stderr="HTTP 429 rate limit")
+        with pytest.raises(_PermanentApiError) as excinfo:
+            _gh_with_retry(["api", "repos/o/r/git/refs/heads/main"])
+
+    assert excinfo.value.kind == "unavailable"
+    # max_attempts=4 -> 3 sleeps before the final attempt fails.
+    assert mock_sleep.call_count == 3
+
+
+def test_gh_with_retry_backoff_grows() -> None:
+    """Backoff should grow exponentially and be capped at the maximum."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch("scripts.dev.check_pr_merge_staleness.time.sleep") as mock_sleep,
+    ):
+        mock_gh.return_value = _gh_response(returncode=1, stderr="HTTP 503")
+        with pytest.raises(_PermanentApiError):
+            _gh_with_retry(["api", "x"], max_attempts=4, backoff_base=1.0, max_backoff=8.0)
+
+    sleeps = [c.args[0] for c in mock_sleep.call_args_list]
+    assert sleeps == [1.0, 2.0, 4.0]
+
+
+def test_fetch_main_sha_with_retry_returns_sha() -> None:
+    """A transient hiccup resolved on retry still yields the main SHA."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch("scripts.dev.check_pr_merge_staleness.time.sleep"),
+    ):
+        mock_gh.side_effect = [
+            _gh_response(returncode=1, stderr="HTTP 503"),
+            _gh_response(stdout="resolved_main_sha"),
+        ]
+        result = _fetch_main_sha_with_retry("owner/repo")
+
+    assert result.sha == "resolved_main_sha"
+    assert result.unavailable is False
+
+
+def test_fetch_main_sha_with_retry_unavailable_on_persistent_failure() -> None:
+    """Persistent transient failure returns an explicit unavailable result."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch("scripts.dev.check_pr_merge_staleness.time.sleep"),
+    ):
+        mock_gh.return_value = _gh_response(returncode=1, stderr="HTTP 429 rate limit")
+        result = _fetch_main_sha_with_retry("owner/repo")
+
+    assert result.sha is None
+    assert result.unavailable is True
+    assert "unavailable" in (result.error or "")
+
+
+def test_fetch_main_sha_with_retry_permanent_not_found() -> None:
+    """A permanent not-found failure is reported without exhausting retries."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch("scripts.dev.check_pr_merge_staleness.time.sleep") as mock_sleep,
+    ):
+        mock_gh.return_value = _gh_response(returncode=1, stderr="HTTP 404 Not Found")
+        result = _fetch_main_sha_with_retry("owner/repo")
+
+    assert result.sha is None
+    assert result.unavailable is False
+    assert mock_sleep.call_count == 0
+
+
+def test_fetch_workflow_runs_with_retry_returns_none_on_persistent_failure() -> None:
+    """Persistent transient failure returns None (fallback path), not a base SHA."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch("scripts.dev.check_pr_merge_staleness.time.sleep"),
+    ):
+        mock_gh.return_value = _gh_response(returncode=1, stderr="HTTP 503")
+        result = _fetch_workflow_runs_with_retry("owner/repo", "feature/x")
+
+    assert result is None
+
+
+def test_check_merge_staleness_error_on_unavailable_main_sha() -> None:
+    """Persistent transient main-SHA failure must not infer freshness; error instead."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch("scripts.dev.check_pr_merge_staleness.time.sleep"),
+    ):
+        mock_gh.return_value = _gh_response(returncode=1, stderr="HTTP 429 rate limit")
+        data = check_merge_staleness("1", base_sha="abc", repo="owner/repo")
+
+    assert data["status"] == "error"
+    assert data["stale"] is None
+    assert data["detection"] == "error"
+    assert data["main_sha"] is None
+    assert "persistent transient" in data["error"]

--- a/tests/dev/test_check_pr_merge_staleness.py
+++ b/tests/dev/test_check_pr_merge_staleness.py
@@ -537,17 +537,29 @@ def test_gh_with_retry_succeeds_after_transient_failure() -> None:
     assert mock_sleep.call_count == 1
 
 
-def test_gh_with_retry_permanent_failure_raises_immediately() -> None:
-    """A permanent (auth/not-found) failure raises without any retry sleep."""
+@pytest.mark.parametrize(
+    ("stderr", "expected_kind"),
+    [
+        ("HTTP 404 Not Found", "not_found"),
+        ("graphql: Could not resolve to a Repository", "permanent"),
+        ("HTTP 403 Forbidden", "permanent"),
+        ("HTTP 401 Unauthorized", "auth"),
+    ],
+)
+def test_gh_with_retry_permanent_failure_raises_immediately(
+    stderr: str, expected_kind: str
+) -> None:
+    """Permanent failures raise without any retry sleep."""
     with (
         patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
         patch("scripts.dev.check_pr_merge_staleness.time.sleep") as mock_sleep,
     ):
-        mock_gh.return_value = _gh_response(returncode=1, stderr="HTTP 404 Not Found")
+        mock_gh.return_value = _gh_response(returncode=1, stderr=stderr)
         with pytest.raises(_PermanentApiError) as excinfo:
             _gh_with_retry(["api", "repos/o/r/git/refs/heads/main"])
 
-    assert excinfo.value.kind == "not_found"
+    assert excinfo.value.kind == expected_kind
+    assert mock_gh.call_count == 1
     assert mock_sleep.call_count == 0
 
 


### PR DESCRIPTION
## What / Why

Issue #5958 follows up on PR #5920's deferred item: the PR merge-staleness
helper (`scripts/dev/check_pr_merge_staleness.py`) could fail closed with a
false result when the current-`main` or workflow-run GitHub API request
transiently failed. This PR adds bounded retry/backoff and fail-closed
diagnostics to those two requests without changing the staleness decision logic.

### Changes (new capability vs PR #5920)
- `_gh_with_retry`: runs any `gh` command with exponential backoff
  (`GH_RETRY_MAX_ATTEMPTS=4`, base 1s, cap 8s) on transient failure.
- `_is_transient_gh_failure`: classifies 429/5xx/timeout/connection as
  transient; auth and not-found as permanent (never retried).
- `_fetch_main_sha_with_retry` / `_fetch_workflow_runs_with_retry`: use the
  retry primitive and preserve the invariant that an unavailable API never
  produces a false `fresh`/`stale` verdict.
- Persistent transient failure returns an explicit `unavailable` error status
  rather than inferring branch freshness.

### Acceptance (from issue)
- Transient 429/5xx/timeout/connection failures retry with a bounded budget. ✅
- Permanent auth/not-found failures fail immediately with an actionable diagnostic. ✅
- Persistent transient failure returns explicit unavailable/error status. ✅
- Focused tests cover retry, permanent failure, and persistent failure paths. ✅
- The canonical staleness command is exercised against a fake API/deterministic fixture. ✅

## Validation
`uv run pytest tests/dev/test_check_pr_merge_staleness.py` → **42 passed**.
`uv run ruff check` and `uv run ruff format --check` → **All checks passed**.

## Notes
This is the full scope of issue #5958 (a self-contained tooling hardening slice);
it fully resolves the issue. No benchmark/paper/dissertation claims are made.

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

Closes #5958
