### PR TITLE
test(planner): cover DWA native comparator defaults

### DIFF
--- a/tests/planner/test_dwa.py
+++ b/tests/planner/test_dwa.py
@@ -102,18 +102,59 @@ def test_dwa_config_builder_applies_explicit_acceleration_parameters() -> None:
 
 
 def test_dwa_prediction_scoring_is_opt_in_in_canonical_configs() -> None:
-    """The classic config retains static scoring while the variant opts into forecasts."""
+    """Canonical DWA configs retain exact defaults and make forecasting explicit."""
     config_dir = Path(__file__).resolve().parents[2] / "configs" / "algos"
     classic = yaml.safe_load((config_dir / "dwa_classic.yaml").read_text(encoding="utf-8"))
     predictive = yaml.safe_load(
         (config_dir / "dwa_prediction_scoring.yaml").read_text(encoding="utf-8")
     )
 
+    common_defaults = {
+        "allow_testing_algorithms": True,
+        "max_linear_speed": 1.0,
+        "max_angular_speed": 1.2,
+        "max_linear_acceleration": 0.8,
+        "max_angular_acceleration": 1.5,
+        "control_dt": 0.2,
+        "prediction_dt": 0.1,
+        "prediction_steps": 15,
+        "linear_samples": 7,
+        "angular_samples": 9,
+        "goal_tolerance": 0.25,
+        "robot_radius": 0.25,
+        "pedestrian_radius": 0.30,
+        "safety_margin": 0.10,
+        "clearance_distance": 2.0,
+        "obstacle_threshold": 0.5,
+        "obstacle_search_cells": 12,
+        "heading_weight": 0.8,
+        "clearance_weight": 1.2,
+        "velocity_weight": 0.25,
+        "progress_weight": 1.0,
+    }
+    assert classic == {
+        **common_defaults,
+        "planner_variant": "dwa",
+        "native_occupancy_resolution": 0.1,
+        "prediction_scoring_enabled": False,
+        "native_command": {
+            "command": [
+                "python3",
+                "scripts/benchmark/frozen_comparator_native_command.py",
+                "--planner-id",
+                "dwa",
+                "--config",
+                "configs/algos/dwa_classic.yaml",
+            ],
+            "entrypoint_path": "scripts/benchmark/frozen_comparator_native_command.py",
+            "mode": "persistent",
+            "step_timeout_sec": 10.0,
+            "require_static_geometry": True,
+        },
+    }
+    assert predictive == {**common_defaults, "prediction_scoring_enabled": True}
     assert build_dwa_config(classic).prediction_scoring_enabled is False
     assert build_dwa_config(predictive).prediction_scoring_enabled is True
-    assert {
-        key: value for key, value in classic.items() if key != "prediction_scoring_enabled"
-    } == {key: value for key, value in predictive.items() if key != "prediction_scoring_enabled"}
 
 
 def test_dwa_prediction_scoring_avoids_a_future_crossing() -> None:
@@ -508,7 +549,7 @@ def test_dwa_route_rescue_classic_config_has_rescue_disabled() -> None:
 
 
 def test_dwa_route_rescue_rescue_config_is_distinct_from_classic() -> None:
-    """The dwa_route_rescue.yaml has rescue enabled and differs from classic only in intervention fields."""
+    """The rescue variant keeps shared defaults while classic owns the native comparator contract."""
     config_dir = Path(__file__).resolve().parents[2] / "configs" / "algos"
     classic = yaml.safe_load((config_dir / "dwa_classic.yaml").read_text(encoding="utf-8"))
     rescue = yaml.safe_load((config_dir / "dwa_route_rescue.yaml").read_text(encoding="utf-8"))
@@ -525,9 +566,18 @@ def test_dwa_route_rescue_rescue_config_is_distinct_from_classic() -> None:
         "feasibility_slowdown_infeasible_ratio",
         "feasibility_slowdown_scale",
     }
