### PR TITLE
P0: unbreak main — pin print contrast PNG to deterministic width (#6088)

### DIFF
--- a/scripts/repro/butterfly_hinge_figure_proto.py
+++ b/scripts/repro/butterfly_hinge_figure_proto.py
@@ -1852,7 +1852,15 @@ def render_hinge_figure(  # noqa: PLR0913 - top-level figure assembly; each argu
     # otherwise stamps the wall-clock time into the PDF, the only source of nondeterminism
     # observed in this script -- geometry/text content is already deterministic).
     fig.savefig(out_pdf, metadata={"CreationDate": None})
-    fig.savefig(out_png, dpi=200)
+    # Pin the print PNG to the figure's STANDARD bbox (not a tight crop of the drawn
+    # artists). Without this, savefig honors rcParams["savefig.bbox"], which is None
+    # locally but can resolve to "tight" under other font/layout environments (e.g.
+    # the CI runner), cropping the PNG to the drawn content and shrinking its width
+    # below PRINT_FIG_WIDTH_IN. Pinning the standard bbox makes the rendered width
+    # deterministically round(PRINT_FIG_WIDTH_IN * dpi) == 1181 at 200 dpi regardless
+    # of font/layout env (issue #6088 root cause: the print-design width contract was
+    # previously satisfied only by environmental accident, not by construction).
+    fig.savefig(out_png, dpi=200, bbox_inches=fig.bbox_inches)
 
     # QA gate: reuse the repo's own text/marker-collision linter (item 4 -- report the
     # exact before/after defect count, not just "pass/fail").


### PR DESCRIPTION
## P0: unbreak main — CI failing at 375cec20b

Closes #6088.

### What broke

main CI failed at `375cec20b` (run
https://github.com/ll7/robot_sf_ll7/actions/runs/29860403505) on:

```
FAILED tests/tools/test_butterfly_trace_tooling.py::test_print_contrast_renderer_uses_final_width_and_role_colors
assert 1091 == 1181
 +  where 1181 = round((5.906 * 200))
```

The rendered print-layout contrast PNG came out **1091 px** wide in CI but
**1181 px** locally. `round(PRINT_FIG_WIDTH_IN * 200)` == `round(5.906 * 200)`
== **1181** is the print-design width contract.

### Root cause

The PNG savefig was `fig.savefig(out_png, dpi=200)` with no `bbox_inches`.
matplotlib's `savefig` resolves `bbox_inches` from `rcParams["savefig.bbox"]`
when the kwarg is omitted. Locally that rcParam is `None`, so the width is
`figsize * dpi` == `round(5.906 * 200)` == **1181**. But under other
font/layout environments (the CI runner) the same call resolves to a **tight
crop** of the drawn artists, which narrows the PNG below `PRINT_FIG_WIDTH_IN`.

Confirmed forensically:

- `tight_layout` never resizes the figure (verified in the matplotlib source —
  `set_size_inches`/`set_figwidth` are not referenced), so the figure width is
  a constant `5.906` in every environment. The only free variable is the
  savefig bbox resolution.
- Reproducing the figure and saving with `bbox_inches="tight"` yields ~1065–1091 px;
  the standard bbox yields exactly 1181.
- With `rcParams["savefig.bbox"] = "tight"`, the pre-fix `fig.savefig(path, dpi=200)`
  reproduces the CI crop; after the fix it stays 1181.

In short: the print-design width contract was satisfied **only by environmental
accident**, not by construction.

### Fix (1 line + comment)

Pin the print PNG to the figure's own **standard bbox** so no environmental
tight-cropping or font/layout drift can change the pixel width:

```python
fig.savefig(out_png, dpi=200, bbox_inches=fig.bbox_inches)
```

This makes the rendered width deterministically
`round(PRINT_FIG_WIDTH_IN * dpi)` == **1181** at 200 dpi regardless of
font/layout env. The PDF path is unchanged (already pinned via
`metadata={"CreationDate": None}`).

The shared role-color contract (`COLOR_A = COLOR_B = tsf.INK`,
`COLOR_PED_FOCAL_OUTLINE = tsf.ORANGE`) already passes and is **untouched** —
this PR does not weaken or delete any assertion.

### Scope

Single-file change, only the allowed path:

- `scripts/repro/butterfly_hinge_figure_proto.py`

No changes to the test, the shared color contract
(`robot_sf/benchmark/trace_scene_figure.py`), the QA linter, `pyproject.toml`,
or CI workflow.

### Validation

- `scripts/dev/run_worktree_shared_venv.sh -- pytest 'tests/tools/test_butterfly_trace_tooling.py::test_print_contrast_renderer_uses_final_width_and_role_colors' -v` → **1 passed**
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/tools/test_butterfly_trace_tooling.py -v` → **5 passed**
- `uv run ruff check scripts/repro/butterfly_hinge_figure_proto.py && uv run ruff format scripts/repro/butterfly_hinge_figure_proto.py` → **All checks passed / 1 file left unchanged**
- Width sanity: renders to **1181** deterministically across default env, `savefig.bbox="tight"` (CI-like), and serif/monospace font envs.

This is a draft PR; merging remains forbidden per the packet contract.

Factory-v2 duplicate reconciliation: Refs #6092 (same main-CI incident as #6088).