### PR TITLE
docs: align shared-venv guide wording (issue #6021)

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -178,8 +178,10 @@ checked.
 
 ### Targeted shared-venv worktree validation
 
-For quick, targeted checks in a sibling worktree, you can reuse the main checkout virtualenv while
-pinning imports to the current worktree:
+For quick, targeted checks in a sibling worktree, prefer
+`scripts/dev/run_worktree_shared_venv.sh -- <uv-run-command>`: it uses an initialized
+current-worktree `.venv` when available, otherwise the main checkout virtualenv, while pinning
+imports to the current worktree:
 
 ```bash
 scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_ci_script_contract.py -q
@@ -188,10 +190,10 @@ scripts/dev/run_worktree_shared_venv.sh --standalone -- \
   python scripts/dev/check_docs_evidence_integrity.py --files docs/dev_guide.md
 ```
 
-The helper runs from `git rev-parse --show-toplevel`, sets `UV_PROJECT_ENVIRONMENT` to the shared
+The helper runs from `git rev-parse --show-toplevel`, sets `UV_PROJECT_ENVIRONMENT` to the selected
 `.venv`, and sets `UV_NO_SYNC=1`. By default it also prepends the worktree root to `PYTHONPATH`.
 This is intended for fast local feedback when dependencies are already current. It should fail if
-the shared virtualenv is missing instead of silently installing into the wrong checkout.
+the selected virtualenv is missing instead of silently installing into the wrong checkout.
 
 Use `--standalone` for a dependency-light command whose tests verify that it does not import
 `robot_sf` or other project packages. This mode still reuses third-party dependencies from the

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -180,7 +180,7 @@ checked.
 
 For quick, targeted checks in a sibling worktree, prefer
 `scripts/dev/run_worktree_shared_venv.sh -- <uv-run-command>`: it uses an initialized
-current-worktree `.venv` when available, otherwise the main checkout virtualenv, while pinning
+current-worktree `.venv` when available, otherwise the main checkout `.venv`, while pinning
 imports to the current worktree:
 
 ```bash
@@ -193,7 +193,7 @@ scripts/dev/run_worktree_shared_venv.sh --standalone -- \
 The helper runs from `git rev-parse --show-toplevel`, sets `UV_PROJECT_ENVIRONMENT` to the selected
 `.venv`, and sets `UV_NO_SYNC=1`. By default it also prepends the worktree root to `PYTHONPATH`.
 This is intended for fast local feedback when dependencies are already current. It should fail if
-the selected virtualenv is missing instead of silently installing into the wrong checkout.
+the selected `.venv` is missing instead of silently installing into the wrong checkout.
 
 Use `--standalone` for a dependency-light command whose tests verify that it does not import
 `robot_sf` or other project packages. This mode still reuses third-party dependencies from the


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** `docs/dev_guide.md` now says the targeted worktree helper uses an initialized current-worktree `.venv` first and otherwise falls back to the main checkout virtualenv.

**Why now:** This corrects the remaining stale description after the helper acquired its worktree-local environment preference.

**Claim boundary:** Documentation-only alignment; no helper, environment, workflow, or runtime behavior changed.

**Required validation:** Focused guidance tests, the documentation proof-consistency check, the prescribed `rg` contract probe, and `git diff --check` all pass locally.

**Remaining blocker:** None for #6021.

Closes #6021.

## Contract delta

No schema fields, fail-closed blockers, or compatibility behavior changed. The guide now accurately describes the existing local-first, main-checkout-fallback selection behavior.

<details>
<summary>Scope, validation, and propagation</summary>

Issue: https://github.com/ll7/robot_sf_ll7/issues/6021

Scope: `docs/dev_guide.md` only.

Validation:

- `uv run pytest -q tests/test_github_workflow_guidance.py tests/test_issue_workflow_batching.py tests/test_ai_prompt_surfaces.py` — 9 passed.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` — passed for one changed file.
- `rg -n "run_worktree_shared_venv|current-worktree|main checkout.*\\.venv" docs/dev_guide.md` — confirms the local-first/fallback wording.
- `git diff --check` — passed.

Artifacts: none generated or committed.

Downstream propagation: not applicable because this is a self-contained documentation correction that closes its source issue; no research or benchmark evidence exists to propagate. The accepted authorization does not permit an issue comment, so this PR is the durable delivery surface.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.
</details>
