### PR TITLE
fix(ci): repair optional reproducibility diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up CI Python environment
         uses: ./.github/actions/setup-ci-python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,19 +239,6 @@ jobs:
           name: ci-smoke-episodes
           path: output/benchmarks/ci_smoke/episodes.jsonl
 
-      - name: Reproducibility check (manual trigger only)
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          echo "Running end-to-end reproducibility validation..."
-          uv run python scripts/benchmark_repro_check.py
-
-      - name: Upload reproducibility report
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: reproducibility-report
-          path: output/benchmarks/reproducibility_check.json
-
       - name: Enforce artifact root policy
         if: >-
           ${{ always() && (steps.smoke_tests.outcome == 'success' ||
@@ -259,6 +246,31 @@ jobs:
         env:
           CI_STEP_TIMEOUT_SECONDS: "300"
         run: bash scripts/dev/ci_step_timer.sh "Enforce artifact root policy" scripts/dev/ci_driver.sh artifact-policy
+
+  reproducibility-check:
+    # This diagnostic runs only when manually requested. It is deliberately not
+    # included in the required `ci` aggregate job, so it cannot act as a PR gate.
+    if: github.event_name == 'workflow_dispatch'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up CI Python environment
+        uses: ./.github/actions/setup-ci-python
+
+      - name: Run optional reproducibility diagnostic
+        run: uv run python scripts/benchmark_repro_check.py
+
+      - name: Upload reproducibility report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: reproducibility-report
+          path: output/benchmarks/reproducibility_check.json
+          if-no-files-found: warn
 
   xdist-scratch-isolation:
     runs-on: ubuntu-latest

--- a/docs/context/issue_1436_reproducibility_flaky_acceptance.md
+++ b/docs/context/issue_1436_reproducibility_flaky_acceptance.md
@@ -60,6 +60,31 @@ matrix YAML.
   and [Issue #832 Paper-Matrix Extended Seed Schedule](issue_832_paper_matrix_extended_seed_schedule.md)
   for the current frozen camera-ready artifact contract.
 
+### Manual Reproducibility Diagnostic (Issue #5990, 2026-07-19)
+
+`reproducibility-check` is a `workflow_dispatch`-only job with
+`continue-on-error: true`. It is excluded from the required `ci` aggregate job,
+so its result cannot become a pull-request gate. The diagnostic still fails
+closed: `scripts/benchmark_repro_check.py` exits non-zero when the canonical
+`simple_policy` aggregate group or required metric/statistic shape is absent,
+writes `output/benchmarks/reproducibility_check.json` before failure exit, and
+then uploads that report with `if: always()`. Failure reports use
+`benchmark_repro_check.report.v1` and include `status`, `stage`, and `error`
+details, so an optional-lane failure remains visible without becoming a gate.
+
+The exact current local command is:
+
+```bash
+scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark_repro_check.py
+```
+
+On 2026-07-19 it passed in two fresh work directories using seed `123` for
+both runs. The fixture validated the canonical episode schema and the
+`collisions`, `path_efficiency`, and `success` aggregate metrics with `mean`,
+`median`, and `p95` statistics. Same-seed aggregate statistics must match
+exactly; no seed-drift tolerance is applied. This is **diagnostic-only**
+reproducibility evidence, not benchmark evidence or a required PR-gate signal.
+
 ## Deterministic vs Stochastic/Statistical Failures
 
 | Category | Examples | Acceptance Rule |

--- a/scripts/benchmark_repro_check.py
+++ b/scripts/benchmark_repro_check.py
@@ -2,8 +2,8 @@
 """
 Benchmark Reproducibility Check
 
-Purpose: End-to-end validation of benchmark reproducibility including episode generation,
-aggregation, and figure regeneration with different seeds.
+Purpose: End-to-end validation of benchmark reproducibility including episode generation
+and aggregation in fresh runs with the same seed.
 """
 
 import json
@@ -11,9 +11,17 @@ import sys
 import tempfile
 import time
 from pathlib import Path
+from typing import Any
 
 from robot_sf.common.artifact_paths import ensure_canonical_tree, get_artifact_category_path
 from robot_sf.render.helper_catalog import ensure_output_dir
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+EPISODE_SCHEMA_PATH = (
+    REPOSITORY_ROOT / "robot_sf" / "benchmark" / "schemas" / "episode.schema.v1.json"
+)
+REQUIRED_AGGREGATE_METRICS = ("collisions", "path_efficiency", "success")
+REQUIRED_AGGREGATE_STATISTICS = ("mean", "median", "p95")
 
 
 def create_minimal_scenario():
@@ -32,6 +40,92 @@ def create_minimal_scenario():
     }
 
 
+def validate_simple_policy_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
+    """Validate the required simple-policy aggregate shape without changing metric semantics.
+
+    Returns:
+        Structured pass/fail diagnostic suitable for a fail-closed compatibility check.
+    """
+    diagnostic: dict[str, Any] = {
+        "schema": "benchmark_repro_check.aggregate_validation.v1",
+        "group": "simple_policy",
+        "required_metrics": list(REQUIRED_AGGREGATE_METRICS),
+        "required_statistics": list(REQUIRED_AGGREGATE_STATISTICS),
+        "missing_metrics": [],
+        "missing_statistics": [],
+    }
+    group_data = summary.get("simple_policy")
+    if not isinstance(group_data, dict):
+        diagnostic["status"] = "failed"
+        diagnostic["missing_group"] = "simple_policy"
+        return diagnostic
+
+    for metric in REQUIRED_AGGREGATE_METRICS:
+        metric_data = group_data.get(metric)
+        if not isinstance(metric_data, dict):
+            diagnostic["missing_metrics"].append(metric)
+            continue
+        for statistic in REQUIRED_AGGREGATE_STATISTICS:
+            if not isinstance(metric_data.get(statistic), int | float):
+                diagnostic["missing_statistics"].append(f"{metric}.{statistic}")
+
+    diagnostic["status"] = (
+        "passed"
+        if not diagnostic["missing_metrics"] and not diagnostic["missing_statistics"]
+        else "failed"
+    )
+    return diagnostic
+
+
+def _pipeline_failure(stage: str, error: str | dict[str, Any]) -> dict[str, Any]:
+    """Return and print a structured fail-closed pipeline diagnostic."""
+    result = {
+        "status": "failed",
+        "stage": stage,
+        "error": error,
+    }
+    print(f"  ERROR: {json.dumps(result, sort_keys=True)}")
+    return result
+
+
+def _report_run(result: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return the JSON-safe subset of a pipeline result."""
+    if result is None:
+        return None
+    return {
+        key: value for key, value in result.items() if key not in {"episodes_file", "summary_file"}
+    }
+
+
+def _write_reproducibility_report(
+    results_base: Path,
+    *,
+    status: str,
+    stage: str,
+    error: str | dict[str, Any] | None,
+    reproducible: bool,
+    run1: dict[str, Any] | None = None,
+    run2: dict[str, Any] | None = None,
+) -> Path:
+    """Write the uploadable report for both successful and failed checks."""
+    report = {
+        "schema": "benchmark_repro_check.report.v1",
+        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "status": status,
+        "stage": stage,
+        "error": error,
+        "reproducible": reproducible,
+        "run1": _report_run(run1),
+        "run2": _report_run(run2),
+    }
+    results_base.mkdir(parents=True, exist_ok=True)
+    report_path = results_base / "reproducibility_check.json"
+    with report_path.open("w", encoding="utf-8") as file:
+        json.dump(report, file, indent=2)
+    print(f"\nReproducibility report saved to: {report_path}")
+    return report_path
+
+
 def run_benchmark_pipeline(work_dir: Path, seed: int = 123):
     """Run complete benchmark pipeline in isolated directory."""
     from robot_sf.benchmark.aggregate import compute_aggregates_with_ci, read_jsonl
@@ -42,17 +136,7 @@ def run_benchmark_pipeline(work_dir: Path, seed: int = 123):
     # Create scenario configuration
     scenario = create_minimal_scenario()
     episodes_path = work_dir / "episodes.jsonl"
-    schema_path = work_dir / "schema.json"
-
-    # Create minimal schema (for validation)
-    schema = {
-        "version": "v1",
-        "required_fields": ["episode_id", "scenario_id", "metrics"],
-        "metrics_fields": ["collision_rate", "efficiency", "jerk"],
-    }
-
-    with schema_path.open("w") as f:
-        json.dump(schema, f, indent=2)
+    schema_path = EPISODE_SCHEMA_PATH
 
     print("Phase 1: Generate episodes...")
     start_time = time.time()
@@ -70,16 +154,14 @@ def run_benchmark_pipeline(work_dir: Path, seed: int = 123):
 
         episode_gen_time = time.time() - start_time
         print(
-            f"  Generated {run_results.get('total_episodes', 0)} episodes in {episode_gen_time:.1f}s",
+            f"  Generated {run_results.get('written', 0)} episodes in {episode_gen_time:.1f}s",
         )
 
     except Exception as e:
-        print(f"  ERROR in episode generation: {e}")
-        return None
+        return _pipeline_failure("episode_generation", str(e))
 
     if not episodes_path.exists() or episodes_path.stat().st_size == 0:
-        print("  ERROR: No episodes generated")
-        return None
+        return _pipeline_failure("episode_generation", "No episodes generated")
 
     print("Phase 2: Aggregate metrics...")
     start_time = time.time()
@@ -87,8 +169,7 @@ def run_benchmark_pipeline(work_dir: Path, seed: int = 123):
     try:
         records = read_jsonl(episodes_path)
         if not records:
-            print("  ERROR: No records found in episodes file")
-            return None
+            return _pipeline_failure("aggregation", "No records found in episodes file")
 
         summary = compute_aggregates_with_ci(
             records,
@@ -107,25 +188,21 @@ def run_benchmark_pipeline(work_dir: Path, seed: int = 123):
             json.dump(summary, f, indent=2)
 
     except Exception as e:
-        print(f"  ERROR in aggregation: {e}")
-        return None
+        return _pipeline_failure("aggregation", str(e))
 
     print("Phase 3: Validation checks...")
 
-    # Basic validation: check for key metrics
-    required_metrics = ["collision_rate", "efficiency"]
-    for group_name, group_data in summary.items():
-        if not isinstance(group_data, dict):
-            continue
+    validation = validate_simple_policy_aggregate(summary)
+    if validation["status"] != "passed":
+        return _pipeline_failure("aggregate_validation", validation)
 
-        for metric in required_metrics:
-            if metric not in group_data:
-                print(f"  ERROR: Missing metric {metric} in group {group_name}")
-                return None
-
-        print(f"  Group {group_name}: {len(group_data)} metrics present")
+    group_data = summary["simple_policy"]
+    print(f"  Group simple_policy: {len(group_data)} aggregate metrics present")
 
     return {
+        "status": "passed",
+        "stage": "completed",
+        "error": None,
         "episodes_file": episodes_path,
         "summary_file": summary_path,
         "episodes_count": len(records),
@@ -135,7 +212,7 @@ def run_benchmark_pipeline(work_dir: Path, seed: int = 123):
     }
 
 
-def compare_reproducibility(results1, results2, tolerance=0.05):
+def compare_reproducibility(results1, results2):
     """Compare two benchmark runs for reproducibility."""
     print("\n=== Reproducibility Analysis ===")
 
@@ -168,33 +245,29 @@ def compare_reproducibility(results1, results2, tolerance=0.05):
     # Compare metric values (should be identical for deterministic algorithms)
     reproducible = True
 
-    for group_name in groups1:
-        if not isinstance(summary1[group_name], dict) or not isinstance(summary2[group_name], dict):
+    for metric in REQUIRED_AGGREGATE_METRICS:
+        metric1 = summary1.get("simple_policy", {}).get(metric)
+        metric2 = summary2.get("simple_policy", {}).get(metric)
+        if not isinstance(metric1, dict) or not isinstance(metric2, dict):
+            print(f"❌ Missing aggregate metric for reproducibility comparison: {metric}")
+            reproducible = False
             continue
 
-        group1 = summary1[group_name]
-        group2 = summary2[group_name]
-
-        common_metrics = set(group1.keys()) & set(group2.keys())
-
-        for metric in common_metrics:
-            if metric.endswith("_ci"):
-                continue  # Skip CI comparisons (bootstrap variability expected)
-
-            val1 = group1.get(metric)
-            val2 = group2.get(metric)
-
-            if val1 is None or val2 is None:
+        for statistic in REQUIRED_AGGREGATE_STATISTICS:
+            val1 = metric1.get(statistic)
+            val2 = metric2.get(statistic)
+            if not isinstance(val1, int | float) or not isinstance(val2, int | float):
+                print(f"❌ Missing numeric aggregate statistic: {metric}.{statistic}")
+                reproducible = False
                 continue
-
-            if isinstance(val1, int | float) and isinstance(val2, int | float):
-                if abs(val1 - val2) > tolerance:
-                    print(
-                        f"❌ {group_name}.{metric}: {val1} vs {val2} (diff: {abs(val1 - val2):.4f})",
-                    )
-                    reproducible = False
-                else:
-                    print(f"✅ {group_name}.{metric}: {val1} ≈ {val2}")
+            if val1 != val2:
+                print(
+                    f"❌ simple_policy.{metric}.{statistic}: {val1} vs {val2} "
+                    f"(diff: {abs(val1 - val2):.17g})",
+                )
+                reproducible = False
+            else:
+                print(f"✅ simple_policy.{metric}.{statistic}: {val1} == {val2}")
 
     return reproducible
 
@@ -204,68 +277,105 @@ def main():
     print("Social Navigation Benchmark - Reproducibility Check")
     print("=" * 60)
 
-    ensure_canonical_tree(categories=("benchmarks",))
-    results_base = get_artifact_category_path("benchmarks")
-    ensure_output_dir(results_base)
+    results_base = REPOSITORY_ROOT / "output" / "benchmarks"
+    results1: dict[str, Any] | None = None
+    results2: dict[str, Any] | None = None
+    try:
+        ensure_canonical_tree(categories=("benchmarks",))
+        results_base = get_artifact_category_path("benchmarks")
+        ensure_output_dir(results_base)
 
-    # Create temporary working directories
-    with (
-        tempfile.TemporaryDirectory(prefix="repro_test1_", dir=results_base) as tmp_dir1,
-        tempfile.TemporaryDirectory(prefix="repro_test2_", dir=results_base) as tmp_dir2,
-    ):
-        work_dir1 = Path(tmp_dir1)
-        work_dir2 = Path(tmp_dir2)
+        with (
+            tempfile.TemporaryDirectory(prefix="repro_test1_", dir=results_base) as tmp_dir1,
+            tempfile.TemporaryDirectory(prefix="repro_test2_", dir=results_base) as tmp_dir2,
+        ):
+            work_dir1 = Path(tmp_dir1)
+            work_dir2 = Path(tmp_dir2)
 
-        print(f"Working directories: {work_dir1.name}, {work_dir2.name}")
+            print(f"Working directories: {work_dir1.name}, {work_dir2.name}")
 
-        # Run same pipeline with different seeds
-        print("\n=== Run 1 (seed=123) ===")
-        results1 = run_benchmark_pipeline(work_dir1, seed=123)
+            # Run the same seeded pipeline twice in fresh directories. Different seeds
+            # represent different stochastic episodes, not a reproducibility failure.
+            print("\n=== Run 1 (seed=123) ===")
+            results1 = run_benchmark_pipeline(work_dir1, seed=123)
+            if results1["status"] != "passed":
+                _write_reproducibility_report(
+                    results_base,
+                    status="failed",
+                    stage=f"run1.{results1['stage']}",
+                    error=results1["error"],
+                    reproducible=False,
+                    run1=results1,
+                )
+                return 1
 
-        print("\n=== Run 2 (seed=456) ===")
-        results2 = run_benchmark_pipeline(work_dir2, seed=456)
+            print("\n=== Run 2 (seed=123) ===")
+            results2 = run_benchmark_pipeline(work_dir2, seed=123)
+            if results2["status"] != "passed":
+                _write_reproducibility_report(
+                    results_base,
+                    status="failed",
+                    stage=f"run2.{results2['stage']}",
+                    error=results2["error"],
+                    reproducible=False,
+                    run1=results1,
+                    run2=results2,
+                )
+                return 1
 
-        if results1 is None or results2 is None:
-            print("❌ Pipeline execution failed")
-            return 1
+            is_reproducible = compare_reproducibility(results1, results2)
 
-        # Compare for reproducibility
-        is_reproducible = compare_reproducibility(results1, results2)
+            print("\n=== Performance Summary ===")
+            print(
+                f"Run 1: {results1['episodes_count']} episodes "
+                f"in {results1['episode_gen_time']:.1f}s",
+            )
+            print(
+                f"Run 2: {results2['episodes_count']} episodes "
+                f"in {results2['episode_gen_time']:.1f}s",
+            )
+            print(f"Aggregation time: {results1['aggregate_time']:.1f}s avg")
 
-        # Performance summary
-        print("\n=== Performance Summary ===")
-        print(
-            f"Run 1: {results1['episodes_count']} episodes in {results1['episode_gen_time']:.1f}s",
-        )
-        print(
-            f"Run 2: {results2['episodes_count']} episodes in {results2['episode_gen_time']:.1f}s",
-        )
-        print(f"Aggregation time: {results1['aggregate_time']:.1f}s avg")
+            if not is_reproducible:
+                _write_reproducibility_report(
+                    results_base,
+                    status="failed",
+                    stage="comparison",
+                    error="Same-seed aggregate statistics differ",
+                    reproducible=False,
+                    run1=results1,
+                    run2=results2,
+                )
+                print("❌ Reproducibility check FAILED")
+                return 1
 
-        # Save reproducibility report
-        report = {
-            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
-            "reproducible": is_reproducible,
-            "run1": {
-                k: v for k, v in results1.items() if k not in ["episodes_file", "summary_file"]
-            },
-            "run2": {
-                k: v for k, v in results2.items() if k not in ["episodes_file", "summary_file"]
-            },
-        }
-
-        report_path = results_base / "reproducibility_check.json"
-        with report_path.open("w") as f:
-            json.dump(report, f, indent=2)
-
-        print(f"\nReproducibility report saved to: {report_path}")
-
-        if is_reproducible:
+            _write_reproducibility_report(
+                results_base,
+                status="passed",
+                stage="completed",
+                error=None,
+                reproducible=True,
+                run1=results1,
+                run2=results2,
+            )
             print("🎉 Reproducibility check PASSED")
             return 0
-        else:
-            print("❌ Reproducibility check FAILED")
-            return 1
+    except Exception as exc:
+        error = f"{type(exc).__name__}: {exc}"
+        print(f"❌ Reproducibility check failed during setup or execution: {error}")
+        try:
+            _write_reproducibility_report(
+                results_base,
+                status="failed",
+                stage="setup_or_execution",
+                error=error,
+                reproducible=False,
+                run1=results1,
+                run2=results2,
+            )
+        except Exception as report_exc:
+            print(f"❌ Could not write reproducibility report: {report_exc}")
+        return 1
 
 
 if __name__ == "__main__":

--- a/scripts/benchmark_repro_check.py
+++ b/scripts/benchmark_repro_check.py
@@ -126,7 +126,7 @@ def _write_reproducibility_report(
     return report_path
 
 
-def run_benchmark_pipeline(work_dir: Path, seed: int = 123):
+def run_benchmark_pipeline(work_dir: Path, seed: int = 123) -> dict[str, Any]:
     """Run complete benchmark pipeline in isolated directory."""
     from robot_sf.benchmark.aggregate import compute_aggregates_with_ci, read_jsonl
     from robot_sf.benchmark.runner import run_batch
@@ -212,7 +212,7 @@ def run_benchmark_pipeline(work_dir: Path, seed: int = 123):
     }
 
 
-def compare_reproducibility(results1, results2):
+def compare_reproducibility(results1: dict[str, Any], results2: dict[str, Any]) -> bool:
     """Compare two benchmark runs for reproducibility."""
     print("\n=== Reproducibility Analysis ===")
 
@@ -272,7 +272,7 @@ def compare_reproducibility(results1, results2):
     return reproducible
 
 
-def main():
+def main() -> int:
     """Run end-to-end reproducibility validation."""
     print("Social Navigation Benchmark - Reproducibility Check")
     print("=" * 60)

--- a/scripts/benchmark_repro_check.py
+++ b/scripts/benchmark_repro_check.py
@@ -360,7 +360,7 @@ def main():
             )
             print("🎉 Reproducibility check PASSED")
             return 0
-    except Exception as exc:
+    except (KeyError, OSError, TypeError, ValueError) as exc:
         error = f"{type(exc).__name__}: {exc}"
         print(f"❌ Reproducibility check failed during setup or execution: {error}")
         try:
@@ -373,7 +373,7 @@ def main():
                 run1=results1,
                 run2=results2,
             )
-        except Exception as report_exc:
+        except (OSError, TypeError, ValueError) as report_exc:
             print(f"❌ Could not write reproducibility report: {report_exc}")
         return 1
 

--- a/tests/test_benchmark_repro_check.py
+++ b/tests/test_benchmark_repro_check.py
@@ -1,0 +1,88 @@
+"""Focused contract tests for the optional benchmark reproducibility check."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "benchmark_repro_check.py"
+SPEC = importlib.util.spec_from_file_location("benchmark_repro_check", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def test_minimal_simple_policy_run_matches_current_aggregate_contract(tmp_path: Path):
+    """A real minimal run passes schema validation and emits the required aggregate shape."""
+    result = MODULE.run_benchmark_pipeline(tmp_path, seed=123)
+    assert result["status"] == "passed"
+    assert result["episodes_count"] == 2
+
+    summary = json.loads(result["summary_file"].read_text(encoding="utf-8"))
+    diagnostic = MODULE.validate_simple_policy_aggregate(summary)
+
+    assert diagnostic["status"] == "passed"
+    assert diagnostic["missing_metrics"] == []
+    assert diagnostic["missing_statistics"] == []
+
+
+def test_reports_missing_aggregate_metric_as_structured_failure():
+    """A stale fixture fails closed with a machine-readable missing-metric diagnostic."""
+    summary = {"simple_policy": {"path_efficiency": {"mean": 1.0, "median": 1.0, "p95": 1.0}}}
+
+    diagnostic = MODULE.validate_simple_policy_aggregate(summary)
+
+    assert diagnostic["status"] == "failed"
+    assert diagnostic["schema"] == "benchmark_repro_check.aggregate_validation.v1"
+    assert diagnostic["missing_metrics"] == ["collisions", "success"]
+    assert diagnostic["missing_statistics"] == []
+
+
+def test_same_seed_comparison_rejects_near_drift(tmp_path: Path):
+    """A 0.04 aggregate drift is a deterministic reproducibility failure."""
+
+    def write_summary(path: Path, collision_mean: float) -> None:
+        statistics = {"mean": 0.0, "median": 0.0, "p95": 0.0}
+        summary = {
+            "simple_policy": {
+                "collisions": {**statistics, "mean": collision_mean},
+                "path_efficiency": dict(statistics),
+                "success": dict(statistics),
+            }
+        }
+        path.write_text(json.dumps(summary), encoding="utf-8")
+
+    summary1 = tmp_path / "summary1.json"
+    summary2 = tmp_path / "summary2.json"
+    write_summary(summary1, 1.0)
+    write_summary(summary2, 1.04)
+    result1 = {"summary_file": summary1, "episodes_count": 2}
+    result2 = {"summary_file": summary2, "episodes_count": 2}
+
+    assert MODULE.compare_reproducibility(result1, result2) is False
+
+
+def test_main_writes_structured_report_before_pipeline_failure_exit(tmp_path: Path, monkeypatch):
+    """The optional lane leaves an uploadable report when a pipeline stage fails."""
+    failure = {
+        "status": "failed",
+        "stage": "aggregate_validation",
+        "error": {"missing_metrics": ["collisions"]},
+    }
+    monkeypatch.setattr(MODULE, "ensure_canonical_tree", lambda **_kwargs: None)
+    monkeypatch.setattr(MODULE, "get_artifact_category_path", lambda _category: tmp_path)
+    monkeypatch.setattr(MODULE, "ensure_output_dir", lambda _path: None)
+    monkeypatch.setattr(MODULE, "run_benchmark_pipeline", lambda _path, seed: failure)
+
+    assert MODULE.main() == 1
+
+    report = json.loads((tmp_path / "reproducibility_check.json").read_text(encoding="utf-8"))
+    assert report["schema"] == "benchmark_repro_check.report.v1"
+    assert report["status"] == "failed"
+    assert report["stage"] == "run1.aggregate_validation"
+    assert report["error"] == {"missing_metrics": ["collisions"]}
+    assert report["reproducible"] is False

--- a/tests/test_benchmark_repro_check.py
+++ b/tests/test_benchmark_repro_check.py
@@ -86,3 +86,24 @@ def test_main_writes_structured_report_before_pipeline_failure_exit(tmp_path: Pa
     assert report["stage"] == "run1.aggregate_validation"
     assert report["error"] == {"missing_metrics": ["collisions"]}
     assert report["reproducible"] is False
+
+
+def test_main_reports_expected_setup_error_with_narrow_handler(tmp_path: Path, monkeypatch):
+    """Expected filesystem setup failures retain the structured-report contract."""
+
+    def fail_setup(**_kwargs) -> None:
+        raise OSError("artifact root unavailable")
+
+    monkeypatch.setattr(MODULE, "REPOSITORY_ROOT", tmp_path)
+    monkeypatch.setattr(MODULE, "ensure_canonical_tree", fail_setup)
+
+    assert MODULE.main() == 1
+
+    report = json.loads(
+        (tmp_path / "output" / "benchmarks" / "reproducibility_check.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert report["status"] == "failed"
+    assert report["stage"] == "setup_or_execution"
+    assert report["error"] == "OSError: artifact root unavailable"


### PR DESCRIPTION
## Summary

Repair the manual reproducibility diagnostic against the aggregate schema the
current `simple_policy` runner actually emits, and isolate that diagnostic from
required pull-request CI.

## Linked Issues

- Closes `#5990`
- Relates `#1436`

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes

## What Changed

- Validate the canonical nested `collisions`, `path_efficiency`, and `success`
  aggregate statistics instead of obsolete flat metrics.
- Compare two fresh same-seed runs exactly and emit a structured report on both
  success and every failure path.
- Add a real minimal-run regression test plus fail-closed drift/error tests.
- Move the manual diagnostic into a separate `workflow_dispatch`-only,
  non-blocking job that is absent from the required `ci` aggregate.
- Record the verified command, result, and evidence boundary in the existing
  reproducibility context note.

## Why It Matters

- Added value: the manual diagnostic is useful again and cannot masquerade as a
  required PR gate.
- Expected impact: exact-head CI remains truthful while reproducibility failures
  retain structured, uploadable evidence.
- Why worth merging now: it removes a recurring false-red integration blocker.

## Research Result Guidance

- Target claim / blocker: reproducibility diagnostic compatibility and CI
  classification only; no simulation-performance claim.
- Comparator or baseline: same seed, two fresh local work directories.
- Evidence tier: diagnostic probe.
- Result classification: blocker-resolution.
- Decision / stop rule: fail if any required group, metric, statistic, report, or
  exact same-seed value differs.
- Parent issue / context note: `#5990`;
  `docs/context/issue_1436_reproducibility_flaky_acceptance.md`.
- New research-facing analysis tool: no; support diagnostic only.

## Domain-Aware Approval

- Required for this PR: yes — diagnostic evidence classification is changed.
- Domains reviewed: evidence classification.
- Status: approved.
- Approver/review source or waiver: independent Terra/high review of the exact diff,
  accepted after the drift, failure-report, and real-fixture findings were fixed.
- Validity checklist:
  - Target claim/hypothesis: the minimal same-seed diagnostic is deterministic
    and its optional CI classification is truthful.
  - Comparator or split/evidence validity: two fresh work directories, identical
    seed and canonical public runner/aggregator.
  - Fallback/degraded exclusions: missing group, metric, statistic, or report
    fails closed; no fallback result is accepted.
  - Claim boundary: passing means the minimal deterministic diagnostic is
    reproducible, not that a benchmark campaign is reproducible.
  - Implementation integrity vs experimental validity: implementation and
    classification were reviewed; no experiment or simulation-performance claim
    is made.

## Falsification / Non-Transfer Check

- Did mechanism activate: yes, the real minimal runner and aggregator executed.
- Result route: continue.
- Follow-up question: none required for this bounded support repair.

## Next Empirical Action

- Rerun needed: no for merge; future manual dispatches remain diagnostic-only.
- Extractor / analysis tool needed: no.
- Stop / revise / continue: continue.

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark_repro_check.py`
  — passed two 2-episode runs with 49 aggregate metrics and exact required values.
- `uv run pytest -q tests/test_benchmark_repro_check.py tests/test_ci_script_contract.py`
  — focused contracts passed.
- `uv run ruff check ...` and `uv run ruff format --check ...` — passed.
- Workflow contract confirms `reproducibility-check` is absent from required
  `ci.needs`.
- Independent Terra/high review: accepted after exact-drift, failure-report, and
  real-fixture findings were fixed.
- Final readiness reached 2,637 passing tests before an unrelated macOS `mktemp`
  collision in `test_ci_script_contract`; that exact test passed immediately in
  isolation. The earlier missing optional `cma` environment dependency was
  installed and its exact test passed.

## Risks / Rollout

- Compatibility risk: aggregate schema changes will now fail closed with a
  structured diagnostic.
- Failure mode: optional manual job concludes failure without making required CI
  red.
- Rollback: revert this PR to restore the previous inline manual step.

## Docs / Provenance

- Updated docs:
  `docs/context/issue_1436_reproducibility_flaky_acceptance.md`.
- Assumption: the canonical episode schema and current aggregator remain the
  authority.

## Downstream Propagation

- Parent issue updated: closes automatically.
- Claim map / benchmark report: NA; support diagnostic only.
- Leaderboard / artifact catalog: NA.
- Registry or config index: NA.
- Context index / memory note: existing context note updated.
- Follow-up issue: NA.

## Follow-Up Issues

- Deferred work: NA - no work is deferred by this bounded repair.
- Issues opened for follow-up: NA - no follow-up is required for acceptance.

## Reviewer Notes

- Verify the optional job remains absent from `ci.needs`.
- Verify a forced near-drift and a pipeline failure both produce fail-closed
  results and the latter writes `benchmark_repro_check.report.v1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark reproducibility checks with stricter validation and exact result comparisons.
  * Added structured diagnostics for setup, execution, validation, and comparison failures.
  * Ensured reproducibility reports are generated even when benchmark execution fails.

* **CI**
  * Moved reproducibility checks into an optional, manually triggered workflow job.
  * Reproducibility artifacts are preserved for troubleshooting without blocking standard checks.

* **Tests**
  * Added coverage for successful validation, missing metrics, deterministic drift, and failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->