### PR TITLE
docs: clarify shared-worktree venv preference (issue #6010)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,10 +100,11 @@ common Git dir, symlink the main `local.machine.md` when present, then run
 alone may silently detect and reuse the main checkout's `.venv` without creating one locally,
 leaving `.venv/bin/activate` missing. After sync, verify `.venv/bin/python` exists before
 continuing; if absent, the environment is not usable and the caller must fail closed. Then
-`source .venv/bin/activate` before Python tooling. For quick targeted validation that intentionally
-reuses the main checkout virtualenv, prefer `scripts/dev/run_worktree_shared_venv.sh -- <uv-run-command>`
-so `PYTHONPATH` points at the active worktree. Use a full local `.venv` and final PR readiness for
-merge proof. Do not include CARLA in routine `--all-extras`; opt into `--group carla` only for
+`source .venv/bin/activate` before Python tooling. For quick targeted validation, prefer
+`scripts/dev/run_worktree_shared_venv.sh -- <uv-run-command>`: it uses an initialized current-worktree
+`.venv` when available, otherwise reuses the main checkout virtualenv, while `PYTHONPATH` points at
+the active worktree. Use a full local `.venv` and final PR readiness for merge proof. Do not include
+CARLA in routine `--all-extras`; opt into `--group carla` only for
 CARLA-capable worktrees and prove runtime with `scripts/dev/check_carla_runtime.sh` when needed.
 
 If the current branch is not `main`, fetch latest `origin/main` and merge it early:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ leaving `.venv/bin/activate` missing. After sync, verify `.venv/bin/python` exis
 continuing; if absent, the environment is not usable and the caller must fail closed. Then
 `source .venv/bin/activate` before Python tooling. For quick targeted validation, prefer
 `scripts/dev/run_worktree_shared_venv.sh -- <uv-run-command>`: it uses an initialized current-worktree
-`.venv` when available, otherwise reuses the main checkout virtualenv, while `PYTHONPATH` points at
+`.venv` when available, otherwise reuses the main checkout `.venv`, while `PYTHONPATH` points at
 the active worktree. Use a full local `.venv` and final PR readiness for merge proof. Do not include
 CARLA in routine `--all-extras`; opt into `--group carla` only for
 CARLA-capable worktrees and prove runtime with `scripts/dev/check_carla_runtime.sh` when needed.

--- a/docs/dev/agents/relocated-agents-guidance.md
+++ b/docs/dev/agents/relocated-agents-guidance.md
@@ -118,10 +118,11 @@ When working in a linked Git worktree, detect bootstrap state before running exp
   `ln -s "$MAIN_REPO_ROOT/local.machine.md" .`
 - After the machine-context symlink is in place, run `uv sync --all-extras`, then
   `source .venv/bin/activate` before using Python tooling.
-- For quick targeted validation from a sibling worktree that intentionally reuses the main
-  checkout virtualenv, prefer `scripts/dev/run_worktree_shared_venv.sh -- <uv-run-command>` so
-  `PYTHONPATH` is pinned to the active worktree while `UV_PROJECT_ENVIRONMENT` points at the shared
-  `.venv`. Use a full local `.venv` and final PR readiness for merge proof.
+- For quick targeted validation from a sibling worktree, prefer
+  `scripts/dev/run_worktree_shared_venv.sh -- <uv-run-command>` so `PYTHONPATH` is pinned to the
+  active worktree while `UV_PROJECT_ENVIRONMENT` points at an initialized current-worktree `.venv`
+  when available, otherwise the shared main-checkout `.venv`. Use a full local `.venv` and final PR
+  readiness for merge proof.
 - Do not add CARLA to the routine `--all-extras` bootstrap. For CARLA-capable worktrees, opt into
   the host-side Python client with `uv sync --all-extras --group carla`, then prove the local
   runtime with `scripts/dev/check_carla_runtime.sh` or `scripts/dev/check_carla_runtime.sh --smoke`


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Updated `AGENTS.md` and the linked worktree guidance to state that
  `run_worktree_shared_venv.sh` selects an initialized current-worktree `.venv` first and falls
  back to the main-checkout `.venv`.
- **Why now:** PR #6009 changed the helper behavior; these two documentation surfaces still
  described only the fallback path.
- **Claim boundary:** Documentation-only clarification. The helper, its selection behavior, and
  its tests are unchanged.
- **Required validation:** Focused helper-contract tests (15 passed), wording audits, the
  docs/proof consistency check, whitespace check, and the accepted-packet scope gate all passed.
- **Remaining blocker:** None for the issue's stated documentation scope.

Closes #6010

## Contract delta

- New schema fields: none.
- New fail-closed blockers: none.
- Compatibility impact: none; this documents the existing initialized-local preference and
  main-checkout fallback.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_ci_script_contract.py -q -k worktree_shared_venv` — 15 passed.
- `rg -n "run_worktree_shared_venv|UV_PROJECT_ENVIRONMENT" AGENTS.md docs/dev/agents/relocated-agents-guidance.md` — both target surfaces found.
- Stale-wording audit over `AGENTS.md` and `docs/` — no old default-only wording remains.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` — passed for 2 changed files.
- `git diff --check` — passed.
- Accepted-packet `--scope-only` gate — `scope_valid` for only `AGENTS.md` and `docs/dev/agents/relocated-agents-guidance.md`.

## Scope and state

- Issue: https://github.com/ll7/robot_sf_ll7/issues/6010
- Scope: documentation-only correction in the two issue-named guidance files.
- State propagation: no separate issue comment is needed because this is one complete,
  low-churn slice and the closing PR is the durable state transition.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no
  paper/dissertation claim edits.

<details>
<summary>Implementation and review appendix</summary>

- Branch is pinned to accepted base `63d9670838e8675302cdd5aebb35a8114c91f325`.
- Late issue refresh immediately before PR creation found no maintainer comments newer than the
  start of this work.
- Fragmentation guard: no merged PRs for #6010 in the preceding 24 hours.
- Artifact decision: no generated artifacts are part of this documentation-only PR.
- Downstream propagation: not applicable; this produces no research, benchmark, metric, or
  paper-facing evidence.
</details>
