### PR TITLE
test: isolate issue #6000 executor provenance

### DIFF
--- a/tests/benchmark/test_issue_4142_dpcbf_dense_executor.py
+++ b/tests/benchmark/test_issue_4142_dpcbf_dense_executor.py
@@ -12,6 +12,7 @@ from typing import Any
 import pytest
 import yaml
 
+import robot_sf.benchmark.issue_4142_dpcbf_dense_runner as dense_runner
 from robot_sf.benchmark.issue_4142_dpcbf_dense_readiness import (
     PACKET_PATH,
     REQUIRED_ARMS,
@@ -30,6 +31,26 @@ from robot_sf.benchmark.issue_4142_dpcbf_dense_runner import (
 )
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(autouse=True)
+def _clean_real_repository_provenance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep executor contract tests independent of the implementation worktree's status.
+
+    Authorized-execution cases use real packet/config inputs from ``REPO_ROOT`` but replace
+    only its git-status probe with a deterministic clean identity. Temporary fixture roots keep
+    their real provenance behavior. The dedicated dirty-worktree test below preserves coverage
+    for the production fail-closed guard.
+    """
+    original_git_provenance = dense_runner._git_provenance
+
+    def git_provenance(repo_root: pathlib.Path) -> tuple[str, bool]:
+        if repo_root.resolve() == REPO_ROOT:
+            return "test-clean-repository", False
+        return original_git_provenance(repo_root)
+
+    monkeypatch.setattr(dense_runner, "_git_provenance", git_provenance)
+
 
 _RUNNABLE_PACKET = {
     "schema_version": "robot_sf.issue_4142_dpcbf_dense_comparison.v1",
@@ -153,6 +174,27 @@ def test_wrong_authorization_raises_before_creating_output(tmp_path: pathlib.Pat
         execute_run_plan(plan, authorization="not-the-id", repo_root=REPO_ROOT, run_batch_fn=fake)
     with pytest.raises(DenseComparisonExecutionGatedError):
         execute_run_plan(plan, authorization="true", repo_root=REPO_ROOT, run_batch_fn=fake)
+
+    assert not out_dir.exists()
+    assert fake.calls == []
+
+
+def test_dirty_git_worktree_is_rejected_before_dispatch(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Production provenance still rejects a dirty repository before an arm dispatches."""
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
+    fake = _RecordingRunBatch()
+    monkeypatch.setattr(dense_runner, "_git_provenance", lambda _root: ("test-dirty", True))
+
+    with pytest.raises(DenseComparisonProvenanceMismatchError, match="dirty git worktree"):
+        execute_run_plan(
+            plan,
+            authorization=REQUIRED_AUTHORIZATION_ID,
+            repo_root=REPO_ROOT,
+            run_batch_fn=fake,
+        )
 
     assert not out_dir.exists()
     assert fake.calls == []


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** executor contract tests now inject a deterministic clean provenance only when
they use the real repository inputs. A new focused test still proves that a dirty Git worktree is
rejected before any arm dispatches.

**Why now:** #6000 documents that every uncommitted implementation diff made the authorized
executor tests fail before reaching their intended assertions.

**Claim boundary:** test isolation only. Production executor code and its fail-closed dirty-worktree
guard are unchanged; this makes no benchmark, metric, or safety-performance claim.

**Required validation:** `pytest tests/benchmark/test_issue_4142_dpcbf_dense_executor.py -q`
passed (20 tests); Ruff check and format check passed. A supplementary `pytest tests -q` run was
stopped after 41 minutes without a terminal result to preserve the packet handoff window.

**Remaining blocker:** none for #6000. The broad repository suite should be run in CI or a
dedicated validation window; it is not evidence of a regression in this narrowly changed contract.

## Contract delta

- New test-only provenance seam: real-repository executor cases receive a fixed clean SHA/status.
- New fail-closed proof: a dirty Git status raises before dispatch and writes no output.
- Compatibility: no runtime, packet, schema, CLI, or benchmark-contract change.

Closes #6000

<details>
<summary>Implementation, validation, and governance appendix</summary>

## Linked issue and scope

- Issue: https://github.com/ll7/robot_sf_ll7/issues/6000
- Scope: `tests/benchmark/test_issue_4142_dpcbf_dense_executor.py` only.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation
  claim edits.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh --no-freshness-check -- pytest tests/benchmark/test_issue_4142_dpcbf_dense_executor.py -q` — passed, 20 tests.
- `scripts/dev/run_worktree_shared_venv.sh --no-freshness-check -- ruff check tests/benchmark/test_issue_4142_dpcbf_dense_executor.py` — passed.
- `scripts/dev/run_worktree_shared_venv.sh --no-freshness-check -- ruff format --check tests/benchmark/test_issue_4142_dpcbf_dense_executor.py` — passed.
- `git diff --check` — passed.
- `scripts/dev/run_worktree_shared_venv.sh --no-freshness-check -- pytest tests -q` — started as supplementary broad CPU validation; stopped after 41 minutes without a terminal result due the packet time budget.

## Research and downstream propagation

- Evidence tier / result classification: NA — support-test fix; no research claim.
- Domain-aware approval: not required — no change to experimental validity, evidence
  classification, or benchmark semantics.
- Artifacts: none created or retained.
- State propagation: no issue comment was posted because this packet denies `comment_issue_or_pr`;
  this PR is the durable delivery surface. The issue has no recent PR churn.

## Risks and review focus

- Review that the autouse fixture only replaces provenance for `REPO_ROOT`; temporary fixture
  roots keep their actual provenance behavior.
- Review the explicit dirty-worktree test, which preserves the production guard's required
  fail-closed behavior.

## Friction

- No new friction issue filed. The shared-venv freshness-check failure encountered during
  validation is already tracked by #6003.

</details>
