### PR TITLE
test(ci): cover reproducibility job timeout

### DIFF
--- a/tests/test_ci_driver_contract.py
+++ b/tests/test_ci_driver_contract.py
@@ -26,6 +26,7 @@ CI_JOB_TIMEOUTS = {
     "compat-matrix": 30,
     "fast-pysf-compat": 10,
     "smoke-artifacts": 30,
+    "reproducibility-check": 10,
     "xdist-scratch-isolation": 15,
     "wheel-smoke-install": 20,
     "examples-smoke": 30,


### PR DESCRIPTION
Closes https://github.com/ll7/robot_sf_ll7/issues/6038

## What changed

Add the existing `reproducibility-check` job and its 10-minute bound to the exact CI job-timeout contract fixture.

This repairs the only failure in the current main run:
https://github.com/ll7/robot_sf_ll7/actions/runs/29697725012

The workflow already has `timeout-minutes: 10`; the strict set-equality fixture was stale after the job was added.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh pytest tests/test_ci_driver_contract.py -q` — 24 passed
- Independent YAML/fixture comparison: all 10 jobs match exactly
- `git diff --check`
- Independent review: ACCEPT

No workflow, production code, or assertion was weakened.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded CI validation to cover the reproducibility-check phase.
  - Added enforcement of a 10-minute execution limit for this phase, improving workflow consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->