### PR TITLE
fix(validation): measure #5248 trace-label floor over failure episodes (#5779)

### DIFF
--- a/configs/benchmarks/issue_4206_trace_capable_h600_rerun_preregistration.yaml
+++ b/configs/benchmarks/issue_4206_trace_capable_h600_rerun_preregistration.yaml
@@ -81,6 +81,15 @@ required_outputs:
     # The re-run is only useful if it recovers real labels: an output where every
     # row is `unknown`/`not_derivable` again is rejected (see fail_closed).
     min_trace_verified_labeled_fraction: 0.5
+    # Issue #5779 structural denominator correction: the floor is measured over
+    # *failure episodes* (rows whose write-time `success` outcome is below 1.0),
+    # not all campaign rows. Success episodes structurally carry no
+    # failure-mechanism label (they did not fail), so an all-rows denominator
+    # made the floor unreachable by construction for any campaign with a healthy
+    # success rate. The threshold value above is unchanged; only the denominator
+    # changes. The registration receipt reports both ratios for transparency but
+    # gates on the failure-episode fraction.
+    min_trace_verified_labeled_fraction_denominator: failure_episodes
   interaction_exposure:
     schema_version: interaction_exposure.v1
     schema_owner: robot_sf/benchmark/interaction_exposure.py

--- a/docs/context/evidence/issue_5248_salvaged_h600_registration_2026-07/README.md
+++ b/docs/context/evidence/issue_5248_salvaged_h600_registration_2026-07/README.md
@@ -1,73 +1,105 @@
-<!-- AI-GENERATED (robot_sf#5248, 2026-07-16) - NEEDS-REVIEW -->
+<!-- AI-GENERATED (robot_sf#5248, 2026-07-20) - NEEDS-REVIEW -->
 # Salvaged h600 harvest registration
 
-Evidence status: `diagnostic-only`; registration is `blocked_campaign_registration`.
+Evidence status: `diagnostic-only`; registration is `ready_for_issue_4206_reanalysis`.
 
-This packet supersedes the 2026-07-14 receipt from #5654. That receipt concluded the campaign
-"never captured trace-verified failure-mechanism labels" because every `seed_episode_rows.csv` row
-carries `mechanism_label == "unknown"`. Re-inspection of the job-13334 episode JSONL on the
-issue-pinned host (`imech156-u`) corrects that conclusion: the campaign **is** trace-capable, and
-trace-verified labels **have** been derived — the receipt now consumes that derivation.
+This packet supersedes the 2026-07-14 receipt from #5654 and the 2026-07-16
+re-inspection. The 2026-07-14 receipt concluded the campaign "never captured
+trace-verified failure-mechanism labels" because every `seed_episode_rows.csv` row
+carries `mechanism_label == "unknown"`. Re-inspection of the job-13334 episode
+JSONL on the issue-pinned host (`imech156-u`) corrected that conclusion: the
+campaign **is** trace-capable, and trace-verified labels **have** been derived. The
+2026-07-20 update applies the issue #5779 structural denominator correction, which
+flips the registration verdict from `blocked` to `ready` for the accurate reason.
 
-## What the checker actually observed
+## Issue #5779 structural denominator correction
+
+The preregistered trace-verified labeled fraction floor
+(`min_trace_verified_labeled_fraction: 0.5`) is now measured over **failure
+episodes** (rows whose write-time `success` outcome is below 1.0) rather than over
+all campaign rows. The threshold value is unchanged; only the denominator changes.
+
+Why this is a structural correction, not a relaxation: success episodes
+structurally carry no failure-mechanism label — they did not fail, so there is no
+failure mechanism to derive. An all-rows denominator therefore included the 3,868
+success episodes as permanently-unlabeled rows, which made the 0.5 floor unreachable
+by construction for any campaign with a healthy success rate. The corrected
+failure-episode denominator measures label coverage over the population that can
+actually carry a failure-mechanism label.
+
+The contract records the correction explicitly
+(`min_trace_verified_labeled_fraction_denominator: failure_episodes` in
+`configs/benchmarks/issue_4206_trace_capable_h600_rerun_preregistration.yaml`), and
+the preregistration checker rejects contracts that omit it or declare `all_rows`.
+The registration receipt reports **both** ratios for transparency, but the gate uses
+the failure-episode fraction.
+
+## What the checker observes on job 13334
 
 The campaign source artifacts are present and structurally valid:
 
-- `reports/campaign_summary.json` read; `campaign.total_episodes == 6480` and
+- `reports/campaign_summary.json`: `campaign.total_episodes == 6480` and
   `campaign.campaign_execution_status == "completed"`.
-- `reports/seed_episode_rows.csv` read; exactly 6,480 data rows.
-- Both source files are recorded with SHA-256 sums in `registration.json`.
+- `reports/seed_episode_rows.csv`: exactly 6,480 data rows.
+- Both source files are recorded with SHA-256 sums in the receipt.
 
-The job was salvaged after the exit-code conflation fixed by #5240; the completed 6,480-episode
-result confirms the FAILED mislabel was spurious. That provenance does **not** promote this packet
-to benchmark, planner, paper, or dissertation evidence.
-
-The host-pinned revalidation on `imech156-u` on 2026-07-16 reported:
-
-```text
-total_episodes=6480, status_completed
-status: blocked_campaign_registration
-```
-
-The first line verifies that the harvest itself is complete. The second is the separate,
-fail-closed trace-label registration decision described below; it does not invalidate the harvest.
+The job was salvaged after the exit-code conflation fixed by #5240; the completed
+6,480-episode result confirms the FAILED mislabel was spurious. That provenance does
+**not** promote this packet to benchmark, planner, paper, or dissertation evidence.
 
 ## Why the campaign IS trace-capable (correction to #5654)
 
-Independent re-inspection of all 11 arms' `episodes.jsonl` shows trace capture was functioning:
+Independent re-inspection of all 11 arms' `episodes.jsonl` shows trace capture was
+functioning:
 
 - Every one of the 6,480 episode records carries a non-empty
   `algorithm_metadata.simulation_step_trace` (`simulation-step-trace.v1`; 1–600 steps each).
 - 2,375 of 6,480 records additionally carry a non-empty `planner_decision_trace`.
 
 The `mechanism_label == "unknown"` on the raw `seed_episode_rows.csv` is therefore **not** a
-trace-capture failure: mechanism labels are a *post-hoc derivation* over the trace surfaces (issue
-#4831), not a write-time field. Issue #4831's builder
-(`scripts/analysis/derive_issue_4206_trace_verified_failure_mechanisms.py`) has already run against
-this harvest and derived trace-verified labels for all 2,612 failure episodes (100% failure
-coverage; `paired_trace` evidence mode). That derivation lives in the declared sidecar
+trace-capture failure: mechanism labels are a *post-hoc derivation* over the trace surfaces
+(issue #4831), not a write-time field. Issue #4831's builder
+(`scripts/analysis/derive_issue_4206_trace_verified_failure_mechanisms.py`) has already run
+against this harvest and derived trace-verified labels for all 2,612 failure episodes (100%
+failure coverage; `paired_trace` evidence mode). That derivation lives in the declared sidecar
 `docs/context/evidence/issue_4831_trace_verified_failure_mechanisms/mechanism_labels.csv`, which
-this receipt now consumes via the checker's `--mechanism-sidecar` overlay.
+the checker consumes via the `--mechanism-sidecar` overlay.
 
-## Why registration still stays blocked
+## Why registration is now ready (issue #5779)
 
-Registration remains `blocked_campaign_registration`, but for the **accurate** reason rather than
-the "trace capture failed" reason recorded in #5654:
+With the #4831 sidecar overlaid, trace-verified labeled rows rise from `0` (raw rows)
+to `2,415` at accepted confidence (`observed_mechanism` / `supported_hypothesis`). The
+remaining `197` derived labels are `weak_hypothesis` (`time_budget_artifact`); they count as
+derived but are below the accepted-confidence bar and do not count toward the floor.
 
-- With the #4831 sidecar overlaid, trace-verified labeled rows rise from `0.000` (raw rows) to
-  `2,415` at accepted confidence (`observed_mechanism` / `supported_hypothesis`) — a fraction of
-  `0.373` over all 6,480 rows.
-- The remaining `197` derived labels are `weak_hypothesis` (`time_budget_artifact`); they count as
-  derived but are below the accepted-confidence bar and do not count toward the floor.
-- The preregistered minimum (`min_trace_verified_labeled_fraction: 0.5`, measured over all rows) is
-  not met. The denominator includes the 3,868 success episodes, which structurally carry no
-  failure-mechanism label, so coverage cannot reach 50% of all rows for this campaign. Whether that
-  denominator should be restricted to failure episodes is a metric-semantics question explicitly out
-  of scope for this registration (#5248 scopes out metric semantics); the floor is honored as
-  ratified in #4350.
+Both ratios are reported in the receipt; only the failure-episode ratio gates:
 
-This is not a "re-run the campaign to capture traces" blocker — the traces and the derived labels
-already exist. The actionable gap is the preregistered floor/denominator, not missing capture.
+| Denominator | Population | Labeled (accepted) | Fraction | vs 0.5 floor |
+| --- | --- | --- | --- | --- |
+| Failure episodes (gate) | 2,612 | 2,415 | **0.925** | meets |
+| All campaign rows (transparency) | 6,480 | 2,415 | 0.373 | (prior, blocked) |
+
+The failure-episode fraction (~0.925) clears the unchanged 0.5 floor, so the campaign is
+`ready_for_issue_4206_reanalysis`. The all-rows ratio (0.373) is the value the prior receipts
+gated on and is retained in the receipt for transparency; it is no longer the gating
+denominator.
+
+The 2,612 failure-episode count is the #4831 failure set (`outcome.route_complete == false`).
+The checker derives the denominator from each row's write-time `success` outcome
+(`success < 1.0`), which coincides with the #4831 failure set for this harvest. Any
+route-complete-but-collision edge row would only be added to the denominator (unlabeled),
+which cannot move the fraction below the 0.5 floor from ~0.925; the exact count is confirmed
+by re-running the checker on the harvest host.
+
+## Relationship to the prior receipts in this directory
+
+`registration.json`, `registration.md`, and `SHA256SUMS` in this directory are the
+**prior** receipts generated on 2026-07-16, which gated on the all-rows denominator
+and recorded `blocked_campaign_registration` at fraction 0.373. They are retained
+here for provenance and are superseded by this README's corrected verdict. They will
+be regenerated by the checker (schema `issue_5248_salvaged_trace_rerun_registration.v2`)
+on the issue-pinned harvest host to produce the `ready` receipt that matches the
+command below; the build host for this packet does not carry the verified harvest.
 
 ## Reproduction
 
@@ -81,17 +113,23 @@ uv run python scripts/validation/check_issue_5248_salvaged_trace_rerun.py \
   --mechanism-sidecar \
     docs/context/evidence/issue_4831_trace_verified_failure_mechanisms/mechanism_labels.csv \
   --output-dir docs/context/evidence/issue_5248_salvaged_h600_registration_2026-07 \
-  --generated-at 2026-07-16T125218Z
+  --generated-at 2026-07-20T000000Z
 ```
 
-Expected result: exit code `2` and status `blocked_campaign_registration`, with
-`trace_labeled_fraction == 0.373` (raised from `0.000` without the sidecar). Requires the verified
-job-13334 harvest and the #4831 sidecar to be present on the issue-pinned host.
+Expected result (issue-pinned host with the verified harvest and #4831 sidecar):
+exit code `0` and status `ready_for_issue_4206_reanalysis`, with
+`trace_labeled_fraction == ~0.925` (failure-episode denominator, raised from `0.000`
+without the sidecar) and `trace_labeled_fraction_all_rows == 0.373` (transparency).
+Requires the verified job-13334 harvest and the #4831 sidecar to be present on the
+issue-pinned host; the test
+`tests/validation/test_check_issue_5248_salvaged_trace_rerun.py::test_job_13334_denominator_correction_makes_campaign_ready`
+skips when either is absent.
 
 ## Next action
 
-The conditional #4206 mechanism cross-cut still cannot run in a ready state, because the
-preregistered trace-label floor (over all rows) is not met. The correct next step is a
-maintainer decision on the floor denominator (failure-episode vs all-episode) — a metric-semantics
-change — not a new campaign run. Resolving that would let the #4831-derived labels register this
-harvest and unblock the #4206 F-C4(ii) cross-cut against the genuinely trace-capable job 13334.
+With the denominator correction applied, the job-13334 harvest registers as ready for
+the issue #4206 mechanism cross-cut. The conditional #4206 F-C4(ii) cross-cut builder
+can now run against this genuinely trace-capable, trace-labeled campaign. This is still
+registration readiness only — it does not establish benchmark, planner, paper, or
+dissertation claims, and the cross-cut's own evidence contract still governs what those
+conclusions may assert.

--- a/scripts/validation/check_issue_4206_trace_capable_h600_rerun_preregistration.py
+++ b/scripts/validation/check_issue_4206_trace_capable_h600_rerun_preregistration.py
@@ -221,6 +221,18 @@ def _validate_required_outputs(required_outputs: Any) -> None:
         "min_trace_verified_labeled_fraction must be in (0, 1] so an all-unknown "
         "re-run cannot pass successful outcome",
     )
+    # Issue #5779 structural denominator correction: the floor is measured over
+    # failure episodes (rows whose write-time ``success`` outcome is below 1.0),
+    # not all campaign rows. Only ``failure_episodes`` is a ratified denominator;
+    # declaring it explicitly here records the correction and prevents silent
+    # drift back to the unreachable all-rows denominator.
+    denominator = mechanism.get("min_trace_verified_labeled_fraction_denominator")
+    _require(
+        denominator == "failure_episodes",
+        "min_trace_verified_labeled_fraction_denominator must be 'failure_episodes' "
+        "(issue #5779 structural correction: success episodes carry no "
+        "failure-mechanism label, so the floor is measured over failure episodes)",
+    )
 
     exposure = required_outputs.get("interaction_exposure")
     _require(isinstance(exposure, dict), "required_outputs.interaction_exposure required")
@@ -350,6 +362,9 @@ def build_dry_run_manifest(payload: dict[str, Any]) -> dict[str, Any]:
                 "schema_version"
             ],
             "min_trace_verified_labeled_fraction": mechanism["min_trace_verified_labeled_fraction"],
+            "min_trace_verified_labeled_fraction_denominator": mechanism[
+                "min_trace_verified_labeled_fraction_denominator"
+            ],
         },
         "downstream_consumer": payload["provenance"]["downstream_consumer"].get("builder"),
     }

--- a/scripts/validation/check_issue_5248_salvaged_trace_rerun.py
+++ b/scripts/validation/check_issue_5248_salvaged_trace_rerun.py
@@ -5,6 +5,15 @@ This checker reads a completed camera-ready campaign in place and writes only a
 small receipt.  It never copies raw episode data, submits compute, or upgrades
 the campaign to benchmark or paper evidence.  A passing receipt says only that
 the campaign is structurally ready for the issue #4206 mechanism cross-cut.
+
+Issue #5779 structural denominator correction: the preregistered trace-verified
+labeled fraction floor is now measured over *failure episodes* (rows whose
+write-time ``success`` outcome is below 1.0) instead of all campaign rows.
+Success episodes structurally carry no failure-mechanism label, so the prior
+all-rows denominator made the floor unreachable by construction for any campaign
+with a healthy success rate. The threshold value is unchanged; the receipt
+reports both the all-rows and failure-episode ratios, but the gate uses the
+failure-episode fraction.
 """
 
 from __future__ import annotations
@@ -25,12 +34,38 @@ from robot_sf.benchmark.failure_mechanism_taxonomy import (
     TRACE_VERIFIED_EVIDENCE_MODES,
 )
 
-SCHEMA_VERSION = "issue_5248_salvaged_trace_rerun_registration.v1"
+SCHEMA_VERSION = "issue_5248_salvaged_trace_rerun_registration.v2"
 READY_STATUS = "ready_for_issue_4206_reanalysis"
 BLOCKED_STATUS = "blocked_campaign_registration"
 SUMMARY_RELATIVE_PATH = Path("reports/campaign_summary.json")
 EPISODE_ROWS_RELATIVE_PATH = Path("reports/seed_episode_rows.csv")
 UNKNOWN_LABELS = {"", "unknown", "not_derivable"}
+
+# Issue #5779 structural denominator correction: the preregistered
+# trace-verified labeled fraction is measured over *failure episodes* (rows
+# whose write-time ``success`` outcome is below 1.0), not over all campaign
+# rows. Success episodes structurally carry no failure-mechanism label (they
+# did not fail), so including them in the denominator made the floor
+# unreachable by construction for any campaign with a healthy success rate.
+# The threshold value (``min_trace_verified_labeled_fraction``) is unchanged;
+# only the denominator changes. The receipt reports both ratios for
+# transparency, but the gate uses the failure-episode fraction.
+FAILURE_EPISODE_DENOMINATOR = "failure_episodes"
+SUPPORTED_FRACTION_DENOMINATORS = {FAILURE_EPISODE_DENOMINATOR}
+DENOMINATOR_CORRECTION_NOTE = (
+    "Issue #5779 structural correction: success episodes carry no "
+    "failure-mechanism label, so the preregistered minimum trace-verified "
+    "labeled fraction is measured over failure episodes (rows with "
+    "success < 1.0) rather than all campaign rows. The threshold is "
+    "unchanged; the receipt reports both ratios but gates on the "
+    "failure-episode fraction."
+)
+# ``success`` column write-time outcome. A row is a failure episode when its
+# success outcome did not reach 1.0. A missing/unparseable outcome is treated
+# conservatively as a failure episode so a malformed campaign degrades to the
+# stricter all-rows denominator rather than silently shrinking the floor.
+SUCCESS_COLUMN = "success"
+SUCCESS_THRESHOLD = 1.0
 
 
 def _sha256(path: Path) -> str:
@@ -90,8 +125,14 @@ def _public_path(path: Path) -> str:
         return path.name
 
 
-def _load_trace_contract(path: Path) -> tuple[set[str], float]:
-    """Load trace modes and minimum labeled fraction from the preregistration contract."""
+def _load_trace_contract(path: Path) -> tuple[set[str], float, str]:
+    """Load trace modes, minimum fraction, and denominator from the preregistration.
+
+    Returns ``(trace_modes, min_fraction, denominator)``. The denominator names
+    which row population the minimum fraction is measured over; issue #5779
+    ratifies ``failure_episodes`` as the structural denominator (see
+    ``FAILURE_EPISODE_DENOMINATOR``).
+    """
 
     try:
         payload = yaml.safe_load(path.read_text(encoding="utf-8"))
@@ -106,6 +147,7 @@ def _load_trace_contract(path: Path) -> tuple[set[str], float]:
         raise ValueError("preregistration config lacks failure-mechanism contract")
     modes = set(mechanism.get("trace_verified_evidence_modes") or ())
     fraction = mechanism.get("min_trace_verified_labeled_fraction")
+    denominator = mechanism.get("min_trace_verified_labeled_fraction_denominator")
     if modes != set(TRACE_VERIFIED_EVIDENCE_MODES):
         raise ValueError("preregistration trace-verified modes drift from the canonical schema")
     if (
@@ -114,7 +156,12 @@ def _load_trace_contract(path: Path) -> tuple[set[str], float]:
         or not 0 < float(fraction) <= 1
     ):
         raise ValueError("preregistration minimum trace-labeled fraction must be in (0, 1]")
-    return modes, float(fraction)
+    if denominator not in SUPPORTED_FRACTION_DENOMINATORS:
+        raise ValueError(
+            "preregistration min_trace_verified_labeled_fraction_denominator must be one of "
+            f"{sorted(SUPPORTED_FRACTION_DENOMINATORS)}; got {denominator!r}"
+        )
+    return modes, float(fraction), str(denominator)
 
 
 def _campaign_block(summary: dict[str, Any]) -> dict[str, Any]:
@@ -214,17 +261,37 @@ def _load_sidecar_overlay(
     return rows, sha256, sidecar_public, None
 
 
+def _is_failure_episode(row: dict[str, str]) -> bool:
+    """Return whether an episode row is a failure (write-time outcome did not succeed).
+
+    Uses the campaign's own ``success`` column (the write-time episode outcome
+    ``route_complete and not collision``). A row whose ``success`` value is
+    absent or unparseable is treated conservatively as a failure episode so a
+    malformed campaign degrades to the stricter all-rows denominator rather
+    than silently shrinking the failure-episode denominator.
+    """
+
+    raw = str(row.get(SUCCESS_COLUMN) or "").strip()
+    try:
+        value = float(raw)
+    except ValueError:
+        return True
+    return value < SUCCESS_THRESHOLD
+
+
 def _compute_trace_coverage(
     rows: list[dict[str, str]],
     *,
     trace_modes: set[str],
     sidecar_by_episode: dict[str, dict[str, str]],
-) -> tuple[int, int, int, float, float]:
-    """Return trace-labeled counts with and without the sidecar overlay.
+) -> tuple[int, int, int, int]:
+    """Return trace-labeled counts plus the failure-episode denominator size.
 
-    The sidecar overlay counts a raw row as trace-labeled when either the raw
-    row itself qualifies or a derived sidecar label for its ``episode_id``
-    qualifies. Returns ``(with_sidecar, without_sidecar, matched, frac, frac_raw)``.
+    Counts trace-labeled rows (with and without the sidecar overlay) and the
+    number of failure episodes. Returns
+    ``(with_sidecar, without_sidecar, matched, failure_episode_count)``. The
+    caller computes both the all-rows and failure-episode fractions from these
+    counts so the receipt can report both while gating on one.
     """
 
     def _row_labeled(row: dict[str, str]) -> bool:
@@ -243,14 +310,8 @@ def _compute_trace_coverage(
         if rows and sidecar_by_episode
         else 0
     )
-    denom = len(rows) if rows else 0
-    return (
-        with_sidecar,
-        without,
-        matched,
-        with_sidecar / denom if denom else 0.0,
-        without / denom if denom else 0.0,
-    )
+    failure_episode_count = sum(_is_failure_episode(row) for row in rows) if rows else 0
+    return with_sidecar, without, matched, failure_episode_count
 
 
 def _validate_campaign_summary(
@@ -334,6 +395,12 @@ def build_registration_receipt(
     are derived after the run; the sidecar is the only place a trace-verified label
     can appear. The receipt records both the raw-row and sidecar-augmented coverage
     so a reviewer can see exactly what the sidecar contributed.
+
+    Issue #5779 structural denominator correction: the preregistered minimum
+    trace-verified labeled fraction is gated over failure episodes (rows whose
+    write-time ``success`` outcome is below 1.0) rather than all campaign rows.
+    The receipt reports both the all-rows and failure-episode ratios, but the
+    gate uses the failure-episode fraction.
     """
 
     blockers: list[str] = []
@@ -345,9 +412,10 @@ def build_registration_receipt(
     rows_loaded = False
     trace_modes: set[str] = set()
     min_fraction: float | None = None
+    denominator: str = FAILURE_EPISODE_DENOMINATOR
 
     try:
-        trace_modes, min_fraction = _load_trace_contract(preregistration_config)
+        trace_modes, min_fraction, denominator = _load_trace_contract(preregistration_config)
     except ValueError as exc:
         blockers.append(str(exc))
 
@@ -385,15 +453,27 @@ def build_registration_receipt(
         trace_labeled_rows,
         trace_labeled_rows_without_sidecar,
         sidecar_matched_rows,
-        trace_labeled_fraction,
-        trace_labeled_fraction_without_sidecar,
+        failure_episode_count,
     ) = _compute_trace_coverage(
         rows, trace_modes=trace_modes, sidecar_by_episode=sidecar_by_episode
     )
+    total_row_count = len(rows)
+    # Issue #5779 denominator correction: the gate measures coverage over
+    # failure episodes, but the receipt reports both ratios for transparency.
+    trace_labeled_fraction_all_rows = (
+        trace_labeled_rows / total_row_count if total_row_count else 0.0
+    )
+    trace_labeled_fraction = (
+        trace_labeled_rows / failure_episode_count if failure_episode_count else 0.0
+    )
+    trace_labeled_fraction_without_sidecar = (
+        trace_labeled_rows_without_sidecar / total_row_count if total_row_count else 0.0
+    )
     if rows_loaded and min_fraction is not None and trace_labeled_fraction < min_fraction:
         blockers.append(
-            "trace-verified labeled fraction must meet preregistration minimum "
-            f"{min_fraction:.3f}; got {trace_labeled_fraction:.3f}"
+            "trace-verified labeled fraction (failure-episode denominator) must meet "
+            f"preregistration minimum {min_fraction:.3f}; got {trace_labeled_fraction:.3f} "
+            f"({trace_labeled_rows} of {failure_episode_count} failure episodes)"
         )
 
     status = READY_STATUS if not blockers else BLOCKED_STATUS
@@ -425,8 +505,13 @@ def build_registration_receipt(
             "required_fields": list(REQUIRED_MECHANISM_FIELDS),
             "trace_verified_evidence_modes": sorted(trace_modes),
             "minimum_labeled_fraction": min_fraction,
+            "minimum_labeled_fraction_denominator": denominator,
+            "denominator_correction": DENOMINATOR_CORRECTION_NOTE,
+            "total_row_count": total_row_count,
+            "failure_episode_count": failure_episode_count,
             "trace_labeled_rows": trace_labeled_rows,
             "trace_labeled_fraction": trace_labeled_fraction,
+            "trace_labeled_fraction_all_rows": trace_labeled_fraction_all_rows,
             "trace_labeled_rows_without_sidecar": trace_labeled_rows_without_sidecar,
             "trace_labeled_fraction_without_sidecar": trace_labeled_fraction_without_sidecar,
         },
@@ -469,8 +554,17 @@ def _render_markdown(receipt: dict[str, Any]) -> str:
         f"| Total episodes | {campaign['total_episodes_observed']} / expected {campaign['total_episodes_expected']} |",
         f"| Execution status | `{campaign['campaign_execution_status']}` |",
         f"| Episode rows | {campaign['episode_row_count']} |",
-        f"| Trace-labeled rows | {trace_labels['trace_labeled_rows']} ({trace_labels['trace_labeled_fraction']:.3f}) |",
-        f"| Minimum trace-labeled fraction | {trace_labels['minimum_labeled_fraction']} |",
+        f"| Failure episodes (denominator) | {trace_labels['failure_episode_count']} |",
+        (
+            f"| Trace-labeled rows (failure episodes) | {trace_labels['trace_labeled_rows']} "
+            f"({trace_labels['trace_labeled_fraction']:.3f}) |"
+        ),
+        (
+            f"| Trace-labeled fraction (all rows) | "
+            f"{trace_labels['trace_labeled_fraction_all_rows']:.3f} |"
+        ),
+        f"| Minimum trace-labeled fraction | {trace_labels['minimum_labeled_fraction']} "
+        f"(denominator: `{trace_labels['minimum_labeled_fraction_denominator']}`) |",
         "",
     ]
     sidecar = receipt.get("mechanism_sidecar")

--- a/tests/validation/test_check_issue_5248_salvaged_trace_rerun.py
+++ b/tests/validation/test_check_issue_5248_salvaged_trace_rerun.py
@@ -80,8 +80,16 @@ def _write_campaign(
     completed: bool = True,
     trace_labeled_rows: int = 2,
     omit_field: str | None = None,
+    success_values: list[str] | None = None,
 ) -> Path:
-    """Write the smallest camera-ready campaign fixture accepted by the checker."""
+    """Write the smallest camera-ready campaign fixture accepted by the checker.
+
+    ``success_values`` sets each row's write-time ``success`` outcome (``"0.0"``
+    = failure episode, ``"1.0""`` = success episode). It defaults to all failures
+    so the failure-episode denominator equals the all-rows denominator, which
+    preserves the pre-#5779 fixture semantics. Tests that exercise the
+    denominator correction pass a mix of failure and success outcomes.
+    """
 
     reports = root / "reports"
     reports.mkdir(parents=True)
@@ -98,7 +106,11 @@ def _write_campaign(
         + "\n",
         encoding="utf-8",
     )
+    if success_values is None:
+        success_values = ["0.0"] * episode_count
     fields = [
+        "episode_id",
+        "success",
         "mechanism_schema_version",
         "mechanism_label",
         "mechanism_confidence",
@@ -115,6 +127,8 @@ def _write_campaign(
         for index in range(episode_count):
             trace_labeled = index < trace_labeled_rows
             row = {
+                "episode_id": f"ep-{index}",
+                "success": success_values[index],
                 "mechanism_schema_version": "failure_mechanism_taxonomy.v1",
                 "mechanism_label": "static_deadlock_or_local_minimum"
                 if trace_labeled
@@ -251,12 +265,20 @@ def test_cli_writes_blocked_receipt_and_nonzero_exit(tmp_path: Path, capsys) -> 
 # ---------------------------------------------------------------------------
 
 
-def _write_unlabeled_campaign(root: Path, *, episode_ids: list[str]) -> Path:
+def _write_unlabeled_campaign(
+    root: Path,
+    *,
+    episode_ids: list[str],
+    success_values: list[str] | None = None,
+) -> Path:
     """Write a completed campaign whose raw episode rows are all unlabeled.
 
     Mirrors the real job-13334 shape: every row carries a valid taxonomy schema
     block but ``unknown`` labels, because mechanism labels are a post-hoc
     derivation. Each row carries a unique ``episode_id`` for sidecar joining.
+    ``success_values`` sets each row's write-time outcome (``"0.0"`` failure /
+    ``"1.0""`` success); it defaults to all failures so the failure-episode
+    denominator equals the all-rows denominator unless a test opts into a mix.
     """
 
     reports = root / "reports"
@@ -274,14 +296,17 @@ def _write_unlabeled_campaign(root: Path, *, episode_ids: list[str]) -> Path:
         + "\n",
         encoding="utf-8",
     )
-    fields = ["episode_id", *REQUIRED_MECHANISM_FIELDS_TUNNEL]
+    if success_values is None:
+        success_values = ["0.0"] * len(episode_ids)
+    fields = ["episode_id", "success", *REQUIRED_MECHANISM_FIELDS_TUNNEL]
     with (reports / "seed_episode_rows.csv").open("w", encoding="utf-8", newline="") as handle:
         writer = csv.DictWriter(handle, fieldnames=fields)
         writer.writeheader()
-        for episode_id in episode_ids:
+        for episode_id, success in zip(episode_ids, success_values, strict=True):
             writer.writerow(
                 {
                     "episode_id": episode_id,
+                    "success": success,
                     "mechanism_schema_version": "failure_mechanism_taxonomy.v1",
                     "mechanism_label": "not_derivable",
                     "mechanism_confidence": "unknown",
@@ -500,6 +525,255 @@ def test_no_sidecar_omits_sidecar_block_and_keeps_legacy_fraction(tmp_path: Path
     assert receipt["trace_labels"]["trace_labeled_rows"] == 2
     assert receipt["trace_labels"]["trace_labeled_fraction"] == 2 / 3
     assert receipt["trace_labels"]["trace_labeled_fraction_without_sidecar"] == 2 / 3
+    # Issue #5779: the receipt records the denominator correction and both ratios.
+    assert receipt["trace_labels"]["minimum_labeled_fraction_denominator"] == "failure_episodes"
+    assert "denominator_correction" in receipt["trace_labels"]
+    assert receipt["trace_labels"]["total_row_count"] == 3
+    # Default fixture has all failure outcomes, so both denominators coincide.
+    assert receipt["trace_labels"]["failure_episode_count"] == 3
+    assert receipt["trace_labels"]["trace_labeled_fraction_all_rows"] == 2 / 3
+
+
+# ---------------------------------------------------------------------------
+# Issue #5779 structural denominator correction: the trace-verified labeled
+# fraction floor is measured over *failure episodes* (rows whose write-time
+# ``success`` outcome is below 1.0), not all campaign rows. Success episodes
+# structurally carry no failure-mechanism label, so an all-rows denominator
+# made the floor unreachable by construction for any campaign with a healthy
+# success rate. These tests pin the denominator logic on portable fixtures.
+# ---------------------------------------------------------------------------
+
+
+def test_failure_episode_denominator_excludes_success_episodes(tmp_path: Path) -> None:
+    """Success episodes are excluded from the gating denominator.
+
+    A campaign with 2 labeled failure episodes, 2 unlabeled failure episodes,
+    and 6 success episodes: the all-rows fraction is 2/10 = 0.2 (below the 0.5
+    floor), but the failure-episode fraction is 2/4 = 0.5 (meets the floor). The
+    gate must use the failure-episode fraction and the campaign must be ready,
+    while the receipt still reports the 0.2 all-rows ratio for transparency.
+    """
+
+    # Rows 0-1: labeled failures. Rows 2-3: unlabeled failures. Rows 4-9: successes.
+    success_values = ["0.0", "0.0", "0.0", "0.0", "1.0", "1.0", "1.0", "1.0", "1.0", "1.0"]
+    campaign = _write_campaign(
+        tmp_path / "campaign",
+        episode_count=10,
+        trace_labeled_rows=2,
+        success_values=success_values,
+    )
+
+    receipt = build_registration_receipt(
+        campaign_root=campaign,
+        job_id="fixture-job",
+        expected_total_episodes=10,
+        preregistration_config=PREREGISTRATION_CONFIG,
+        generated_at="2026-07-20T000000Z",
+    )
+
+    assert receipt["status"] == READY_STATUS
+    assert receipt["blockers"] == []
+    trace_labels = receipt["trace_labels"]
+    assert trace_labels["total_row_count"] == 10
+    assert trace_labels["failure_episode_count"] == 4
+    assert trace_labels["trace_labeled_rows"] == 2
+    # The gate uses the failure-episode denominator.
+    assert trace_labels["trace_labeled_fraction"] == 0.5
+    # The all-rows ratio is still reported for transparency.
+    assert trace_labels["trace_labeled_fraction_all_rows"] == 0.2
+
+
+def test_all_rows_denominator_would_block_but_failure_denominator_passes(
+    tmp_path: Path,
+) -> None:
+    """The denominator correction flips a blocked (all-rows) verdict to ready.
+
+    Mirrors the job-13334 shape: a small campaign where labeled failures are a
+    minority of all rows but a majority of failure episodes. Under the old
+    all-rows denominator this blocked; under the corrected failure-episode
+    denominator it is ready. The receipt records both ratios so a reviewer can
+    see exactly what the denominator correction changed.
+    """
+
+    # 3 labeled failures, 1 unlabeled failure, 8 successes: 3/12 = 0.25 all rows,
+    # 3/4 = 0.75 failure episodes.
+    success_values = ["0.0", "0.0", "0.0", "0.0"] + ["1.0"] * 8
+    campaign = _write_campaign(
+        tmp_path / "campaign",
+        episode_count=12,
+        trace_labeled_rows=3,
+        success_values=success_values,
+    )
+
+    receipt = build_registration_receipt(
+        campaign_root=campaign,
+        job_id="fixture-job",
+        expected_total_episodes=12,
+        preregistration_config=PREREGISTRATION_CONFIG,
+        generated_at="2026-07-20T000000Z",
+    )
+
+    assert receipt["status"] == READY_STATUS
+    trace_labels = receipt["trace_labels"]
+    assert trace_labels["trace_labeled_fraction"] == 0.75
+    assert trace_labels["trace_labeled_fraction_all_rows"] == 0.25
+    assert trace_labels["failure_episode_count"] == 4
+
+
+def test_sidecar_failure_denominator_excludes_success_episodes(tmp_path: Path) -> None:
+    """The failure-episode denominator applies with the sidecar overlay too.
+
+    A fully-unlabeled campaign with 4 failures + 4 successes: the sidecar labels
+    3 of the 4 failures at accepted confidence. All-rows fraction is 3/8 = 0.375
+    (below 0.5), but the failure-episode fraction is 3/4 = 0.75 (meets 0.5), so
+    the campaign is ready and the success episodes do not penalize the floor.
+    """
+
+    episode_ids = [f"ep-{i}" for i in range(8)]
+    # First 4 are failures, last 4 are successes.
+    success_values = ["0.0"] * 4 + ["1.0"] * 4
+    campaign = _write_unlabeled_campaign(
+        tmp_path / "campaign", episode_ids=episode_ids, success_values=success_values
+    )
+    # Sidecar labels the first 3 failure episodes (ep-0, ep-1, ep-2).
+    sidecar = _write_sidecar(tmp_path / "side.csv", labeled=episode_ids[:3])
+
+    receipt = build_registration_receipt(
+        campaign_root=campaign,
+        job_id="fixture-job",
+        expected_total_episodes=8,
+        preregistration_config=PREREGISTRATION_CONFIG,
+        generated_at="2026-07-20T000000Z",
+        mechanism_sidecar=sidecar,
+    )
+
+    assert receipt["status"] == READY_STATUS
+    trace_labels = receipt["trace_labels"]
+    assert trace_labels["failure_episode_count"] == 4
+    assert trace_labels["trace_labeled_rows"] == 3
+    assert trace_labels["trace_labeled_fraction"] == 0.75
+    assert trace_labels["trace_labeled_fraction_all_rows"] == 0.375
+
+
+def test_failure_denominator_below_floor_still_blocks(tmp_path: Path) -> None:
+    """A low failure-episode fraction (not all-rows) still fails closed."""
+
+    # 4 failures, 1 labeled -> 0.25 failure-episode fraction, below the 0.5 floor.
+    success_values = ["0.0", "0.0", "0.0", "0.0"] + ["1.0"] * 6
+    campaign = _write_campaign(
+        tmp_path / "campaign",
+        episode_count=10,
+        trace_labeled_rows=1,
+        success_values=success_values,
+    )
+
+    receipt = build_registration_receipt(
+        campaign_root=campaign,
+        job_id="fixture-job",
+        expected_total_episodes=10,
+        preregistration_config=PREREGISTRATION_CONFIG,
+        generated_at="2026-07-20T000000Z",
+    )
+
+    assert receipt["status"] == BLOCKED_STATUS
+    blocker = next(b for b in receipt["blockers"] if "trace-verified labeled fraction" in b)
+    assert "failure-episode denominator" in blocker
+    assert "1 of 4 failure episodes" in blocker
+    assert receipt["trace_labels"]["trace_labeled_fraction"] == 0.25
+
+
+def test_missing_success_column_degrades_to_all_rows_denominator(tmp_path: Path) -> None:
+    """A campaign without a ``success`` column conservatively counts every row.
+
+    A missing/unparseable write-time outcome is treated as a failure episode so a
+    malformed campaign degrades to the stricter all-rows denominator rather than
+    silently shrinking the failure-episode floor.
+    """
+
+    reports = tmp_path / "campaign" / "reports"
+    reports.mkdir(parents=True)
+    (reports / "campaign_summary.json").write_text(
+        json.dumps(
+            {
+                "campaign": {
+                    "total_episodes": 4,
+                    "campaign_execution_status": "completed",
+                    "status": "accepted_unavailable_only",
+                }
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    # No ``success`` column: every row is conservatively a failure episode.
+    fields = list(REQUIRED_MECHANISM_FIELDS_TUNNEL)
+    with (reports / "seed_episode_rows.csv").open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        for index in range(4):
+            trace_labeled = index < 1
+            writer.writerow(
+                {
+                    "mechanism_schema_version": "failure_mechanism_taxonomy.v1",
+                    "mechanism_label": "static_deadlock_or_local_minimum"
+                    if trace_labeled
+                    else "not_derivable",
+                    "mechanism_confidence": "observed_mechanism" if trace_labeled else "unknown",
+                    "mechanism_evidence_mode": "paired_trace" if trace_labeled else "unknown",
+                    "mechanism_evidence_uri": f"trace://fixture/{index}" if trace_labeled else "",
+                    "mechanism_case_id": f"fixture-{index}",
+                    "mechanism_caveat": "",
+                }
+            )
+
+    receipt = build_registration_receipt(
+        campaign_root=tmp_path / "campaign",
+        job_id="fixture-job",
+        expected_total_episodes=4,
+        preregistration_config=PREREGISTRATION_CONFIG,
+        generated_at="2026-07-20T000000Z",
+    )
+
+    trace_labels = receipt["trace_labels"]
+    # No success column -> every row counted as a failure -> both denominators 4.
+    assert trace_labels["failure_episode_count"] == 4
+    assert trace_labels["total_row_count"] == 4
+    assert trace_labels["trace_labeled_fraction"] == 0.25
+    assert trace_labels["trace_labeled_fraction_all_rows"] == 0.25
+    assert receipt["status"] == BLOCKED_STATUS
+
+
+def test_denominator_field_read_from_contract(tmp_path: Path) -> None:
+    """The checker reads and honors the declared denominator from the contract."""
+
+    modes, fraction, denominator = _load_trace_contract(PREREGISTRATION_CONFIG)
+    assert modes == {
+        "paired_trace",
+        "deterministic_replay",
+        "direct_probe",
+        "root_cause",
+    }
+    assert fraction == 0.5
+    assert denominator == "failure_episodes"
+
+
+def test_trace_contract_rejects_missing_denominator(tmp_path: Path) -> None:
+    """A contract that omits the denominator declaration fails closed."""
+    import yaml
+
+    payload = yaml.safe_load(PREREGISTRATION_CONFIG.read_text(encoding="utf-8"))
+    del payload["required_outputs"]["failure_mechanism"][
+        "min_trace_verified_labeled_fraction_denominator"
+    ]
+    config = tmp_path / "preregistration.yaml"
+    config.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    try:
+        _load_trace_contract(config)
+    except ValueError as exc:
+        assert "min_trace_verified_labeled_fraction_denominator" in str(exc)
+    else:
+        raise AssertionError("expected missing denominator to fail closed")
 
 
 REAL_MECHANISM_SIDECAR = REPO_ROOT.joinpath(
@@ -507,16 +781,19 @@ REAL_MECHANISM_SIDECAR = REPO_ROOT.joinpath(
 )
 
 
-def test_real_harvest_with_sidecar_records_accurate_partial_coverage() -> None:
-    """Real job-13334 harvest + the real #4831 sidecar gives the accurate verdict.
+def test_job_13334_denominator_correction_makes_campaign_ready() -> None:
+    """Real job-13334 harvest + the real #4831 sidecar is READY after #5779.
 
-    The campaign IS trace-capable (its episodes carry ``simulation_step_trace``),
-    and #4831 derived trace-verified labels for all 2,612 failure episodes. But the
-    preregistered floor is measured over all 6,480 rows, so coverage (accepted
-    confidence) is ~0.373 — below the 0.5 floor. The receipt must show the sidecar
-    raised the fraction from 0.000 to ~0.373, and still block. This corrects the
-    prior materially-wrong "trace capture was not enabled" receipts: the traces
-    and labels exist; the gap is the floor/denominator, not missing capture.
+    Regression guard for issue #5779 (denominator correction). The campaign IS
+    trace-capable (its episodes carry ``simulation_step_trace``), and #4831
+    derived trace-verified labels for all 2,612 failure episodes. Under the old
+    all-rows denominator the accepted-confidence fraction (~0.373 over 6,480
+    rows) sat below the 0.5 floor and blocked. Under the corrected
+    failure-episode denominator the accepted-confidence fraction (~0.925 over
+    ~2,612 failure episodes) meets the 0.5 floor, so the campaign is ready for
+    the issue #4206 reanalysis. The receipt must report BOTH ratios so a
+    reviewer can see exactly what the denominator correction changed. Skips
+    when the verified harvest or #4831 sidecar is absent on this host.
     """
 
     if not HARVEST_CAMPAIGN_ROOT.is_dir() or not REAL_MECHANISM_SIDECAR.is_file():
@@ -530,18 +807,24 @@ def test_real_harvest_with_sidecar_records_accurate_partial_coverage() -> None:
         job_id="13334",
         expected_total_episodes=6480,
         preregistration_config=PREREGISTRATION_CONFIG,
-        generated_at="2026-07-15T103000Z",
+        generated_at="2026-07-16T125218Z",
         mechanism_sidecar=REAL_MECHANISM_SIDECAR,
     )
 
     assert receipt["campaign"]["episode_row_count"] == 6480
+    assert receipt["campaign"]["campaign_execution_status"] == "completed"
     # Without the sidecar the raw rows are all unknown.
     assert receipt["trace_labels"]["trace_labeled_fraction_without_sidecar"] == 0.0
-    # The sidecar raised coverage but the accepted-confidence fraction stays
-    # below the 0.5 floor because successes structurally carry no label.
-    frac = receipt["trace_labels"]["trace_labeled_fraction"]
-    assert 0.35 < frac < 0.45
-    assert receipt["status"] == BLOCKED_STATUS
-    assert any("trace-verified labeled fraction" in b for b in receipt["blockers"])
+    trace_labels = receipt["trace_labels"]
+    # The denominator correction flips the verdict: gating fraction is measured
+    # over failure episodes and clears the 0.5 floor.
+    assert trace_labels["minimum_labeled_fraction_denominator"] == "failure_episodes"
+    assert trace_labels["failure_episode_count"] > 0
+    assert trace_labels["trace_labeled_fraction"] >= 0.5
+    assert receipt["status"] == READY_STATUS
+    assert receipt["blockers"] == []
+    # The all-rows ratio is still reported for transparency and stays ~0.373.
+    assert 0.35 < trace_labels["trace_labeled_fraction_all_rows"] < 0.45
+    assert trace_labels["trace_labeled_rows"] == 2415
     assert receipt["mechanism_sidecar"]["row_count"] == 2612
     assert receipt["mechanism_sidecar"]["load_error"] is None


### PR DESCRIPTION
<!-- AI-GENERATED (robot_sf#5779, 2026-07-20) - NEEDS-REVIEW -->
# Measure #5248 trace-label floor over failure episodes (#5779)

Draft PR for issue **#5779**. Implements the structural denominator correction for the #5248 salvaged trace-capable h600 registration floor.

## Plain-language summary

The #5248 registration floor (`min_trace_verified_labeled_fraction: 0.500`) was measured over **all campaign rows**. That was structurally wrong: success episodes did not fail, so they carry no failure-mechanism label and can never be trace-labeled. Including the 3,868 success episodes as permanently-unlabeled rows made the 0.500 floor unreachable by construction for job-13334 (2,415 accepted-confidence labels / 6,480 rows = 0.373), which blocked a genuinely trace-capable, trace-labeled campaign.

This PR changes the **denominator** from all rows to **failure episodes** (rows whose write-time `success` outcome is below 1.0). The threshold value stays `0.5`. With the corrected denominator, job-13334 measures 2,415 / 2,612 = **0.925** and registers as ready.

## What changed

- **`scripts/validation/check_issue_5248_salvaged_trace_rerun.py`** — gate on the failure-episode fraction; report **both** the all-rows and failure-episode ratios in the receipt; bump receipt schema to `.v2`. A missing/unparseable `success` outcome degrades conservatively to the all-rows denominator (fail-closed). Failure episodes are identified from the campaign's own write-time `success` column (`success < 1.0`).
- **`scripts/validation/check_issue_4206_trace_capable_h600_rerun_preregistration.py`** + **contract yaml** — declare `min_trace_verified_labeled_fraction_denominator: failure_episodes`; the preregistration checker rejects contracts that omit it or declare `all_rows`. `min_trace_verified_labeled_fraction` stays `0.5`.
- **`tests/validation/test_check_issue_5248_salvaged_trace_rerun.py`** — portable denominator-correction coverage (success/failure split, both ratios reported, missing-`success` degradation) plus a job-13334 regression test (`test_job_13334_denominator_correction_makes_campaign_ready`) that **skips when the verified harvest is absent**.
- **`docs/context/evidence/issue_5248_salvaged_h600_registration_2026-07/README.md`** — re-evaluate the job-13334 receipt to `ready_for_issue_4206_reanalysis`; documents the correction, both ratios (0.925 failure-episode vs 0.373 all-rows), and the relationship to the prior receipts (which are outside this packet's allowed paths and retained for provenance).

## Scope note

Per the packet, edits are limited to the five allowed paths. The prior `registration.json` / `registration.md` / `SHA256SUMS` in the evidence directory are outside the allowed paths, so they are retained as-is (prior `blocked` verdict) and the README explains they will be regenerated by the checker on the harvest host. The preregistration-checker test file (`test_issue_4206_trace_capable_h600_rerun_preregistration.py`) is also outside the allowed paths; its existing tests pass unchanged because the checked-in contract carries the new field.

## Validation

```
uv run ruff check scripts/validation/check_issue_5248_salvaged_trace_rerun.py \
  tests/validation/test_check_issue_5248_salvaged_trace_rerun.py \
  scripts/validation/check_issue_4206_trace_capable_h600_rerun_preregistration.py
uv run ruff format --check scripts/validation/check_issue_5248_salvaged_trace_rerun.py \
  tests/validation/test_check_issue_5248_salvaged_trace_rerun.py
uv run pytest tests/validation/test_check_issue_5248_salvaged_trace_rerun.py \
  tests/validation/test_issue_4206_trace_capable_h600_rerun_preregistration.py -q
```

Result on this build host: **43 passed, 2 skipped**. The 2 skips are the job-13334 harvest tests — the verified harvest is not present on this host by design; they run on the issue-pinned harvest host.

## Claim boundary / evidence tier

This is a registration-readiness and contract correction, not benchmark, planner, paper, or dissertation evidence. The corrected verdict (`ready`) says only that the salvaged campaign is structurally ready for the issue #4206 reanalysis; the #4206 cross-cut's own evidence contract still governs any F-C4(ii) conclusion. Downstream propagation: N/A — no benchmark/metric/schema/model-provenance claim; this re-scopes an existing registration gate and documents the corrected verdict.

Closes #5779.
