### PR TITLE
Issue #5981: disposition issue-5948 run-summary finding in evidence-registry ratchet (cheap-lane worker)

### DIFF
--- a/scripts/validation/evidence_registry_baseline_review.yaml
+++ b/scripts/validation/evidence_registry_baseline_review.yaml
@@ -17,13 +17,8 @@ source_issue_addendum: 5981
 prior_baseline_commit: 9fa96c01bf1c8152459f5fa8c481e938fb1e6725
 prior_baseline_total_findings: 359
 prior_baseline_files_with_findings: 73
-<<<<<<< HEAD
 refreshed_baseline_total_findings: 411
 refreshed_baseline_files_with_findings: 87
-=======
-refreshed_baseline_total_findings: 409
-refreshed_baseline_files_with_findings: 86
->>>>>>> d88eae2cd (fix: make evidence baseline increases reviewable)
 decision_summary: >-
   Fourteen evidence files merged after the 2026-07-11 baseline introduced 52 findings across
   eight codes. Every introduced code is already in the strict-CI exclusion policy, so no active
@@ -156,17 +151,6 @@ reviewed_files:
       This is the legacy provenance gap identified by Issue #5972; repairing the external artifact
       binding is outside this baseline reconciliation, so the finding is explicitly dispositioned
       as baseline under the existing strict-CI policy.
-reviewed_baseline_increases:
-  - path: docs/context/evidence/issue_4848_group_crossing_exemplars_2026-07/goal/classic_group_crossing_high_seed24_best/metadata.json
-    codes: [dangling_commit]
-    disposition: baseline
-    reason: >-
-      Campaign-level aggregation for issue4206_trace_capable_h600_rerun_20260704 attributes the
-      unresolved producer commit 62e08add1c2a5a750a6fd68a823319280c2dccd6 from the issue #4891
-      records to this canonical path. The target issue #4848 metadata itself references
-      0b0214ced856eac77fa9a4c15b02921eabab1661, but the shared campaign identity makes the
-      provenance set inconsistent. Carry the per-code increase explicitly until #5986 repairs
-      the campaign provenance; do not treat this as a new-file disposition.
 reviewed_baseline_increases:
   - path: docs/context/evidence/issue_4848_group_crossing_exemplars_2026-07/goal/classic_group_crossing_high_seed24_best/metadata.json
     codes: [dangling_commit]

--- a/scripts/validation/evidence_registry_baseline_review.yaml
+++ b/scripts/validation/evidence_registry_baseline_review.yaml
@@ -17,8 +17,13 @@ source_issue_addendum: 5981
 prior_baseline_commit: 9fa96c01bf1c8152459f5fa8c481e938fb1e6725
 prior_baseline_total_findings: 359
 prior_baseline_files_with_findings: 73
+<<<<<<< HEAD
 refreshed_baseline_total_findings: 411
 refreshed_baseline_files_with_findings: 87
+=======
+refreshed_baseline_total_findings: 409
+refreshed_baseline_files_with_findings: 86
+>>>>>>> d88eae2cd (fix: make evidence baseline increases reviewable)
 decision_summary: >-
   Fourteen evidence files merged after the 2026-07-11 baseline introduced 52 findings across
   eight codes. Every introduced code is already in the strict-CI exclusion policy, so no active
@@ -151,3 +156,25 @@ reviewed_files:
       This is the legacy provenance gap identified by Issue #5972; repairing the external artifact
       binding is outside this baseline reconciliation, so the finding is explicitly dispositioned
       as baseline under the existing strict-CI policy.
+reviewed_baseline_increases:
+  - path: docs/context/evidence/issue_4848_group_crossing_exemplars_2026-07/goal/classic_group_crossing_high_seed24_best/metadata.json
+    codes: [dangling_commit]
+    disposition: baseline
+    reason: >-
+      Campaign-level aggregation for issue4206_trace_capable_h600_rerun_20260704 attributes the
+      unresolved producer commit 62e08add1c2a5a750a6fd68a823319280c2dccd6 from the issue #4891
+      records to this canonical path. The target issue #4848 metadata itself references
+      0b0214ced856eac77fa9a4c15b02921eabab1661, but the shared campaign identity makes the
+      provenance set inconsistent. Carry the per-code increase explicitly until #5986 repairs
+      the campaign provenance; do not treat this as a new-file disposition.
+reviewed_baseline_increases:
+  - path: docs/context/evidence/issue_4848_group_crossing_exemplars_2026-07/goal/classic_group_crossing_high_seed24_best/metadata.json
+    codes: [dangling_commit]
+    disposition: baseline
+    reason: >-
+      Campaign-level aggregation for issue4206_trace_capable_h600_rerun_20260704 attributes the
+      unresolved producer commit 62e08add1c2a5a750a6fd68a823319280c2dccd6 from the issue #4891
+      records to this canonical path. The target issue #4848 metadata itself references
+      0b0214ced856eac77fa9a4c15b02921eabab1661, but the shared campaign identity makes the
+      provenance set inconsistent. Carry the per-code increase explicitly until #5986 repairs
+      the campaign provenance; do not treat this as a new-file disposition.

