### PR TITLE
docs: align issue snapshot command with CLI (#6031)

### DIFF
--- a/docs/templates/token_efficient_thread_profile.md
+++ b/docs/templates/token_efficient_thread_profile.md
@@ -38,7 +38,7 @@ changes.
   instead of redefining classes here.
 - `context_budget` defaults to compact helpers before broad reads:
   `uv run python scripts/dev/autopilot_state_snapshot.py --include-worktrees`,
-  `uv run python scripts/dev/snapshot_issue_batch.py --json`,
+  `uv run python scripts/dev/snapshot_issue_batch.py --claimable --json`,
   `uv run python scripts/dev/snapshot_pr_queue.py --active --json`, and
   `uv run python scripts/dev/run_compact_validation.py -- <command>`.
 - `resume_checkpoint` should be the first thing refreshed after compaction or

--- a/tests/dev/test_token_efficient_thread_profile_issue_snapshot_command.py
+++ b/tests/dev/test_token_efficient_thread_profile_issue_snapshot_command.py
@@ -1,0 +1,72 @@
+"""Regression coverage for the issue snapshot command in the token-efficient profile."""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from scripts.dev.snapshot_issue_batch import _parse_args, main
+
+DOC_PATH = (
+    Path(__file__).resolve().parents[2] / "docs" / "templates" / "token_efficient_thread_profile.md"
+)
+SNAPSHOT_COMMAND_RE = re.compile(
+    r"`uv run python scripts/dev/snapshot_issue_batch\.py (?P<args>[^`]+)`"
+)
+
+
+def _snapshot_invocations(doc_text: str) -> list[str]:
+    """Return argument strings for documented issue snapshot invocations."""
+    return [match.group("args").strip() for match in SNAPSHOT_COMMAND_RE.finditer(doc_text)]
+
+
+def test_documented_issue_snapshot_uses_claimable_selector() -> None:
+    """The broad-discovery issue snapshot command must use ``--claimable``."""
+    invocations = _snapshot_invocations(DOC_PATH.read_text(encoding="utf-8"))
+
+    assert any("--claimable" in args for args in invocations)
+
+
+def test_documented_issue_snapshot_is_not_selector_less() -> None:
+    """The documented issue snapshot must not use the rejected bare ``--json`` form."""
+    invocations = _snapshot_invocations(DOC_PATH.read_text(encoding="utf-8"))
+
+    for invocation in invocations:
+        parsed = _parse_args(shlex.split(invocation))
+        assert parsed.claimable or parsed.issues, (
+            f"documented snapshot_issue_batch.py invocation lacks a selector: {invocation!r}"
+        )
+
+
+def test_documented_issue_snapshot_succeeds_against_cli() -> None:
+    """The documented broad-discovery command drives the production parser offline."""
+    invocations = _snapshot_invocations(DOC_PATH.read_text(encoding="utf-8"))
+    claimable_invocations = [
+        invocation for invocation in invocations if _parse_args(shlex.split(invocation)).claimable
+    ]
+    assert claimable_invocations, "expected a --claimable issue snapshot invocation"
+
+    issue_payload = [
+        {
+            "number": 6031,
+            "title": "example claimable issue",
+            "state": "OPEN",
+            "url": "https://github.test/issues/6031",
+            "labels": [],
+            "assignees": [],
+        }
+    ]
+    with (
+        patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh,
+        patch("scripts.dev.snapshot_issue_batch._batch_claim_statuses") as mock_claims,
+    ):
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_payload), stderr="")
+        mock_claims.return_value = {
+            6031: {"ok": True, "claimed": False, "claim_ref": None, "sha": None}
+        }
+        rc = main(shlex.split(claimable_invocations[0]))
+
+    assert rc == 0

--- a/tests/dev/test_token_efficient_thread_profile_issue_snapshot_command.py
+++ b/tests/dev/test_token_efficient_thread_profile_issue_snapshot_command.py
@@ -27,13 +27,17 @@ def test_documented_issue_snapshot_uses_claimable_selector() -> None:
     """The broad-discovery issue snapshot command must use ``--claimable``."""
     invocations = _snapshot_invocations(DOC_PATH.read_text(encoding="utf-8"))
 
-    assert any("--claimable" in args for args in invocations)
+    assert invocations, "No documented snapshot_issue_batch.py invocations found"
+    assert any(_parse_args(shlex.split(args)).claimable for args in invocations), (
+        "Expected at least one documented invocation to use the --claimable selector"
+    )
 
 
 def test_documented_issue_snapshot_is_not_selector_less() -> None:
     """The documented issue snapshot must not use the rejected bare ``--json`` form."""
     invocations = _snapshot_invocations(DOC_PATH.read_text(encoding="utf-8"))
 
