### PR TITLE
fix(validation): regenerate pristine evidence registry baseline (issue #6014)

### DIFF
--- a/scripts/validation/evidence_registry_baseline.json
+++ b/scripts/validation/evidence_registry_baseline.json
@@ -34,10 +34,12 @@
       "missing_config_sha256": 1
     },
     "docs/context/evidence/issue_1344_paired_amv_primary_2026-05-20/nominal_campaign_summary.json": {
+      "dangling_commit": 1,
       "missing_config_path": 1,
       "missing_config_sha256": 1
     },
     "docs/context/evidence/issue_1344_paired_amv_primary_2026-05-20/stress_campaign_summary.json": {
+      "dangling_commit": 1,
       "missing_config_path": 1,
       "missing_config_sha256": 1
     },
@@ -63,7 +65,7 @@
     },
     "docs/context/evidence/issue_1454_s10_h500_candidates_2026-05-23/campaign_manifest.json": {
       "config_missing_at_commit": 1,
-      "dangling_commit": 1,
+      "dangling_commit": 2,
       "duplicate_campaign_id": 1,
       "missing_config_sha256": 1
     },
@@ -76,7 +78,7 @@
       "missing_config_sha256": 1
     },
     "docs/context/evidence/issue_1454_stage_a_fixed_h100_2026-05-22/reports/campaign_analysis.json": {
-      "dangling_commit": 1,
+      "dangling_commit": 2,
       "missing_config_path": 1,
       "missing_config_sha256": 1
     },
@@ -84,7 +86,7 @@
       "hash_without_artifact_path": 4
     },
     "docs/context/evidence/issue_1484_broader_cross_kinematics_2026-05-28/campaign_manifest.json": {
-      "dangling_commit": 1,
+      "dangling_commit": 2,
       "missing_config_path": 1,
       "missing_config_sha256": 1
     },
@@ -331,14 +333,14 @@
       "hash_without_artifact_path": 1
     }
   },
-  "generated_at": "2026-07-18T04:59:02Z",
+  "generated_at": "2026-07-19T07:07:43Z",
   "linter": "scripts/tools/lint_evidence_registry.py",
   "schema_version": 1,
   "summary": {
     "by_code": {
       "artifact_hash_mismatch": 15,
       "config_missing_at_commit": 4,
-      "dangling_commit": 12,
+      "dangling_commit": 17,
       "duplicate_campaign_id": 6,
       "hash_without_artifact_path": 85,
       "invalid_sha256": 1,
@@ -348,6 +350,6 @@
       "uncommitted_artifact_missing_location": 158
     },
     "files_with_findings": 87,
-    "total_findings": 411
+    "total_findings": 416
   }
 }

--- a/scripts/validation/evidence_registry_baseline_review.yaml
+++ b/scripts/validation/evidence_registry_baseline_review.yaml
@@ -152,6 +152,46 @@ reviewed_files:
       binding is outside this baseline reconciliation, so the finding is explicitly dispositioned
       as baseline under the existing strict-CI policy.
 reviewed_baseline_increases:
+  - path: docs/context/evidence/issue_1344_paired_amv_primary_2026-05-20/nominal_campaign_summary.json
+    codes: [dangling_commit]
+    disposition: baseline
+    reason: >-
+      The producer commit is reachable from preserved pull-request history but not from main's
+      ordinary branch/tag reachability in a pristine full-history single-branch checkout. Record
+      this checkout-dependent historical provenance finding explicitly; do not rewrite the
+      artifact or producer SHA in this baseline reconciliation.
+  - path: docs/context/evidence/issue_1344_paired_amv_primary_2026-05-20/stress_campaign_summary.json
+    codes: [dangling_commit]
+    disposition: baseline
+    reason: >-
+      The producer commit is reachable from preserved pull-request history but not from main's
+      ordinary branch/tag reachability in a pristine full-history single-branch checkout. Record
+      this checkout-dependent historical provenance finding explicitly; do not rewrite the
+      artifact or producer SHA in this baseline reconciliation.
+  - path: docs/context/evidence/issue_1454_s10_h500_candidates_2026-05-23/campaign_manifest.json
+    codes: [dangling_commit]
+    disposition: baseline
+    reason: >-
+      The producer commit is reachable from preserved pull-request history but not from main's
+      ordinary branch/tag reachability in a pristine full-history single-branch checkout. Record
+      this checkout-dependent historical provenance finding explicitly; do not rewrite the
+      artifact or producer SHA in this baseline reconciliation.
+  - path: docs/context/evidence/issue_1454_stage_a_fixed_h100_2026-05-22/reports/campaign_analysis.json
+    codes: [dangling_commit]
+    disposition: baseline
+    reason: >-
+      The producer commit is reachable from preserved pull-request history but not from main's
+      ordinary branch/tag reachability in a pristine full-history single-branch checkout. Record
+      this checkout-dependent historical provenance finding explicitly; do not rewrite the
+      artifact or producer SHA in this baseline reconciliation.
+  - path: docs/context/evidence/issue_1484_broader_cross_kinematics_2026-05-28/campaign_manifest.json
+    codes: [dangling_commit]
+    disposition: baseline
+    reason: >-
+      The producer commit is reachable from preserved pull-request history but not from main's
+      ordinary branch/tag reachability in a pristine full-history single-branch checkout. Record
+      this checkout-dependent historical provenance finding explicitly; do not rewrite the
+      artifact or producer SHA in this baseline reconciliation.
   - path: docs/context/evidence/issue_4848_group_crossing_exemplars_2026-07/goal/classic_group_crossing_high_seed24_best/metadata.json
     codes: [dangling_commit]
     disposition: baseline


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** Regenerated the evidence-registry baseline from a pristine, full-history, single-branch checkout and added reviewed ledger entries for exactly five `dangling_commit` count increases.

