### PR TITLE
fix(dev): prefer initialized worktree venv (#5984)

### DIFF
--- a/scripts/dev/run_worktree_shared_venv.sh
+++ b/scripts/dev/run_worktree_shared_venv.sh
@@ -26,8 +26,8 @@ Standalone commands with a verified boundary that does not import project packag
 to PYTHONPATH, while still reusing the shared environment for third-party dependencies.
 
 Options:
-  --venv PATH            Shared virtualenv path exported as UV_PROJECT_ENVIRONMENT. Defaults to the
-                         main checkout .venv for linked worktrees.
+  --venv PATH            Shared virtualenv path exported as UV_PROJECT_ENVIRONMENT. Defaults to an
+                         initialized current-worktree .venv, otherwise the main checkout .venv.
   --standalone           Run a command that is verified not to import project packages. This skips
                          the project-source freshness check and does not prepend the worktree root
                          to PYTHONPATH.
@@ -100,7 +100,13 @@ if [[ "$git_common_dir" != /* ]]; then
 fi
 main_repo_root="$(cd "$git_common_dir/.." && pwd)"
 
-venv_path="${venv_override:-$main_repo_root/.venv}"
+if [[ -n "$venv_override" ]]; then
+  venv_path="$venv_override"
+elif [[ -x "$repo_root/.venv/bin/python" ]]; then
+  venv_path="$repo_root/.venv"
+else
+  venv_path="$main_repo_root/.venv"
+fi
 if [[ "$venv_path" != /* ]]; then
   venv_path="$repo_root/$venv_path"
 fi

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -774,7 +774,10 @@ def test_worktree_shared_venv_helper_pins_current_checkout_imports() -> None:
 
     assert 'repo_root="$(git rev-parse --show-toplevel)"' in script_text
     assert 'main_repo_root="$(cd "$git_common_dir/.." && pwd)"' in script_text
-    assert 'venv_path="${venv_override:-$main_repo_root/.venv}"' in script_text
+    assert 'if [[ -n "$venv_override" ]]; then' in script_text
+    assert 'elif [[ -x "$repo_root/.venv/bin/python" ]]; then' in script_text
+    assert 'venv_path="$repo_root/.venv"' in script_text
+    assert 'venv_path="$main_repo_root/.venv"' in script_text
     assert 'export UV_PROJECT_ENVIRONMENT="$venv_path"' in script_text
     assert "export UV_NO_SYNC=1" in script_text
     assert (
@@ -897,7 +900,7 @@ def _make_freshness_fixture_repo(
     """
     repo = tmp_path / "repo"
     fake_bin = repo / "fake-bin"
-    venv = repo / "shared-venv"
+    venv = repo / ".venv"
     site_packages = venv / "lib" / "python3.12" / "site-packages"
     installed_pkg = site_packages / "pysocialforce"
     src_pkg = repo / "fast-pysf" / "pysocialforce"
@@ -913,6 +916,7 @@ def _make_freshness_fixture_repo(
     # Installed copy is whatever the caller passes (matching = fresh, divergent = stale).
     (installed_pkg / "scene.py").write_text(installed_scene, encoding="utf-8")
     (installed_pkg / "__init__.py").write_text("", encoding="utf-8")
+    (repo / ".gitignore").write_text(".venv/\n", encoding="utf-8")
 
     # The helper only checks venv presence via bin/python executability.
     py = venv / "bin" / "python"
@@ -922,6 +926,7 @@ def _make_freshness_fixture_repo(
     fake_uv = fake_bin / "uv"
     fake_uv.write_text(
         '#!/usr/bin/env bash\nprintf "uv-reached %s\\n" "$*" >&2\n'
+        'printf "venv=%s\\n" "${UV_PROJECT_ENVIRONMENT-}" >&2\n'
         'printf "pythonpath=%s\\n" "${PYTHONPATH-}" >&2\nexit 7\n',
         encoding="utf-8",
     )
@@ -1021,6 +1026,78 @@ def test_worktree_shared_venv_freshness_check_passes_on_fresh_env(
     # The freshness gate passes, so the helper reaches the underlying command (fake uv exits 7).
     assert result.returncode == 7
     assert "uv-reached" in result.stderr
+    assert "Shared virtualenv is stale" not in result.stderr
+
+
+def test_worktree_shared_venv_prefers_initialized_local_env(tmp_path: Path) -> None:
+    """A linked worktree selects its usable local env before a stale main env (issue #5984)."""
+    matching_scene = "def normalize_integration_scheme(value=None):\n    return value\n"
+    repo, main_venv, env = _make_freshness_fixture_repo(
+        tmp_path,
+        installed_scene="# stale main install\n",
+    )
+    worktree = tmp_path / "worktree"
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", str(worktree)],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    local_venv = worktree / ".venv"
+    local_site_packages = local_venv / "lib" / "python3.12" / "site-packages" / "pysocialforce"
+    local_site_packages.mkdir(parents=True)
+    (local_venv / "bin").mkdir()
+    local_python = local_venv / "bin" / "python"
+    local_python.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    local_python.chmod(0o755)
+    (local_site_packages / "scene.py").write_text(matching_scene, encoding="utf-8")
+    (local_site_packages / "__init__.py").write_text("", encoding="utf-8")
+
+    result = subprocess.run(
+        [str(RUN_WORKTREE_SHARED_VENV), "--", "python", "-V"],
+        cwd=worktree,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 7
+    assert f"venv={local_venv}" in result.stderr
+    assert f"venv={main_venv}" not in result.stderr
+    assert "Shared virtualenv is stale" not in result.stderr
+
+
+def test_worktree_shared_venv_falls_back_to_main_env_without_local_env(tmp_path: Path) -> None:
+    """A linked worktree without an executable local env selects the fresh main env (issue #5984)."""
+    matching_scene = "def normalize_integration_scheme(value=None):\n    return value\n"
+    repo, main_venv, env = _make_freshness_fixture_repo(tmp_path, installed_scene=matching_scene)
+    worktree = tmp_path / "worktree"
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", str(worktree)],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    incomplete_local_venv = worktree / ".venv" / "bin"
+    incomplete_local_venv.mkdir(parents=True)
+    (incomplete_local_venv / "python").write_text("not executable\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [str(RUN_WORKTREE_SHARED_VENV), "--", "python", "-V"],
+        cwd=worktree,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 7
+    assert f"venv={main_venv}" in result.stderr
     assert "Shared virtualenv is stale" not in result.stderr
 
 


### PR DESCRIPTION
## Reviewer-critical summary

What changed: `run_worktree_shared_venv.sh` now selects an executable `.venv/bin/python` in the active worktree by default, falling back to the main checkout’s `.venv` only when the local environment is absent or incomplete. The existing `--venv` override remains first priority.

Why now: the confirmed batch-gate failure selected a stale main environment even though the isolated review worktree had a usable local environment.

Claim boundary: this is a CPU-only developer-tooling behavior fix. It does not change the `pysocialforce` freshness-comparison algorithm, `--standalone`, `--no-freshness-check`, `ROBOT_SF_VENV_FRESHNESS_CHECK=skip`, or per-worktree `COVERAGE_FILE` isolation.

Required validation: `uv run pytest tests/test_ci_script_contract.py -q -k worktree_shared_venv` (15 passed) and `bash -n scripts/dev/run_worktree_shared_venv.sh` (passed).

Remaining blocker: none for issue #5984’s stated acceptance criteria.

Closes #5984

## Contract delta

- New default-selection behavior: no `--venv` now prefers the current worktree’s executable `.venv/bin/python`; an absent or incomplete local environment falls back to the main checkout environment.
- Fail-closed behavior retained: the unchanged freshness check runs against whichever environment is selected and still rejects divergence before `uv` runs.
- Compatibility: explicit `--venv` remains highest precedence; no schema fields or command-line flags changed.

## Validation / proof

- `uv run pytest tests/test_ci_script_contract.py -q -k worktree_shared_venv` — 15 passed, including real linked-worktree tests for local preference with a stale main environment and fallback from a non-executable local Python.
- `bash -n scripts/dev/run_worktree_shared_venv.sh` — passed.
- `uv run ruff check tests/test_ci_script_contract.py` — passed.
- `uv run ruff format --check tests/test_ci_script_contract.py` — passed.
- `git diff --check` — passed.

<details>
<summary>Scope, risk, and process notes</summary>

## Linked issue and scope

- Issue: https://github.com/ll7/robot_sf_ll7/issues/5984
- Changed paths: `scripts/dev/run_worktree_shared_venv.sh`, `tests/test_ci_script_contract.py`.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

## Risks / rollback

- Risk: callers without `--venv` now use a local environment when it is executable. The retained freshness gate prevents treating a divergent local environment as valid.
- Rollback: revert this two-file commit to restore main-checkout-first selection.

## Research and downstream propagation

- Research result guidance: NA — support helper only; no benchmark, metric, or paper claim.
- Domain-aware approval: not required — no evidence classification or experimental interpretation changes.
- Downstream propagation: no issue status comment was added because this accepted packet does not authorize issue/PR comments; the closing reference in this PR is the durable issue linkage.
- Artifacts: no `output/` artifacts produced or required.

## Reviewer notes

- Verify that local selection occurs only after checking `-x .venv/bin/python`, and that the existing override branch precedes it.
- The test fixture’s fake `uv` records `UV_PROJECT_ENVIRONMENT`; it proves selection without executing project code.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development environment selection for linked worktrees.
  * Automatically uses an initialized local `.venv` when available.
  * Falls back to the main checkout’s virtual environment when no local environment is available.
* **Tests**
  * Added coverage for local-environment preference and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->