+    assert invocations, "No documented snapshot_issue_batch.py invocations found"
     for invocation in invocations:
         parsed = _parse_args(shlex.split(invocation))
         assert parsed.claimable or parsed.issues, (
@@ -41,7 +45,7 @@ def test_documented_issue_snapshot_is_not_selector_less() -> None:
         )
 
 
-def test_documented_issue_snapshot_succeeds_against_cli() -> None:
+def test_documented_issue_snapshot_succeeds_against_cli(capsys) -> None:  # type: ignore[no-untyped-def]
     """The documented broad-discovery command drives the production parser offline."""
     invocations = _snapshot_invocations(DOC_PATH.read_text(encoding="utf-8"))
     claimable_invocations = [
@@ -69,4 +73,14 @@ def test_documented_issue_snapshot_succeeds_against_cli() -> None:
         }
         rc = main(shlex.split(claimable_invocations[0]))
 
-    assert rc == 0
+    assert rc == 0, f"Expected documented command to succeed, got exit code {rc}"
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema"] == "issue_batch_snapshot.v1", "CLI emitted an unexpected schema"
+    assert payload["mode"] == "claimable", "CLI did not run the documented claimable mode"
+    issues_by_number = {issue["number"]: issue for issue in payload["issues"]}
+    assert list(issues_by_number) == [6031], "CLI did not emit the mocked claimable issue"
+    assert issues_by_number[6031]["classification"] == "claimable", (
+        "Mocked unclaimed issue was not classified as claimable"
+    )
+    mock_gh.assert_called_once()
+    mock_claims.assert_called_once_with([6031], remote="origin")

--- a/tests/dev/test_token_efficient_thread_profile_issue_snapshot_command.py
+++ b/tests/dev/test_token_efficient_thread_profile_issue_snapshot_command.py
@@ -45,6 +45,14 @@ def test_documented_issue_snapshot_is_not_selector_less() -> None:
         )
 
 
+def test_selector_less_issue_snapshot_is_rejected(capsys) -> None:  # type: ignore[no-untyped-def]
+    """The bare ``--json`` form must remain invalid without a selector."""
+    rc = main(["--json"])
+
+    assert rc == 1
+    assert "at least one issue number is required unless --claimable" in capsys.readouterr().err
+
+
 def test_documented_issue_snapshot_succeeds_against_cli(capsys) -> None:  # type: ignore[no-untyped-def]
     """The documented broad-discovery command drives the production parser offline."""
     invocations = _snapshot_invocations(DOC_PATH.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

Align the token-efficient profile's issue snapshot command with the supported CLI discovery form and add an offline parser regression test.

Refs #6031

## Linked Issues

- Refs #6031

## Stack / Dependency

- Base dependency: none
- Safe to review independently: yes

## What Changed

- Document `uv run python scripts/dev/snapshot_issue_batch.py --claimable --json` for broad issue discovery.
- Add a focused test that parses the documented invocation and drives the production CLI with GitHub mocked.
- The implementation helper is unchanged.

## Why It Matters

The documented workflow now uses the CLI's supported no-number discovery selector, and the regression test prevents selector-less drift from returning.

## Research Result Guidance

NA — documentation and focused test only; no research, benchmark, metric, schema, or paper-facing claim.

## Domain-Aware Approval

- Required for this PR: no — docs-only support change with no evidence claim.
- Status: not required.

## Validation / Proof

- `uv run python scripts/dev/snapshot_issue_batch.py --claimable --json`
- `uv run pytest -q tests/dev/test_snapshot_issue_batch.py`
- `uv run ruff check tests/dev/test_snapshot_issue_batch.py`
- `git diff --check`
- `uv run pytest -q tests/dev/test_snapshot_issue_batch.py tests/dev/test_token_efficient_thread_profile_issue_snapshot_command.py`
- `uv run ruff check tests/dev/test_snapshot_issue_batch.py tests/dev/test_token_efficient_thread_profile_issue_snapshot_command.py`
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`

All pass; the snapshot command returned a valid `issue_batch_snapshot.v1` payload and the focused suite passed 23 tests.

## Docs / Provenance

- Updated docs: `docs/templates/token_efficient_thread_profile.md`.
- Artifact classification: no generated artifacts are committed; `/tmp/issue-6031-snapshot.json` is disposable validation output.

## Downstream Propagation

- Parent issue updated: no.
- Claim map / benchmark report / registry / context index: NA.
- Not applicable because this is a support documentation and regression-test change with no research evidence.

## Follow-Up Issues

- None.

## Reviewer Notes

- Verify the documented command includes `--claimable` and that the regression test uses the real parser and `main()` with GitHub mocked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage that validates the “issue snapshot” command examples referenced in the documentation.
  * Ensured documented invocations always include an explicit selector (e.g., claimable or issues) and that at least one uses the claimable selector.
  * Added negative coverage to confirm selector-less usage is rejected with the expected error.
  * Added an integration-style check that the documented claimable invocation runs successfully and emits the expected JSON output shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->