### PR TITLE
docs(workflow): reconcile continue-patch retries (#6008)

### DIFF
--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -1,5 +1,9 @@
 # Context Retrieval Index
 
+Issue #6008 continue-patch retry reconciliation: the fail-closed pre-dispatch
+contract that blocks duplicate retries when their patch is missing, ambiguous,
+or already merged: [issue_6008_state.yaml](issue_6008_state.yaml).
+
 Issue #5936 result-job durability gate — producer-side probe (`result_job_durability.v1`) that a completed result job must pass (checksum + versioned schema + canonical rerun command + durable public-safe pointer) before any `analysis:` successor issue may be created or admitted; clean-checkout reproducible, fails closed on local-only pointers:
 [issue_5936_result_job_durability_gate.md](issue_5936_result_job_durability_gate.md).
 

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1,5 +1,5 @@
 version: 1
-updated_at: 2026-07-17
+updated_at: 2026-07-19
 policy: context-catalog.v1
 description: 'Machine-readable catalog for the current retrieval-first context index.
   This is not a full inventory of docs/context; it covers curated entry points from
@@ -20,6 +20,10 @@ freshness_values:
   policy: Durable policy boundary; update only when the policy changes.
   evidence: Evidence pointer or manifest; preserve provenance and checksums when applicable.
 entries:
+- path: docs/context/issue_6008_state.yaml
+  status: current
+  freshness: maintained
+  area: workflow_evidence
 - path: docs/context/evidence/issue_5948_doorway_provenance_2026-07-17/README.md
   status: evidence
   freshness: dated

--- a/docs/context/issue_6008_state.yaml
+++ b/docs/context/issue_6008_state.yaml
@@ -5,7 +5,7 @@
 # durable reconciliation behavior only; it intentionally excludes target hosts,
 # worktree paths, packet lineage, and other transient queue-routing state.
 issue: 6008
-title: "friction: reconcile stale continue-patch retries before dispatch"
+title: "Friction: Reconcile Stale Continue-Patch Retries Before Dispatch (#6008)"
 schema: robot_sf.issue_state.v1
 state_surface: continue_patch_retry_reconciliation
 

--- a/docs/context/issue_6008_state.yaml
+++ b/docs/context/issue_6008_state.yaml
@@ -5,7 +5,7 @@
 # durable reconciliation behavior only; it intentionally excludes target hosts,
 # worktree paths, packet lineage, and other transient queue-routing state.
 issue: 6008
-title: "Friction: Reconcile Stale Continue-Patch Retries Before Dispatch (#6008)"
+title: "friction: reconcile stale continue-patch retries before dispatch (#6008)"
 schema: robot_sf.issue_state.v1
 state_surface: continue_patch_retry_reconciliation
 

--- a/docs/context/issue_6008_state.yaml
+++ b/docs/context/issue_6008_state.yaml
@@ -1,0 +1,87 @@
+# Canonical issue-state surface for #6008.
+#
+# This append-only contract prevents a continuation retry from creating duplicate
+# work when its referenced patch has disappeared or has already landed. It records
+# durable reconciliation behavior only; it intentionally excludes target hosts,
+# worktree paths, packet lineage, and other transient queue-routing state.
+issue: 6008
+title: "friction: reconcile stale continue-patch retries before dispatch"
+schema: robot_sf.issue_state.v1
+state_surface: continue_patch_retry_reconciliation
+
+entries:
+  - recorded_at_utc: "2026-07-19T00:00:00Z"
+    status: contract_defined__dispatcher_owner_implementation_pending
+    source:
+      issue_url: "https://github.com/ll7/robot_sf_ll7/issues/6008"
+      observed_condition: >-
+        A continuation retry referenced an unavailable patch location even though
+        the matching implementation had already landed in merged PR #5951.
+      merged_implementation:
+        pr: 5951
+        commit: "8c1f5499e"
+        ancestry: "ancestor_of_origin_main_at_issue_intake"
+    claim_boundary: >-
+      This is a fail-closed interface contract and local regression guard, not an
+      implementation of the private dispatcher. It does not establish that any
+      retry was reconciled in production.
+    reconciliation_contract:
+      contract_version: continue_patch_retry_reconciliation.v1
+      applies_when: "retry.kind == continue_patch before worker dispatch"
+      required_identity:
+        - "stable patch identity (commit, content digest, or immutable review reference)"
+        - "declared changed-path set or equivalent patch manifest"
+      decisions:
+        patch_available_and_unmerged:
+          dispatch: true
+          receipt: "dispatches only after identity and changed paths resolve"
+        patch_already_merged:
+          dispatch: false
+          terminal_state: superseded
+          receipt: "records merged evidence and selects no duplicate continuation"
+        patch_reference_missing:
+          dispatch: false
+          terminal_state: blocked
+          receipt: "records unavailable reference; never reconstructs a patch from a stale retry"
+        patch_identity_indeterminate:
+          dispatch: false
+          terminal_state: blocked
+          receipt: "requires review rather than comparing an ambiguous path-only reference"
+      invariants:
+        - "A path-only continue_patch retry is never enough authority to dispatch."
+        - "A superseded or blocked retry creates no worker session."
+        - "Every non-dispatch decision emits a durable reason and the resolved patch identity."
+        - "Only a newly reviewed retry with a fresh immutable identity may replace a blocked retry."
+      acceptance_matrix:
+        - case: "available, identified, and not merged"
+          expected_decision: dispatch
+        - case: "identified patch is already merged"
+          expected_decision: superseded_without_dispatch
+        - case: "referenced patch location is unavailable"
+          expected_decision: blocked_without_dispatch
+        - case: "identity cannot be resolved from supplied retry data"
+          expected_decision: blocked_without_dispatch
+    owner_boundary:
+      required_change: >-
+        Implement this pre-dispatch decision in the orchestrator that owns
+        continue_patch retries, before it creates a worker session.
+      repository_status: >-
+        The dispatcher implementation is outside the authorized robot_sf paths;
+        this repository carries the durable contract and its regression guard.
+    closure_boundary:
+      closure_call_for_this_pr: keep_open
+      remaining:
+        - "Port the v1 decision matrix to the dispatcher owner and add its runtime tests."
+        - "Exercise one already-merged and one missing-reference retry through the real dispatch boundary."
+      next_empirical_action: >-
+        Run the dispatcher-owner tests against fixtures for all four acceptance
+        matrix rows, then inspect the emitted non-dispatch receipts before
+        enabling the reconciler for live queue items.
+    out_of_scope_confirmed:
+      full_benchmark_campaign_run: false
+      slurm_or_gpu_submission: false
+      paper_or_dissertation_claim_edit: false
+      issue_comment: false
+      release: false
+      merge: false
+      deletion: false

--- a/tests/dev/test_issue_6008_continue_patch_retry_contract.py
+++ b/tests/dev/test_issue_6008_continue_patch_retry_contract.py
@@ -1,0 +1,52 @@
+"""Regression guard for the fail-closed continue-patch retry contract (#6008)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+STATE_PATH = ROOT / "docs/context/issue_6008_state.yaml"
+
+
+def _contract() -> dict:
+    state = yaml.safe_load(STATE_PATH.read_text(encoding="utf-8"))
+    assert state["issue"] == 6008
+    assert state["schema"] == "robot_sf.issue_state.v1"
+    assert len(state["entries"]) == 1
+    return state["entries"][0]["reconciliation_contract"]
+
+
+def test_continue_patch_contract_fails_closed_for_stale_or_ambiguous_retries() -> None:
+    """Missing, merged, and path-only retries cannot create duplicate work."""
+    contract = _contract()
+    decisions = contract["decisions"]
+
+    assert contract["applies_when"] == "retry.kind == continue_patch before worker dispatch"
+    assert decisions["patch_already_merged"] == {
+        "dispatch": False,
+        "terminal_state": "superseded",
+        "receipt": "records merged evidence and selects no duplicate continuation",
+    }
+    assert decisions["patch_reference_missing"]["dispatch"] is False
+    assert decisions["patch_reference_missing"]["terminal_state"] == "blocked"
+    assert decisions["patch_identity_indeterminate"]["dispatch"] is False
+    assert decisions["patch_identity_indeterminate"]["terminal_state"] == "blocked"
+    assert (
+        "A path-only continue_patch retry is never enough authority to dispatch."
+        in contract["invariants"]
+    )
+
+
+def test_continue_patch_contract_allows_only_an_identified_unmerged_patch() -> None:
+    """The positive lane remains available after the stale-retry guard is added."""
+    contract = _contract()
+    available = contract["decisions"]["patch_available_and_unmerged"]
+
+    assert available["dispatch"] is True
+    assert "identity and changed paths" in available["receipt"]
+    assert contract["required_identity"] == [
+        "stable patch identity (commit, content digest, or immutable review reference)",
+        "declared changed-path set or equivalent patch manifest",
+    ]

--- a/tests/dev/test_issue_6008_continue_patch_retry_contract.py
+++ b/tests/dev/test_issue_6008_continue_patch_retry_contract.py
@@ -14,8 +14,8 @@ def _contract() -> dict:
     state = yaml.safe_load(STATE_PATH.read_text(encoding="utf-8"))
     assert state["issue"] == 6008
     assert state["schema"] == "robot_sf.issue_state.v1"
-    assert len(state["entries"]) == 1
-    return state["entries"][0]["reconciliation_contract"]
+    assert len(state["entries"]) >= 1
+    return state["entries"][-1]["reconciliation_contract"]
 
 
 def test_continue_patch_contract_fails_closed_for_stale_or_ambiguous_retries() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** adds a versioned, machine-checked `continue_patch` pre-dispatch reconciliation contract and its focused regression test.
- **Why now:** #6008 found a retry whose patch location was gone although the matching change was already merged; retrying would duplicate delivered work.
- **Claim boundary:** this PR defines and guards the public contract only. It does not implement or prove the private dispatcher’s runtime behavior.
- **Required validation:** `uv run pytest tests/dev/test_issue_6008_continue_patch_retry_contract.py tests/validation/test_check_docs_proof_consistency.py -q` (53 passed); focused Ruff checks passed.
- **Remaining blocker:** the dispatcher owner must implement the four-row decision matrix and exercise it at the real dispatch boundary.

Issue: https://github.com/ll7/robot_sf_ll7/issues/6008

Refs #6008

## Contract delta

- New `continue_patch_retry_reconciliation.v1` requires immutable patch identity plus changed paths before dispatch.
- Already-merged patches become `superseded`; missing or ambiguous references become `blocked`; all three states forbid worker creation.
- An identified, unmerged patch remains dispatchable, preserving the legitimate continuation path.
- Compatibility impact: the contract is additive. The dispatcher implementation is intentionally outside this repository’s authorized paths.

## Remaining work

- [ ] Port the v1 pre-dispatch decision to the orchestrator owner with runtime tests for all acceptance-matrix rows.
- [ ] Exercise already-merged and missing-reference fixtures through the live dispatch boundary and inspect their durable non-dispatch receipts.

<details>
<summary>Scope, validation, and governance appendix</summary>

### Scope summary

Changed only `docs/context/` discovery/state surfaces and a focused `tests/dev/` contract test. The new capability is a durable, fail-closed continuation-retry contract that prevents duplicate dispatch before the private owner implements it.

### Validation

- `uv run pytest tests/dev/test_issue_6008_continue_patch_retry_contract.py tests/validation/test_check_docs_proof_consistency.py -q` — 53 passed.
- `uv run ruff check tests/dev/test_issue_6008_continue_patch_retry_contract.py` — passed.
- `uv run ruff format --check tests/dev/test_issue_6008_continue_patch_retry_contract.py` — passed.
- `git diff --check` — passed.
- The issue’s cited commit `8c1f5499e` was verified as an ancestor of `origin/main`; PR #5951 is merged.
- The required scope-only packet gate accepted all four changed paths with the accepted packet SHA-256.

`check_docs_proof_consistency.py` itself reports two pre-existing ignored-artifact catalog entries outside this diff; tracked separately as #6011. Its focused test suite passed.

### State propagation

`docs/context/issue_6008_state.yaml` is the canonical durable state surface created by this PR. No issue comment was posted: the issue is low churn and the accepted authorization disallows comments.

### Explicitly out of scope

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits. No merge, release, deletion, or private-dispatcher edit.

</details>
