### PR TITLE
fix(dev): repair snapshot output command (issue #6002)

### DIFF
--- a/scripts/dev/snapshot_pr_queue.py
+++ b/scripts/dev/snapshot_pr_queue.py
@@ -653,6 +653,19 @@ def write_snapshot_artifact(payload: dict[str, Any], path: Path | None) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def emit_snapshot(
+    payload: dict[str, Any], path: Path | None, *, as_json: bool, exit_code: int
+) -> int:
+    """Write an optional snapshot artifact, emit stdout, and return the CLI status."""
+    try:
+        write_snapshot_artifact(payload, path)
+    except OSError as exc:
+        print(f"snapshot output write failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(payload, indent=2, sort_keys=True) if as_json else json.dumps(payload))
+    return exit_code
+
+
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("prs", nargs="*", type=int, help="PR numbers to snapshot.")
@@ -749,11 +762,14 @@ def main(argv: list[str] | None = None) -> int:
     except subprocess.TimeoutExpired as exc:
         print(f"snapshot command timed out: {exc}", file=sys.stderr)
         return 1
-    write_snapshot_artifact(payload, args.output)
-    print(json.dumps(payload, indent=2, sort_keys=True) if args.json else json.dumps(payload))
     has_pr_errors = any(pr.get("status") == "error" for pr in payload["prs"])
     has_artifact_errors = payload.get("raw_review_comments_artifact_status") == "error"
-    return 1 if has_pr_errors or has_artifact_errors else 0
+    return emit_snapshot(
+        payload,
+        args.output,
+        as_json=args.json,
+        exit_code=1 if has_pr_errors or has_artifact_errors else 0,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/dev/snapshot_pr_queue.py
+++ b/scripts/dev/snapshot_pr_queue.py
@@ -645,6 +645,14 @@ def write_raw_review_comments_artifact(
     return payload
 
 
+def write_snapshot_artifact(payload: dict[str, Any], path: Path | None) -> None:
+    """Write a compact queue snapshot to *path* with stable JSON formatting."""
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("prs", nargs="*", type=int, help="PR numbers to snapshot.")
@@ -678,6 +686,11 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
             "Opt-in path for raw review-comment payloads, including diff_hunk/full bodies; "
             "artifact is written to disk and never printed to stdout."
         ),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write the compact queue snapshot JSON to this path.",
     )
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     return parser.parse_args(argv)
@@ -736,6 +749,7 @@ def main(argv: list[str] | None = None) -> int:
     except subprocess.TimeoutExpired as exc:
         print(f"snapshot command timed out: {exc}", file=sys.stderr)
         return 1
+    write_snapshot_artifact(payload, args.output)
     print(json.dumps(payload, indent=2, sort_keys=True) if args.json else json.dumps(payload))
     has_pr_errors = any(pr.get("status") == "error" for pr in payload["prs"])
     has_artifact_errors = payload.get("raw_review_comments_artifact_status") == "error"

--- a/tests/dev/test_snapshot_pr_queue.py
+++ b/tests/dev/test_snapshot_pr_queue.py
@@ -518,6 +518,37 @@ def test_raw_review_comments_artifact_rejects_invalid_repo(tmp_path) -> None:  #
     mock_gh.assert_not_called()
 
 
+def test_main_output_writes_snapshot_without_changing_stdout(
+    tmp_path,
+    capsys,
+) -> None:  # type: ignore[no-untyped-def]
+    """The --output path should receive the same compact payload printed by the CLI."""
+    artifact = tmp_path / "nested" / "snapshot.json"
+    pr_payload = {
+        "number": 2698,
+        "title": "output PR",
+        "state": "OPEN",
+        "isDraft": False,
+        "url": "https://github.test/pull/2698",
+        "labels": [],
+        "headRefName": "feature",
+        "headRefOid": "abc998",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [],
+        "reviews": [],
+        "comments": [],
+    }
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr="")
+        rc = main(["--prs", "2698", "--output", str(artifact), "--json"])
+
+    stdout_payload = json.loads(capsys.readouterr().out)
+    artifact_payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert rc == 0
+    assert artifact_payload == stdout_payload
+    assert artifact.read_text(encoding="utf-8").endswith("\n")
+
+
 def test_main_raw_review_artifact_keeps_hunks_out_of_stdout(
     tmp_path,
     capsys,

--- a/tests/dev/test_snapshot_pr_queue.py
+++ b/tests/dev/test_snapshot_pr_queue.py
@@ -549,6 +549,38 @@ def test_main_output_writes_snapshot_without_changing_stdout(
     assert artifact.read_text(encoding="utf-8").endswith("\n")
 
 
+def test_main_output_write_failure_returns_controlled_error(capsys) -> None:  # type: ignore[no-untyped-def]
+    """An unwritable output path should fail without printing a traceback or payload."""
+    pr_payload = {
+        "number": 2699,
+        "title": "output error PR",
+        "state": "OPEN",
+        "isDraft": False,
+        "url": "https://github.test/pull/2699",
+        "labels": [],
+        "headRefName": "feature",
+        "headRefOid": "abc999",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [],
+        "reviews": [],
+        "comments": [],
+    }
+    with (
+        patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh,
+        patch(
+            "scripts.dev.snapshot_pr_queue.write_snapshot_artifact",
+            side_effect=OSError("disk full"),
+        ),
+    ):
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr="")
+        rc = main(["--prs", "2699", "--output", "snapshot.json", "--json"])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert captured.out == ""
+    assert captured.err == "snapshot output write failed: disk full\n"
+
+
 def test_main_raw_review_artifact_keeps_hunks_out_of_stdout(
     tmp_path,
     capsys,


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** added `--output PATH` to `scripts/dev/snapshot_pr_queue.py`; it writes the compact JSON snapshot to that path using stable `indent=2`, sorted-key formatting while preserving the existing stdout payload.
- **Why now:** the documented `goal-pr-review` snapshot command requires this file-output capability.
- **Claim boundary:** this is a local CLI-contract repair only. It preserves all existing modes and the stdout/exit-code behavior for callers that omit `--output`.
- **Required validation:** `uv run pytest tests/dev/test_snapshot_pr_queue.py -q` (21 passed), plus Ruff lint/format and `git diff --check`.
- **Remaining blocker:** none for issue #6002's requested implementation.

Closes #6002

## Contract delta

- New optional CLI argument: `--output PATH` writes the compact queue snapshot payload to disk, creating parent directories as needed.
- The written payload uses the repository's existing stable JSON artifact formatting (`indent=2`, `sort_keys=True`, trailing newline).
- No new schema fields, fail-closed blockers, or compatibility changes. Existing `--active`, explicit PR numbers, `--prs`, `--json`, `--review-threads`, and `--raw-review-comments-artifact` behavior remains intact.

## Scope and validation

- Issue: https://github.com/ll7/robot_sf_ll7/issues/6002
- Changed only `scripts/dev/snapshot_pr_queue.py` and `tests/dev/test_snapshot_pr_queue.py`.
- Validation: `uv run pytest tests/dev/test_snapshot_pr_queue.py -q` — passed (21 tests); `uv run ruff check scripts/dev/snapshot_pr_queue.py tests/dev/test_snapshot_pr_queue.py` — passed; `uv run ruff format --check scripts/dev/snapshot_pr_queue.py tests/dev/test_snapshot_pr_queue.py` — passed; `git diff --check` — passed.
- State propagation: no issue comment was added because the accepted authorization profile forbids issue/PR comments; this complete, closing PR is the durable state surface.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

<details>
<summary>Implementation notes</summary>

The regression test stubs the compact PR payload, verifies `--output` creates nested parent directories, and asserts that the artifact JSON exactly matches the existing JSON stdout payload. No generated artifacts are committed. No qualifying session friction issue was filed: the only implementation-time lint feedback was resolved by keeping the optional write in a small helper, and it did not indicate a separate actionable repository problem.

</details>
