### PR TITLE
fix(dev): allow checkout-local fast-pysf source

### DIFF
--- a/scripts/dev/run_worktree_shared_venv.sh
+++ b/scripts/dev/run_worktree_shared_venv.sh
@@ -12,14 +12,10 @@ For linked worktrees, the helper also derives a per-worktree COVERAGE_FILE unles
 set, preventing parallel focused pytest runs from sharing output/coverage/.coverage state.
 
 Because the shared env is reused without resync (UV_NO_SYNC=1), a stale owning-checkout .venv can
-lag the current worktree source. The vendored `pysocialforce` package (force-included from
-fast-pysf/pysocialforce and shadowed by PYTHONPATH=$PWD:$PWD/fast-pysf) is especially drift-prone: importing
-a newer API from a stale install fails mid-collection with a confusing ImportError. The helper
-therefore runs a cheap freshness check comparing the installed `pysocialforce` package against this
-checkout's fast-pysf/pysocialforce source and fails early with an actionable message when they
-diverge. Refresh the owning checkout with
-`uv sync --all-extras --reinstall-package robot-sf`; a plain sync does not rebuild this
-force-included source.
+lag the current worktree source. The vendored `pysocialforce` package is shadowed by
+PYTHONPATH=$PWD:$PWD/fast-pysf, so an initialized checkout source is authoritative and must not be
+rejected because the reused installed copy differs. If the source package is unavailable, the
+helper leaves the installed-environment decision to the command that imports it.
 
 Standalone commands with a verified boundary that does not import project packages can use
 --standalone. That mode skips the project-source freshness check and does not add the worktree root
@@ -31,9 +27,8 @@ Options:
   --standalone           Run a command that is verified not to import project packages. This skips
                          the project-source freshness check and does not prepend the worktree root
                          to PYTHONPATH.
-  --no-freshness-check   Skip the shared-venv freshness check. Use only when you have confirmed the
-                         reused env matches this checkout (e.g. an editable install that already
-                         points at this source). Also skippable via
+  --no-freshness-check   Retained for compatibility; checkout-local fast-pysf source already takes
+                         precedence over any reused installed copy. Also accepted via
                          ROBOT_SF_VENV_FRESHNESS_CHECK=skip.
   -h, --help             Show this help message.
 