-    assert {key: value for key, value in classic.items() if key not in intervention_keys} == {
-        key: value for key, value in rescue.items() if key not in intervention_keys
+    classic_only_comparator_keys = {
+        "planner_variant",
+        "native_occupancy_resolution",
+        "native_command",
     }
+    assert set(classic) - set(rescue) == classic_only_comparator_keys
+    assert set(rescue) - set(classic) == intervention_keys
+    assert {
+        key: value
+        for key, value in classic.items()
+        if key not in intervention_keys | classic_only_comparator_keys
+    } == {key: value for key, value in rescue.items() if key not in intervention_keys}
 
 
 def test_dwa_route_rescue_diagnostics_report_rescue_state() -> None:


### PR DESCRIPTION
## Summary

Update the exact DWA config-contract tests for the native comparator fields
merged in #6043. No production or configuration behavior changes.

## Linked Issues

- Refs #6046
- Relates to #6043

## Stack / Dependency

- Base dependency: main
- Required prior PRs: #6043
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason: exact test contract follows the already-merged
  canonical DWA config.

## What Changed

- Preserve strict whole-dictionary assertions for classic and predictive DWA.
- Add `planner_variant`, `native_occupancy_resolution`, and the complete
  persistent `native_command` contract.
- Keep the route-rescue comparison exact while permitting only its intentional
  intervention fields.

## Why Matters

- Added value: restores green main CI without weakening config coverage.
- Expected impact: both observed main failures have one known assertion fixed.
- Why worth merging now: main is red on this single deterministic regression.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: main-CI regression
  only.
- Comparator or baseline, if applicable: NA.
- Evidence tier: NA.
- Result classification: NA.
- Decision / stop rule, if applicable: merge only after exact-head review and
  focused test success.
- Parent issue / synthesis surface update: #6046.
- New analysis tool: NA — test-only contract update.

## Domain-Aware Approval

- Required for this PR: no — no execution, evidence, or claim semantics change.
- Domains reviewed: NA.
- Status: not required.
- Approver/review source or waiver: independent exact-head code review.
- Validity checklist: existing runtime/config behavior is unchanged.

## Falsification / Non-Transfer Check

- Did mechanism activate? NA.
- Did intervention change command source or trajectory? no.
- Did scenario contain the failure mode? yes — exact config assertion mismatch.
- Result route: continue.
- Follow-up issue: none.

## Next Empirical Action

- Rerun needed: no research rerun; hosted CI must rerun.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: continue through normal exact-head gate.
- Proposed child issue or existing follow-up: none.

## Validation / Proof

- Evidence change works here: the focused assertion now matches the canonical
  config without subset weakening.
- Benchmarks / smoke tests:

```text
scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/planner/test_dwa.py -q
# 39 passed

scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check tests/planner/test_dwa.py
git diff --check
```

Independent exact-head review accepted
`aa10a1476f89cc3d44aa9c2a57a5be113b6ba8f4`.

## Risks / Rollout

- Compatibility risks: none; tests only.
- Failure modes: accidentally omitting a config default; prevented by exact
  dictionary comparison.
- Rollback / fallback plan: revert this test-only PR if #6043 is reverted.

## Docs / Provenance

- Updated docs: NA.
- Relevant design provenance: #6043 and failed main runs 29704571555,
  29704669257.
- Assumptions to preserve: native comparator fields remain part of the frozen
  classic DWA config.

## Downstream Propagation

- Parent issue updated: no — after merge, confirm green main and update #6046.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened: no.
- Not applicable because: test-only CI repair.

## Follow-Up Issues

- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes

- Verify the assertion remains exact rather than a subset.
- Verify no production/config file changed.
- Known limitations: hosted full CI remains the final green-main proof.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened configuration contract tests for prediction scoring to verify complete expected settings and generated configurations.
  * Improved route-rescue validation to ensure only approved comparator and intervention settings differ from the classic configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