**Why now:** Main CI’s clean-checkout ratchet baseline was produced from a developer object store that contained pull-request-only commits. The pristine reproduction reports 416 findings against the prior 411 baseline; the refreshed baseline records those five reviewed historical-provenance findings.

**Claim boundary:** This restores checkout-independent ratchet accounting only. It does not repair or rewrite evidence artifacts, producer SHAs, workflows, linter/ratchet behavior, benchmark semantics, or research claims.

**Required validation:** A no-promisor, non-shallow `git clone --no-local --branch main --single-branch` checkout, with the accepted base fetched explicitly, reproduced the five approved increases and passed after the canonical `--write-baseline` regeneration (416/416). Focused ratchet tests and strict policy lint also pass.

**Remaining blocker:** None for the bounded #6014 baseline-repair scope; GitHub CI remains the post-open confirmation.

Closes #6014

## Contract delta

- New baseline counts: five reviewed historical `dangling_commit` increases are recorded (411 -> 416 total findings).
- New review-ledger coverage: the same five paths carry the explicit preserved-PR-history / main-unreachable rationale.
- New fail-closed blockers: none; the per-file/per-code downward ratchet remains unchanged.
- Compatibility impact: the baseline now matches a pristine full-history checkout; no runtime, schema, or artifact contract changes.

<details>
<summary>Scope, validation, and handoff details</summary>

Issue: https://github.com/ll7/robot_sf_ll7/issues/6014

Scope: only `scripts/validation/evidence_registry_baseline.json` and `scripts/validation/evidence_registry_baseline_review.yaml` changed. Canonical writer output adds only the five approved `dangling_commit` increments: two 0 -> 1 entries and three 1 -> 2 entries. No third file changed.

Validation:

- Pristine full-history reproduction: `git clone --no-local --branch main --single-branch`, then the accepted base `a05f2a5d82169d9896f526de153f57c84d7b799a` was fetched explicitly because it was not advertised by the current single branch. `remote.origin.promisor` was unset and `git rev-parse --is-shallow-repository` returned `false`.
- Pre-regeneration ratchet: failed with exactly the five approved increases; `findings=416 (baseline=411)`.
- `uv run python scripts/dev/evidence_registry_ratchet.py --write-baseline` — passed; rewrote only the baseline to 416 findings across 87 files.
- Pristine post-regeneration `uv run python scripts/dev/evidence_registry_ratchet.py --check` — passed (416/416).
- `uv run python scripts/dev/evidence_registry_ratchet.py --check` — passed in the implementation worktree (414 live findings vs 416 baseline; two checkout-object-store decrease notices only).
- `uv run pytest -q tests/dev/test_evidence_registry_ratchet.py` — 23 passed, 1 xfailed; existing advisory warning documents checkout-sensitive writer reproducibility.
- `uv run python scripts/tools/lint_evidence_registry.py --strict --strict-exclusion-policy docs/context/evidence/evidence_registry_strict_ci_policy.yaml` — passed (zero active strict findings).
- `python3 -m json.tool scripts/validation/evidence_registry_baseline.json`, YAML safe-load, and `git diff --check` — passed.
- Accepted packet scope gate — passed for exactly the two authorized paths.

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits were performed. No friction issue was filed: the known checkout-sensitive advisory is already tracked by the existing test/issue history, and the packet’s corrected strict-linter command worked as specified.

State propagation: no separate issue comment was posted because the accepted authorization profile forbids issue/PR comments, and this focused PR is the durable handoff surface.

Downstream propagation: not applicable; this is a CI baseline repair with no new benchmark result, evidence artifact, or claim promotion.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated validation baselines to account for five additional dangling-commit findings.
  * Refreshed baseline metadata and review records for evidence files whose history is preserved through pull-request references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->