### PR TITLE
feat(canary): surface executed_scenario_id in Robot SF receipt (#5963)

### DIFF
--- a/robot_sf/benchmark/socnavbench_canary.py
+++ b/robot_sf/benchmark/socnavbench_canary.py
@@ -455,9 +455,15 @@ def run_robot_sf_receipt_from_rollout(
     This is the canonical path for ``run_canary``: the rollout is executed once and shared
     across both suite receipts to guarantee that the trajectory and denominator are identical.
 
+    The receipt records ``executed_scenario_id`` from ``PolicyRolloutResult.scenario_id`` so it
+    honestly reflects the scenario that *actually ran*, independent of the canonical cross-suite
+    mapping label (``scenario_mapping.robot_sf_scenario_id``). The two are expected to agree for
+    this canary, but carrying the executed value separately keeps the receipt honest if they
+    ever diverge and avoids re-deriving ground truth from the mapping.
+
     Returns:
         JSON-safe Robot SF receipt dict with policy identity (including runtime provenance),
-        mapping, metric value, and the suite-specific ratio definition.
+        mapping, metric value, the suite-specific ratio definition, and the executed scenario id.
     """
     if rollout.scenario_id != mapping.robot_sf_scenario_id:
         raise CanaryError(
@@ -490,6 +496,9 @@ def run_robot_sf_receipt_from_rollout(
         "denominator": denominator,
         "trajectory_length": len(rollout.robot_positions),
         "executed_policy": True,
+        # Actually-executed scenario name from PolicyRolloutResult.scenario_id, recorded
+        # additively so the receipt reports what ran independent of the mapping label.
+        "executed_scenario_id": rollout.scenario_id,
         "claim_boundary": CROSS_BENCHMARK_CLAIM_BOUNDARY,
     }
 

--- a/tests/benchmark/test_socnavbench_canary.py
+++ b/tests/benchmark/test_socnavbench_canary.py
@@ -179,6 +179,43 @@ def test_robot_sf_receipt_is_deterministic() -> None:
     assert first["denominator"] == second["denominator"]
 
 
+def test_robot_sf_receipt_records_executed_scenario_id_from_rollout() -> None:
+    """The Robot SF receipt surfaces PolicyRolloutResult.scenario_id as executed_scenario_id.
+
+    The additive field records the scenario that *actually ran*, independent of the canonical
+    cross-suite mapping label (scenario_mapping.robot_sf_scenario_id), so the receipt stays
+    honest if the two ever diverge. It must come from the rollout ground truth, not from the
+    mapping, and it must never silently reuse the SocNavBench (cross-suite) label.
+    """
+    from robot_sf.benchmark.canary_rollout import execute_pinned_policy
+
+    policy = resolve_pinned_policy()
+    mapping = resolve_scenario_mapping()
+    rollout = execute_pinned_policy(seed=mapping.seed, algo_config=PINNED_POLICY_ALGO_CONFIG)
+    receipt = run_robot_sf_receipt_from_rollout(policy=policy, mapping=mapping, rollout=rollout)
+    # The field is present and carries the actually-executed scenario id from the rollout.
+    assert "executed_scenario_id" in receipt
+    assert receipt["executed_scenario_id"] == rollout.scenario_id
+    # It is a concrete, non-placeholder string.
+    assert isinstance(receipt["executed_scenario_id"], str)
+    assert receipt["executed_scenario_id"].strip()
+    assert "tbd" not in receipt["executed_scenario_id"].lower()
+    # For this canary the executed id agrees with the declared Robot SF mapping label...
+    assert receipt["executed_scenario_id"] == mapping.robot_sf_scenario_id
+    # ...but it is recorded independently and must not reuse the cross-suite label.
+    assert receipt["executed_scenario_id"] != mapping.socnavbench_scenario_id
+    assert receipt["executed_scenario_id"] != receipt["scenario_mapping"]["socnavbench_scenario_id"]
+
+
+def test_run_canary_robot_sf_suite_records_executed_scenario_id(tmp_path: Path) -> None:
+    """The joint receipt's Robot SF suite must carry the executed_scenario_id field."""
+    receipt = run_canary(out_dir=tmp_path, allow_synthetic_traversible=True)
+    robot_sf_suite = next(s for s in receipt["suites"] if s["suite"] == "Robot SF")
+    assert "executed_scenario_id" in robot_sf_suite
+    assert robot_sf_suite["executed_scenario_id"] == receipt["scenario_mapping"]["robot_sf_scenario_id"]
+    assert robot_sf_suite["executed_scenario_id"] != receipt["scenario_mapping"]["socnavbench_scenario_id"]
+
+
 def test_socnavbench_receipt_runs_without_licensed_data_via_test_flag(tmp_path: Path) -> None:
     """The SocNavBench receipt runs the vendored metric when the test-only flag is set.
 


### PR DESCRIPTION
## Summary

Closes #5963 (draft — merge forbidden by packet contract).

Surfaces the actually-executed scenario name (`PolicyRolloutResult.scenario_id`) into the **Robot SF canary receipt** as an additive `executed_scenario_id` field, so the receipt honestly records what *ran* independent of the canonical cross-suite mapping label.

## Why

The Robot SF receipt already records `scenario_mapping.robot_sf_scenario_id` (the declared cross-suite mapping label), but it did not record the scenario id that the pinned policy actually executed on the Robot SF path. The two are expected to agree for this canary (the rollout is validated against the mapping and the canary fails closed on mismatch), but re-deriving ground truth from the declared mapping is a receipt-honesty gap. Carrying `executed_scenario_id` separately — straight from `PolicyRolloutResult.scenario_id` — keeps the receipt honest if the two ever diverge.

## What changed

- `robot_sf/benchmark/socnavbench_canary.py`
  - `run_robot_sf_receipt_from_rollout` now includes `executed_scenario_id` (set to `rollout.scenario_id`) in the returned receipt. This propagates into the joint receipt's Robot SF suite entry.
  - Purely additive; no existing field changed or removed.
- `tests/benchmark/test_socnavbench_canary.py`
  - `test_robot_sf_receipt_records_executed_scenario_id_from_rollout`: asserts the field equals the rollout's `scenario_id`, matches the declared Robot SF mapping label, is a non-placeholder string, and never reuses the SocNavBench cross-suite label.
  - `test_run_canary_robot_sf_suite_records_executed_scenario_id`: asserts the joint receipt's Robot SF suite carries the field.

## Out of scope (not touched)

Per packet contract, these paths are forbidden and were not modified:
- `robot_sf/benchmark/canary_rollout.py`
- `configs/scenarios/canary_corridor.yaml`
- `configs/algos/social_force_holonomic_tuned_tau_low.yaml`

## Validation

All three packet-scope validation commands pass:

- `uv run ruff check robot_sf/benchmark/socnavbench_canary.py` → All checks passed
- `uv run ruff format --check robot_sf/benchmark/socnavbench_canary.py` → 1 file already formatted
- `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests/benchmark/test_socnavbench_canary.py -v` → **30 passed** (2 new tests included)

## Status

- Evidence grade: exploratory / additive receipt-honesty change. No benchmark, metric-definition, or equivalence claim changed.
- Classification: support/tooling change, no research claim (`NA` for research-synthesis fields).
- This is a **draft** PR. Merge is forbidden by the packet contract; review only.

Refs #5963
