### PR TITLE
refactor: route three acceptance reports through evidence writers (#4921)

### DIFF
--- a/scripts/analysis/audit_issue_4013_acceptance.py
+++ b/scripts/analysis/audit_issue_4013_acceptance.py
@@ -16,6 +16,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from robot_sf.evidence.writers import write_json, write_text
+
 _ISSUE = 4013
 _DEFAULT_EVIDENCE_DIR = Path("docs/context/evidence/issue_4013_learned_model_based_planning")
 
@@ -227,8 +229,8 @@ def write_acceptance_audit(
         else evidence_dir / "acceptance_audit.v1.md"
     )
     output_json.parent.mkdir(parents=True, exist_ok=True)
-    output_json.write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    output_markdown.write_text(_render_markdown(audit), encoding="utf-8")
+    write_json(output_json, audit)
+    write_text(output_markdown, _render_markdown(audit), issue_ref=f"robot_sf#{_ISSUE}")
     return audit
 
 

--- a/scripts/analysis/audit_issue_4016_acceptance.py
+++ b/scripts/analysis/audit_issue_4016_acceptance.py
@@ -14,6 +14,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from robot_sf.evidence.writers import write_json, write_text
+
 _ISSUE = 4016
 _REQUIRED_METRICS = (
     "success_rate",
@@ -101,8 +103,8 @@ def write_acceptance_audit(
         else evidence_dir / "acceptance_audit.md"
     )
     output_json.parent.mkdir(parents=True, exist_ok=True)
-    output_json.write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    output_markdown.write_text(_render_markdown(audit), encoding="utf-8")
+    write_json(output_json, audit)
+    write_text(output_markdown, _render_markdown(audit), issue_ref=f"robot_sf#{_ISSUE}")
     return audit
 
 

--- a/scripts/analysis/build_issue_2910_publication_suite_certification_report.py
+++ b/scripts/analysis/build_issue_2910_publication_suite_certification_report.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -13,6 +12,7 @@ from typing import Any
 import yaml
 
 from robot_sf.benchmark.identity.hash_utils import load_json as _load_json
+from robot_sf.evidence.writers import write_json, write_text
 
 SCHEMA_VERSION = "issue_2910_publication_suite_certification_report.v1"
 DEFAULT_SCENARIO_CERTIFICATION_SUMMARY = Path(
@@ -516,11 +516,8 @@ def main(argv: list[str] | None = None) -> int:
         publication_suite_policy=publication_suite_policy,
     )
     args.output_dir.mkdir(parents=True, exist_ok=True)
-    (args.output_dir / "report.json").write_text(
-        json.dumps(report, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-    (args.output_dir / "report.md").write_text(render_markdown(report), encoding="utf-8")
+    write_json(args.output_dir / "report.json", report)
+    write_text(args.output_dir / "report.md", render_markdown(report))
     return 0
 
 

--- a/tests/analysis/test_audit_issue_4013_acceptance.py
+++ b/tests/analysis/test_audit_issue_4013_acceptance.py
@@ -127,7 +127,11 @@ def test_write_acceptance_audit_outputs_json_and_markdown(tmp_path: Path) -> Non
     assert json.loads(output_json.read_text(encoding="utf-8"))["schema_version"] == (
         "issue_4013.acceptance_audit.v1"
     )
+    payload = json.loads(output_json.read_text(encoding="utf-8"))
+    assert payload["review_marker"] == "AI-GENERATED NEEDS-REVIEW"
+    assert {key: value for key, value in payload.items() if key != "review_marker"} == audit
     markdown = output_markdown.read_text(encoding="utf-8")
+    assert markdown.startswith("<!-- AI-GENERATED (robot_sf#4013) - NEEDS-REVIEW -->\n")
     assert "# Issue #4013 Acceptance Audit" in markdown
     assert "Real pedestrian trajectory dataset" in markdown
     assert audit["closure_status"] == "partial"

--- a/tests/analysis/test_audit_issue_4013_acceptance.py
+++ b/tests/analysis/test_audit_issue_4013_acceptance.py
@@ -124,10 +124,8 @@ def test_write_acceptance_audit_outputs_json_and_markdown(tmp_path: Path) -> Non
         output_markdown=output_markdown,
     )
 
-    assert json.loads(output_json.read_text(encoding="utf-8"))["schema_version"] == (
-        "issue_4013.acceptance_audit.v1"
-    )
     payload = json.loads(output_json.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "issue_4013.acceptance_audit.v1"
     assert payload["review_marker"] == "AI-GENERATED NEEDS-REVIEW"
     assert {key: value for key, value in payload.items() if key != "review_marker"} == audit
     markdown = output_markdown.read_text(encoding="utf-8")

--- a/tests/analysis/test_audit_issue_4016_acceptance.py
+++ b/tests/analysis/test_audit_issue_4016_acceptance.py
@@ -138,7 +138,12 @@ def test_write_acceptance_audit_outputs_json_and_markdown(tmp_path: Path) -> Non
     assert json.loads(output_json.read_text(encoding="utf-8"))["schema_version"] == (
         "issue_4016.acceptance_audit.v1"
     )
-    assert "# Issue #4016 Acceptance Audit" in output_markdown.read_text(encoding="utf-8")
+    payload = json.loads(output_json.read_text(encoding="utf-8"))
+    assert payload["review_marker"] == "AI-GENERATED NEEDS-REVIEW"
+    assert {key: value for key, value in payload.items() if key != "review_marker"} == audit
+    markdown = output_markdown.read_text(encoding="utf-8")
+    assert markdown.startswith("<!-- AI-GENERATED (robot_sf#4016) - NEEDS-REVIEW -->\n")
+    assert "# Issue #4016 Acceptance Audit" in markdown
     assert audit["closure_status"] == "partial"
 
 

--- a/tests/analysis/test_audit_issue_4016_acceptance.py
+++ b/tests/analysis/test_audit_issue_4016_acceptance.py
@@ -135,10 +135,8 @@ def test_write_acceptance_audit_outputs_json_and_markdown(tmp_path: Path) -> Non
         output_markdown=output_markdown,
     )
 
-    assert json.loads(output_json.read_text(encoding="utf-8"))["schema_version"] == (
-        "issue_4016.acceptance_audit.v1"
-    )
     payload = json.loads(output_json.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "issue_4016.acceptance_audit.v1"
     assert payload["review_marker"] == "AI-GENERATED NEEDS-REVIEW"
     assert {key: value for key, value in payload.items() if key != "review_marker"} == audit
     markdown = output_markdown.read_text(encoding="utf-8")

--- a/tests/analysis/test_build_issue_2910_publication_suite_certification_report.py
+++ b/tests/analysis/test_build_issue_2910_publication_suite_certification_report.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from robot_sf.benchmark.identity.hash_utils import load_json as _load_json
 from scripts.analysis.build_issue_2910_publication_suite_certification_report import (
     DEFAULT_RELEASE_CLAIM_MATRIX,
@@ -153,3 +155,7 @@ def test_cli_writes_json_and_markdown(tmp_path) -> None:
     assert payload["summary"]["blocker_count"] == 0
     assert payload["summary"]["publication_suite_policy_status"] == "applied"
     assert "Publication Suite Certification Report" in markdown
+    assert (tmp_path / "report.json").read_text(encoding="utf-8") == (
+        json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    )
+    assert markdown == render_markdown(payload)


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Routes the three remaining named analysis generators through `robot_sf.evidence.writers.write_json` and `write_text`.
- **Why now:** PR #5547 delivered the shared writer API and guard; these are the next explicitly listed analysis-packet migrations for #4921.
- **Claim boundary:** Implementation/contract evidence only. No audit value, evidence classification, filename, hash input, metric, scenario, or claim wording was changed; #4013 and #4016 gain the required review markers, while #2910's existing marked JSON and Markdown remain byte-compatible.
- **Required validation:** Focused writer/analysis/guard tests, Ruff, formatter, changed-file usage guard, `git diff --check`, and the final clean-HEAD readiness gate all passed.
- **Remaining blocker:** #4921 still needs its other historical analysis, validation, and benchmark-packet writers migrated or explicitly exempted; this PR is the bounded three-generator progression slice.

## Contract delta

- #4013 and #4016 generated JSON now carries the shared top-level `review_marker`; their generated Markdown now starts with the shared `AI-GENERATED ... NEEDS-REVIEW` marker.
- #2910 now uses the shared writers without a payload or byte-format change because its JSON and Markdown were already marked.
- No schema version, evidence value, classification, filename, checksum algorithm, or fail-closed decision changes.
- Compatibility impact: consumers that parse the #4013/#4016 JSON as a strict closed schema must tolerate the already-standard `review_marker` field.

## Slice inventory

| Generator | Generated evidence output | Shared-writer disposition |
| --- | --- | --- |
| `scripts/analysis/audit_issue_4013_acceptance.py` | acceptance JSON + Markdown | migrated |
| `scripts/analysis/audit_issue_4016_acceptance.py` | acceptance JSON + Markdown | migrated |
| `scripts/analysis/build_issue_2910_publication_suite_certification_report.py` | certification JSON + Markdown | migrated |

## Validation

- `uv run pytest -q tests/analysis/test_audit_issue_4013_acceptance.py tests/analysis/test_audit_issue_4016_acceptance.py tests/analysis/test_build_issue_2910_publication_suite_certification_report.py tests/test_evidence_writers.py tests/ci/test_evidence_writer_usage_guard.py` — 44 passed.
- `uv run ruff check ...` on all six changed files — passed.
- `uv run ruff format --check ...` on all six changed files — passed.
- `uv run python scripts/ci/check_evidence_writer_usage.py --changed-files-file <(git diff --name-only)` — passed.
- `git diff --check` — passed.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed; clean-HEAD readiness recorded for `fdc7e99c4502d95bae9478b4898bcdaa87d59371`.

Refs #4921

<details>
<summary>Scope, propagation, and exclusions</summary>

- Issue: https://github.com/ll7/robot_sf_ll7/issues/4921
- Scope is limited to the three named generators and their focused tests. The existing #5547 inventory remains the issue-wide inventory; this table records every candidate in this authorized slice.
- State propagation: no issue comment was posted because this packet explicitly forbids issue/PR comments, and the single durable issue-state table is outside the authorized paths. This PR body is the handoff surface.
- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, and no generated evidence artifacts were committed.
- No target-host or packet-lineage state was added to tracked files.
- No friction issue filed: the only transient cleanup was an unused import introduced and removed within this slice; no separate reusable repository friction was encountered.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when generating acceptance audits and publication certification reports in JSON and Markdown formats.
  * Preserved expected formatting and review markers in generated artifacts.

* **Tests**
  * Added stronger validation for generated JSON contents, Markdown headers, and exact report formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->