### PR TITLE
fix(training): refresh issue 3068 checksum and run-ready manifest

### DIFF
--- a/configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
+++ b/configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
@@ -76,7 +76,7 @@ training_starting_points:
   resume_policy_id: ppo_expert_br06_v3_15m_all_maps_randomized
   checksums:
     configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml: 91f9d9a7c0bcb54f3628beef9140181a64277ab8bdf9b12dcdc37f0251a7d437
-    configs/algos/ppo_v3_camera_ready.yaml: 6e7efd7bef68d4cdbac23bda7a0fa12d206229d5c0566c1e38f84cd9122a73c8
+    configs/algos/ppo_v3_camera_ready.yaml: ee914f1167da5d8513b90f1e3d90adabc83420d993306be9885f49c83f5b2efc
     configs/algos/guarded_ppo_relaxed_v2.yaml: 666eda5a47de6e452eba9b2f3cb15bda16fc97abcd7137434661a87ac9ff85d8
     configs/scenarios/classic_interactions_francis2023.yaml: d9e148e4b544b4c7e2b6ba98e599aef47046d114e0e25645f021946674cb9dc5
     configs/benchmarks/seed_sets_v1.yaml: 3aaab9171517b8d33bafc679d4a2c740864db0f96650e24d75c4c7e927d239e6

--- a/experiments/run_ready_manifest.yaml
+++ b/experiments/run_ready_manifest.yaml
@@ -1,6 +1,6 @@
 schema_version: run-ready-launch-packet-manifest.v1
 packet_glob: configs/**/*launch_packet*.yaml
-packet_count: 7
+packet_count: 11
 ready_count: 1
 entries:
 - issue: 3216
@@ -15,7 +15,7 @@ entries:
   - field: runnable_config.config
     path: configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml
     exists: true
-    sha256: 3bf75ebb05cc5523c33271e956b21b14749fc427fc9d986438c83d09eee8b75c
+    sha256: 249968670830c3b710e1407aecb2256d140cd1ba76294766421447bd89357f15
     sha256_matches: true
   - field: runnable_config.scenario_matrix
     path: configs/scenarios/classic_interactions_francis2023.yaml
@@ -82,12 +82,258 @@ entries:
     state: proposed
     job_class: policy_search_sweep
     source: public_launch_packet_preflight
