### PR TITLE
fix(ci): clamp per_page to GitHub max in PR files collector (#5924)

### DIFF
--- a/scripts/ci/collect_pr_files.py
+++ b/scripts/ci/collect_pr_files.py
@@ -57,6 +57,11 @@ if TYPE_CHECKING:
 
 DEFAULT_REPO = "ll7/robot_sf_ll7"
 DEFAULT_PER_PAGE = 100
+# GitHub silently caps the pulls/.../files ``per_page`` at 100 regardless of the
+# requested size (https://docs.github.com/rest/pulls/pulls#list-pull-requests-files).
+# ``fetch_all_pr_files`` clamps to this so pagination termination compares
+# against the page size the server actually honors (issue #5924).
+GITHUB_MAX_PER_PAGE = 100
 DEFAULT_MAX_ATTEMPTS = 5
 DEFAULT_BASE_DELAY = 1.0
 DEFAULT_MAX_DELAY = 30.0
@@ -230,7 +235,9 @@ def fetch_all_pr_files(  # noqa: PLR0913
     repo, pr_number:
         GitHub ``owner/repo`` and PR number.
     per_page:
-        Page size (GitHub caps this at 100).
+        Requested page size. GitHub caps this at ``GITHUB_MAX_PER_PAGE`` (100);
+        any larger value is clamped down so the pagination-termination check
+        compares against the page size the server actually honors.
     max_attempts:
         Retry attempts *per page* before failing closed.
     base_delay, max_delay:
@@ -243,6 +250,11 @@ def fetch_all_pr_files(  # noqa: PLR0913
         raise ValueError("max_attempts must be at least 1")
     if per_page < 1:
         raise ValueError("per_page must be at least 1")
+    # GitHub silently caps ``per_page`` at 100. Clamp to the effective maximum so
+    # the ``len(files) < per_page`` termination check below reflects the page
+    # size the server actually honors; otherwise a requested size above the cap
+    # would terminate pagination after the first page and truncate the list.
+    per_page = min(per_page, GITHUB_MAX_PER_PAGE)
 
     # Resolve injectable seams lazily so tests (and callers) that patch the
     # module-level ``_run_gh_api_page`` / ``time.sleep`` references at runtime are

--- a/tests/ci/test_collect_pr_files.py
+++ b/tests/ci/test_collect_pr_files.py
@@ -281,6 +281,46 @@ def test_pagination_collects_all_pages() -> None:
     assert files[-1]["filename"] == "c.py"
 
 
+def test_per_page_above_github_max_does_not_truncate_pagination() -> None:
+    """Regression for issue #5924: requesting ``per_page`` above GitHub's 100 cap
+    must not terminate pagination early.
+
+    GitHub silently caps ``per_page`` at 100, so each response page carries at
+    most 100 entries regardless of the request. Without clamping, the
+    ``len(files) < per_page`` termination check is always true for a requested
+    ``per_page`` above the cap, pagination stops after the first page, and the
+    collected file list is truncated. ``fetch_all_pr_files`` must clamp to the
+    effective maximum so the comparison reflects the page size the server
+    honors, and the clamped size must flow through to the page fetcher.
+    """
+    seen_per_page: list[int] = []
+    full_page = [_entry(f"a{i}.py", "modified") for i in range(100)]
+    last_page = [_entry("b.py", "added")]
+
+    def run_page(repo, pr_number, page, per_page, *, timeout):
+        seen_per_page.append(per_page)
+        if page == 1:
+            return _proc(stdout=json.dumps(full_page))
+        if page == 2:
+            return _proc(stdout=json.dumps(last_page))
+        return _proc(stdout="[]")
+
+    files = fetch_all_pr_files(
+        "o/r",
+        "5924",
+        per_page=500,  # above GitHub's 100 cap
+        run_page=run_page,
+        sleep=lambda _d: None,
+        rng=lambda: 0.0,
+    )
+
+    # The clamped page size (100) is what the fetcher actually requests, and
+    # pagination continued past the first full page to collect every entry.
+    assert seen_per_page == [100, 100]
+    assert len(files) == 101
+    assert files[-1]["filename"] == "b.py"
+
+
 # ── outputs: changed / status TSV / added ────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fixes the pagination-truncation bug in `fetch_all_pr_files` tracked by #5924.

`fetch_all_pr_files` (`scripts/ci/collect_pr_files.py`) drove its pagination
termination check off the **requested** `per_page`:

```python
if len(files) < per_page:
    break  # last (partial) page
```

GitHub silently caps the `repos/{owner}/{repo}/pulls/{number}/files`
`per_page` query parameter at **100** regardless of what is requested. So when
a caller passes a `per_page` above the cap (e.g. `--per-page 500`, or any
larger default), the server still returns at most 100-entry pages, but the
termination check `len(files) < per_page` (e.g. `100 < 500`) is **always**
true — pagination stops after the very first page and the collected changed-file
list is silently truncated. The downstream `PR Contract Check` / `PR body
contracts` jobs then operate on an incomplete file set.

## Fix

Clamp `per_page` to GitHub's hard cap (`GITHUB_MAX_PER_PAGE = 100`) inside
`fetch_all_pr_files`, after the existing `per_page >= 1` validation. The
clamped value then flows both into the page request and into the termination
check, so the check compares against the page size the server actually honors.

## Test

Adds an offline regression test
`test_per_page_above_github_max_does_not_truncate_pagination` in
`tests/ci/test_collect_pr_files.py`. With a requested `per_page=500` it scripts
a 100-entry first page, a 1-entry second page, and an empty third page, then
asserts:

- the page fetcher receives the clamped size (`[100, 100]`), and
- pagination continues past the first full page to collect all `101` entries.

Red-phase proof: with the clamp line removed, the test fails as
`seen_per_page == [500]` (one page fetched, pagination terminated early) —
exactly the truncation the issue describes.

## Validation

All run from this worktree via the shared-venv runner (`PYTHONPATH` pointing at
the active worktree):

```sh
uv run ruff check scripts/ci/collect_pr_files.py tests/ci/test_collect_pr_files.py   # All checks passed!
uv run ruff format --check scripts/ci/collect_pr_files.py tests/ci/test_collect_pr_files.py   # 2 files already formatted
uv run pytest tests/ci/test_collect_pr_files.py -v   # 21 passed
```

## Scope

Only the two in-scope files are touched; no workflow, dependency, or config
changes. Opened as a **draft** per packet contract — merging remains forbidden.

Refs #5924


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request file collection when requesting more than 100 files per page.
  * Pagination now continues correctly, ensuring complete changed-file lists are returned.

* **Tests**
  * Added coverage for requests exceeding the service’s 100-item page limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->