@@ -118,13 +113,9 @@ if [[ ! -x "$venv_path/bin/python" ]]; then
 fi
 
 check_shared_venv_freshness() {
-  # Guard the shared-venv fast path against a stale owning-checkout environment.
-  #
-  # The vendored `pysocialforce` package is force-included from fast-pysf/pysocialforce and is
-  # shadowed by PYTHONPATH=$PWD:$PWD/fast-pysf. With UV_NO_SYNC=1 a reused env can lag the current
-  # worktree source, so importing a newer
-  # API from a stale install fails mid-collection with a confusing ImportError. Compare the
-  # installed package's .py files against this checkout's source and fail early on divergence.
+  # A checkout-local fast-pysf source package is authoritative because it is placed first on
+  # PYTHONPATH below. Do not compare it with the reused installed copy: that copy may belong to the
+  # owning checkout and can legitimately differ from this linked worktree.
   local venv="$1"
   local src_pkg="$repo_root/fast-pysf/pysocialforce"
 
@@ -132,37 +123,9 @@ check_shared_venv_freshness() {
     return 0
   fi
 
-  local installed_pkg=""
-  local candidate
-  for candidate in "$venv"/lib/python*/site-packages/pysocialforce; do
-    if [[ -d "$candidate" ]]; then
-      installed_pkg="$candidate"
-      break
-    fi
-  done
-
-  if [[ -z "$installed_pkg" ]]; then
-    return 0
-  fi
-
-  local src_file rel_path installed_file
-  while IFS= read -r -d '' src_file; do
-    rel_path="${src_file#"$src_pkg"/}"
-    installed_file="$installed_pkg/$rel_path"
-    if [[ ! -f "$installed_file" ]] || ! cmp -s "$src_file" "$installed_file"; then
-      cat >&2 <<EOF
-Shared virtualenv is stale relative to this checkout: $venv
-  diverging module: pysocialforce/$rel_path
-The reused env (UV_NO_SYNC=1) lacks source present in fast-pysf/pysocialforce, so imports can
-fail mid-run with a confusing ImportError. Refresh the owning checkout with
-'uv sync --all-extras --reinstall-package robot-sf'; a plain sync does not rebuild this
-force-included source; use --standalone for a command verified not to import project packages, or rerun with
---no-freshness-check (or ROBOT_SF_VENV_FRESHNESS_CHECK=skip) once you have confirmed the env matches
-this checkout.
-EOF
-      return 1
-    fi
-  done < <(find "$src_pkg" -type f -name '*.py' -print0)
+  # PYTHONPATH makes the checkout source authoritative; an owning checkout's
+  # installed copy is intentionally not a freshness boundary for this helper.
+  return 0
 }
 
 if [[ -z "$standalone" && -z "$skip_freshness" && "${ROBOT_SF_VENV_FRESHNESS_CHECK:-}" != "skip" ]]; then

--- a/scripts/dev/run_worktree_shared_venv.sh
+++ b/scripts/dev/run_worktree_shared_venv.sh
@@ -113,15 +113,7 @@ if [[ ! -x "$venv_path/bin/python" ]]; then
 fi
 
 check_shared_venv_freshness() {
-  # A checkout-local fast-pysf source package is authoritative because it is placed first on
-  # PYTHONPATH below. Do not compare it with the reused installed copy: that copy may belong to the
-  # owning checkout and can legitimately differ from this linked worktree.
-  local venv="$1"
   local src_pkg="$repo_root/fast-pysf/pysocialforce"
-
-  if [[ ! -d "$src_pkg" ]]; then
-    return 0
-  fi
 
   # PYTHONPATH makes the checkout source authoritative; an owning checkout's
   # installed copy is intentionally not a freshness boundary for this helper.

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -961,17 +961,12 @@ def test_worktree_shared_venv_helper_has_freshness_check_wiring() -> None:
     """The shared-venv helper must guard the reused env against source drift (issue #5023)."""
     script_text = RUN_WORKTREE_SHARED_VENV.read_text(encoding="utf-8")
 
-    # The freshness gate compares the vendored pysocialforce install against fast-pysf source.
+    # The freshness gate recognizes the checkout-local source as authoritative.
     assert "check_shared_venv_freshness()" in script_text
     assert 'local src_pkg="$repo_root/fast-pysf/pysocialforce"' in script_text
-    assert 'for candidate in "$venv"/lib/python*/site-packages/pysocialforce' in script_text
-    assert 'cmp -s "$src_file" "$installed_file"' in script_text
-    assert "Shared virtualenv is stale relative to this checkout" in script_text
-    assert "diverging module: pysocialforce/" in script_text
-    assert "uv sync --all-extras --reinstall-package robot-sf" in script_text
-    # Standalone commands with a verified no-project-import boundary can skip project drift safely.
+    assert "source package is authoritative" in script_text
+    # Standalone commands with a verified no-project-import boundary remain supported.
     assert "--standalone" in script_text
-    assert "use --standalone for a command verified not to import project packages" in script_text
     assert 'if [[ -z "$standalone" ]]; then' in script_text
     # The gate is skippable for advanced users with a confirmed-matching env.
     assert "--no-freshness-check" in script_text
@@ -1059,7 +1054,7 @@ def _make_freshness_fixture_repo(
 def test_worktree_shared_venv_freshness_check_fails_early_on_stale_env(
     tmp_path: Path,
 ) -> None:
-    """A stale shared env (missing the newer source API) must fail before uv runs (issue #5023)."""
+    """A checkout source package must win over a stale installed copy (issue #6003)."""
     repo, venv, env = _make_freshness_fixture_repo(
         tmp_path,
         installed_scene="# stale install without normalize_integration_scheme\n",
@@ -1083,12 +1078,9 @@ def test_worktree_shared_venv_freshness_check_fails_early_on_stale_env(
         check=False,
     )
 
-    assert result.returncode == 2
-    assert "Shared virtualenv is stale relative to this checkout" in result.stderr
-    assert "diverging module: pysocialforce/scene.py" in result.stderr
-    assert "uv sync --all-extras --reinstall-package robot-sf" in result.stderr
-    # The freshness gate must fire before the underlying command is executed.
-    assert "uv-reached" not in result.stderr
+    assert result.returncode == 7
+    assert "uv-reached" in result.stderr
+    assert "Shared virtualenv is stale" not in result.stderr
 
 
 def test_worktree_shared_venv_freshness_check_passes_on_fresh_env(

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -958,13 +958,13 @@ def test_worktree_shared_venv_helper_reports_relative_missing_env() -> None:
 
 
 def test_worktree_shared_venv_helper_has_freshness_check_wiring() -> None:
-    """The shared-venv helper must guard the reused env against source drift (issue #5023)."""
+    """The shared-venv helper recognizes checkout-local source as authoritative (issue #6003)."""
     script_text = RUN_WORKTREE_SHARED_VENV.read_text(encoding="utf-8")
 
     # The freshness gate recognizes the checkout-local source as authoritative.
     assert "check_shared_venv_freshness()" in script_text
     assert 'local src_pkg="$repo_root/fast-pysf/pysocialforce"' in script_text
-    assert "source package is authoritative" in script_text
+    assert "checkout source authoritative" in script_text
     # Standalone commands with a verified no-project-import boundary remain supported.
     assert "--standalone" in script_text
     assert 'if [[ -z "$standalone" ]]; then' in script_text
@@ -1051,7 +1051,7 @@ def _make_freshness_fixture_repo(
     return repo, venv, env
 
 
-def test_worktree_shared_venv_freshness_check_fails_early_on_stale_env(
+def test_worktree_shared_venv_ignores_stale_installed_copy(
     tmp_path: Path,
 ) -> None:
     """A checkout source package must win over a stale installed copy (issue #6003)."""


### PR DESCRIPTION
Closes #6003\n\nThe shared-venv helper now trusts the checkout-local fast-pysf source, which is already first on PYTHONPATH, instead of rejecting a differing reused installed copy.\n\nValidation: scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_ci_script_contract.py -q (84 passed); bash -n; uv run ruff check tests/test_ci_script_contract.py.