### PR TITLE
fix(ci): make evidence commit resolution HEAD-reachable

### DIFF
--- a/scripts/tools/lint_evidence_registry.py
+++ b/scripts/tools/lint_evidence_registry.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import re
 import subprocess
+import sys
 from collections import Counter, defaultdict
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
@@ -78,6 +79,30 @@ def _git_succeeds(repo_root: Path, *args: str) -> bool:
         ).returncode
         == 0
     )
+
+
+class ShallowRepositoryError(RuntimeError):
+    """Raised when commit reachability cannot be classified completely."""
+
+
+def _require_full_history(repo_root: Path) -> None:
+    """Fail before classifying commits when Git history is shallow."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--is-shallow-repository"],
+        cwd=repo_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("evidence-registry linter could not determine Git repository depth")
+    if result.stdout.strip().lower() == "true":
+        raise ShallowRepositoryError(
+            "evidence-registry commit reachability requires a full-history Git "
+            "repository; shallow repository detected. Run `git fetch --unshallow` "
+            "(or use a full-history checkout) before rerunning."
+        )
 
 
 def _commit_is_head_reachable(repo_root: Path, commit: str) -> bool:
@@ -509,6 +534,7 @@ def lint_evidence_registry(
 ) -> dict[str, Any]:
     """Return a deterministic integrity report for every supported evidence file."""
     repo_root = repo_root.resolve()
+    _require_full_history(repo_root)
     registry_root = registry_root.resolve()
     campaigns: dict[str, list[_DocumentRecord]] = defaultdict(list)
     findings: list[dict[str, str]] = []
@@ -642,7 +668,11 @@ def main(argv: list[str] | None = None) -> int:
         exclude_codes = exclude_codes | frozenset(
             code.strip() for code in args.exclude_codes.split(",") if code.strip()
         )
-    report = lint_evidence_registry(repo_root, registry_root, disposition_path, exclude_codes)
+    try:
+        report = lint_evidence_registry(repo_root, registry_root, disposition_path, exclude_codes)
+    except ShallowRepositoryError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
     print(json.dumps(report, indent=2, sort_keys=True))
     return 1 if args.strict and report["summary"]["findings"] > 0 else 0
 

--- a/scripts/tools/lint_evidence_registry.py
+++ b/scripts/tools/lint_evidence_registry.py
@@ -80,6 +80,20 @@ def _git_succeeds(repo_root: Path, *args: str) -> bool:
     )
 
 
+def _commit_is_head_reachable(repo_root: Path, commit: str) -> bool:
+    """Return whether ``commit`` exists and belongs to the checked-out history.
+
+    Git object stores may also contain commits fetched through unrelated branches
+    or tags. Treating raw object presence as provenance resolution makes the
+    evidence baseline depend on which refs happened to be fetched. Reachability
+    from ``HEAD`` gives full-history checkouts one stable authority while still
+    rejecting missing commit objects.
+    """
+    return _git_succeeds(repo_root, "cat-file", "-e", f"{commit}^{{commit}}") and _git_succeeds(
+        repo_root, "merge-base", "--is-ancestor", commit, "HEAD"
+    )
+
+
 def _git_bytes(repo_root: Path, *args: str) -> bytes | None:
     """Return Git command output bytes, or ``None`` when the object is unavailable."""
 
@@ -374,9 +388,7 @@ def _campaign_metadata_findings(  # noqa: C901 - rule-to-finding mapping is inte
             _issue(display_path, "missing_commit", "campaign_id requires a full producing commit")
         )
     resolved_commits = [
-        commit
-        for commit in set(commits)
-        if _git_succeeds(repo_root, "cat-file", "-e", f"{commit}^{{commit}}")
+        commit for commit in set(commits) if _commit_is_head_reachable(repo_root, commit)
     ]
     declared_config_hashes = {item.lower() for item in config_hashes if SHA256_RE.fullmatch(item)}
     for config_path in sorted(set(config_paths)):
@@ -516,7 +528,7 @@ def lint_evidence_registry(
         config_hashes = [item for document in documents for item in document.config_hashes]
         commits = [commit for document in documents for commit in document.commits]
         for commit in sorted(set(commits)):
-            if not _git_succeeds(repo_root, "cat-file", "-e", f"{commit}^{{commit}}"):
+            if not _commit_is_head_reachable(repo_root, commit):
                 findings.append(
                     _issue(canonical_path, "dangling_commit", f"commit {commit} does not resolve")
                 )

--- a/tests/tools/test_lint_evidence_registry.py
+++ b/tests/tools/test_lint_evidence_registry.py
@@ -109,6 +109,40 @@ def test_dangling_commit_is_classified(tmp_path: Path) -> None:
     assert {issue["code"] for issue in report["issues"]} >= {"dangling_commit"}
 
 
+def test_commit_on_unrelated_ref_stays_dangling_until_head_reaches_it(
+    tmp_path: Path,
+) -> None:
+    """Incidental branch or tag objects must not change provenance resolution."""
+    linter = _load_linter()
+    repo, evidence, base_commit, config_sha256 = _make_repo(tmp_path)
+    artifact_sha256 = hashlib.sha256((evidence / "artifact.json").read_bytes()).hexdigest()
+
+    _git(repo, "checkout", "-qb", "unrelated-provenance")
+    _git(repo, "commit", "--allow-empty", "-qm", "unrelated provenance")
+    unrelated_commit = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "tag", "unrelated-provenance-tag", unrelated_commit)
+    _git(repo, "checkout", "--detach", "-q", base_commit)
+
+    _write_entry(
+        evidence,
+        campaign_id="campaign-unrelated-ref",
+        commit=unrelated_commit,
+        config_sha256=config_sha256,
+        artifact_sha256=artifact_sha256,
+        name="unrelated-ref.json",
+    )
+
+    unrelated_report = linter.lint_evidence_registry(repo, evidence)
+    assert any(
+        issue["code"] == "dangling_commit" and unrelated_commit in issue["message"]
+        for issue in unrelated_report["issues"]
+    )
+
+    _git(repo, "checkout", "--detach", "-q", unrelated_commit)
+    reachable_report = linter.lint_evidence_registry(repo, evidence)
+    assert not any(issue["code"] == "dangling_commit" for issue in reachable_report["issues"])
+
+
 def test_hash_mismatch_is_classified(tmp_path: Path) -> None:
     """A hash next to a committed artifact must match its current tracked bytes."""
     linter = _load_linter()

--- a/tests/tools/test_lint_evidence_registry.py
+++ b/tests/tools/test_lint_evidence_registry.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 LINTER = ROOT / "scripts" / "tools" / "lint_evidence_registry.py"
 
@@ -141,6 +143,54 @@ def test_commit_on_unrelated_ref_stays_dangling_until_head_reaches_it(
     _git(repo, "checkout", "--detach", "-q", unrelated_commit)
     reachable_report = linter.lint_evidence_registry(repo, evidence)
     assert not any(issue["code"] == "dangling_commit" for issue in reachable_report["issues"])
+
+
+def test_shallow_repository_fails_before_commit_classification(
+    tmp_path: Path,
+) -> None:
+    """Unknown shallow ancestors must not become misleading lint findings."""
+    linter = _load_linter()
+    source, _evidence, _commit, _config_sha256 = _make_repo(tmp_path)
+    _git(source, "commit", "--allow-empty", "-qm", "shallow clone tip")
+    shallow = tmp_path / "shallow"
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            "--quiet",
+            "--depth",
+            "1",
+            source.as_uri(),
+            str(shallow),
+        ],
+        check=True,
+    )
+    assert _git(shallow, "rev-parse", "--is-shallow-repository") == "true"
+    registry = shallow / "docs" / "context" / "evidence"
+
+    with pytest.raises(
+        linter.ShallowRepositoryError,
+        match=r"full-history Git repository.*git fetch --unshallow",
+    ):
+        linter.lint_evidence_registry(shallow, registry)
+
+    cli = subprocess.run(
+        [
+            sys.executable,
+            str(LINTER),
+            "--repo-root",
+            str(shallow),
+            "--registry-root",
+            "docs/context/evidence",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert cli.returncode == 2
+    assert cli.stdout == ""
+    assert "shallow repository detected" in cli.stderr
+    assert "git fetch --unshallow" in cli.stderr
 
 
 def test_hash_mismatch_is_classified(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Make evidence commit resolution deterministic across clones by requiring producer commits to exist and be reachable from the checked-out `HEAD`. Add a regression for commits present only through unrelated branches/tags.

## Linked Issues

- Closes #6032
- Repairs main CI failure: https://github.com/ll7/robot_sf_ll7/actions/runs/29678618355/job/88170680455

## Stack / Dependency

- Base dependency: current `main` (`bd2e53f`)
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason: focused CI/evidence-linter determinism fix

## What Changed

- Added one `_commit_is_head_reachable` predicate: the Git object must exist and be an ancestor of `HEAD`.
- Applied it consistently to per-campaign resolved commits and aggregate dangling-commit classification.
- Added a branch/tag-only regression proving incidental fetched refs cannot change the result.

## Why Matters

- Added value: evidence-registry findings no longer depend on which unrelated refs happened to be fetched.
- Expected impact: single-branch clones, full GitHub Actions fetches, and larger local object stores reproduce the same committed baseline.
- Why worth merging now: current protected main is CI-red on this exact nondeterminism.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA — CI/evidence-linter support repair
- Comparator or baseline, applicable: committed evidence-registry baseline remains 416 findings across 87 files
- Evidence tier: NA
- Result classification: NA
- Decision stop rule, applicable: stop if evidence payloads or the baseline need rewriting
- Parent issue, claim map, registry, context note, synthesis surface update: #6032
- New research/benchmark/metric/paper-facing analysis tool: NA — support helper only

## Domain-Aware Approval

- Required this PR: no
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: deterministic tooling-only change; no evidence payload or claim change

## Falsification / Non-Transfer Check

- Did mechanism activate? NA
- Did intervention change command source, selected command, trajectory, or route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: NA
- Follow-up question or issue: NA

## Next Empirical Action

- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: continue with normal CI
- Proposed child issue or existing follow-up: none

## Validation / Proof

- Focused regression plus exact previously failing baseline test: `2 passed`
- Full linter and ratchet suites: passed
- Temporary baseline regeneration: 416 findings across 87 files; semantic JSON equals committed baseline apart from timestamp
- `evidence_registry_ratchet.py --check`: passed
- Strict policy lint, Ruff, Python compile, pre-commit, and `git diff --check`: passed

## Risks / Rollout

- Compatibility risks: producer commits available only through unrelated refs remain dangling by design.
- Failure modes: a producer commit must belong to the checked-out history to resolve.
- Rollback / fallback plan: revert this commit; do not refresh the baseline to an environment-specific count.

## Docs / Provenance

- Updated docs: none
- Relevant design provenance notes: #6032 and the failed main CI job linked above
- Assumptions to preserve: current `HEAD` history is the authority for evidence provenance

## Downstream Propagation

- Parent issue updated: yes, via this PR
- Claim map / benchmark report updated: NA
- Leaderboard / artifact catalog updated: NA
- Registry or config index updated: NA
- Context index / memory note updated: NA
- Follow-up issue opened for deferred propagation: no
- Not applicable because: tooling-only determinism fix; no research evidence or claim changed

## Follow-Up Issues

- Deferred work: none
- Issues opened as follow-up: none

## Reviewer Notes

- Verify both classification call sites use the same reachability predicate.
- Verify the regression creates a real branch/tag-only commit before moving `HEAD` to it.
- Known limitations: intentionally uses the current checked-out history rather than any ambient Git object.