+- issue: 3810
+  packet_path: configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+  schema_version: research-campaign-manifest.v0.1
+  kind: benchmark
+  ready: false
+  reasons:
+  - missing launch/validation command
+  - missing claim gate or execution boundary
+  - 'durable_evidence.plan.path: path is not an existing file: docs/context/evidence/issue_3810_long_horizon_snqi/'
+  - 'launch_packet.horizon_sensitivity_report.command.token[7]: path is not an existing
+    file: docs/context/evidence/prior_scoped_h100_reference'
+  - 'analysis_and_retention_packet.horizon_sensitivity_report.command.token[7]: path
+    is not an existing file: docs/context/evidence/prior_scoped_h100_reference'
+  - 'placeholder values remain: launch_packet.campaign_command'
+  configs:
+  - field: scenario_suite.matrix_path
+    path: configs/scenarios/classic_interactions_francis2023.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: planners.rows[0].config_path
+    path: configs/algos/prediction_planner_camera_ready.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: planners.rows[4].config_path
+    path: configs/baselines/ppo_15m_grid_socnav.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: planners.rows[8].config_path
+    path: configs/baselines/ppo_15m_grid_socnav.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: planners.rows[9].config_path
+    path: configs/algos/predictive_mppi_camera_ready.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: planners.rows[10].config_path
+    path: configs/algos/risk_dwa_camera_ready.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: seed_policy.seed_sets_path
+    path: configs/benchmarks/seed_sets_v1.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: durable_evidence.plan.path
+    path: docs/context/evidence/issue_3810_long_horizon_snqi/
+    exists: false
+    sha256: null
+    sha256_matches: null
+  - field: launch_packet.campaign_command.token[4]
+    path: scripts/tools/run_camera_ready_benchmark.py
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: launch_packet.config_patch.base_config
+    path: configs/benchmarks/camera_ready_all_planners_strict_socnav.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: launch_packet.config_patch.required_overrides.scenario_matrix
+    path: configs/scenarios/classic_interactions_francis2023.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: launch_packet.horizon_sensitivity_report.command.token[3]
+    path: scripts/benchmark/build_horizon_timestep_denominator_report.py
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: launch_packet.horizon_sensitivity_report.command.token[7]
+    path: docs/context/evidence/prior_scoped_h100_reference
+    exists: false
+    sha256: null
+    sha256_matches: null
+  - field: analysis_and_retention_packet.horizon_sensitivity_report.command.token[3]
+    path: scripts/benchmark/build_horizon_timestep_denominator_report.py
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: analysis_and_retention_packet.horizon_sensitivity_report.command.token[7]
+    path: docs/context/evidence/prior_scoped_h100_reference
+    exists: false
+    sha256: null
+    sha256_matches: null
+  seed_budget:
+    mode: fixed-list
+    seed_set: paper_eval_s30
+    seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+    seeds:
+    - 111
+    - 112
+    - 113
+    - 114
+    - 115
+    - 116
+    - 117
+    - 118
+    - 119
+    - 120
+    - 121
+    - 122
+    - 123
+    - 124
+    - 125
+    - 126
+    - 127
+    - 128
+    - 129
+    - 130
+    - 131
+    - 132
+    - 133
+    - 134
+    - 135
+    - 136
+    - 137
+    - 138
+    - 139
+    - 140
+    repeat_policy: every_planner_scenario_pair
+  command: null
+  claim_gate: null
+  queue_hint:
+    public_issue: ll7/robot_sf_ll7#3810
+    review_required: true
+    submit_ready: false
+    state: proposed
+    job_class: policy_search_sweep
+    source: public_launch_packet_preflight
+- issue: 3813
+  packet_path: configs/benchmarks/issue_3813_sustained_flow_launch_packet.yaml
+  schema_version: research-campaign-manifest.v0.1
+  kind: benchmark
+  ready: false
+  reasons:
+  - missing launch/validation command
+  - missing claim gate or execution boundary
+  configs:
+  - field: campaign.scenario_suite.matrix_path
+    path: configs/scenarios/sets/issue_3813_sustained_flow_scaffold_v0.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: campaign.scenario_suite.contract_path
+    path: configs/scenarios/contracts/issue_3813_sustained_flow_contracts.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  seed_budget: null
+  command: null
+  claim_gate: null
+  queue_hint:
+    public_issue: ll7/robot_sf_ll7#3813
+    review_required: true
+    submit_ready: false
+    state: proposed
+    job_class: policy_search_sweep
+    source: public_launch_packet_preflight
+- issue: 5348
+  packet_path: configs/benchmarks/issue_5348_s30_attempt6_resume_launch_packet.yaml
+  schema_version: s30-attempt6-resume-launch-packet.v1
+  kind: benchmark
+  ready: false
+  reasons:
+  - 'placeholder values remain: generating_commit, resume_execution.resume_command_shape,
+    publication.evidence_dir'
+  configs:
+  - field: campaign.config
+    path: configs/benchmarks/paper_experiment_matrix_v1_h600_hybrid_vs_orca_s30.yaml
+    exists: true
+    sha256: 82eee7a1dca241df9bec65e18072f2dd3c46c86489b3b55816d2504af88896b6
+    sha256_matches: true
+  - field: validation_command.token[3]
+    path: scripts/validation/check_issue_5348_s30_resume_launch_packet.py
+    exists: true
+    sha256: null
+    sha256_matches: null
+  seed_budget: null
+  command: uv run python scripts/validation/check_issue_5348_s30_resume_launch_packet.py
+    --json
+  claim_gate:
+    full_campaign_in_this_issue: false
+    submit_slurm_from_this_issue: false
+    status_until_run: ready_for_resume_submission
+  queue_hint:
+    public_issue: ll7/robot_sf_ll7#5348
+    review_required: true
+    submit_ready: false
+    state: proposed
+    job_class: policy_search_sweep
+    source: public_launch_packet_preflight
+- issue: 3637
+  packet_path: configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml
+  schema_version: reactivity_replay_rank_study_preflight.v1
+  kind: benchmark
+  ready: false
+  reasons:
+  - missing launch/validation command
+  - missing claim gate or execution boundary
+  - 'placeholder values remain: rank_stability_analysis.seed_sufficiency_gate_command,
+    post_run_gate'
+  configs:
+  - field: scenario_set
+    path: configs/scenarios/sets/classic_crossing_subset.yaml
+    exists: true
+    sha256: a5baf5cd4b6aebd333a30f76e319646dd3f3451406db1678ef55d5ea3b972db6
+    sha256_matches: true
+  seed_budget:
+  - 101
+  - 102
+  - 103
+  - 104
+  - 105
+  - 106
+  - 107
+  - 108
+  - 109
+  - 110
+  - 111
+  - 112
+  - 113
+  - 114
+  - 115
+  - 116
+  - 117
+  - 118
+  - 119
+  - 120
+  command: null
+  claim_gate: null
+  queue_hint:
+    public_issue: ll7/robot_sf_ll7#3637
+    review_required: true
+    submit_ready: false
+    state: proposed
+    job_class: policy_search_sweep
+    source: public_launch_packet_preflight
 - issue: 1554
   packet_path: configs/benchmarks/s20_s30_seed_budget_issue_1554_launch_packet.yaml
   schema_version: s20-s30-seed-budget-launch-packet.v1
   kind: benchmark
   ready: false
   reasons:
