### PR TITLE
Issue #6028: align token-efficient profile PR queue snapshot command with CLI (cheap-lane worker)

### DIFF
--- a/docs/templates/token_efficient_thread_profile.md
+++ b/docs/templates/token_efficient_thread_profile.md
@@ -39,7 +39,7 @@ changes.
 - `context_budget` defaults to compact helpers before broad reads:
   `uv run python scripts/dev/autopilot_state_snapshot.py --include-worktrees`,
   `uv run python scripts/dev/snapshot_issue_batch.py --json`,
-  `uv run python scripts/dev/snapshot_pr_queue.py --json`, and
+  `uv run python scripts/dev/snapshot_pr_queue.py --active --json`, and
   `uv run python scripts/dev/run_compact_validation.py -- <command>`.
 - `resume_checkpoint` should be the first thing refreshed after compaction or
   automatic continuation. If it is fresh, do not reread full skills, broad

--- a/tests/dev/test_token_efficient_thread_profile_snapshot_command.py
+++ b/tests/dev/test_token_efficient_thread_profile_snapshot_command.py
@@ -1,0 +1,109 @@
+"""Regression tests for the PR queue snapshot command documented in the token-efficient profile.
+
+Issue #6028 (friction): the ``goal-pr-review`` queue snapshot command documented in
+``docs/templates/token_efficient_thread_profile.md`` must succeed against the current
+``scripts/dev/snapshot_pr_queue.py`` CLI. The bare ``snapshot_pr_queue.py --json`` form
+previously documented there is rejected by the helper ("at least one PR number is required")
+because the CLI requires either ``--active`` or explicit PR numbers. These tests pin the
+documented form to a selector the CLI accepts so the friction cannot silently return.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from scripts.dev.snapshot_pr_queue import main
+
+DOC_PATH = (
+    Path(__file__).resolve().parents[2] / "docs" / "templates" / "token_efficient_thread_profile.md"
+)
+SNAPSHOT_COMMAND_RE = re.compile(
+    r"`uv run python scripts/dev/snapshot_pr_queue\.py (?P<args>[^`]+)`"
+)
+
+
+def _snapshot_invocations(doc_text: str) -> list[str]:
+    """Return the argument strings for each documented ``snapshot_pr_queue.py`` invocation."""
+    return [match.group("args").strip() for match in SNAPSHOT_COMMAND_RE.finditer(doc_text)]
+
+
+def test_documented_snapshot_command_is_present() -> None:
+    """The token-efficient profile must document at least one PR queue snapshot command."""
+    doc_text = DOC_PATH.read_text(encoding="utf-8")
+    invocations = _snapshot_invocations(doc_text)
+
+    assert invocations, "expected a snapshot_pr_queue.py invocation in the token-efficient profile"
+
+
+def test_documented_snapshot_command_uses_active_selector() -> None:
+    """The documented broad-discovery command must use the CLI's ``--active`` selector."""
+    doc_text = DOC_PATH.read_text(encoding="utf-8")
+    invocations = _snapshot_invocations(doc_text)
+
+    assert any("--active" in args for args in invocations), (
+        "documented snapshot_pr_queue.py invocation must use --active for broad queue discovery"
+    )
+
+
+def test_documented_snapshot_command_is_not_the_bare_rejected_form() -> None:
+    """The documented command must not be the selector-less ``--json`` form the CLI rejects.
+
+    Regression for issue #6028: ``snapshot_pr_queue.py --json`` without ``--active`` or a PR
+    number exits with status 1 ("at least one PR number is required").
+    """
+    doc_text = DOC_PATH.read_text(encoding="utf-8")
+    invocations = _snapshot_invocations(doc_text)
+
+    for args in invocations:
+        tokens = args.split()
+        has_selector = bool(set(tokens) & {"--active", "--prs"}) or any(
+            token.isdigit() for token in tokens
+        )
+        assert has_selector, (
+            f"documented snapshot_pr_queue.py invocation lacks a CLI selector: {args!r}"
+        )
+
+
+def test_documented_snapshot_command_succeeds_against_cli(capsys) -> None:  # type: ignore[no-untyped-def]
+    """The documented queue snapshot command must exit 0 against the current CLI.
+
+    This is the literal issue #6028 acceptance criterion ("the documented command succeeds
+    against the current CLI"). The ``--active`` form is exercised with ``gh`` mocked so the
+    test stays offline while still driving the real ``main()`` argument and selector gates.
+    """
+    doc_text = DOC_PATH.read_text(encoding="utf-8")
+    invocations = _snapshot_invocations(doc_text)
+    active_invocations = [args for args in invocations if "--active" in args.split()]
+    assert active_invocations, (
+        "documented snapshot_pr_queue.py invocation must use --active so the command succeeds"
+    )
+    active_invocation = active_invocations[0]
+
+    pr_payload = [
+        {
+            "number": 6027,
+            "title": "example PR",
+            "state": "OPEN",
+            "isDraft": False,
+            "url": "https://github.test/pull/6027",
+            "labels": [],
+            "headRefName": "feature",
+            "headRefOid": "cafe00",
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [],
+            "reviews": [],
+            "comments": [],
+        }
+    ]
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr="")
+        rc = main(active_invocation.split())
+
+    assert rc == 0, (
+        f"documented command 'snapshot_pr_queue.py {active_invocation}' failed against the CLI"
+    )
+    # ``main`` should not have printed a selector-required error for the documented form.
+    assert "at least one PR" not in capsys.readouterr().err

