### PR TITLE
fix(ci): fetch provenance history for evidence ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # The evidence-registry ratchet resolves historical producing commits.
+          # A shallow checkout turns reachable provenance into false
+          # ``dangling_commit`` findings and makes main CI environment-dependent.
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up CI Python environment
         uses: ./.github/actions/setup-ci-python

--- a/scripts/validation/evidence_registry_baseline.json
+++ b/scripts/validation/evidence_registry_baseline.json
@@ -290,6 +290,7 @@
       "hash_without_artifact_path": 6
     },
     "docs/context/evidence/issue_4848_group_crossing_exemplars_2026-07/goal/classic_group_crossing_high_seed24_best/metadata.json": {
+      "dangling_commit": 1,
       "duplicate_campaign_id": 1,
       "missing_config_path": 1,
       "missing_config_sha256": 1
@@ -305,6 +306,10 @@
     },
     "docs/context/evidence/issue_5305_certified_archive/acceptance_report.json": {
       "config_missing_at_commit": 1
+    },
+    "docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration/preregistration_config_registry.json": {
+      "config_missing_at_commit": 1,
+      "dangling_commit": 1
     },
     "docs/context/evidence/issue_5446_release_0_0_3_candidates/campaign_atlas/campaign_atlas_catalog.yaml": {
       "uncommitted_artifact_missing_location": 5
@@ -326,14 +331,14 @@
       "hash_without_artifact_path": 1
     }
   },
-  "generated_at": "2026-07-17T13:22:07Z",
+  "generated_at": "2026-07-18T04:59:02Z",
   "linter": "scripts/tools/lint_evidence_registry.py",
   "schema_version": 1,
   "summary": {
     "by_code": {
       "artifact_hash_mismatch": 15,
-      "config_missing_at_commit": 3,
-      "dangling_commit": 10,
+      "config_missing_at_commit": 4,
+      "dangling_commit": 12,
       "duplicate_campaign_id": 6,
       "hash_without_artifact_path": 85,
       "invalid_sha256": 1,
@@ -342,7 +347,7 @@
       "missing_config_sha256": 53,
       "uncommitted_artifact_missing_location": 158
     },
-    "files_with_findings": 86,
-    "total_findings": 408
+    "files_with_findings": 87,
+    "total_findings": 411
   }
 }

--- a/scripts/validation/evidence_registry_baseline_review.yaml
+++ b/scripts/validation/evidence_registry_baseline_review.yaml
@@ -16,13 +16,13 @@ source_issue: 5972
 prior_baseline_commit: 9fa96c01bf1c8152459f5fa8c481e938fb1e6725
 prior_baseline_total_findings: 359
 prior_baseline_files_with_findings: 73
-refreshed_baseline_total_findings: 408
-refreshed_baseline_files_with_findings: 86
+refreshed_baseline_total_findings: 411
+refreshed_baseline_files_with_findings: 87
 decision_summary: >-
-  Thirteen evidence files merged after the 2026-07-11 baseline introduced 49 findings across
+  Fourteen evidence files merged after the 2026-07-11 baseline introduced 52 findings across
   eight codes. Every introduced code is already in the strict-CI exclusion policy, so no active
   strict-linter finding was introduced (strict mode remains at zero active findings). Each file
-  was reviewed against its source to decide remediate-vs-baseline. All thirteen use the same
+  was reviewed against its source to decide remediate-vs-baseline. All fourteen use the same
   legacy-debt pattern as the original 359 findings: artifact provenance gaps
   (external/private/untracked artifacts, ambiguous bare filenames) and campaign provenance gaps
   (dangling historical commits, missing producing config). None is trivially remediable without
@@ -100,6 +100,15 @@ reviewed_files:
       Certified-archive acceptance report declares config_sha256 but the producing
       campaign_config.json is absent at the declared commit; provenance-backfill-required legacy
       debt (recover the producing config or commit with source evidence).
+  - path: docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration/preregistration_config_registry.json
+    codes: [config_missing_at_commit, dangling_commit]
+    disposition: baseline
+    reason: >-
+      The preregistration registry records the planned factorial campaign's producing config and
+      commit, but the declared config is absent at that historical commit and the commit is not
+      reachable in this checkout. This is diagnostic provenance debt for an unrun campaign, not
+      evidence of a benchmark result; recovering the historical config/commit is a provenance
+      backfill task rather than a safe in-place rewrite of the preregistration record.
   - path: docs/context/evidence/issue_5446_release_0_0_3_candidates/campaign_atlas/campaign_atlas_catalog.yaml
     codes: [uncommitted_artifact_missing_location]
     disposition: baseline


### PR DESCRIPTION
Refs #5754.

Makes the main CI checkout full-history before the evidence-ratchet test resolves historical producing commits, then refreshes the explicitly reviewed baseline for the two remaining full-history findings.

Validation:

- `scripts/dev/run_worktree_shared_venv.sh --standalone -- python scripts/dev/evidence_registry_ratchet.py --check`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest -q tests/dev/test_evidence_registry_ratchet.py` (24 passed)
