### PR TITLE
feat(benchmark): add S30 population-contract canary (#6070)

### DIFF
--- a/scripts/benchmark/s30_campaign_canary.py
+++ b/scripts/benchmark/s30_campaign_canary.py
@@ -22,7 +22,7 @@ from robot_sf.benchmark.heterogeneous_population_ablation import (
     build_runtime_population_control_trace_labels,
 )
 from robot_sf.benchmark.heterogeneous_population_ablation_runner import build_episode_scenario
-from robot_sf.benchmark.map_runner import _build_policy
+from robot_sf.benchmark.map_runner import build_map_policy
 from robot_sf.benchmark.map_runner_episode import run_map_episode
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -141,7 +141,7 @@ def run_manifest_cell(
         record_planner_decision_trace=False,
         record_simulation_step_trace=True,
         pedestrian_control_trace_label_builder=capture_runtime_labels,
-        policy_builder=_build_policy,
+        policy_builder=build_map_policy,
     )
     if instantiated is None or emitted_labels is None:
         raise ValueError("runtime did not emit the instantiated population and trace labels")

--- a/scripts/benchmark/s30_campaign_canary.py
+++ b/scripts/benchmark/s30_campaign_canary.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Fail fast when a campaign manifest's pedestrian population contract drifts.
+
+For every row in a generated heterogeneous-population manifest, this CPU-only
+canary runs a short episode and checks that the declared population equals the
+population instantiated by the simulator, the runtime trace labels, and the
+per-pedestrian rows in the emitted control trace.  It is a pre-campaign
+diagnostic, not benchmark evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.heterogeneous_population_ablation import (
+    PopulationMixNotRealizableError,
+    build_runtime_population_control_trace_labels,
+)
+from robot_sf.benchmark.heterogeneous_population_ablation_runner import build_episode_scenario
+from robot_sf.benchmark.map_runner import _build_policy
+from robot_sf.benchmark.map_runner_episode import run_map_episode
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CONTROL_TRACE_PATH = ("algorithm_metadata", "pedestrian_control_trace", "pedestrians")
+_SPAWN_SYNTHESIS_ERROR = "force_population_size requires a pedestrian route or crowded zone"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse the bounded manifest canary command line."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        required=True,
+        help="Generated JSON manifest with a manifest_rows sequence.",
+    )
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=20,
+        help="Maximum simulation steps per manifest row (default: 20).",
+    )
+    return parser.parse_args()
+
+
+def load_manifest_rows(manifest_path: Path) -> list[dict[str, Any]]:
+    """Load the existing generated-manifest row contract without inventing cells."""
+
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot load JSON manifest {manifest_path}: {exc}") from exc
+    if not isinstance(payload, Mapping):
+        raise ValueError("manifest must be a JSON mapping")
+    rows = payload.get("manifest_rows")
+    if not isinstance(rows, Sequence) or isinstance(rows, str) or not rows:
+        raise ValueError("manifest.manifest_rows must be a non-empty sequence")
+    if not all(isinstance(row, Mapping) for row in rows):
+        raise ValueError("manifest.manifest_rows entries must be mappings")
+    return [dict(row) for row in rows]
+
+
+def _declared_population(row: Mapping[str, Any]) -> int:
+    """Read one row's declared population from its arm counts."""
+
+    arm_population = row.get("arm_population")
+    if not isinstance(arm_population, Mapping):
+        raise ValueError("arm_population must be a mapping")
+    counts = arm_population.get("counts")
+    if not isinstance(counts, Mapping) or not counts:
+        raise ValueError("arm_population.counts must be a non-empty mapping")
+    try:
+        values = [int(value) for value in counts.values()]
+    except (TypeError, ValueError) as exc:
+        raise ValueError("arm_population.counts values must be integers") from exc
+    if any(value < 0 for value in values):
+        raise ValueError("arm_population.counts values must be non-negative")
+    return sum(values)
+
+
+def _cell_identity(row: Mapping[str, Any], row_index: int) -> dict[str, Any]:
+    """Return stable, human-readable coordinates for a manifest row."""
+
+    return {
+        "row_index": row_index,
+        "scenario": str(row.get("scenario_id", f"manifest_rows[{row_index}]")),
+        "population_arm": str(row.get("population_arm", "unknown")),
+        "planner": str(row.get("planner", "unknown")),
+        "seed": row.get("seed"),
+    }
+
+
+def _trace_row_count(record: Mapping[str, Any]) -> int:
+    """Count the emitted per-pedestrian trace rows in one episode record."""
+
+    value: Any = record
+    for key in _CONTROL_TRACE_PATH:
+        if not isinstance(value, Mapping):
+            raise ValueError(f"emitted record missing {'.'.join(_CONTROL_TRACE_PATH)}")
+        value = value.get(key)
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        raise ValueError(f"emitted record {'.'.join(_CONTROL_TRACE_PATH)} must be a sequence")
+    return len(value)
+
+
+def run_manifest_cell(
+    row: Mapping[str, Any], *, manifest_path: Path, max_steps: int
+) -> dict[str, int]:
+    """Run one bounded manifest row and return independently observed counts."""
+
+    declared = _declared_population(row)
+    instantiated: int | None = None
+    emitted_labels: int | None = None
+    scenario = build_episode_scenario(dict(row), max_episode_steps=max_steps)
+
+    def capture_runtime_labels(instantiated_count: int) -> list[dict[str, Any]]:
+        nonlocal instantiated, emitted_labels
+        instantiated = int(instantiated_count)
+        labels = build_runtime_population_control_trace_labels(
+            row["arm_population"],
+            instantiated,
+        )
+        emitted_labels = len(labels)
+        return labels
+
+    record = run_map_episode(
+        scenario=scenario,
+        seed=int(row["seed"]),
+        horizon=max_steps,
+        dt=0.1,
+        record_forces=True,
+        snqi_weights=None,
+        snqi_baseline=None,
+        algo=str(row["planner"]),
+        scenario_path=manifest_path,
+        record_planner_decision_trace=False,
+        record_simulation_step_trace=True,
+        pedestrian_control_trace_label_builder=capture_runtime_labels,
+        policy_builder=_build_policy,
+    )
+    if instantiated is None or emitted_labels is None:
+        raise ValueError("runtime did not emit the instantiated population and trace labels")
+    return {
+        "declared_population": declared,
+        "instantiated_pedestrians": instantiated,
+        "emitted_labels": emitted_labels,
+        "trace_rows": _trace_row_count(record),
+    }
+
+
+def _failure_disposition(exc: Exception) -> str:
+    """Classify known no-spawn failures without treating them as a green canary."""
+
+    if _SPAWN_SYNTHESIS_ERROR in str(exc):
+        return "unrealizable_without_spawn_synthesis"
+    if isinstance(exc, PopulationMixNotRealizableError):
+        return "unrealizable_population_mix"
+    return "runtime_error"
+
+
+def run_canary(
+    rows: Sequence[Mapping[str, Any]], *, manifest_path: Path, max_steps: int
+) -> dict[str, Any]:
+    """Check every manifest row and retain every failure for actionable triage."""
+
+    if max_steps <= 0:
+        raise ValueError("max_steps must be positive")
+
+    cells: list[dict[str, Any]] = []
+    for row_index, row in enumerate(rows):
+        cell = _cell_identity(row, row_index)
+        try:
+            counts = run_manifest_cell(row, manifest_path=manifest_path, max_steps=max_steps)
+            cell.update(counts)
+            count_values = set(counts.values())
+            cell["status"] = "passed" if len(count_values) == 1 else "failed"
+            if cell["status"] == "failed":
+                cell["reason"] = "declared!=instantiated!=labels!=traces"
+        except (AssertionError, KeyError, OSError, RuntimeError, TypeError, ValueError) as exc:
+            cell["declared_population"] = _safe_declared_population(row)
+            cell["instantiated_pedestrians"] = None
+            cell["emitted_labels"] = None
+            cell["trace_rows"] = None
+            cell["status"] = _failure_disposition(exc)
+            cell["reason"] = str(exc)
+        cells.append(cell)
+
+    failed_cells = [cell for cell in cells if cell["status"] != "passed"]
+    return {
+        "schema_version": "s30_campaign_canary.v1",
+        "evidence_status": "diagnostic-only",
+        "passed": not failed_cells,
+        "cell_count": len(cells),
+        "failed_cell_count": len(failed_cells),
+        "cells": cells,
+    }
+
+
+def _safe_declared_population(row: Mapping[str, Any]) -> int | None:
+    """Preserve a declared count in malformed-cell diagnostics when possible."""
+
+    try:
+        return _declared_population(row)
+    except ValueError:
+        return None
+
+
+def main() -> int:
+    """Run the pre-campaign diagnostic and return a fail-closed process status."""
+
+    args = parse_args()
+    if args.max_steps <= 0:
+        print("error: --max-steps must be positive", file=sys.stderr)
+        return 2
+    manifest_path = Path(args.manifest).expanduser()
+    if not manifest_path.is_absolute():
+        manifest_path = (_REPO_ROOT / manifest_path).resolve()
+    try:
+        rows = load_manifest_rows(manifest_path)
+        report = run_canary(rows, manifest_path=manifest_path, max_steps=args.max_steps)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_s30_campaign_canary.py
+++ b/tests/benchmark/test_s30_campaign_canary.py
@@ -1,0 +1,123 @@
+"""Regression coverage for the issue #6070 S30 population-contract canary."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts" / "benchmark" / "s30_campaign_canary.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("s30_campaign_canary", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _row(scenario_id: str) -> dict[str, Any]:
+    return {
+        "scenario_id": scenario_id,
+        "population_arm": "heterogeneous",
+        "planner": "goal",
+        "seed": 101,
+        "density": 0.02,
+        "map_file": "maps/svg_maps/classic_crossing.svg",
+        "arm_population": {"counts": {"cautious": 1, "standard": 2}},
+    }
+
+
+def test_canary_cli_reports_pass_and_every_named_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A two-cell manifest keeps a pass and the broken cell's full count tuple."""
+
+    module = _load_module()
+    manifest_path = tmp_path / "micro-manifest.json"
+    manifest_path.write_text(
+        json.dumps({"manifest_rows": [_row("passing_cell"), _row("broken_cell")]}),
+        encoding="utf-8",
+    )
+
+    def fake_run_manifest_cell(row: dict[str, Any], **_kwargs: Any) -> dict[str, int]:
+        if row["scenario_id"] == "broken_cell":
+            return {
+                "declared_population": 3,
+                "instantiated_pedestrians": 3,
+                "emitted_labels": 3,
+                "trace_rows": 2,
+            }
+        return {
+            "declared_population": 3,
+            "instantiated_pedestrians": 3,
+            "emitted_labels": 3,
+            "trace_rows": 3,
+        }
+
+    monkeypatch.setattr(module, "run_manifest_cell", fake_run_manifest_cell)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [MODULE_PATH.name, "--manifest", str(manifest_path), "--max-steps", "2"],
+    )
+
+    assert module.main() == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["passed"] is False
+    assert report["failed_cell_count"] == 1
+    assert report["cells"][0]["status"] == "passed"
+    assert report["cells"][1] == {
+        "declared_population": 3,
+        "emitted_labels": 3,
+        "instantiated_pedestrians": 3,
+        "planner": "goal",
+        "population_arm": "heterogeneous",
+        "reason": "declared!=instantiated!=labels!=traces",
+        "row_index": 1,
+        "scenario": "broken_cell",
+        "seed": 101,
+        "status": "failed",
+        "trace_rows": 2,
+    }
+
+
+def test_load_manifest_rows_rejects_ambiguous_or_empty_manifest(tmp_path: Path) -> None:
+    """The canary fails closed instead of manufacturing cells from a config."""
+
+    module = _load_module()
+    manifest_path = tmp_path / "ambiguous.json"
+    manifest_path.write_text(json.dumps({"scenarios": []}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="manifest_rows"):
+        module.load_manifest_rows(manifest_path)
+
+
+def test_canary_reports_missing_spawn_synthesis_without_crashing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An unmerged spawn-synthesis dependency stays a named failed cell."""
+
+    module = _load_module()
+
+    def missing_spawn_synthesis(*_args: Any, **_kwargs: Any) -> dict[str, int]:
+        raise ValueError(
+            "force_population_size requires a pedestrian route or crowded zone for the "
+            "remaining 11 background pedestrians"
+        )
+
+    monkeypatch.setattr(module, "run_manifest_cell", missing_spawn_synthesis)
+
+    report = module.run_canary([_row("geometryless_cell")], manifest_path=tmp_path, max_steps=2)
+
+    assert report["passed"] is False
+    assert report["cells"][0]["scenario"] == "geometryless_cell"
+    assert report["cells"][0]["declared_population"] == 3
+    assert report["cells"][0]["status"] == "unrealizable_without_spawn_synthesis"


### PR DESCRIPTION
## Summary

Add a CPU-only S30 pre-campaign canary that detects population-contract drift before a full campaign starts.

## Linked Issues

- Closes #6070

## Stack / Dependency

- Base dependency: none
- Required prior PRs: PR #5837 (merged spawn-synthesis groundwork)
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: The canary calls the existing generated `manifest_rows` and episode-runtime contracts.

## What Changed

- Added `scripts/benchmark/s30_campaign_canary.py`, which runs each manifest row for a bounded number of steps and compares declared population, the simulator-instantiated count, emitted control-trace labels, and emitted control-trace rows.
- Added a two-cell regression fixture for pass and named mismatch reporting, plus the pre-merge spawn-synthesis disposition.

## Why It Matters

- Added value: catches the S30 startup failure class before campaign dispatch and names every affected cell.
- Expected impact: prevents a declared population from silently diverging from runtime and trace metadata.
- Why this is worth merging now: it is a bounded, CPU-only gate for the rank-1 S30 pre-campaign workflow.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: #6070 blocker — population identity must be verified before S30 campaign dispatch.
- Comparator or baseline, if applicable: no campaign comparator; this checks each declared manifest row against its own runtime observation.
- Evidence tier: NA - support helper; diagnostic integrity check only, not benchmark evidence.
- Result classification: NA - the PR adds a guard and makes no benchmark result claim.
- Decision or stop rule, if applicable: non-zero when any cell differs or cannot realize the population.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #6070; the eventual S30 launch packet must invoke the canary.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it reports runtime contract integrity and does not interpret research evidence.

## Domain-Aware Approval

- Required for this PR: no - it adds an implementation-integrity diagnostic and does not alter evidence classification, comparison methodology, figure eligibility, benchmark interpretation, or paper-facing claims.
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: NA
- Validity checklist:
  - Target claim/hypothesis: NA - no experimental claim.
  - Comparator or split/evidence validity: NA.
  - Fallback/degraded exclusions: failed or unrealizable cells return non-zero and are not success evidence.
  - Claim boundary: diagnostic-only.
  - Implementation integrity vs experimental validity: implementation integrity only.

## Falsification / Non-Transfer Check

- Did the mechanism activate? NA - support helper.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? The regression fixture supplies a trace-row mismatch; the real smoke run verifies the normal geometry-less spawn path.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action

- Rerun needed: no for this implementation; yes before dispatching any new S30 manifest.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: no durable S30 heterogeneity manifest is tracked in this repository yet.
- Stop / revise / continue decision: continue only after the actual generated S30 manifest returns exit code 0.
- Proposed child issue or existing follow-up: #6070 launch-packet integration remains the parent issue's downstream action.

## Validation / Proof

- Commands run:
  - `uv run pytest tests/benchmark/test_s30_campaign_canary.py tests/benchmark/test_issue_5829_acceptance_e2e.py -q`
  - `uv run ruff check scripts/benchmark/s30_campaign_canary.py tests/benchmark/test_s30_campaign_canary.py`
  - `uv run python scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574.py --config configs/benchmarks/issue_5829_geometryless_forced_population_smoke.yaml --output output/issue_6070/s30_canary_smoke_manifest.json`
  - `uv run python scripts/benchmark/s30_campaign_canary.py --manifest output/issue_6070/s30_canary_smoke_manifest.json --max-steps 20`
- Evidence that the change works here: the real two-row geometry-less forced-population manifest reported `12 == 12 == 12 == 12` for both population arms in 12.687 seconds; the regression fixture reports its deliberately broken cell and exits non-zero.
- Benchmarks or smoke tests, if applicable: targeted CPU smoke only; diagnostic-only, not benchmark evidence.

## Risks / Rollout

- Compatibility risks: accepts the existing generated JSON `manifest_rows` contract only; ambiguous config-shaped input fails closed.
- Failure modes: an unrealizable population or missing spawn synthesis is reported as a named failed cell, with no success classification.
- Rollback or fallback plan: do not dispatch the affected campaign; repair the manifest/runtime contract and rerun the canary.

## Docs / Provenance

- Updated docs: none; CLI help and JSON report carry the operational contract.
- Relevant design or provenance notes: #6070, #5829, PR #5837, and the shared heterogeneous-population runtime.
- Any assumptions that need to be preserved: the final S30 launcher must provide a generated manifest JSON with `manifest_rows`.

## Downstream Propagation

- Parent issue updated (yes/no/NA): yes - implementation claim comment posted.
- Claim map / benchmark report updated (yes/no/NA): NA - this PR creates diagnostic tooling, not evidence.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no durable benchmark artifact.
- Registry or config index updated (yes/no/NA): NA - consumes the existing manifest contract.
- Context index / memory note updated (yes/no/NA): NA - the issue and PR carry the bounded operational handoff.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA - no independently actionable scope was discovered.
- Not applicable because: the canary itself creates no benchmark result or durable artifact; the eventual launch packet must invoke it against the committed S30 manifest.

## Follow-Up Issues

- Deferred work: wire the canary into the eventual S30 launch packet and run it against that committed manifest.
- Issues opened for follow-up: none.

## Reviewer Notes

- Anything a reviewer should verify closely: the count sources are independent: declaration from arm counts, instantiation from the runtime callback, labels returned by that callback, and trace rows from the emitted episode record.
- Any known limitations: this repository currently lacks a separately tracked full S30 heterogeneity manifest, so local executable proof uses the merged two-row #5829 geometry-less smoke manifest.
- Shared-helper migration: not applicable; this is a new thin CLI over existing manifest and runtime helpers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CPU-only campaign manifest validation tool.
  * Reports whether declared populations match simulator instances, control labels, and emitted trace rows.
  * Produces structured JSON diagnostics with per-scenario pass, failure, and unrealizable statuses.
  * Uses fail-closed exit codes for validation failures and invalid inputs.

* **Tests**
  * Added regression coverage for successful validation, detailed mismatch reporting, invalid manifests, and missing spawn-synthesis handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->