--- a/tests/dev/test_token_efficient_thread_profile_snapshot_command.py
+++ b/tests/dev/test_token_efficient_thread_profile_snapshot_command.py
@@ -12,10 +12,11 @@ from __future__ import annotations
 
 import json
 import re
+import shlex
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from scripts.dev.snapshot_pr_queue import main
+from scripts.dev.snapshot_pr_queue import _parse_args, main
 
 DOC_PATH = (
     Path(__file__).resolve().parents[2] / "docs" / "templates" / "token_efficient_thread_profile.md"
@@ -28,6 +29,11 @@ SNAPSHOT_COMMAND_RE = re.compile(
 def _snapshot_invocations(doc_text: str) -> list[str]:
     """Return the argument strings for each documented ``snapshot_pr_queue.py`` invocation."""
     return [match.group("args").strip() for match in SNAPSHOT_COMMAND_RE.finditer(doc_text)]
+
+
+def _parsed_documented_invocation(args: str):  # type: ignore[no-untyped-def]
+    """Parse one documented shell argument string using the production CLI parser."""
+    return _parse_args(shlex.split(args))
 
 
 def test_documented_snapshot_command_is_present() -> None:
@@ -58,10 +64,8 @@ def test_documented_snapshot_command_is_not_the_bare_rejected_form() -> None:
     invocations = _snapshot_invocations(doc_text)
 
     for args in invocations:
-        tokens = args.split()
-        has_selector = bool(set(tokens) & {"--active", "--prs"}) or any(
-            token.isdigit() for token in tokens
-        )
+        parsed = _parsed_documented_invocation(args)
+        has_selector = parsed.active or bool(parsed.prs_option or parsed.prs)
         assert has_selector, (
             f"documented snapshot_pr_queue.py invocation lacks a CLI selector: {args!r}"
         )
@@ -76,7 +80,9 @@ def test_documented_snapshot_command_succeeds_against_cli(capsys) -> None:  # ty
     """
     doc_text = DOC_PATH.read_text(encoding="utf-8")
     invocations = _snapshot_invocations(doc_text)
-    active_invocations = [args for args in invocations if "--active" in args.split()]
+    active_invocations = [
+        args for args in invocations if _parsed_documented_invocation(args).active
+    ]
     assert active_invocations, (
         "documented snapshot_pr_queue.py invocation must use --active so the command succeeds"
     )
@@ -100,7 +106,7 @@ def test_documented_snapshot_command_succeeds_against_cli(capsys) -> None:  # ty
     ]
     with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
         mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr="")
-        rc = main(active_invocation.split())
+        rc = main(shlex.split(active_invocation))
 
     assert rc == 0, (
         f"documented command 'snapshot_pr_queue.py {active_invocation}' failed against the CLI"


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** `docs/templates/token_efficient_thread_profile.md` previously documented the PR queue snapshot command as `uv run python scripts/dev/snapshot_pr_queue.py --json`, which the helper rejects with exit 1 ("at least one PR number is required"). The documented command is corrected to the CLI-supported broad-discovery form `uv run python scripts/dev/snapshot_pr_queue.py --active --json`. A new focused regression test pins the documented invocation against the live CLI so the friction cannot silently return.

**Why now:** closes the issue #6028 friction observed in the #6027 gate — a documented goal-pr-review queue snapshot command that did not succeed against the current CLI. The skill surface (`.agents/skills/goal-pr-review/SKILL.md`) was already aligned to `--active` by #6020; this PR aligns the sibling docs surface and adds a regression guard.

**Claim boundary:** documentation alignment and its focused text regression only. No runtime, benchmark, metric, schema, model-provenance, or research-claim change.

**Required validation:** the new regression test, the existing skill/CLI contract tests, Ruff, format check, docs-proof consistency check, and `git diff --check` all pass.

**Remaining blocker:** none for the issue's stated scope.

Closes #6028

## Linked Issues
- Closes #6028
- Relates to #6020 (already aligned the `.agents/skills/goal-pr-review/SKILL.md` surface)

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- `docs/templates/token_efficient_thread_profile.md`: the `context_budget` default for the PR queue snapshot was corrected from the bare `snapshot_pr_queue.py --json` (rejected by the CLI) to `snapshot_pr_queue.py --active --json` (the CLI's documented broad-discovery selector).
- `tests/dev/test_token_efficient_thread_profile_snapshot_command.py`: new focused regression test. It reads the documented invocation(s) from the doc and asserts (a) a command is present, (b) the broad-discovery form uses `--active`, (c) no selector-less form remains, and (d) the documented `--active` invocation drives the real `main()` to exit 0 with `gh` mocked (the literal issue acceptance: "the documented command succeeds against the current CLI").

## Why It Matters
- Added value: the documented token-efficient profile workflow runs as written; the friction class is pinned by a test that fails if a selector-less `snapshot_pr_queue.py` invocation is reintroduced to this docs surface.
- Expected impact: no behavior change; docs/test only.
- Why this is worth merging now: it removes a live docs/CLI drift that breaks the documented review workflow, and the regression test prevents recurrence on this surface.

## Research Result Guidance
NA — support documentation fix with no research claim.
- Target claim / hypothesis / blocker this should affect: NA
- Comparator or baseline, if applicable: NA
- Evidence tier: docs-only
- Result classification: NA
- Decision or stop rule, if applicable: the documented command must succeed against the current CLI (issue #6028 acceptance).
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #6028 only.
- New research/benchmark/metric/paper-facing analysis tool: NA - support documentation; this PR does not interpret research evidence.

## Domain-Aware Approval
- Required for this PR: no - docs-only support change with no evidence claim.
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: docs-only opt-out.

## Falsification / Non-Transfer Check
NA — support documentation fix with no research claim.
- Did the mechanism activate?: NA
- Did the intervention change command source, selected command, trajectory, or route progress?: NA
- Did the scenario actually contain the targeted failure mode?: NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
NA — docs-only support change with no empirical claim.
- Rerun needed: NA
- Extractor or analysis tool needed: NA
- Artifact missing or unavailable: NA
- Stop / revise / continue decision: continue to normal review.
- Proposed child issue or existing follow-up: none.

## Risks / Rollout
- Compatibility risks: none expected; the documented guidance now matches the existing CLI interface (`scripts/dev/snapshot_pr_queue.py --active --json`).
- Failure modes: future CLI selector changes could make this prose stale; the new regression test pins the `--active` selector and the selector-presence requirement on this docs surface.
- Rollback or fallback plan: revert the two-file commit.

## Docs / Provenance
- Updated docs: `docs/templates/token_efficient_thread_profile.md`.
- Relevant design or provenance notes: live issue #6028 and the current CLI help (`scripts/dev/snapshot_pr_queue.py --help` documents `--active`).
- Any assumptions that need to be preserved: `--active` is the intended broad queue-discovery selector, consistent with the already-aligned `.agents/skills/goal-pr-review/SKILL.md`.

## Downstream Propagation
- Parent issue updated: no — the accepted authorization profile forbids issue/PR comments.
- Claim map / benchmark report updated: NA — no claim change.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened for deferred propagation: no.
- Not applicable because: docs-only support change with no research, benchmark, metric, schema, or claim-map surface.

## Follow-Up Issues
- Deferred work: [#6031](https://github.com/ll7/robot_sf_ll7/issues/6031) tracks the separate
  `snapshot_issue_batch.py --json` documentation/CLI friction in this profile.
- Issues opened for follow-up: #6031.

## Reviewer Notes
- Anything a reviewer should verify closely: the one-line docs edit and the new test. To confirm the test is a meaningful regression, revert only the docs line to `snapshot_pr_queue.py --json`; 3 of the 4 new tests then fail.
- Any known limitations: the regression test guards the `docs/templates/token_efficient_thread_profile.md` surface; the skill surface (`.agents/skills/goal-pr-review/SKILL.md`) is already guarded by `test_goal_pr_review_snapshot_discovery_uses_the_active_cli_mode` from #6020 and is outside this packet's allowed paths.
- Shared-helper migration: NA — no shared-helper migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage that parses the documented thread profile snapshot command from the template and verifies it includes a valid PR selector.
  * Ensures at least one documented invocation uses the supported `--active` selector.
  * Confirms the documented invocation is not the selector-less form and that executing it succeeds without selector-related “at least one PR” errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