+  - 'campaign_config.checksums.configs/benchmarks/alyassi_comparability_map_v1.yaml:
+    sha256 mismatch expected 22fc166ea438aa30da79c4888e270eee4afba8f1b9611080a3d51f4bb2cf200d
+    observed d889072792fd5bcb06886ef1119658d1449891cf918af838baf4de3e3800687a'
   - 'placeholder values remain: generating_commit, durable_storage_plan.promote_to_evidence'
   configs:
   - field: campaign_config.checksums.configs/benchmarks/issue_1454_s10_scenario_horizons_h500_candidates.yaml
@@ -109,7 +355,7 @@ entries:
     path: configs/benchmarks/alyassi_comparability_map_v1.yaml
     exists: true
     sha256: 22fc166ea438aa30da79c4888e270eee4afba8f1b9611080a3d51f4bb2cf200d
-    sha256_matches: true
+    sha256_matches: false
   - field: campaign_config.checksums.configs/benchmarks/snqi_weights_camera_ready_v3.json
     path: configs/benchmarks/snqi_weights_camera_ready_v3.json
     exists: true
@@ -230,6 +476,11 @@ entries:
     exists: true
     sha256: 1b8598dced652de2983d8919e29e22e9b48905049e30ee5340d381e8e8dc89f2
     sha256_matches: true
+  - field: slurm_execution.config
+    path: configs/training/learned_risk_model_v1.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
   - field: baseline_comparison.candidate_config
     path: configs/policy_search/candidates/hybrid_rule_v3_static_margin0_waypoint2.yaml
     exists: true
@@ -311,12 +562,12 @@ entries:
   - field: training_starting_points.checksums.configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
     path: configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
     exists: true
-    sha256: a374a624eb38402e5e4e2612f92440c0f80ff1eb0554a34f33dd36c16920a426
+    sha256: 91f9d9a7c0bcb54f3628beef9140181a64277ab8bdf9b12dcdc37f0251a7d437
     sha256_matches: true
   - field: training_starting_points.checksums.configs/algos/ppo_v3_camera_ready.yaml
     path: configs/algos/ppo_v3_camera_ready.yaml
     exists: true
-    sha256: 6e7efd7bef68d4cdbac23bda7a0fa12d206229d5c0566c1e38f84cd9122a73c8
+    sha256: ee914f1167da5d8513b90f1e3d90adabc83420d993306be9885f49c83f5b2efc
     sha256_matches: true
   - field: training_starting_points.checksums.configs/algos/guarded_ppo_relaxed_v2.yaml
     path: configs/algos/guarded_ppo_relaxed_v2.yaml
@@ -368,6 +619,16 @@ entries:
     exists: true
     sha256: null
     sha256_matches: null
+  - field: queue_hint.preflight_proof.required_checks.missing_config.command.token[2]
+    path: configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: queue_hint.preflight_proof.required_checks.packet_contract.command.token[3]
+    path: tests/training/test_ppo_curriculum_launch_packet_issue_3068.py
+    exists: true
+    sha256: null
+    sha256_matches: null
   seed_budget:
     training:
     - 123
@@ -395,37 +656,67 @@ entries:
     assert d['no_training_result_claim'] is True; print('valid', d['campaign_id'])"
   claim_gate:
     full_training_in_this_issue: false
-    submit_slurm_from_this_issue: true
+    submit_slurm_from_this_issue: false
     local_preflight_command: 'uv run pytest tests/training/test_ppo_curriculum_launch_packet_issue_3068.py
       -q
 
       '
-    slurm_command_shape: 'Submit through private operations only, using public worktree
-      that owns issue-3068 launch branch. First launchable run is a full-surface scout
-      that records training-curve artifacts under issue-3068 PPO curriculum campaign,
-      but does not by itself establish full curriculum-vs-baseline final benchmark
-      claim.
+    slurm_command_shape: 'No submission is authorized by this packet slice. A future
+      submitter may use the queue_hint route/script/resource/preflight fields below
+      after rerunning the exact validation_commands and replacing pending durable
+      artifact aliases.
 
       '
   queue_hint:
     public_issue: ll7/robot_sf_ll7#3068
