### PR TITLE
Issue #5957: process_spawns diagnostic + >=5-step one-spawn guard (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/map_runner_native_command.py
+++ b/robot_sf/benchmark/map_runner_native_command.py
@@ -368,7 +368,6 @@ class NativeCommandPlanner:
 
     def _start_process(self) -> None:
         self._stop_process()
-        self._process_spawns += 1
         try:
             self._process = subprocess.Popen(
                 self._spec.command,
@@ -378,6 +377,7 @@ class NativeCommandPlanner:
                 stderr=subprocess.DEVNULL,
                 bufsize=0,
             )
+            self._process_spawns += 1
         except OSError as exc:
             raise NativeCommandContractError(
                 f"failed to launch native command {self._spec.command}: {exc}",

--- a/robot_sf/benchmark/map_runner_native_command.py
+++ b/robot_sf/benchmark/map_runner_native_command.py
@@ -345,6 +345,11 @@ class NativeCommandPlanner:
         self._diagnostics: dict[str, Any] = dict.fromkeys(_DIAGNOSTICS_KEYS, 0)
         self._diagnostics["exit_codes"] = []
         self._diagnostics["last_exit_code"] = None
+        # How many times a subprocess was actually launched. This is the observable
+        # that makes the persistent-mode respawn bug (issue #5957) directly visible
+        # in episode diagnostics: a healthy persistent run records exactly one spawn
+        # regardless of horizon, while the per-episode mode records one spawn per step.
+        self._process_spawns = 0
         self._runtimes: list[float] = []
         self._deadlock = _NoProgressDeadlockDetector()
         # Plain serializable run state, updated every step so episode finalization can
@@ -363,6 +368,7 @@ class NativeCommandPlanner:
 
     def _start_process(self) -> None:
         self._stop_process()
+        self._process_spawns += 1
         try:
             self._process = subprocess.Popen(
                 self._spec.command,
@@ -456,6 +462,7 @@ class NativeCommandPlanner:
         return linear, angular
 
     def _plan_per_episode(self, request: str) -> tuple[list[str], float, float]:
+        self._process_spawns += 1
         try:
             proc = subprocess.run(
                 self._spec.command,
@@ -572,6 +579,7 @@ class NativeCommandPlanner:
             _RUNTIME_FIELD: [float(value) for value in self._runtimes],
             "exit_codes": list(self._diagnostics["exit_codes"]),
             "last_exit_code": self._diagnostics["last_exit_code"],
+            "process_spawns": int(self._process_spawns),
         }
 
     @property

--- a/robot_sf/benchmark/map_runner_native_command.py
+++ b/robot_sf/benchmark/map_runner_native_command.py
@@ -462,7 +462,6 @@ class NativeCommandPlanner:
         return linear, angular
 
     def _plan_per_episode(self, request: str) -> tuple[list[str], float, float]:
-        self._process_spawns += 1
         try:
             proc = subprocess.run(
                 self._spec.command,
@@ -473,6 +472,9 @@ class NativeCommandPlanner:
                 check=False,
             )
         except subprocess.TimeoutExpired as exc:
+            # The child was launched but exceeded the step budget, so it counts as a
+            # spawn (matches the persistent path's "only count an actual launch" rule).
+            self._process_spawns += 1
             self._diagnostics["runtime_bound_exits"] += 1
             self._diagnostics.setdefault("exit_codes", []).append(None)
             self._diagnostics["last_exit_code"] = None
@@ -480,9 +482,13 @@ class NativeCommandPlanner:
                 f"native command exceeded step timeout {self._spec.step_timeout_sec}s",
             ) from exc
         except OSError as exc:
+            # Not counted: the subprocess never launched (contract/launch failure).
             raise NativeCommandContractError(
                 f"failed to launch native command {self._spec.command}: {exc}",
             ) from exc
+        # The child launched and returned; count it even on a nonzero exit, since it
+        # did run (consistent with runner.py's _spawn-then-communicate per-episode path).
+        self._process_spawns += 1
         self._diagnostics.setdefault("exit_codes", []).append(proc.returncode)
         self._diagnostics["last_exit_code"] = proc.returncode
         if proc.returncode != 0:

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -606,10 +606,9 @@ class _NativeCommandPolicy:
         Returns:
             The spawned subprocess.Popen object.
         """
-        self._diagnostics["process_spawns"] += 1
         child_env = dict(os.environ)
         child_env.update({str(k): str(v) for k, v in self._env.items()})
-        return subprocess.Popen(
+        process = subprocess.Popen(
             self._argv,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
@@ -617,6 +616,8 @@ class _NativeCommandPolicy:
             env=child_env,
             bufsize=0,
         )
+        self._diagnostics["process_spawns"] += 1
+        return process
 
     def _ensure_process(self) -> subprocess.Popen[bytes]:
         """Start the persistent child process if needed.

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -562,6 +562,9 @@ class _NativeCommandPolicy:
     diagnostics the issue #5416 analyzer probe requires: per-step runtime,
     runtime-bound exits, fallback count, and expansion/commitment counters
     (zero for the thin native-command wrapper; a real SIPP binary owns those).
+    Also records ``process_spawns`` (the count of subprocess launches), which makes
+    the persistent-mode respawn regression (#5957) directly observable: a healthy
+    persistent run reports exactly one spawn regardless of horizon.
     """
 
     def __init__(
@@ -590,6 +593,11 @@ class _NativeCommandPolicy:
             NATIVE_COMMAND_RUNTIME_FIELD: [],
             "exit_codes": [],
             "last_exit_code": None,
+            # How many times a subprocess was actually launched. Makes the
+            # persistent-mode respawn bug (issue #5957) directly observable in
+            # episode diagnostics: a healthy persistent run records exactly one
+            # spawn regardless of horizon, while per-episode mode records one per step.
+            "process_spawns": 0,
         }
 
     def _spawn(self) -> subprocess.Popen[bytes]:
@@ -598,6 +606,7 @@ class _NativeCommandPolicy:
         Returns:
             The spawned subprocess.Popen object.
         """
+        self._diagnostics["process_spawns"] += 1
         child_env = dict(os.environ)
         child_env.update({str(k): str(v) for k, v in self._env.items()})
         return subprocess.Popen(

--- a/tests/benchmark/test_map_runner_native_command.py
+++ b/tests/benchmark/test_map_runner_native_command.py
@@ -263,19 +263,21 @@ class TestNativeCommandPolicyBuilder:
         policy._planner_reset(seed=111)
         planner = policy._native_planner
 
-        num_steps = 6  # >= 5 as required by the issue
-        for _ in range(num_steps):
-            linear, angular = policy(obs)
-            assert isinstance(linear, float)
-            assert isinstance(angular, float)
+        try:
+            num_steps = 6  # >= 5 as required by the issue
+            for _ in range(num_steps):
+                linear, angular = policy(obs)
+                assert isinstance(linear, float)
+                assert isinstance(angular, float)
 
-        diag = planner.diagnostics
-        # One persistent child reused across every step — the whole point of #5957.
-        assert diag["process_spawns"] == 1
-        # And it genuinely served all steps with no fallback.
-        assert diag["fallback_count"] == 0
-        assert diag["runtime_bound_exits"] == 0
-        policy._planner_close()
+            diag = planner.diagnostics
+            # One persistent child reused across every step — the whole point of #5957.
+            assert diag["process_spawns"] == 1
+            # And it genuinely served all steps with no fallback.
+            assert diag["fallback_count"] == 0
+            assert diag["runtime_bound_exits"] == 0
+        finally:
+            policy._planner_close()
 
     def test_per_episode_plan_spawns_once_per_step(self) -> None:
         """Per-episode mode legitimately launches one fresh child per step.
@@ -299,14 +301,16 @@ class TestNativeCommandPolicyBuilder:
         policy._planner_reset(seed=111)
         planner = policy._native_planner
 
-        num_steps = 4
-        for _ in range(num_steps):
-            policy(obs)
+        try:
+            num_steps = 4
+            for _ in range(num_steps):
+                policy(obs)
 
-        diag = planner.diagnostics
-        # Per-episode: one spawn per step, as designed.
-        assert diag["process_spawns"] == num_steps
-        policy._planner_close()
+            diag = planner.diagnostics
+            # Per-episode: one spawn per step, as designed.
+            assert diag["process_spawns"] == num_steps
+        finally:
+            policy._planner_close()
 
     def test_persistent_plan_timeout(self, tmp_path: Path) -> None:
         import sys

--- a/tests/benchmark/test_map_runner_native_command.py
+++ b/tests/benchmark/test_map_runner_native_command.py
@@ -312,6 +312,37 @@ class TestNativeCommandPolicyBuilder:
         finally:
             policy._planner_close()
 
+    def test_per_episode_failed_launch_not_counted_as_spawn(self) -> None:
+        """A per-episode launch that never starts must not be counted as a spawn.
+
+        Companion to the "count only successful spawns" rule applied to the
+        persistent path: ``process_spawns`` records how many subprocesses were
+        actually launched, so an ``OSError`` launch failure (e.g. a missing
+        binary) must leave the counter at zero even though ``_plan_per_episode``
+        was invoked.
+        """
+        policy, _ = build_native_command_policy(
+            "native_command",
+            {"command": ["/nonexistent/native_planner_binary"], "mode": "per_episode"},
+            scenario_id="corridor",
+            seed=111,
+            horizon=500,
+            dt=0.1,
+        )
+        obs = {
+            "robot": {"position": [0.0, 0.0], "heading": [0.0]},
+            "goal": {"current": [5.0, 0.0]},
+        }
+        planner = policy._native_planner
+
+        try:
+            with pytest.raises(NativeCommandContractError, match="failed to launch native command"):
+                policy(obs)
+            # The launch never happened, so it must not be counted as a spawn.
+            assert planner.diagnostics["process_spawns"] == 0
+        finally:
+            policy._planner_close()
+
     def test_persistent_plan_timeout(self, tmp_path: Path) -> None:
         import sys
 

--- a/tests/benchmark/test_map_runner_native_command.py
+++ b/tests/benchmark/test_map_runner_native_command.py
@@ -241,6 +241,73 @@ class TestNativeCommandPolicyBuilder:
         policy._planner_close()
         assert planner._process is None
 
+    def test_persistent_plan_single_spawn_across_five_steps(self) -> None:
+        """A long-lived (loops-over-stdin) persistent planner spawns exactly once across >=5 steps.
+
+        The literal regression guard requested by issue #5957: the pre-fix persistent
+        branch respawned the child every step, so the new ``process_spawns`` diagnostic
+        must read exactly 1 for a healthy persistent run, no matter how many steps run.
+        """
+        policy, _ = build_native_command_policy(
+            "native_command",
+            {"command": ["python3", _FAKE_PLANNER], "mode": "persistent"},
+            scenario_id="corridor",
+            seed=111,
+            horizon=500,
+            dt=0.1,
+        )
+        obs = {
+            "robot": {"position": [0.0, 0.0], "heading": [0.0]},
+            "goal": {"current": [5.0, 0.0]},
+        }
+        policy._planner_reset(seed=111)
+        planner = policy._native_planner
+
+        num_steps = 6  # >= 5 as required by the issue
+        for _ in range(num_steps):
+            linear, angular = policy(obs)
+            assert isinstance(linear, float)
+            assert isinstance(angular, float)
+
+        diag = planner.diagnostics
+        # One persistent child reused across every step — the whole point of #5957.
+        assert diag["process_spawns"] == 1
+        # And it genuinely served all steps with no fallback.
+        assert diag["fallback_count"] == 0
+        assert diag["runtime_bound_exits"] == 0
+        policy._planner_close()
+
+    def test_per_episode_plan_spawns_once_per_step(self) -> None:
+        """Per-episode mode legitimately launches one fresh child per step.
+
+        Contrast case giving ``process_spawns`` meaning: per-episode mode must record
+        one spawn per step, so the counter reflects the chosen launch contract rather
+        than being pinned to 1 universally.
+        """
+        policy, _ = build_native_command_policy(
+            "native_command",
+            {"command": ["python3", _FAKE_PLANNER], "mode": "per_episode"},
+            scenario_id="corridor",
+            seed=111,
+            horizon=500,
+            dt=0.1,
+        )
+        obs = {
+            "robot": {"position": [0.0, 0.0], "heading": [0.0]},
+            "goal": {"current": [5.0, 0.0]},
+        }
+        policy._planner_reset(seed=111)
+        planner = policy._native_planner
+
+        num_steps = 4
+        for _ in range(num_steps):
+            policy(obs)
+
+        diag = planner.diagnostics
+        # Per-episode: one spawn per step, as designed.
+        assert diag["process_spawns"] == num_steps
+        policy._planner_close()
+
     def test_persistent_plan_timeout(self, tmp_path: Path) -> None:
         import sys
 

--- a/tests/benchmark/test_runner_native_command_arm.py
+++ b/tests/benchmark/test_runner_native_command_arm.py
@@ -133,6 +133,65 @@ def test_native_command_persistent_process_runs(tmp_path: Path):
     assert am["command_mode"] == "persistent_process"
     assert am["planner_kinematics"]["execution_mode"] == "native"
     assert len(am["planner_diagnostics"]["planner_step_runtime_seconds"]) == 30
+    # Issue #5957: one persistent child must serve all 30 steps (no per-step respawn).
+    assert am["planner_diagnostics"]["process_spawns"] == 1
+
+
+def test_native_command_persistent_process_single_spawn_across_steps():
+    """A long-lived (loops-over-stdin) persistent planner spawns exactly once across >=5 steps.
+
+    This is the literal regression guard requested by issue #5957: the pre-fix persistent
+    branch called ``process.communicate()`` per step, which closed stdin and forced a
+    respawn every step (N ``_spawn()`` calls for N steps). The new ``process_spawns``
+    diagnostic makes that regression directly observable: a healthy persistent run must
+    record exactly one spawn regardless of how many steps it serves.
+    """
+    policy = runner_mod._NativeCommandPolicy(
+        argv=[sys.executable, "-c", _NATIVE_PERSISTENT_STUB_SRC],
+        env={},
+        timeout_s=2.0,
+        persistent=True,
+    )
+    try:
+        num_steps = 6  # >= 5 as required by the issue
+        for _ in range(num_steps):
+            command = policy.step(np.zeros(2), np.zeros(2), np.ones(2), np.empty((0, 2)), 0.1)
+            assert command.shape == (2,)
+            assert np.all(np.isfinite(command))
+        diag = policy.diagnostics()
+        # The whole point: one persistent child reused across every step.
+        assert diag["process_spawns"] == 1
+        # And the child genuinely served all steps (no per-step fallback).
+        assert diag["fallback_count"] == 0
+        assert diag["runtime_bound_exits"] == 0
+        assert len(diag["planner_step_runtime_seconds"]) == num_steps
+    finally:
+        policy.close()
+
+
+def test_native_command_per_episode_spawns_once_per_step():
+    """Per-episode mode legitimately spawns one fresh child per step.
+
+    This is the contrast case that gives ``process_spawns`` meaning: per-episode mode
+    must record one spawn per step (closing stdin after each request is desired there),
+    so the diagnostic is not pinned to 1 universally — it reflects the actual launch
+    contract of the chosen mode.
+    """
+    policy = runner_mod._NativeCommandPolicy(
+        argv=[sys.executable, "-c", _NATIVE_STUB_SRC],
+        env={},
+        timeout_s=2.0,
+        persistent=False,
+    )
+    try:
+        num_steps = 4
+        for _ in range(num_steps):
+            policy.step(np.zeros(2), np.zeros(2), np.ones(2), np.empty((0, 2)), 0.1)
+        diag = policy.diagnostics()
+        # Per-episode: one spawn per step, as designed.
+        assert diag["process_spawns"] == num_steps
+    finally:
+        policy.close()
 
 
 def test_native_command_persistent_timeout_is_bounded():


### PR DESCRIPTION
## Issue #5957: add `process_spawns` diagnostic to native-command paths (successor slice)

### What / Why

Issue #5957 reports that the native-command persistent mode respawned the child every step
because `_NativeCommandPolicy.step` called `process.communicate()` (which closes stdin). The
core fix — keep one child alive via `stdin.write + flush + readline_with_timeout`, enforce a
per-step timeout, and align the response-parser contract — was already delivered by **PR #5947**
(merged into `origin/main` at e807125a3). A maintainer comment on the issue marks it resolved as
a duplicate of #5932 / PR #5947.

This PR is a **successor slice; it does not duplicate PR #5947**. The issue also asked, as an
explicit deliverable, for a regression test asserting *"a truly long-lived planner (loops over
stdin) asserting exactly one process spawn across >=5 steps"*. PR #5947's coverage of that
requirement is a 2-step object-identity check (`test_persistent_plan_reuses_process`) — weaker
than the issue's literal spec, and there was **no observable** that records how many times the
persistent process was spawned, so the original "N `_spawn()` calls for N steps" symptom was not
directly visible in episode diagnostics at all.

This PR closes that gap with **new observability + the literally-specified guard**:

1. **New diagnostic `process_spawns`** added to `planner_diagnostics` on both native-command
   paths — `_NativeCommandPolicy` (`robot_sf/benchmark/runner.py`) and `NativeCommandPlanner`
   (`robot_sf/benchmark/map_runner_native_command.py`). It counts subprocess launches, so a
   healthy persistent run reports exactly `1` regardless of horizon while per-episode mode
   reports one-per-step. The original bug would now show up in production diagnostics as
   `process_spawns == horizon` instead of being silent.
2. **The literal regression guards from the issue**: a long-lived (loops-over-stdin) persistent
   planner run across **>=5 steps** asserting exactly one spawn — added for *both* execution
   paths (`test_runner_native_command_arm.py` and `test_map_runner_native_command.py`).
3. **Per-episode contrast cases** so `process_spawns` has meaning (it is not pinned to 1
   universally; it reflects the chosen launch contract).
4. **Episode-level spawn-count check** added to the existing integrated persistent test
   (`test_native_command_persistent_process_runs`, horizon=30 → `process_spawns == 1`).

`planner_diagnostics` has `additionalProperties: true` in `episode.schema.v1.json`, so the new
key is schema-valid and does not affect the issue #5416 analyzer (which reads only its known
keys via `.get()`). No existing metric or status semantics change; every emitted field is additive.

### Validation (CPU-only)

```
uv run python -m pytest \
  tests/benchmark/test_runner_native_command_arm.py \
  tests/benchmark/test_map_runner_native_command.py -v
```

Result:

```
45 passed in 15.38s
```

New/changed tests, all passing:
- `test_native_command_persistent_process_single_spawn_across_steps` (runner.py path, 6 steps → 1 spawn, no fallback)
- `test_native_command_per_episode_spawns_once_per_step` (runner.py path, 4 steps → 4 spawns)
- `TestNativeCommandPolicyBuilder::test_persistent_plan_single_spawn_across_five_steps` (map-runner path, 6 steps → 1 spawn, no fallback)
- `TestNativeCommandPolicyBuilder::test_per_episode_plan_spawns_once_per_step` (map-runner path, 4 steps → 4 spawns)
- `test_native_command_persistent_process_runs` (integrated episode, horizon=30 → `process_spawns == 1`, schema-valid)

Lint/format:

```
uv run ruff check   <changed files>   → All checks passed!
uv run ruff format --check <changed files> → 4 files already formatted
```

Validation ran from an isolated worktree reusing the shared venv
(`scripts/dev/run_worktree_shared_venv.sh`, `PYTHONPATH` pinned to the worktree). No campaigns,
no Slurm, no training runs.

### Status / scope

This is a focused, low-risk, additive observability + test slice. It does not change any
benchmark, metric, schema semantics, planner behavior, or provenance. The two requested tests
from the issue are now present in the literally-specified form (>=5 steps, exact spawn count),
on both execution paths.

The maintainer comment on the issue indicates the issue is considered resolved by PR #5947; this
PR adds the spawn-count observability and the precise >=5-step guard that PR #5947 did not
include, so the issue's literal test requirement is now fully and durably covered.

Refs #5957 (issue remains owned by the dispatcher for closure reconciliation; this PR adds new
capability on top of PR #5947 rather than duplicating it).

### Downstream propagation

No evidence-registry, benchmark, metric, or paper-facing surfaces are touched. The new
`process_spawns` field is additive diagnostics only; no downstream consumer is required to read
it. NA for evidence-producing PR fields (this is a test + additive-diagnostic change with no
research claim).

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
