### PR TITLE
docs(ux): add canonical adoption path (#5791)

### DIFF
--- a/docs/adoption_path.md
+++ b/docs/adoption_path.md
@@ -1,0 +1,103 @@
+# Adoption path: install, run, inspect, and explore
+
+This page gives a newcomer one short path from a fresh install to a visible Robot SF run and the
+next useful exploration step. It is the user-facing index for the adoption/UX product layer; the
+[User Guide](user-guide.md) remains the broader task-oriented reference.
+
+## Claim boundary
+
+This is a discoverability guide. The commands below provide local smoke or inspection evidence,
+not benchmark evidence. Demo summaries, recipe outputs, notebook plots, and gallery metadata are
+worktree-local convenience artifacts unless they are separately promoted through the benchmark
+provenance workflow. A single run or an estimated runtime must not be used to rank planners or
+support a paper-facing claim.
+
+## 1. Install and check the host
+
+From the repository root, install the standard development dependencies and ask the readiness
+checker for actionable local diagnostics:
+
+```bash
+uv sync --all-extras
+uv run robot-sf doctor
+```
+
+For a quick host-only check that does not execute the environment or manifest quickstarts, use:
+
+```bash
+uv run robot-sf doctor --skip-env-smoke --skip-quickstart-smoke
+```
+
+The doctor report is the first fail-closed boundary: fix reported missing tools, imports, model
+artifacts, or quickstart failures before interpreting later output.
+
+## 2. Run one visible episode
+
+Run the deterministic CPU demo and open the generated viewer in a browser:
+
+```bash
+uv run robot-sf demo --output-root output/demo/latest --seed 270
+```
+
+The disposable output directory contains:
+
+| Artifact | Use |
+| --- | --- |
+| `episode.jsonl` | Inspect the recorded per-step trace. |
+| `summary.json` | Read the plain-English outcome and claim boundary. |
+| `metrics.json` | Inspect machine-readable local outcome metrics. |
+| `viewer/index.html` | Play back the episode in a browser. |
+| `thumbnail.png` | See the top-down map and route at a glance. |
+
+These artifacts answer “does the install run and produce something visible?” They do not answer
+“which planner is better?”
+
+## 3. Discover examples and blessed workflows
+
+Use the manifest-backed example catalog when you want source-level examples, and the curated recipe
+catalog when you want a copy-pasteable workflow without learning repository paths first:
+
+```bash
+uv run robot-sf examples list
+uv run robot-sf examples run quickstart/01_basic_robot --fast
+
+uv run robot-sf recipe list
+uv run robot-sf recipe explain first-demo
+uv run robot-sf recipe run first-demo
+```
+
+`examples` is the source-of-truth inventory for example scripts. Recipes are thin mappings to
+existing scripts and configs; they do not add simulation or training logic. Use
+`uv run robot-sf recipe run <id> --dry-run` to inspect a command before executing it. The
+`ppo-smoke` recipe exercises config loading in dry-run mode and is not a training result.
+
+## 4. Inspect scenarios and try a controlled comparison
+
+Build the self-contained scenario gallery to browse maps, scenario metadata, estimated runtime,
+and runnable commands:
+
+```bash
+uv run robot-sf gallery build \
+  --matrix configs/baselines/example_matrix.yaml \
+  --out-dir output/gallery
+```
+
+Open `output/gallery/index.html`. The gallery's thumbnails, supported-planner labels, and runtime
+estimates are inspection aids. They are not measured per-scenario capabilities or benchmark
+results. For a rigorous comparison, follow the [Research & Benchmark Guide](research-guide.md)
+and its declared matrix, seeds, metrics, and artifact-provenance requirements.
+
+## 5. Continue by task
+
+- Compare or visualize teaching runs: [beginner notebooks](../notebooks/README.md).
+- Check local model availability: `uv run robot-sf models list` and
+  `uv run robot-sf models verify`.
+- Check external-data layout without downloading: `uv run robot-sf datasets list` and
+  `uv run robot-sf datasets prepare <id>`.
+- Discover the supported environment catalog: `uv run robot-sf envs list` and
+  `uv run robot-sf envs describe <env-id>`.
+- Move to reproducible evaluation: [Research & Benchmark Guide](research-guide.md).
+
+All generated files in this path belong under the git-ignored `output/` directory. Keep raw runs,
+videos, checkpoints, and large datasets out of the repository; promote only durable, provenance-
+complete evidence through the established evidence workflow.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -10,6 +10,8 @@ internals or research methodology.
 
 ## 1. Install and first run
 
+- [Adoption path](./adoption_path.md) — the shortest install → doctor → demo → examples → recipes
+  → gallery journey.
 - [Quickstart Map](./quickstart.md) — first local checks, install, and one-command demos.
 - [Development Guide](./dev_guide.md#setup) — full `uv sync --all-extras` setup, virtualenv, and
   pre-commit hooks.
@@ -19,6 +21,8 @@ internals or research methodology.
 
 ## 2. Run a demo
 
+- The [Adoption path](./adoption_path.md) shows the complete beginner flow and the claim boundary
+  for its local smoke/inspection artifacts.
 - [Examples Index](../examples/README.md) — quickstart, advanced, benchmark, and plotting workflows.
   + `examples/quickstart/01_basic_robot.py` — minimal robot simulation.
   + `examples/quickstart/02_trained_model.py` — run a trained model.

--- a/tests/test_adoption_ux_path.py
+++ b/tests/test_adoption_ux_path.py
@@ -1,0 +1,64 @@
+"""Keep the user-facing adoption path aligned with shipped UX surfaces."""
+
+from pathlib import Path
+
+import pytest
+
+from robot_sf.cli import _build_parser
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+ADOPTION_PATH = REPOSITORY_ROOT / "docs" / "adoption_path.md"
+
+
+@pytest.fixture(scope="module")
+def adoption_text() -> str:
+    """Read the canonical adoption path once for the contract tests."""
+    return ADOPTION_PATH.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "uv run robot-sf doctor",
+        "uv run robot-sf demo",
+        "uv run robot-sf examples list",
+        "uv run robot-sf recipe list",
+        "uv run robot-sf gallery build",
+    ),
+)
+def test_adoption_path_names_each_product_layer_command(adoption_text: str, command: str) -> None:
+    """The documented install-to-gallery path must not silently lose a layer."""
+    assert command in adoption_text
+
+
+def test_adoption_path_claim_boundary_is_explicit(adoption_text: str) -> None:
+    """Local UX output must not be presented as benchmark evidence."""
+    assert "not benchmark evidence" in adoption_text
+    assert "not a training result" in adoption_text
+    assert "not measured per-scenario capabilities" in adoption_text
+
+
+def test_adoption_path_artifact_locations_are_documented(adoption_text: str) -> None:
+    """The visible demo and gallery outputs have stable, documented locations."""
+    for artifact in (
+        "output/demo/latest",
+        "episode.jsonl",
+        "summary.json",
+        "viewer/index.html",
+        "thumbnail.png",
+        "output/gallery/index.html",
+    ):
+        assert artifact in adoption_text
+
+
+def test_adoption_path_commands_are_registered_by_the_umbrella_cli() -> None:
+    """The route names in the guide must remain available in the top-level parser."""
+    parser = _build_parser()
+    subparser_action = next(action for action in parser._actions if action.dest == "cmd")
+    assert {
+        "doctor",
+        "demo",
+        "examples",
+        "recipe",
+        "gallery",
+    } <= set(subparser_action.choices)

