### PR TITLE
test(validation): lock issue #6011 mixed --path catalog scoping at CLI level

### DIFF
--- a/tests/validation/test_check_docs_proof_consistency.py
+++ b/tests/validation/test_check_docs_proof_consistency.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -22,6 +23,7 @@ from scripts.validation.check_docs_proof_consistency import (
     _parse_name_status,
     _selected_files,
     _should_check_context_catalog,
+    main,
 )
 
 
@@ -1381,3 +1383,117 @@ def test_evidence_catalog_missing_catalog_file_passes(tmp_path: Path) -> None:
 
     # Without a catalog, every bundle is uncovered — should still report, not crash.
     assert any("issue_999_no_catalog" in d.message for d in diagnostics), diagnostics
+
+
+# ---------------------------------------------------------------------------
+# CLI-level scoping regression for mixed --path selections (issue #6011)
+# ---------------------------------------------------------------------------
+
+
+def _build_issue_6011_repo(tmp_path: Path) -> Path:
+    """Build a repo mirroring issue #6011: a requested note plus unrelated debt.
+
+    The catalog carries one historical evidence row that points at ignored
+    ``output/`` artifacts (the debt that used to block focused checks) alongside
+    a clean row for the requested note. Committing everything lets the
+    ``--base HEAD`` selection resolve the requested paths as modified.
+    """
+    repo_root = tmp_path
+    _run_git(repo_root, "init")
+    _run_git(repo_root, "config", "user.name", "Test Author")
+    _run_git(repo_root, "config", "user.email", "test@example.com")
+
+    context_dir = repo_root / "docs/context"
+    context_dir.mkdir(parents=True)
+    (context_dir / "README.md").write_text("# Context\n", encoding="utf-8")
+    (context_dir / "INDEX.md").write_text("# Index\n", encoding="utf-8")
+    requested = context_dir / "issue_6008_state.yaml"
+    requested.write_text("state: ok\n", encoding="utf-8")
+
+    evidence_dir = context_dir / "evidence"
+    evidence_dir.mkdir(parents=True)
+    (evidence_dir / "legacy_report.md").write_text(
+        "See output/runs/report.json.\n", encoding="utf-8"
+    )
+
+    catalog = context_dir / "catalog.yaml"
+    catalog.write_text(
+        "version: 1\n"
+        "entries:\n"
+        "  - path: docs/context/evidence/legacy_report.md\n"
+        "    status: evidence\n"
+        "    freshness: evidence\n"
+        "  - path: docs/context/issue_6008_state.yaml\n"
+        "    status: current\n"
+        "    freshness: maintained\n",
+        encoding="utf-8",
+    )
+    _commit_all(repo_root, "issue_6011 fixture", iso_date="2026-01-01T00:00:00+00:00")
+    return repo_root
+
+
+def test_main_mixed_path_selection_scopes_unrelated_catalog_debt(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Issue #6011: a mixed --path selection must not surface unrelated catalog debt.
+
+    End-to-end CLI regression for the exact command reported in the issue: a
+    mixed selection of ``INDEX.md``, ``catalog.yaml``, and a requested note must
+    scope catalog-row diagnostics to the requested entries so a historical
+    evidence row pointing at ignored ``output/`` artifacts no longer blocks the
+    focused check. The catalog's top-level schema is still validated.
+    """
+    repo_root = _build_issue_6011_repo(tmp_path)
+    monkeypatch.chdir(repo_root)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_docs_proof_consistency.py",
+            "--base",
+            "HEAD",
+            "--path",
+            "docs/context/INDEX.md",
+            "--path",
+            "docs/context/catalog.yaml",
+            "--path",
+            "docs/context/issue_6008_state.yaml",
+        ],
+    )
+
+    return_code = main()
+    captured = capsys.readouterr()
+
+    assert return_code == 0
+    assert "ignored output/ artifacts" not in captured.out
+    assert "3 changed file(s)" in captured.out
+
+
+def test_main_forced_context_catalog_keeps_full_audit(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Issue #6011: explicit --check-context-catalog retains the full row audit.
+
+    The scoping in the previous test must not weaken the explicit full-catalog
+    mode: ``--check-context-catalog`` still reports the historical evidence row
+    that points at ignored ``output/`` artifacts, preserving the separate
+    full-audit path the issue asked to keep.
+    """
+    repo_root = _build_issue_6011_repo(tmp_path)
+    monkeypatch.chdir(repo_root)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_docs_proof_consistency.py",
+            "--base",
+            "HEAD",
+            "--path",
+            "docs/context/issue_6008_state.yaml",
+            "--check-context-catalog",
+        ],
+    )
+
+    return_code = main()
+    captured = capsys.readouterr()
+
+    assert return_code == 1
+    assert "ignored output/ artifacts" in captured.out


