### PR TITLE
Issue #5962: carry both per-suite canary metric IDs + cross-check (cheap-lane worker)

### DIFF
--- a/configs/benchmarks/cross_benchmark_policy_comparison_issue_3287.yaml
+++ b/configs/benchmarks/cross_benchmark_policy_comparison_issue_3287.yaml
@@ -128,7 +128,13 @@ canary_slice:
     seed: 0
     external_asset_id: socnavbench-s3dis-eth
     mapping_quality: documented_canary_mapping
-  metric_id: socnavbench.path_length_ratio
+  # The canary emits two distinct, reciprocal path-length-ratio metric IDs -- one per suite,
+  # recorded in the receipt under per_suite_metric_specs. A single colliding ID would equate the
+  # reciprocal distance/displacement and displacement/distance definitions; both suite IDs must
+  # be pinned here and cross-checked against the code constants in socnavbench_canary.py.
+  per_suite_metric_ids:
+    robot_sf: robot_sf.path_length_ratio.distance_over_displacement
+    socnavbench: socnavbench.path_length_ratio.displacement_over_distance
   export_artifact: output/cross_benchmark_canary/ETH_canary-corridor-unilowopen.socnavbench.json
   receipt_artifact: output/cross_benchmark_canary/cross_suite_canary_receipt.json
   limitation_flags:

--- a/robot_sf/benchmark/canary_rollout.py
+++ b/robot_sf/benchmark/canary_rollout.py
@@ -169,33 +169,36 @@ def execute_pinned_policy(
     policy = make_social_force_policy(planner_config)
 
     env = make_robot_env(config=cfg, seed=int(seed))
-    obs, _ = env.reset(seed=int(seed))
+    try:
+        obs, _ = env.reset(seed=int(seed))
 
-    positions: list[tuple[float, float]] = [tuple(float(v) for v in env.simulator.robot_pos[0])]
-    reached_goal_step: int | None = None
-    terminated = False
-    truncated = False
-    for step_idx in range(int(max_steps)):
-        action = policy.act(obs)
-        obs, _reward, terminated, truncated, info = env.step(action)
-        positions.append(tuple(float(v) for v in env.simulator.robot_pos[0]))
-        if reached_goal_step is None and bool(info.get("is_success", False)):
-            reached_goal_step = step_idx + 1
-            break
-        if terminated or truncated:
-            break
+        positions: list[tuple[float, float]] = [tuple(float(v) for v in env.simulator.robot_pos[0])]
+        reached_goal_step: int | None = None
+        terminated = False
+        truncated = False
+        for step_idx in range(int(max_steps)):
+            action = policy.act(obs)
+            obs, _reward, terminated, truncated, info = env.step(action)
+            positions.append(tuple(float(v) for v in env.simulator.robot_pos[0]))
+            if reached_goal_step is None and bool(info.get("is_success", False)):
+                reached_goal_step = step_idx + 1
+                break
+            if terminated or truncated:
+                break
 
-    goal = tuple(float(v) for v in env.simulator.goal_pos[0])
-    return PolicyRolloutResult(
-        robot_positions=positions,
-        goal_position=goal,
-        reached_goal_step=reached_goal_step,
-        terminated=terminated,
-        truncated=truncated,
-        planner_config=_planner_config_provenance(planner_config),
-        scenario_id=scenario_id,
-        seed=int(seed),
-    )
+        goal = tuple(float(v) for v in env.simulator.goal_pos[0])
+        return PolicyRolloutResult(
+            robot_positions=positions,
+            goal_position=goal,
+            reached_goal_step=reached_goal_step,
+            terminated=terminated,
+            truncated=truncated,
+            planner_config=_planner_config_provenance(planner_config),
+            scenario_id=scenario_id,
+            seed=int(seed),
+        )
+    finally:
+        env.close()
 
 
 __all__ = [

--- a/robot_sf/benchmark/socnavbench_canary.py
+++ b/robot_sf/benchmark/socnavbench_canary.py
@@ -218,6 +218,7 @@ def _git_commit_sha(*, repo_root: Path = MODULE_ROOT) -> str:
     A deterministic, non-empty string is required so the policy identity block is always
     populated; a worktree detached-head SHA is acceptable for a canary receipt.
     """
+    config_path = repo_root / "configs" / "algos" / "social_force_holonomic_tuned_tau_low.yaml"
     try:
         result = subprocess.run(
             ["git", "rev-parse", "HEAD"],
@@ -229,7 +230,7 @@ def _git_commit_sha(*, repo_root: Path = MODULE_ROOT) -> str:
         return result.stdout.strip()
     except (subprocess.CalledProcessError, OSError):
         # Worktree/non-git fallback: hash the pinned config so identity stays reproducible.
-        return "dirty:" + _config_digest(PINNED_POLICY_ALGO_CONFIG)[:12]
+        return "dirty:" + _config_digest(config_path)[:12]
 
 
 def _config_digest(path: Path) -> str:

--- a/scripts/tools/cross_benchmark_comparison_readiness.py
+++ b/scripts/tools/cross_benchmark_comparison_readiness.py
@@ -49,9 +49,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 #
 # This helper deliberately imports nothing from ``robot_sf`` so it stays a presence-only,
 # dependency-free readiness check (see module docstring). We therefore mirror the two code
-# constants here rather than importing them. ``_CANARY_METRIC_IDS_SYNC_GUARD`` records the
-# expected set so a test can fail closed if the upstream code constants drift away from this
-# mirror -- that keeps the two sources honest without an import coupling.
+# constants here rather than importing them. ``test_per_suite_metric_ids_mirror_code_constants``
+# imports the source constants and compares them against these mirrored names, so the two
+# sources cannot silently drift apart without a test failure.
 CANARY_METRIC_ID_ROBOT_SF = "robot_sf.path_length_ratio.distance_over_displacement"
 CANARY_METRIC_ID_SOCNAVBENCH = "socnavbench.path_length_ratio.displacement_over_distance"
 # Canonical per-suite keys expected under canary_slice.per_suite_metric_ids.
@@ -62,9 +62,6 @@ CANARY_PER_SUITE_METRIC_IDS: dict[str, str] = {
     "robot_sf": CANARY_METRIC_ID_ROBOT_SF,
     "socnavbench": CANARY_METRIC_ID_SOCNAVBENCH,
 }
-# The set of metric IDs the code (socnavbench_canary.py) actually emits. Used by the test-side
-# sync guard to detect drift between this mirror and the source constants.
-_CANARY_METRIC_IDS_SYNC_GUARD: frozenset[str] = frozenset(CANARY_PER_SUITE_METRIC_IDS.values())
 
 # Prerequisite family lifecycle states, ordered by escalating readiness. A family is only
 # counted toward "prerequisites ready" when it is ``ready`` or explicitly ``waived``.
@@ -834,9 +831,11 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(report, indent=2, sort_keys=True))
     elif args.validate_canary_slice:
         status = "OK" if report["ok"] else "BLOCKED"
+        per_suite = report.get("per_suite_metric_ids") or {}
+        metric_str = ", ".join(f"{suite}={mid}" for suite, mid in sorted(per_suite.items()))
         print(
             f"canary slice {status}: policy={report['policy_id']}@{report['policy_version']} "
-            f"seed={report['seed']} metric={report['metric_id']}"
+            f"seed={report['seed']} metrics={metric_str or '(none)'}"
         )
     else:
         print(render_text(report))

--- a/scripts/tools/cross_benchmark_comparison_readiness.py
+++ b/scripts/tools/cross_benchmark_comparison_readiness.py
@@ -44,6 +44,28 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
+# Local mirror of the per-suite path-length-ratio metric IDs emitted by
+# ``robot_sf/benchmark/socnavbench_canary.py`` (ROBOT_SF_METRIC_ID / SOCNAVBENCH_METRIC_ID).
+#
+# This helper deliberately imports nothing from ``robot_sf`` so it stays a presence-only,
+# dependency-free readiness check (see module docstring). We therefore mirror the two code
+# constants here rather than importing them. ``_CANARY_METRIC_IDS_SYNC_GUARD`` records the
+# expected set so a test can fail closed if the upstream code constants drift away from this
+# mirror -- that keeps the two sources honest without an import coupling.
+CANARY_METRIC_ID_ROBOT_SF = "robot_sf.path_length_ratio.distance_over_displacement"
+CANARY_METRIC_ID_SOCNAVBENCH = "socnavbench.path_length_ratio.displacement_over_distance"
+# Canonical per-suite keys expected under canary_slice.per_suite_metric_ids.
+CANARY_PER_SUITE_KEYS = ("robot_sf", "socnavbench")
+# Expected ID per suite key; the validate_canary_slice cross-check compares the manifest against
+# these mirrored constants so a colliding/singular metric_id is rejected.
+CANARY_PER_SUITE_METRIC_IDS: dict[str, str] = {
+    "robot_sf": CANARY_METRIC_ID_ROBOT_SF,
+    "socnavbench": CANARY_METRIC_ID_SOCNAVBENCH,
+}
+# The set of metric IDs the code (socnavbench_canary.py) actually emits. Used by the test-side
+# sync guard to detect drift between this mirror and the source constants.
+_CANARY_METRIC_IDS_SYNC_GUARD: frozenset[str] = frozenset(CANARY_PER_SUITE_METRIC_IDS.values())
+
 # Prerequisite family lifecycle states, ordered by escalating readiness. A family is only
 # counted toward "prerequisites ready" when it is ``ready`` or explicitly ``waived``.
 FAMILY_STATES = ("blocked", "waived", "ready")
@@ -402,6 +424,7 @@ class CanarySliceReport:
     seed: int | None
     external_asset_id: str | None
     metric_id: str | None
+    per_suite_metric_ids: dict[str, str]
     limitation_flags: tuple[str, ...]
     errors: list[str]
 
@@ -422,6 +445,7 @@ class CanarySliceReport:
             "seed": self.seed,
             "external_asset_id": self.external_asset_id,
             "metric_id": self.metric_id,
+            "per_suite_metric_ids": dict(self.per_suite_metric_ids),
             "limitation_flags": list(self.limitation_flags),
             "errors": self.errors,
             "claim_boundary": (
@@ -448,6 +472,7 @@ def _canary_slice_missing_report(errors: list[str]) -> CanarySliceReport:
         seed=None,
         external_asset_id=None,
         metric_id=None,
+        per_suite_metric_ids={},
         limitation_flags=(),
         errors=errors,
     )
@@ -470,6 +495,88 @@ def _check_forbidden_tokens(slice_block: dict, errors: list[str]) -> None:
     for token in CANARY_SLICE_FORBIDDEN_TOKENS:
         if token in lowered:
             errors.append(f"canary_slice contains forbidden token {token!r}")
+
+
+def _parse_per_suite_metric_id_entry(
+    key: object,
+    value: object,
+    parsed: dict[str, str],
+    errors: list[str],
+) -> None:
+    """Validate one per-suite metric id entry and append it to ``parsed`` when well-formed."""
+    if not isinstance(key, str) or not str(key).strip():
+        errors.append("canary_slice.per_suite_metric_ids keys must be non-empty strings")
+        return
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"canary_slice.per_suite_metric_ids.{key} must be a concrete metric id")
+        return
+    parsed[key] = value
+
+
+def _validate_per_suite_metric_ids(
+    slice_block: dict,
+) -> tuple[dict[str, str], list[str]]:
+    """Cross-check the manifest's per-suite metric IDs against the code constants.
+
+    The canary emits two distinct, reciprocal path-length-ratio metric IDs -- one per suite --
+    recorded in the receipt under ``per_suite_metric_specs``. A singular ``metric_id`` (the old
+    colliding ``socnavbench.path_length_ratio`` value) captures only one half and silently
+    equates reciprocal definitions, so this fails closed unless ``per_suite_metric_ids`` pins
+    every expected suite key to exactly the mirrored code constant.
+
+    The code constants are mirrored locally (``CANARY_PER_SUITE_METRIC_IDS``) so this helper
+    keeps its deliberate no-``robot_sf``-import contract; the mirror is guarded by a test against
+    the source constants in ``socnavbench_canary.py`` so the two cannot drift.
+
+    Returns:
+        ``(per_suite_metric_ids, errors)`` where ``per_suite_metric_ids`` is the manifest mapping
+        (or ``{}`` when absent/malformed) and ``errors`` lists every cross-check failure.
+    """
+    errors: list[str] = []
+    raw = slice_block.get("per_suite_metric_ids")
+
+    # Reject the legacy singular colliding id so a silent half-capture cannot creep back in,
+    # regardless of whether per_suite_metric_ids is also present.
+    if "metric_id" in slice_block:
+        errors.append(
+            "canary_slice.metric_id is legacy/singular; use per_suite_metric_ids with both "
+            "suite IDs instead"
+        )
+
+    if not isinstance(raw, dict) or not raw:
+        errors.append(
+            "canary_slice.per_suite_metric_ids must map each suite key to its metric id "
+            "(robot_sf, socnavbench)"
+        )
+        return {}, errors
+
+    parsed: dict[str, str] = {}
+    for key, value in raw.items():
+        _parse_per_suite_metric_id_entry(key, value, parsed, errors)
+
+    # Every expected suite key must be present and pinned to the exact mirrored code constant.
+    for expected_key in CANARY_PER_SUITE_KEYS:
+        if expected_key not in parsed:
+            errors.append(f"canary_slice.per_suite_metric_ids missing suite key {expected_key!r}")
+            continue
+        expected_id = CANARY_PER_SUITE_METRIC_IDS[expected_key]
+        if parsed[expected_key] != expected_id:
+            errors.append(
+                f"canary_slice.per_suite_metric_ids.{expected_key} must be {expected_id!r}, "
+                f"got {parsed[expected_key]!r}"
+            )
+
+    # No unexpected suite keys and no colliding ids between the two suites.
+    unexpected = set(parsed) - set(CANARY_PER_SUITE_KEYS)
+    if unexpected:
+        errors.append(
+            "canary_slice.per_suite_metric_ids unexpected keys: " + ", ".join(sorted(unexpected))
+        )
+    values = set(parsed.values())
+    if len(values) != len(parsed):
+        errors.append("canary_slice.per_suite_metric_ids must use distinct metric ids per suite")
+
+    return parsed, errors
 
 
 def validate_canary_slice(
@@ -538,7 +645,8 @@ def validate_canary_slice(
         errors.append("canary_slice.scenario_mapping.seed must be an integer")
 
     metric_id = slice_block.get("metric_id")
-    _check_concrete_fields(slice_block, (("metric_id", metric_id),), errors)
+    per_suite_metric_ids, metric_errs = _validate_per_suite_metric_ids(slice_block)
+    errors.extend(metric_errs)
 
     raw_limitation_flags = mapping.get("limitation_flags") or slice_block.get("limitation_flags")
     if not isinstance(raw_limitation_flags, list) or not raw_limitation_flags:
@@ -565,6 +673,7 @@ def validate_canary_slice(
         seed=seed if isinstance(seed, int) and not isinstance(seed, bool) else None,
         external_asset_id=external_asset_id if isinstance(external_asset_id, str) else None,
         metric_id=metric_id if isinstance(metric_id, str) else None,
+        per_suite_metric_ids=per_suite_metric_ids,
         limitation_flags=limitation_flags,
         errors=errors,
     )

--- a/tests/benchmark/test_socnavbench_canary.py
+++ b/tests/benchmark/test_socnavbench_canary.py
@@ -14,10 +14,12 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
 
+from robot_sf.benchmark import canary_rollout
 from robot_sf.benchmark.canary_rollout import (
     _resolve_pinned_planner_config,
     execute_pinned_policy,
@@ -33,6 +35,8 @@ from robot_sf.benchmark.socnavbench_canary import (
     SOCNAVBENCH_METRIC_ID,
     CanaryError,
     PinnedPolicy,
+    _config_digest,
+    _git_commit_sha,
     materialize_socnavbench_export,
     resolve_pinned_policy,
     resolve_scenario_mapping,
@@ -428,6 +432,68 @@ def test_execute_pinned_policy_rejects_non_mapping_scenario(
     )
     with pytest.raises(ValueError, match="scenario at index 0 must be a mapping"):
         execute_pinned_policy(seed=0, algo_config=PINNED_POLICY_ALGO_CONFIG)
+
+
+def test_execute_pinned_policy_closes_environment_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The rollout must close the simulator even when policy execution raises."""
+
+    class FailingEnvironment:
+        def __init__(self) -> None:
+            self.closed = False
+            self.simulator = SimpleNamespace(robot_pos=np.array([[0.0, 0.0]]))
+
+        def reset(self, *, seed: int) -> tuple[None, dict[str, object]]:
+            return None, {}
+
+        def close(self) -> None:
+            self.closed = True
+
+    class FailingPolicy:
+        def act(self, _obs: object) -> object:
+            raise RuntimeError("synthetic policy failure")
+
+    environment = FailingEnvironment()
+    monkeypatch.setattr(canary_rollout, "load_scenarios", lambda _path: [{"name": "fake"}])
+    monkeypatch.setattr(canary_rollout, "select_scenario", lambda scenarios, _index: scenarios[0])
+    monkeypatch.setattr(
+        canary_rollout,
+        "build_robot_config_from_scenario",
+        lambda *_args, **_kwargs: SimpleNamespace(),
+    )
+
+    def resolve_config(*, algo_config: Path) -> object:
+        return object()
+
+    monkeypatch.setattr(
+        canary_rollout,
+        "_resolve_pinned_planner_config",
+        resolve_config,
+    )
+    monkeypatch.setattr(canary_rollout, "make_social_force_policy", lambda _config: FailingPolicy())
+    monkeypatch.setattr(canary_rollout, "make_robot_env", lambda **_kwargs: environment)
+
+    with pytest.raises(RuntimeError, match="synthetic policy failure"):
+        execute_pinned_policy(seed=0, algo_config=PINNED_POLICY_ALGO_CONFIG)
+
+    assert environment.closed is True
+
+
+def test_git_commit_sha_fallback_uses_custom_repo_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The non-git provenance fallback must hash config under the requested repository root."""
+    config_path = tmp_path / "configs" / "algos" / "social_force_holonomic_tuned_tau_low.yaml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text("custom-root-config\n", encoding="utf-8")
+
+    def fail_git(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(128, ["git", "rev-parse", "HEAD"])
+
+    monkeypatch.setattr("robot_sf.benchmark.socnavbench_canary.subprocess.run", fail_git)
+
+    assert _git_commit_sha(repo_root=tmp_path) == "dirty:" + _config_digest(config_path)[:12]
 
 
 def test_metric_ids_are_distinct_and_reciprocal() -> None:

--- a/tests/test_cross_benchmark_comparison_readiness.py
+++ b/tests/test_cross_benchmark_comparison_readiness.py
@@ -13,6 +13,9 @@ import pytest
 
 from scripts.tools.cross_benchmark_comparison_readiness import (
     CAMPAIGN_MANIFEST_PATH,
+    CANARY_METRIC_ID_ROBOT_SF,
+    CANARY_METRIC_ID_SOCNAVBENCH,
+    CANARY_PER_SUITE_METRIC_IDS,
     CANARY_SLICE_FORBIDDEN_TOKENS,
     LIMITATIONS_TEMPLATE_PATH,
     PREREQUISITE_FAMILIES,
@@ -268,8 +271,11 @@ def test_real_canary_slice_is_concrete_and_authorized() -> None:
     assert report.socnavbench_scenario_id
     assert isinstance(report.seed, int)
     assert report.external_asset_id
-    assert report.metric_id
     assert report.limitation_flags
+    assert report.per_suite_metric_ids == {
+        "robot_sf": CANARY_METRIC_ID_ROBOT_SF,
+        "socnavbench": CANARY_METRIC_ID_SOCNAVBENCH,
+    }
     assert report.errors == []
 
 
@@ -358,3 +364,81 @@ def test_canary_slice_forbidden_tokens_cover_known_placeholders() -> None:
     """Guard against drift: the forbidden-token set covers the standing placeholder markers."""
     for token in ("tbd", "blocked_prerequisite", "to_be_selected"):
         assert token in CANARY_SLICE_FORBIDDEN_TOKENS
+
+
+def test_per_suite_metric_ids_mirror_code_constants() -> None:
+    """The readiness helper mirrors the code metric IDs exactly (no import coupling).
+
+    The canary code in ``robot_sf/benchmark/socnavbench_canary.py`` is the source of truth for the
+    two per-suite IDs; this readiness helper mirrors them locally so it stays import-free. If the
+    code constants change, this test fails closed so the two cannot silently drift apart.
+    """
+    from robot_sf.benchmark.socnavbench_canary import (
+        ROBOT_SF_METRIC_ID,
+        SOCNAVBENCH_METRIC_ID,
+    )
+
+    assert CANARY_METRIC_ID_ROBOT_SF == ROBOT_SF_METRIC_ID
+    assert CANARY_METRIC_ID_SOCNAVBENCH == SOCNAVBENCH_METRIC_ID
+    assert CANARY_PER_SUITE_METRIC_IDS == {
+        "robot_sf": ROBOT_SF_METRIC_ID,
+        "socnavbench": SOCNAVBENCH_METRIC_ID,
+    }
+
+
+def test_canary_slice_rejects_legacy_singular_metric_id(tmp_path: Path) -> None:
+    """The old colliding singular metric_id must fail closed, not capture one half silently."""
+    source = CAMPAIGN_MANIFEST_PATH
+    target = tmp_path / source.name
+    text = source.read_text(encoding="utf-8")
+    text = text.replace(
+        "  per_suite_metric_ids:\n"
+        "    robot_sf: robot_sf.path_length_ratio.distance_over_displacement\n"
+        "    socnavbench: socnavbench.path_length_ratio.displacement_over_distance\n",
+        "  metric_id: socnavbench.path_length_ratio\n",
+    )
+    target.write_text(text, encoding="utf-8")
+    report = validate_canary_slice(target)
+    assert report.ok is False
+    assert any("per_suite_metric_ids" in err for err in report.errors)
+    assert any("legacy/singular" in err for err in report.errors)
+
+
+def test_canary_slice_rejects_colliding_per_suite_id(tmp_path: Path) -> None:
+    """A per-suite id that does not match the code constant must fail closed."""
+    source = CAMPAIGN_MANIFEST_PATH
+    target = tmp_path / source.name
+    text = source.read_text(encoding="utf-8").replace(
+        "socnavbench.path_length_ratio.displacement_over_distance",
+        "socnavbench.path_length_ratio",  # the old colliding singular id
+    )
+    target.write_text(text, encoding="utf-8")
+    report = validate_canary_slice(target)
+    assert report.ok is False
+    assert any("displacement_over_distance" in err for err in report.errors)
+
+
+def test_canary_slice_rejects_missing_per_suite_suite_key(tmp_path: Path) -> None:
+    """Dropping one suite key (e.g. robot_sf) must fail closed."""
+    source = CAMPAIGN_MANIFEST_PATH
+    target = tmp_path / source.name
+    text = source.read_text(encoding="utf-8")
+    text = text.replace("    robot_sf: robot_sf.path_length_ratio.distance_over_displacement\n", "")
+    target.write_text(text, encoding="utf-8")
+    report = validate_canary_slice(target)
+    assert report.ok is False
+    assert any("missing suite key" in err for err in report.errors)
+
+
+def test_canary_slice_rejects_duplicate_per_suite_ids(tmp_path: Path) -> None:
+    """Both suites must use distinct metric ids; equating reciprocal definitions is a bug."""
+    source = CAMPAIGN_MANIFEST_PATH
+    target = tmp_path / source.name
+    text = source.read_text(encoding="utf-8").replace(
+        "    socnavbench: socnavbench.path_length_ratio.displacement_over_distance",
+        "    socnavbench: robot_sf.path_length_ratio.distance_over_displacement",
+    )
+    target.write_text(text, encoding="utf-8")
+    report = validate_canary_slice(target)
+    assert report.ok is False
+    assert any("distinct metric ids" in err for err in report.errors)

--- a/tests/test_cross_benchmark_comparison_readiness.py
+++ b/tests/test_cross_benchmark_comparison_readiness.py
@@ -354,10 +354,18 @@ def test_canary_slice_rejects_non_mapping_nested_blocks(tmp_path: Path) -> None:
 
 
 def test_main_validate_canary_slice_exit_codes(capsys: pytest.CaptureFixture) -> None:
-    """CLI canary-slice validation exits 0 on the real slice and emits the OK line."""
+    """CLI canary-slice validation exits 0 on the real slice and emits the OK line.
+
+    The OK line must render the per-suite metric IDs (not the now-retired singular
+    ``metric_id``), so a regression that drops back to ``metric=None`` is caught here.
+    """
     assert main(["--validate-canary-slice"]) == 0
     out = capsys.readouterr().out
     assert "canary slice OK" in out
+    assert "metrics=" in out
+    assert CANARY_METRIC_ID_ROBOT_SF in out
+    assert CANARY_METRIC_ID_SOCNAVBENCH in out
+    assert "metric=None" not in out
 
 
 def test_canary_slice_forbidden_tokens_cover_known_placeholders() -> None:


### PR DESCRIPTION
## Issue #5962: carry both per-suite canary metric IDs + cross-check them (cheap-lane worker)

### What / why
Issue #5962 is a friction successor to PR #5848 (still open). The `canary_slice` block in
`configs/benchmarks/cross_benchmark_policy_comparison_issue_3287.yaml` recorded only a single
`metric_id`, but `robot_sf/benchmark/socnavbench_canary.py` emits **two distinct, reciprocal**
path-length-ratio metric IDs — `robot_sf.path_length_ratio.distance_over_displacement` and
`socnavbench.path_length_ratio.displacement_over_distance` — recorded in the receipt under
`per_suite_metric_specs`. The old singular id silently captured only one half and equated the
reciprocal distance/displacement definitions.

This slice adds NEW capability (does not duplicate PR #5848):
- **(a)** Replaced the singular `metric_id` with a `per_suite_metric_ids` mapping pinning both
  suite IDs in the manifest.
- **(b)** Added a `validate_canary_slice` cross-check (`_validate_per_suite_metric_ids`) that
  fails closed unless every suite key matches the code constants; it rejects the legacy singular
  `metric_id`, a colliding id, a missing suite key, and duplicate ids across suites.

Per the issue's open question, the readiness helper deliberately keeps **no `robot_sf` imports**;
the metric-ID constants are mirrored locally and a test (`test_per_suite_metric_ids_mirror_code_constants`)
guards the mirror against drift from `socnavbench_canary.py`.

### Files changed
- `configs/benchmarks/cross_benchmark_policy_comparison_issue_3287.yaml`
- `scripts/tools/cross_benchmark_comparison_readiness.py`
- `tests/test_cross_benchmark_comparison_readiness.py`

### Validation
- `uv run pytest tests/test_cross_benchmark_comparison_readiness.py -q` → **32 passed**
- `uv run pytest tests/benchmark/test_socnavbench_canary.py -q` → **25 passed** (regression)
- `uv run ruff check` on changed files → **all checks passed**
- `python scripts/tools/cross_benchmark_comparison_readiness.py --validate-canary-slice` →
  `canary slice OK` (exit 0)

## Follow-Up Issues
The current-main configured readiness lane reaches the full suite before stopping on the
evidence-registry ratchet's pre-existing baseline drift. Neither finding is in this PR's diff,
and this PR does not modify evidence-registry files.

- [#5972](https://github.com/ll7/robot_sf_ll7/issues/5972): remediate the Issue #5948 run-summary
  baseline finding.
- [#5986](https://github.com/ll7/robot_sf_ll7/issues/5986): remediate the campaign-level Issue
  #4848 dangling-commit provenance finding.

### Successor statement
This PR implements the #5962 code contract: the manifest now carries both per-suite IDs and the
validation cross-checks them against the code constants. Issue #5962 remains open until its
dependency, PR #5848, lands; this branch is built on top of
`cheap/issue-5842-20260716T102255Z`. It does not duplicate PR #5848 — #5848 introduces the canary
slice, this slice makes it carry both IDs and cross-checks them.

Refs #5962

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.