--- a/tests/test_adoption_ux_path.py
+++ b/tests/test_adoption_ux_path.py
@@ -38,23 +38,32 @@ def test_adoption_path_claim_boundary_is_explicit(adoption_text: str) -> None:
     assert "not measured per-scenario capabilities" in adoption_text
 
 
-def test_adoption_path_artifact_locations_are_documented(adoption_text: str) -> None:
-    """The visible demo and gallery outputs have stable, documented locations."""
-    for artifact in (
+@pytest.mark.parametrize(
+    "artifact",
+    (
         "output/demo/latest",
         "episode.jsonl",
         "summary.json",
         "viewer/index.html",
         "thumbnail.png",
         "output/gallery/index.html",
-    ):
-        assert artifact in adoption_text
+    ),
+)
+def test_adoption_path_artifact_locations_are_documented(adoption_text: str, artifact: str) -> None:
+    """The visible demo and gallery outputs have stable, documented locations."""
+    assert artifact in adoption_text, (
+        f"Expected artifact '{artifact}' to be documented in adoption text"
+    )
 
 
 def test_adoption_path_commands_are_registered_by_the_umbrella_cli() -> None:
     """The route names in the guide must remain available in the top-level parser."""
     parser = _build_parser()
-    subparser_action = next(action for action in parser._actions if action.dest == "cmd")
+    subparser_action = next(
+        (action for action in parser._actions if action.dest == "cmd"),
+        None,
+    )
+    assert subparser_action is not None, "Subcommand action 'cmd' not found in parser"
     assert {
         "doctor",
         "demo",


### PR DESCRIPTION
## Reviewer-critical summary

This PR adds the missing integration slice for the adoption/UX epic #5791: one canonical beginner
path from install → doctor → demo → examples → recipes → gallery, linked from the User Guide.
It turns the already-merged child surfaces into a coherent product flow and adds a regression
contract so the documented route, artifact locations, and claim boundary do not silently drift.

- Why now: the demo, doctor, examples, recipes, gallery, model/data, notebook, and documentation
  child slices are already present, but their user journey was not indexed in one place.
- Claim boundary: this is discoverability and local smoke/inspection evidence, not benchmark or
  paper-facing evidence; local outputs and estimates must not be used to rank planners.
- Required validation: focused CPU UX/CLI suite, full repository test command for baseline
  classification, Ruff, formatting, link checks, and final readiness preflight.
- Remaining blocker: the epic's aggressive install-profile split (#5799) remains a separate,
  maintainer-led packaging task; this PR intentionally does not change dependency semantics.

## Contract delta

- New user-facing documentation contract: `docs/adoption_path.md` is the canonical install-to-gallery
  route and documents fail-closed doctor usage, demo artifacts, source-of-truth examples, thin
  recipes, gallery inspection, and evidence limitations.
- Navigation delta: `docs/user-guide.md` links the adoption path from the first-run and demo sections.
- Regression contract: `tests/test_adoption_ux_path.py` requires all five core route commands, the
  stable demo/gallery artifact locations, explicit non-benchmark wording, and top-level CLI
  registration.
- Compatibility impact: documentation and tests only; no runtime, config, metric, model, or
  dependency behavior changes.

## Scope and validation

- Issue: https://github.com/ll7/robot_sf_ll7/issues/5791
- Accepted base: `5dc97e21e6d98ea0504ac1690cb335afd19756fd`
- Branch: `issue-5791-adoption-ux-epic-user-facing-product-layer-demo-doctor-examples-recipes`
- Changed files: `docs/adoption_path.md`, `docs/user-guide.md`,
  `tests/test_adoption_ux_path.py`.
- Focused CPU validation: `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest
  tests/test_adoption_ux_path.py tests/test_cli_doctor.py tests/test_recipes.py
  tests/examples/test_examples_cli.py tests/gallery/test_gallery_build.py -q` — **122 passed**.
- New contract validation: `uv run pytest tests/test_adoption_ux_path.py -q` — **8 passed**.
- Ruff/format: changed test passes `uv run ruff check` and `uv run ruff format --check`.
- Link validation: all changed documentation targets exist.
- Full CPU command: `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests -q` —
  **17,575 passed, 52 skipped, 1 xfailed, 15 baseline failures**. The 12 issue-4142 failures
  reject the intentionally dirty worktree provenance; 3 evidence-registry failures report known
  accepted-base baseline drift. No failure names the changed files or adoption tests.

## Remaining work

- [ ] Keep #5799 as the separate maintainer-led install-matrix/dependency-split task.
- [ ] Continue any future adoption polish as separate, evidence-bounded child slices rather than
  changing benchmark semantics in this documentation integration PR.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no training run, and no paper/dissertation
claim edits. No output artifacts are committed or treated as durable evidence.

<details>
<summary>Governance and propagation details</summary>

Evidence status: smoke evidence for the documentation/CLI route contract only; no benchmark claim.
The new test proves route-name and claim-boundary synchronization, while the adjacent tests prove
the existing child CLI surfaces still execute on CPU. Gallery thumbnails, recipe outputs, demo
traces, and notebook outputs remain worktree-local and regenerable under `output/`.

Downstream propagation: not applicable because this PR changes no benchmark, metric, schema,
model-provenance, leaderboard, or paper-facing surface. The User Guide is the durable navigation
surface updated here; no issue comment was added because the accepted authorization profile forbids
issue/PR comments outside PR creation.

</details>

Refs #5791


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify consistency between the documented adoption path and available command-line workflows.
  * Confirmed documented commands, routes, output locations, and guidance distinguishing local UX results from benchmark or training evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->