### PR TITLE
fix(dev): reject process-substitution PR body paths (#5993)

### DIFF
--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -20,8 +20,12 @@ Environment variables:
                       Ignored when PR_READY_MODE is set.
   PR_READY_SKIP_PREFLIGHT  Set to "1" to skip cheap preflight checks for
                       test-collection dependencies and the bundled fast-pysf API.
-  PR_READY_PR_BODY_FILE  Optional markdown PR body. When set, readiness checks
-                      that deferred work has a linked issue or explicit NA.
+  PR_READY_PR_BODY_FILE  Optional markdown PR body from an existing readable
+                      regular file.
+                      Process-substitution paths such as /dev/fd/63 are rejected
+                      because their descriptors do not survive into downstream
+                      readiness processes. When set, readiness checks that
+                      deferred work has a linked issue or explicit NA.
   PR_READY_REQUIRE_OPEN_FOLLOWUP_ISSUES
                       Set to "0" to skip open-state verification for linked
                       follow-up issues when PR_READY_PR_BODY_FILE is set.
@@ -50,6 +54,32 @@ export PR_READY_MODE="${PR_READY_MODE:-}"
 export PR_READY_SKIP_PREFLIGHT="${PR_READY_SKIP_PREFLIGHT:-0}"
 export PR_READY_PR_BODY_FILE="${PR_READY_PR_BODY_FILE:-}"
 export PR_READY_REQUIRE_OPEN_FOLLOWUP_ISSUES="${PR_READY_REQUIRE_OPEN_FOLLOWUP_ISSUES:-1}"
+
+validate_pr_body_file() {
+  local body_file="$PR_READY_PR_BODY_FILE"
+  [[ -z "$body_file" ]] && return
+
+  if [[ -f "$body_file" && -r "$body_file" ]]; then
+    return
+  fi
+
+  printf 'PR_READY_PR_BODY_FILE must name an existing readable regular file; received %q.\n' \
+    "$body_file" >&2
+  case "$body_file" in
+    /dev/fd/*|/proc/*/fd/*)
+      printf 'Process-substitution paths are not supported because their file descriptors are not inherited by readiness subprocesses.\n' >&2
+      printf 'Write the body to a persistent file first, for example:\n' >&2
+      printf '  body_file="%s"; gh pr view ... --json body --jq .body >"%s"; PR_READY_PR_BODY_FILE="%s" %q\n' \
+        '$(mktemp)' '$body_file' '$body_file' "$0" >&2
+      ;;
+    *)
+      printf 'Create the file first, then rerun with PR_READY_PR_BODY_FILE=/path/to/body.md.\n' >&2
+      ;;
+  esac
+  exit 2
+}
+
+validate_pr_body_file
 
 worktree_state() {
   if [[ -n "$(git status --porcelain --untracked-files=normal)" ]]; then

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -668,6 +668,97 @@ def test_pr_ready_check_final_mode_preflights_analytics_dependencies(tmp_path: P
     assert "ruff_fix_format" not in result.stderr
 
 
+def test_pr_ready_check_rejects_process_substitution_body_paths(tmp_path: Path) -> None:
+    """Process substitution fails at the wrapper boundary; regular files reach preflight."""
+    repo = tmp_path / "repo"
+    script_dir = repo / "scripts" / "dev"
+    fake_bin = repo / "fake-bin"
+    script_dir.mkdir(parents=True)
+    fake_bin.mkdir()
+
+    for script_name in ("pr_ready_check.sh", "common_setup.sh"):
+        source = ROOT / "scripts" / "dev" / script_name
+        target = script_dir / script_name
+        target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+        target.chmod(0o755)
+
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        "#!/usr/bin/env bash\necho 'duckdb, pyarrow' >&2\nexit 1\n",
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=agent@example.invalid",
+            "-c",
+            "user.name=Agent",
+            "commit",
+            "-m",
+            "fixture",
+        ],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "BASE_REF": "HEAD",
+        "PR_READY_MODE": "final",
+    }
+
+    process_substitution = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'body_source=<(printf "## Summary\\nbody\\n"); PR_READY_PR_BODY_FILE="$body_source" "$1"',
+            "bash",
+            str(script_dir / "pr_ready_check.sh"),
+        ],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert process_substitution.returncode == 2
+    assert (
+        "PR_READY_PR_BODY_FILE must name an existing readable regular file"
+        in process_substitution.stderr
+    )
+    assert "Process-substitution paths are not supported" in process_substitution.stderr
+    assert "mktemp" in process_substitution.stderr
+    assert "Final PR readiness requires analytics dependencies" not in process_substitution.stderr
+
+    body_file = tmp_path / "pr-body.md"
+    body_file.write_text("## Summary\nbody\n", encoding="utf-8")
+    regular_file = subprocess.run(
+        [str(script_dir / "pr_ready_check.sh")],
+        cwd=repo,
+        env={**env, "PR_READY_PR_BODY_FILE": str(body_file)},
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert regular_file.returncode == 2
+    assert "Final PR readiness requires analytics dependencies" in regular_file.stderr
+    assert (
+        "PR_READY_PR_BODY_FILE must name an existing readable regular file"
+        not in regular_file.stderr
+    )
+
+
 def test_pr_ready_check_help_long() -> None:
     """pr_ready_check.sh --help prints usage and exits 0."""
     result = subprocess.run(


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** `pr_ready_check.sh` now defines `PR_READY_PR_BODY_FILE` as an existing, readable regular-file contract and rejects process-substitution descriptors such as `/dev/fd/63` at the wrapper boundary.

**Why now:** a shell process-substitution path may be readable by the caller but its descriptor does not survive into the downstream Python readiness checks, producing an opaque `FileNotFoundError`.

**Claim boundary:** this only makes the body-file transport contract fail closed and actionable; it does not alter PR-body requirements or the downstream contract checks.

**Required validation:** `bash -n scripts/dev/pr_ready_check.sh`, focused `tests/test_ci_script_contract.py -k pr_ready_check`, diff check, and Ruff checks all pass.

**Remaining blocker:** none for #5993.

## Contract delta

- `PR_READY_PR_BODY_FILE` now explicitly accepts an existing readable regular file.
- Process-substitution and other non-regular descriptor paths fail with exit code 2 before downstream readiness processes, including a `mktemp` remediation.
- Existing regular-file inputs remain compatible and reach the normal preflight path.

Closes #5993

<details>
<summary>Scope, evidence, and handoff details</summary>

### Linked issue and scope

- Issue: https://github.com/ll7/robot_sf_ll7/issues/5993
- Changed only `scripts/dev/pr_ready_check.sh` and `tests/test_ci_script_contract.py`.
- Regression coverage proves both the rejected process-substitution path and the retained regular-file path.

### Validation

- `bash -n scripts/dev/pr_ready_check.sh` — passed.
- `uv run pytest tests/test_ci_script_contract.py -k pr_ready_check -q` — 10 passed, 73 deselected.
- `git diff --check 63d9670838e8675302cdd5aebb35a8114c91f325...HEAD` — passed.
- `uv run ruff check tests/test_ci_script_contract.py` — passed.
- `uv run ruff format --check tests/test_ci_script_contract.py` — passed.

### Scope and propagation

- No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.
- Artifact classification: workflow-only validation; no durable generated artifacts.
- Downstream propagation: not applicable—this is a tooling contract with no research claim or durable evidence surface. No issue comment was added because this authorization profile disallows issue/PR comments; this PR is the canonical delivery record.
- Domain-aware approval: not required—support tooling only, with no benchmark, metric, or paper-facing claim.

### Reviewer notes

- Review the regular-file boundary rather than the downstream body parser: no parser semantics changed.
- No friction issues filed: no new, actionable friction beyond the issue being resolved was encountered.

</details>