--- a/scripts/validation/evidence_registry_baseline_review.yaml
+++ b/scripts/validation/evidence_registry_baseline_review.yaml
@@ -13,6 +13,7 @@ evidence_status: diagnostic-only
 approved_by: ll7
 approved_date: 2026-07-17
 source_issue: 5972
+source_issue_addendum: 5981
 prior_baseline_commit: 9fa96c01bf1c8152459f5fa8c481e938fb1e6725
 prior_baseline_total_findings: 359
 prior_baseline_files_with_findings: 73
@@ -33,6 +34,15 @@ decision_summary: >-
   Accordingly each file is dispositioned baseline below. A future maintainer who backfills
   provenance for any of these files should refresh the baseline with --write-baseline to lock in
   the reduction.
+  Review addendum (issue #5983): campaign-level aggregation for
+  `issue4206_trace_capable_h600_rerun_20260704` attributes the unresolved producer commit
+  62e08add1c2a5a750a6fd68a823319280c2dccd6 from the issue #4891 records to the canonical Issue
+  #4848 metadata path. The Issue #4848 metadata itself references
+  0b0214ced856eac77fa9a4c15b02921eabab1661, which resolves, but the shared campaign identity
+  makes the provenance set inconsistent. The current clean checkout therefore reports a
+  `dangling_commit` increase, which is explicitly recorded below as a reviewed baseline increase
+  until follow-up issue #5986 repairs the campaign provenance. This is not a silent suppression or
+  a claim that the historical provenance is not complete.
 disposition_legend:
   baseline: >-
     Finding kept as reviewed legacy debt; the file is now tracked in the committed baseline so the

--- a/tests/dev/test_evidence_registry_ratchet.py
+++ b/tests/dev/test_evidence_registry_ratchet.py
@@ -467,9 +467,7 @@ def test_review_companion_covers_every_post_5317_baseline_file() -> None:
         if path in prior_findings and current_count > prior_findings[path].get(code, 0)
     }
     declared_increases = [
-        (entry.get("path"), code)
-        for entry in increase_entries
-        for code in entry.get("codes", [])
+        (entry.get("path"), code) for entry in increase_entries for code in entry.get("codes", [])
     ]
     assert len(declared_increases) == len(set(declared_increases)), (
         "reviewed_baseline_increases contains duplicate path/code rows."

--- a/tests/dev/test_evidence_registry_ratchet.py
+++ b/tests/dev/test_evidence_registry_ratchet.py
@@ -417,19 +417,17 @@ def test_committed_baseline_passes_live_check_on_clean_main(
 
 
 def test_review_companion_covers_every_post_5317_baseline_file() -> None:
-    """Every file added since the #5275/#5317 baseline has an explicit disposition (#5952 DoD).
+    """Every baseline delta has an explicit machine-checkable disposition (#5952 DoD).
 
-    The downward ratchet only stops drift if newly-baselined files are deliberate. This guard
-    fails if the committed baseline grew beyond the documented prior boundary without a matching
-    explicit per-file disposition in the review companion. It is self-contained: the prior
-    boundary file count and the refresh delta are both recorded in the review companion, so the
-    invariant is ``len(baseline_files) == prior_count + len(reviewed_files)`` together with
-    ``reviewed_files ⊆ baseline_files`` and a valid disposition on every reviewed entry. Future
-    net-new drift is additionally caught by the live check above.
+    Newly baselined files are listed under ``reviewed_files``. Per-code increases on files that
+    were already in the anchored baseline are listed under ``reviewed_baseline_increases`` so a
+    baseline refresh cannot silently grandfather a regression. Future net-new drift is additionally
+    caught by the live check above.
     """
     assert REVIEW.is_file(), "evidence_registry_baseline_review.yaml is missing."
     review = yaml.safe_load(REVIEW.read_text(encoding="utf-8"))
     reviewed_entries = review.get("reviewed_files", [])
+    increase_entries = review.get("reviewed_baseline_increases", [])
     reviewed = {entry["path"] for entry in reviewed_entries}
     baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
     baseline_files = set(baseline["findings_by_path"])
@@ -450,6 +448,8 @@ def test_review_companion_covers_every_post_5317_baseline_file() -> None:
     assert prior_proc.returncode == 0, prior_proc.stderr
     prior_baseline = json.loads(prior_proc.stdout)
     prior_files = set(prior_baseline["findings_by_path"])
+    prior_findings = prior_baseline["findings_by_path"]
+    current_findings = baseline["findings_by_path"]
 
     # (2) The committed baseline must decompose as actual prior files + reviewed delta.
     prior_count = int(review["prior_baseline_files_with_findings"])
@@ -458,6 +458,25 @@ def test_review_companion_covers_every_post_5317_baseline_file() -> None:
         "The committed baseline contains a file not present in the anchored prior baseline "
         "without an explicit disposition in evidence_registry_baseline_review.yaml. Add a "
         "reviewed_files entry naming the new path and its remediate-or-baseline disposition."
+    )
+
+    expected_increases = {
+        (path, code)
+        for path, current_codes in current_findings.items()
+        for code, current_count in current_codes.items()
+        if path in prior_findings and current_count > prior_findings[path].get(code, 0)
+    }
+    declared_increases = [
+        (entry.get("path"), code)
+        for entry in increase_entries
+        for code in entry.get("codes", [])
+    ]
+    assert len(declared_increases) == len(set(declared_increases)), (
+        "reviewed_baseline_increases contains duplicate path/code rows."
+    )
+    assert set(declared_increases) == expected_increases, (
+        "Every per-code baseline increase must have an explicit reviewed_baseline_increases "
+        "entry, and stale entries must be removed."
     )
 
     # (3) Every reviewed entry must still be in the baseline (review stays honest).
@@ -476,6 +495,27 @@ def test_review_companion_covers_every_post_5317_baseline_file() -> None:
         )
         assert isinstance(entry.get("codes"), list) and entry["codes"], (
             f"reviewed file {entry.get('path')} must list its finding codes"
+        )
+
+    # (5) Per-code increases must be existing files with a valid explicit disposition.
+    for entry in increase_entries:
+        path = entry.get("path")
+        assert path in prior_files and path in baseline_files, (
+            f"reviewed baseline increase {path!r} must refer to an existing baseline file"
+        )
+        assert entry.get("disposition") in valid_dispositions, (
+            f"reviewed baseline increase {path} lacks a valid disposition "
+            f"(got {entry.get('disposition')!r})"
+        )
+        assert isinstance(entry.get("codes"), list) and entry["codes"], (
+            f"reviewed baseline increase {path} must list its finding codes"
+        )
+        for code in entry["codes"]:
+            assert current_findings[path].get(code, 0) > prior_findings[path].get(code, 0), (
+                f"reviewed baseline increase {path}::{code} is not a current per-code increase"
+            )
+        assert isinstance(entry.get("reason"), str) and entry["reason"].strip(), (
+            f"reviewed baseline increase {path} must explain its disposition"
         )
 
 


### PR DESCRIPTION
## Issue #5981: make evidence-registry baseline increases reviewable

### What / why

This PR hardens the evidence-registry ratchet so a per-code increase on an already-tracked
evidence file cannot be silently grandfathered into the baseline. The current-main baseline
refresh itself is already present on `main`; this slice documents its Issue #4848 provenance
increase and makes the review contract machine-checked.

### Changes

- `scripts/validation/evidence_registry_baseline_review.yaml` records the Issue #4848
  `dangling_commit` increase with an explicit baseline disposition and the separate #5986
  remediation follow-up.
- `tests/dev/test_evidence_registry_ratchet.py` requires every existing-file per-code baseline
  increase to have one valid, non-empty companion disposition.

### Validation

- `uv run python scripts/dev/evidence_registry_ratchet.py --check`
- `uv run python scripts/tools/lint_evidence_registry.py --strict --strict-exclusion-policy docs/context/evidence/evidence_registry_strict_ci_policy.yaml`
- `uv run pytest tests/dev/test_evidence_registry_ratchet.py -q`
- `uv run ruff check tests/dev/test_evidence_registry_ratchet.py`

### What remains

- Issue #4848 campaign-level `dangling_commit` remediation remains tracked in [#5986](https://github.com/ll7/robot_sf_ll7/issues/5986); after that provenance is repaired, regenerate and review the baseline.

This PR is a non-closing follow-up slice for the existing evidence-registry work.

Refs #5981, #5972, #5948

## Follow-Up Issues

- [#5986](https://github.com/ll7/robot_sf_ll7/issues/5986): remediate the unresolved Issue #4848 producer-commit provenance and refresh the reviewed baseline.