-    state: ready
-    submit_ready: true
+    state: no_submit_preflight_ready
+    submit_ready: false
     review_required: false
     source: issue_3068_launch_packet
     job_class: robot_sf_gpu_training_small
     route_id: imech192:a30
+    cluster: imech192
+    partition: a30
+    qos: a30-gpu
     script: /home/luttkule/git/robot_sf_ll7-private-ops/auxme/SLURM/issue_791_reward_curriculum.sl
     config: configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml
     campaign: 2026-06-issue3068-ppo-curriculum
-    cpus: 20
-    gpus: 1
-    mem_gb: 120
-    estimated_elapsed_sec: 43200
+    resources:
+      cpus: 20
+      gpus: 1
+      mem_gb: 120
+      estimated_elapsed_sec: 43200
+    preflight_proof:
+      local_only: true
+      requires_private_ops_checkout: true
+      requires_slurm_submit: false
+      required_checks:
+        missing_script:
+          command: test -f /home/luttkule/git/robot_sf_ll7-private-ops/auxme/SLURM/issue_791_reward_curriculum.sl
+          expected: script exists on submit host before any future submission
+        missing_config:
+          command: test -f configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml
+          expected: public training config exists in the worktree
+        packet_contract:
+          command: uv run pytest tests/training/test_ppo_curriculum_launch_packet_issue_3068.py
+            -q
+          expected: launch-packet contract passes without Slurm submission
     submit_args: --sbatch-arg --qos=a30-gpu --sbatch-arg --cpus-per-task=20 --sbatch-arg
       --mem=120G --sbatch-arg --nice=10000 --sbatch-arg --export=ALL,ISSUE791_TRAIN_CONFIG=configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml,ISSUE791_WANDB_POLICY=require
-    remote_results: output/slurm/issue3068-ppo-curriculum
-    local_results: output/issue3068-ppo-curriculum
+    expected_outputs:
+      remote_results: output/slurm/issue3068-ppo-curriculum
+      local_results: output/issue3068-ppo-curriculum
+      wandb_group: issue-3068-ppo-curriculum
+      required_files:
+      - train_curve_metrics.csv
+      - checkpoint_manifest.json
+      - run_summary.json
+    validation_commands:
+    - uv run python -c "import yaml; d=yaml.safe_load(open('configs/training/ppo_curriculum_issue_3068_launch_packet.yaml'));
+      assert d['execution_boundary']['submit_slurm_from_this_issue'] is False; assert
+      d['queue_hint']['submit_ready'] is False; print('no-submit', d['campaign_id'])"
+    - uv run pytest tests/training/test_ppo_curriculum_launch_packet_issue_3068.py
+      -q
     success_criteria:
     - training wrapper starts with W&B enabled
     - train-curve metrics and checkpoint manifest are written
@@ -478,7 +769,7 @@ entries:
   - field: training_starting_points.checksums.configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
     path: configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
     exists: true
-    sha256: a374a624eb38402e5e4e2612f92440c0f80ff1eb0554a34f33dd36c16920a426
+    sha256: 91f9d9a7c0bcb54f3628beef9140181a64277ab8bdf9b12dcdc37f0251a7d437
     sha256_matches: true
   - field: training_starting_points.checksums.configs/policy_search/candidates/risk_guarded_ppo_v1.yaml
     path: configs/policy_search/candidates/risk_guarded_ppo_v1.yaml


### PR DESCRIPTION
## Summary

- refresh the issue #3068 PPO launch-packet checksum after #5964 intentionally changed `ppo_v3_camera_ready.yaml`
- deterministically rebuild the tracked run-ready manifest so it no longer claims stale checksum matches
- keep unrelated incomplete packets fail-closed; the pre-existing #1554 mismatch is now surfaced truthfully as non-ready

## Why

The first post-#6033 `main` run failed only
`test_referenced_configs_exist_and_checksums_match`: the launch packet still pinned
the pre-#5964 PPO config digest. The generated run-ready manifest carried the same
stale digest and also needed reconciliation.

Refs #5754.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh pytest -q tests/dev/test_build_run_ready_manifest.py tests/dev/test_preflight_launch_packet.py tests/training/test_ppo_curriculum_launch_packet_issue_3068.py` — 23 passed
- two independent manifest generations exactly matched the checked-in artifact
- all five #3068 config checksum assertions recompute as matching
- `git diff --check`
- pre-commit YAML and repository hooks

## Scope

This changes only the #3068 checksum pin and its deterministic derived run-ready
index. It does not submit compute, relax a scientific gate, or mark the surfaced
#1554 packet ready.