### PR DESCRIPTION
## Summary

Durable, CLI-level regression coverage confirming issue #6011 is resolved.

The core fix for issue #6011 — scoping `docs`/proof-consistency catalog row checks to the entries requested by a mixed `--path` selection, while preserving the explicit full-catalog audit — shipped in #6053 (commit `7dac3b8ea`) and is **already on `origin/main`**. Issue #6011 is still **open**, and the exact command from the issue now passes on an unmodified tree. This PR adds the missing CLI-level regression tests that lock that contract end-to-end and provide durable evidence the reported symptom is gone.

## Linked Issues
- References `#6011`

## Why this PR is test-only

I am a packet-bound auxiliary worker whose allowed paths are `scripts/validation/check_docs_proof_consistency.py` and `tests/validation/test_check_docs_proof_consistency.py`. The authoritative objective (scope catalog row checks to requested entries; retain full-audit mode) is already implemented on `main` by #6053, and the validation contract passes against unmodified `main`. Rather than duplicate or revert/re-apply already-merged code, this PR contributes the one genuinely missing piece within scope: integration-level tests at the `main()` boundary for the exact command the issue reported, which the existing unit tests (which call `_collect_diagnostics` directly) did not cover.

## What Changed
- Added `test_main_mixed_path_selection_scopes_unrelated_catalog_debt`: the exact issue command (`--path INDEX.md --path catalog.yaml --path issue_6008_state.yaml`) against a fixture catalog with a historical `output/`-pointing evidence row scopes row diagnostics to the requested entries → exit 0, no `ignored output/ artifacts`.
- Added `test_main_forced_context_catalog_keeps_full_audit`: `--check-context-catalog` still performs the full row audit and reports the historical debt → exit 1, preserving the separate full-audit mode the issue asked to keep.
- Added a small `_build_issue_6011_repo` fixture builder mirroring the issue's scenario (requested note + unrelated historical evidence debt).

No change to `scripts/validation/check_docs_proof_consistency.py` (the implementation is already on `main`), `docs/context/catalog.yaml`, or anything under `docs/context/evidence/`.

## Why It Matters
- The exact human-facing command from issue #6011 is now locked by a regression test at the CLI boundary, so a future regression in argparse wiring, `_should_check_context_catalog`, or the requested-entry computation would be caught.
- Provides executable evidence that the still-open issue #6011's symptom is resolved.

## Validation / Proof
All four validation-contract commands pass:
- `uv run python -m pytest tests/validation/test_check_docs_proof_consistency.py -q` → **57 passed** (55 prior + 2 new)
- `uv run python scripts/validation/check_docs_proof_consistency.py --base origin/main --path docs/context/INDEX.md --path docs/context/catalog.yaml --path docs/context/issue_6008_state.yaml` → `OK docs/proof consistency check passed for 3 changed file(s).`
- `uv run ruff check scripts/validation/check_docs_proof_consistency.py tests/validation/test_check_docs_proof_consistency.py` → `All checks passed!`
- `uv run ruff format --check scripts/validation/check_docs_proof_consistency.py tests/validation/test_check_docs_proof_consistency.py` → `2 files already formatted`

Run via the worktree shared venv (`scripts/dev/run_worktree_shared_venv.sh`).

## Risks / Rollout
- Test-only change; no runtime behavior change. The implementation it locks is already on `main`.
- Rollback: revert the single commit.

## Research Result Guidance
- NA — validation/test support change with no research claim.

## Downstream Propagation
- Not applicable: test-only change, no evidence/registry output.

---

Draft per packet lifecycle contract (merge remains forbidden by the packet). Opened to confirm delivery; the substantive fix for #6011 is already merged in #6053.
