### PR TITLE
packaging: slimmer default install via aggressive extras split (#5799)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ uv run python examples/quickstart/02_trained_model.py
 uv run python examples/quickstart/03_custom_map.py
 ```
 
+> **Slim core install (Issue #5799):** for a smaller first install, the default
+> dependencies are just the simulator + gym-env + social-force core. Optional
+> capability stacks live behind extras: `[viz]` (pygame/moviepy/seaborn),
+> `[maps]` (osmnx/geopandas/pyproj), `[training]` (SB3/torch/wandb), and
+> `[benchmark]` (pandas/duckdb). Use `uv pip install -e ".[all]"` for the four
+> primary extras, or see [`docs/ENVIRONMENT.md`](docs/ENVIRONMENT.md) for the
+> full matrix. Using a feature without its extra raises a clear
+> `install robot_sf[<extra>]` error.
+
 `uv run robot-sf demo` runs a short deterministic scenario, writes a recorded episode
 (`episode.jsonl`), a static browser viewer (`viewer/index.html`), a map thumbnail
 (`thumbnail.png`), and a plain-English summary under `output/demo/latest/`. It is the

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -22,6 +22,53 @@ Optional (GPU):
 This creates/uses a `.venv` in the repo by default. Activate if desired:
 - macOS/Linux: `source .venv/bin/activate`
 
+### Slim core and optional extras (Issue #5799)
+
+Robot SF ships a **slim core** install plus PEP 621 extras so the first install
+is small. The core (`uv pip install -e .` with no extras) is enough to
+`import robot_sf`, build environments through the gym-env factory, run the
+social-force simulator and route planning, and run the random/social-force
+smoke. Optional capability stacks are pulled by extras:
+
+| Extra | Provides | Typical modules |
+| --- | --- | --- |
+| `[viz]` | `pygame`, `moviepy`, `seaborn` — viewer and video/plot extras | `robot_sf.render.sim_view` |
+| `[maps]` | `osmnx`, `geopandas`, `pyproj`, `svgelements` — OSM/geospatial map authoring | `robot_sf.nav.osm_map_builder`, `robot_sf.nav.geojson_map_builder` |
+| `[training]` | `stable-baselines3`, `torch`, `scikit-learn`, `optuna`, `tensorboard`, `wandb`, `sb3-contrib`, `tqdm` | `robot_sf.training.distributional_rl` |
+| `[benchmark]` | `pandas`, `duckdb`, `pyarrow`, `seaborn` — tabular aggregation/reporting | `robot_sf.research.aggregation` |
+| `[all]` | the four primary extras above (`viz`, `maps`, `training`, `benchmark`) | — |
+
+Specialized planner/runtime backends (`[rllib]`, `[sacadrl]`, `[orca]`,
+`[socnav]`, `[browser]`, `[criticality]`, `[gpu]`) remain standalone extras;
+install them individually or via `uv sync --all-extras`. `[all]` intentionally
+omits them so the default resolver stays compatible with the `imitation` dev
+group (see `[tool.uv] conflicts` in `pyproject.toml`).
+
+```bash
+# Slim core only (simulator + gym env + social-force smoke)
+uv pip install -e .
+
+# Add one capability stack
+uv pip install -e ".[viz]"
+uv pip install -e ".[maps]"
+uv pip install -e ".[training]"
+uv pip install -e ".[benchmark]"
+
+# All four primary extras
+uv pip install -e ".[all]"
+```
+
+Modules that need an optional dependency resolve it through
+`robot_sf.common.optional_import.require_extra`, so using a feature without its
+extra raises a clear error such as:
+
+```
+ModuleNotFoundError: The optional dependency 'geopandas' is required for this
+feature but is not installed. Install it with the 'maps' extra, e.g.:
+    uv pip install -e ".[maps]"   # editable worktree
+    pip install "robot_sf[maps]"      # from a built wheel
+```
+
 ## Headless settings (CI and servers)
 Some tests and examples import pygame/matplotlib. For headless runs, set:
 - `SDL_VIDEODRIVER=dummy`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,40 +19,62 @@ requires-python = ">=3.11"
 classifiers = [
     "Typing :: Typed",
 ]
+# Dependency layout (Issue #5799): a slim core install plus PEP 621 extras.
+# Core is the minimum needed to ``import robot_sf`` and run the gym-env factory,
+# the simulator, route/global planning, and the random/social-force smoke.
+# Optional capability stacks live behind extras so the first install is small;
+# modules that use them guard their imports and raise a clear
+# "install robot_sf[<extra>]" error when the extra is missing (see
+# robot_sf/common/_optional.py).
 dependencies = [
-    # Core dependencies
+    # Core simulation / gym stack
     "numpy>=2.4.6",
     "gymnasium>=0.29,<1.2",
     "numba>=0.66.0",
-    "pygame>=2.6.1",
-    # Data processing
-    "pandas>=3.0.3",
     "scipy>=1.17.1",
-    "matplotlib>=3.11.0",
-    "pillow>=10.4.0",
-    "svgelements>=1.9.6",
-    # Utilities
-    "loguru>=0.7.2",
-    "rich>=15.0.0",
-    "psutil>=6.1.0",
-    "moviepy>=2.0.0",
-    "jsonschema>=4.23.0",
+    # Social-force pedestrian engine (vendored under fast-pysf). Declared as a
+    # core dependency so editable installs resolve the local source in
+    # [tool.uv.sources]; the wheel also force-includes it (see [tool.hatch...]).
+    "pysocialforce>=2.0.0",
+    # Spatial / planning primitives used by the simulator and route planning
     "shapely>=2.1.2",
     "networkx>=3.6.1,<4.0",
     "pyvisgraph>=0.2.1",
     "python-motion-planning>=2.0.1,<3",
-    # OSM map extraction (Issue #392)
-    "osmnx>=2.1.0",
-    "geopandas>=1.1.4",
-    "pyproj>=3.6",
+    # Image + plotting used by core map types and the global planner's grid
+    # visualizer. Moving these fully behind [viz] needs import-guard work in
+    # nav/map_config.py and planner/classic_global_planner.py (see follow-up).
+    "pillow>=10.4.0",
+    "matplotlib>=3.11.0",
+    # Config / logging / utilities
+    "loguru>=0.7.2",
+    "psutil>=6.1.0",
+    "jsonschema>=4.23.0",
     "pyyaml>=6.0",
     "orjson>=3.11.5",
+    # ``tqdm`` is a runtime import dependency of the core ``pyvisgraph`` planner
+    # backend (pyvisgraph.vis_graph imports tqdm at module load).
+    "tqdm>=4.68.4",
 ]
 
 [project.optional-dependencies]
-gpu = [
-    "torch[cuda]>=2.13.0,<2.14.0",
+# Visualization / rendering extras: pygame viewer, movie generation, statistical
+# plotting. ``pygame`` is needed by robot_sf/render/* (sim_view) and ``moviepy``
+# by render and benchmark video export; ``seaborn`` for statistical figures.
+viz = [
+    "pygame>=2.6.1",
+    "moviepy>=2.0.0",
+    "seaborn>=0.13.2",
 ]
+# Map authoring / OSM geospatial extraction (Issue #392): osmnx/geopandas/pyproj
+# for OSM downloads, and svgelements retained for legacy SVG map tooling.
+maps = [
+    "osmnx>=2.1.0",
+    "geopandas>=1.1.4",
+    "pyproj>=3.6",
+    "svgelements>=1.9.6",
+]
+# Reinforcement-learning training stack.
 training = [
     "stable-baselines3>=2.9.0",
     "torch>=2.13.0,<2.14.0",
@@ -61,25 +83,23 @@ training = [
     "tensorboard>=2.21.0",
     "wandb>=0.28.0",
     "optuna-dashboard>=0.20.0",
-]
-recurrent = [
     "sb3-contrib>=2.9.0,<2.10.0",
-]
-rllib = [
-    "ray[rllib]>=2.53.0",
-]
-progress = [
     "tqdm>=4.68.4",
 ]
-analysis = [
-    "seaborn>=0.13.2",
-]
-analytics = [
+# Benchmark / reporting tooling: tabular aggregation and columnar analytics.
+benchmark = [
+    "pandas>=3.0.3",
     "duckdb>=1.5.4",
     "pyarrow>=25.0.0",
-]
-viz = [
     "seaborn>=0.13.2",
+]
+# CUDA build of torch for GPU training. Superset of the training torch pin.
+gpu = [
+    "torch[cuda]>=2.13.0,<2.14.0",
+]
+# Specialized research / planner backends (kept as narrow extras).
+rllib = [
+    "ray[rllib]>=2.53.0",
 ]
 browser = [
     "playwright>=1.61.0",
@@ -103,6 +123,18 @@ socnav = [
 ]
 criticality = [
     "cma>=3.3.0",
+]
+# Convenience aggregator: every primary capability extra (Issue #5799). The
+# specialized planner/runtime backends (rllib, browser, sacadrl, orca, socnav,
+# criticality) stay standalone so ``[all]`` stays resolvable alongside the
+# ``imitation`` dev group (see [tool.uv] conflicts); install them individually or
+# via ``uv sync --all-extras``. GPU torch is excluded so the default CPU-friendly
+# resolver is used; install [gpu] explicitly for CUDA.
+all = [
+    "robot_sf[viz]",
+    "robot_sf[maps]",
+    "robot_sf[training]",
+    "robot_sf[benchmark]",
 ]
 
 [build-system]

--- a/robot_sf/common/optional_import.py
+++ b/robot_sf/common/optional_import.py
@@ -79,3 +79,97 @@ def try_import(name: str) -> ModuleType | None:
         return importlib.import_module(name)
     except ImportError:
         return None
+
+
+# Map of optional dependency import names to the PEP 621 extra that provides
+# them (Issue #5799). Keep this aligned with ``[project.optional-dependencies]``
+# in pyproject.toml.
+_EXTRA_FOR_DEPENDENCY: dict[str, str] = {
+    # [viz]
+    "pygame": "viz",
+    "moviepy": "viz",
+    "seaborn": "viz",
+    # [maps]
+    "osmnx": "maps",
+    "geopandas": "maps",
+    "pyproj": "maps",
+    "svgelements": "maps",
+    # [training]
+    "stable_baselines3": "training",
+    "torch": "training",
+    "sklearn": "training",
+    "optuna": "training",
+    "tensorboard": "training",
+    "wandb": "training",
+    # [benchmark]
+    "pandas": "benchmark",
+    "duckdb": "benchmark",
+    "pyarrow": "benchmark",
+}
+
+
+def missing_extra_error(name: str, extra: str | None = None) -> ModuleNotFoundError:
+    """Build a clear ``ModuleNotFoundError`` pointing at the missing extra.
+
+    Use this together with :func:`try_import` when a feature *requires* an
+    optional dependency (i.e. it cannot degrade gracefully). The returned error
+    carries an actionable ``install robot_sf[<extra>]`` hint so users see exactly
+    what to install instead of a bare import failure.
+
+    Parameters
+    ----------
+    name:
+        The optional dependency import name (e.g. ``"pygame"``).
+    extra:
+        The extra that provides it. If ``None``, the known mapping in
+        ``_EXTRA_FOR_DEPENDENCY`` is used, falling back to ``[all]``.
+
+    Returns
+    -------
+    ModuleNotFoundError
+        An error whose message tells the user which extra to install.
+
+    Examples
+    --------
+    >>> pygame = try_import("pygame")
+    >>> if pygame is None:
+    ...     raise missing_extra_error("pygame", "viz")
+    """
+    resolved_extra = extra or _EXTRA_FOR_DEPENDENCY.get(name, "all")
+    return ModuleNotFoundError(
+        f"The optional dependency '{name}' is required for this feature but is "
+        f"not installed. Install it with the '{resolved_extra}' extra, e.g.:\n"
+        f'    uv pip install -e ".[{resolved_extra}]"   # editable worktree\n'
+        f'    pip install "robot_sf[{resolved_extra}]"      # from a built wheel'
+    )
+
+
+def require_extra(name: str, extra: str | None = None) -> ModuleType:
+    """Import and return an optional dependency, or raise a clear error.
+
+    Combines :func:`try_import` with :func:`missing_extra_error`: it returns the
+    module when installed, otherwise raises a ``ModuleNotFoundError`` with an
+    actionable ``install robot_sf[<extra>]`` hint. Use this (rather than
+    ``try_import``) for modules that genuinely need the extra and cannot degrade.
+
+    This helper introduces no new ``except ImportError`` spelling at call sites,
+    so it stays within the optional-import guard inventory ratchet
+    (``tests/test_optional_import_guard_inventory.py``).
+
+    Parameters
+    ----------
+    name:
+        The optional dependency import name (e.g. ``"torch"``).
+    extra:
+        The extra that provides it. If ``None``, the known mapping in
+        ``_EXTRA_FOR_DEPENDENCY`` is used, falling back to ``[all]``.
+
+    Returns
+    -------
+    ModuleType
+        The imported module.
+    """
+    module = try_import(name)
+    if module is None:
+        raise missing_extra_error(name, extra)
+    return module

--- a/robot_sf/nav/geojson_map_builder.py
+++ b/robot_sf/nav/geojson_map_builder.py
@@ -18,8 +18,6 @@ import argparse
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import geopandas
-import pandas
 import yaml
 from loguru import logger
 from shapely.affinity import translate
@@ -27,8 +25,16 @@ from shapely.errors import TopologicalError
 from shapely.geometry import GeometryCollection, LineString, MultiLineString, MultiPolygon, Polygon
 from shapely.ops import unary_union
 
+from robot_sf.common.optional_import import require_extra
 from robot_sf.nav.map_config import MapDefinition, serialize_map
 from robot_sf.nav.osm_map_builder import OSMTagFilters, cleanup_polygons, compute_obstacles
+
+# GeoJSON/OSM map building depends on the geospatial ([maps]) extra (Issue #5799).
+# ``pandas`` is provided transitively by ``geopandas``. Resolve both through the
+# canonical optional-import helper so a missing extra raises a clear install
+# hint instead of a bare ModuleNotFoundError.
+geopandas = require_extra("geopandas", "maps")
+pandas = require_extra("pandas", "maps")
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/robot_sf/nav/osm_map_builder.py
+++ b/robot_sf/nav/osm_map_builder.py
@@ -24,15 +24,22 @@ Design decisions:
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import geopandas
-import pandas as pd
 from loguru import logger
 from shapely.affinity import translate
 from shapely.errors import TopologicalError
 from shapely.geometry import LineString, MultiPolygon, Polygon, box
 from shapely.ops import triangulate, unary_union
 
+from robot_sf.common.optional_import import require_extra
 from robot_sf.nav.map_config import MapDefinition, Obstacle
+
+# OSM PBF ingestion depends on the geospatial ([maps]) and tabular ([benchmark])
+# extras (Issue #5799). Resolve them through the canonical optional-import
+# helper so a missing extra raises a clear install hint instead of a bare
+# ModuleNotFoundError. ``pandas`` is provided transitively by ``geopandas``
+# under [maps] but is declared under [benchmark] for standalone report tooling.
+geopandas = require_extra("geopandas", "maps")
+pd = require_extra("pandas", "benchmark")
 
 
 @dataclass

--- a/robot_sf/render/sim_view.py
+++ b/robot_sf/render/sim_view.py
@@ -12,9 +12,9 @@ from math import ceil, cos, floor, pi, sin
 os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "hide"
 
 import numpy as np
-import pygame
 from loguru import logger
 
+from robot_sf.common.optional_import import require_extra
 from robot_sf.common.types import PedPose, RgbColor, RobotPose, Vec2D
 from robot_sf.nav.map_config import MapDefinition, Obstacle
 from robot_sf.nav.occupancy_grid import (
@@ -39,6 +39,12 @@ except ImportError:
 from robot_sf.render.sim_view_text_overlay import SimViewTextOverlay
 
 ## Note: PYGAME_HIDE_SUPPORT_PROMPT is set before importing pygame above
+
+# ``pygame`` is an optional [viz] extra dependency (Issue #5799). Resolve it
+# through the canonical optional-import helper so a missing extra raises a clear
+# install hint instead of a bare ModuleNotFoundError. ``moviepy`` (above) uses the
+# same helper family but degrades gracefully (video recording disabled).
+pygame = require_extra("pygame", "viz")
 
 
 BACKGROUND_COLOR = (255, 255, 255)

--- a/robot_sf/research/aggregation.py
+++ b/robot_sf/research/aggregation.py
@@ -24,9 +24,14 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-import pandas as pd
 
 from robot_sf.common.logging import get_logger
+from robot_sf.common.optional_import import require_extra
+
+# ``pandas`` is a [benchmark] extra dependency (Issue #5799). Resolve it through
+# the canonical optional-import helper so a missing extra raises a clear install
+# hint instead of a bare ModuleNotFoundError.
+pd = require_extra("pandas", "benchmark")
 
 logger = get_logger(__name__)
 

--- a/robot_sf/training/distributional_rl.py
+++ b/robot_sf/training/distributional_rl.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-import torch
-from torch import nn
+# ``torch`` is a [training] extra dependency (Issue #5799). Resolve it through the
+# canonical optional-import helper so a missing extra raises a clear install
+# hint instead of a bare ModuleNotFoundError.
+from robot_sf.common.optional_import import require_extra
+
+torch = require_extra("torch", "training")
+nn = torch.nn
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/test_extras_install_guards.py
+++ b/tests/test_extras_install_guards.py
@@ -1,0 +1,262 @@
+"""Tests for the PEP 621 extras split and optional-import guards (Issue #5799).
+
+These tests pin three properties of the slim-core install:
+
+1. The canonical optional-import helpers (``try_import`` already existed;
+   ``require_extra`` / ``missing_extra_error`` are new) produce actionable
+   ``install robot_sf[<extra>]`` errors when an extra is missing.
+2. Each primary extra (``viz``, ``maps``, ``training``, ``benchmark``) has a
+   representative module that imports its dependency through ``require_extra``,
+   so the friendly error is reachable from a real call site (not just the unit
+   helper).
+3. ``[all]`` aggregates exactly the four primary capability extras so
+   ``uv sync --all-extras`` stays resolvable alongside the ``imitation`` dev
+   group (see ``[tool.uv] conflicts`` in pyproject.toml).
+
+The full install matrix (``uv pip install -e .`` with no extras, then each
+``.[<extra>]``) is exercised out-of-band by the issue #5799 validation contract;
+these in-process tests cover the guard contracts without needing a subprocess
+venv per extra.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestRequireExtraHelper:
+    """Contract tests for the new require_extra / missing_extra_error helpers."""
+
+    def test_require_extra_returns_module_when_available(self) -> None:
+        from robot_sf.common.optional_import import require_extra
+
+        module = require_extra("json")
+        import json as stdlib_json
+
+        assert module is stdlib_json
+
+    def test_require_extra_raises_friendly_error_when_missing(self) -> None:
+        from robot_sf.common.optional_import import require_extra
+
+        with pytest.raises(ModuleNotFoundError) as excinfo:
+            require_extra("definitely_not_a_real_module_zzz_5799", "viz")
+
+        msg = str(excinfo.value)
+        assert "install" in msg.lower()
+        assert "[viz]" in msg
+
+    def test_require_extra_infers_extra_from_known_mapping(self) -> None:
+        """The extra is inferred from the dependency name when not passed."""
+        from robot_sf.common.optional_import import require_extra
+
+        with pytest.raises(ModuleNotFoundError) as excinfo:
+            require_extra("definitely_not_a_real_module_zzz_5799_pandas")
+
+        # Unknown dependency name falls back to the [all] extra hint.
+        assert "[all]" in str(excinfo.value)
+
+    def test_missing_extra_error_message_names_dependency_and_extra(self) -> None:
+        from robot_sf.common.optional_import import missing_extra_error
+
+        err = missing_extra_error("torch", "training")
+        assert isinstance(err, ModuleNotFoundError)
+        msg = str(err)
+        assert "torch" in msg
+        assert "[training]" in msg
+        assert "uv pip install" in msg
+
+    def test_missing_extra_error_falls_back_to_all_for_unknown_dependency(self) -> None:
+        from robot_sf.common.optional_import import missing_extra_error, require_extra
+
+        assert missing_extra_error("some_unknown_dep").args[0].count("[all]") >= 1
+        # And require_extra surfaces the same fallback.
+        with pytest.raises(ModuleNotFoundError, match=r"\[all\]"):
+            require_extra("some_unknown_dep_5799")
+
+    def test_require_extra_does_not_swallow_runtime_error(self) -> None:
+        """A broken-but-importable dependency must surface, not be masked.
+
+        ``require_extra`` is built on ``try_import`` which catches only
+        ``ImportError``; a broken native dependency raising ``RuntimeError``
+        must propagate.
+        """
+        import sys
+
+        from robot_sf.common.optional_import import require_extra
+
+        fake_name = "_fake_broken_optional_dep_5799"
+
+        class _BrokenLoader:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == fake_name:
+                    from importlib.machinery import ModuleSpec
+
+                    return ModuleSpec(fake_name, self)
+                return None
+
+            def create_module(self, spec):
+                raise RuntimeError("simulated broken native dependency")
+
+            def exec_module(self, module):
+                raise RuntimeError("simulated broken native dependency")
+
+        loader = _BrokenLoader()
+        sys.meta_path.insert(0, loader)
+        try:
+            with pytest.raises(RuntimeError, match="simulated broken native dependency"):
+                require_extra(fake_name)
+        finally:
+            sys.meta_path.remove(loader)
+            sys.modules.pop(fake_name, None)
+
+
+# Representative module + dependency + extra for each primary extra. These are the
+# real guarded call sites; importing them without the extra must surface the
+# friendly error for that extra. (When the extra *is* installed, they import
+# cleanly, which is the normal dev/CI environment.)
+_REPRESENTATIVE_MODULES = [
+    pytest.param("robot_sf.render.sim_view", "pygame", "viz", id="viz"),
+    pytest.param("robot_sf.nav.osm_map_builder", "geopandas", "maps", id="maps"),
+    pytest.param("robot_sf.training.distributional_rl", "torch", "training", id="training"),
+    pytest.param("robot_sf.research.aggregation", "pandas", "benchmark", id="benchmark"),
+]
+
+
+class TestRepresentativeGuardedModules:
+    """Each primary extra has a real module that imports its dep via require_extra."""
+
+    @pytest.mark.parametrize(("module_path", "dep_name", "extra"), _REPRESENTATIVE_MODULES)
+    def test_guarded_module_uses_require_extra(
+        self, module_path: str, dep_name: str, extra: str
+    ) -> None:
+        """The representative module must resolve its dep via require_extra.
+
+        This is a static AST check so it does not require the extra to be
+        uninstalled: it confirms the friendly-error path is wired through the
+        canonical helper (and therefore stays within the optional-import guard
+        inventory ratchet) rather than a bare ``import`` or an ad-hoc
+        ``try/except``.
+        """
+        module_rel = module_path.replace(".", "/") + ".py"
+        source = (REPO_ROOT / module_rel).read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=module_rel)
+
+        require_extra_calls: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                if node.func.id == "require_extra" and node.args:
+                    first = node.args[0]
+                    if isinstance(first, ast.Constant) and first.value == dep_name:
+                        require_extra_calls.append(dep_name)
+
+        assert require_extra_calls, (
+            f"{module_rel} should resolve '{dep_name}' via require_extra(...) so a "
+            f"missing [{extra}] extra raises a clear install hint (Issue #5799)."
+        )
+
+
+class TestAllExtraAggregation:
+    """``[all]`` aggregates exactly the four primary capability extras."""
+
+    def _load_pyproject(self) -> dict[str, object]:
+        import tomllib
+
+        with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
+            return tomllib.load(fh)
+
+    def test_all_lists_exactly_the_four_primary_extras(self) -> None:
+        project = self._load_pyproject()
+        optional_deps = project["project"]["optional-dependencies"]
+        assert "all" in optional_deps, "pyproject.toml is missing the [all] extra"
+        all_entries = optional_deps["all"]
+        # Each entry is a self-reference like 'robot_sf[viz]'. Extract the extra name.
+        import re
+
+        extras = [m for entry in all_entries for m in re.findall(r"robot_sf\[([a-z]+)\]", entry)]
+        # The four primary capability extras from Issue #5799. Specialized
+        # planner/runtime backends (rllib, sacadrl, orca, ...) stay standalone so
+        # ``[all]`` + the ``imitation`` dev group stays resolvable.
+        assert extras == ["viz", "maps", "training", "benchmark"]
+
+
+class TestCoreInstallSlimness:
+    """The slim core must not pull the optional capability stacks by default."""
+
+    def _parse_dependencies(self) -> set[str]:
+        import tomllib
+
+        with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
+            project = tomllib.load(fh)
+        # Match the package name before any version specifier / extras.
+        import re
+
+        deps = project["project"]["dependencies"]
+        return {re.split(r"[<>=!\[\s]", d, maxsplit=1)[0].lower() for d in deps}
+
+    def test_viz_stacks_are_not_core(self) -> None:
+        core = self._parse_dependencies()
+        # pygame / moviepy / seaborn belong to [viz], not core.
+        assert "pygame" not in core
+        assert "moviepy" not in core
+        assert "seaborn" not in core
+
+    def test_maps_stacks_are_not_core(self) -> None:
+        core = self._parse_dependencies()
+        # osmnx / geopandas / pyproj / svgelements belong to [maps], not core.
+        assert "osmnx" not in core
+        assert "geopandas" not in core
+        assert "pyproj" not in core
+        assert "svgelements" not in core
+
+    def test_training_stacks_are_not_core(self) -> None:
+        core = self._parse_dependencies()
+        assert "stable-baselines3" not in core
+        assert "torch" not in core
+        assert "wandb" not in core
+
+    def test_benchmark_tabular_stack_is_not_core(self) -> None:
+        core = self._parse_dependencies()
+        assert "pandas" not in core
+        assert "duckdb" not in core
+        assert "pyarrow" not in core
+
+    def test_core_keeps_simulation_primitives(self) -> None:
+        """The slim core still ships the sim/gym/nav primitives needed for smoke."""
+        core = self._parse_dependencies()
+        for required in ("numpy", "gymnasium", "numba", "scipy", "shapely", "loguru"):
+            assert required in core, f"{required} must remain a core dependency"
+
+
+class TestCoreImportAndSmoke:
+    """``import robot_sf`` and the gym-env factory stay importable in the slim core.
+
+    These run in the full dev/CI environment (all extras present), so they do
+    not prove the no-extras path directly; the no-extras ``import robot_sf`` +
+    random/social-force smoke is proven by the issue #5799 validation contract
+    out-of-band. Here we at least confirm the factory path imports and steps
+    without error under the current environment.
+    """
+
+    def test_import_robot_sf_is_lightweight(self) -> None:
+        import sys
+
+        before = set(sys.modules)
+        # Drop any cached robot_sf to measure a fresh top-level import.
+        for name in [n for n in sys.modules if n == "robot_sf" or n.startswith("robot_sf.")]:
+            del sys.modules[name]
+        try:
+            importlib.import_module("robot_sf")
+        finally:
+            pass
+        after = set(sys.modules)
+        # ``import robot_sf`` must not eagerly pull heavy extras.
+        for blocked in ("stable_baselines3", "wandb", "osmnx", "geopandas", "pygame"):
+            assert not any(m == blocked or m.startswith(blocked + ".") for m in after - before), (
+                f"import robot_sf eagerly pulled '{blocked}' (should stay behind an extra)."
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -4761,6 +4761,37 @@ version = "0.0.0"
 source = { directory = "third_party/python-rvo2" }
 
 [[package]]
+name = "pysocialforce"
+version = "2.0.0"
+source = { editable = "fast-pysf" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pygame" },
+    { name = "scipy" },
+    { name = "toml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
+    { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "matplotlib", specifier = ">=3.9.2" },
+    { name = "matplotlib", marker = "extra == 'plot'", specifier = ">=3.9.2" },
+    { name = "numba", specifier = ">=0.60.0" },
+    { name = "numpy", specifier = ">=1.26.4" },
+    { name = "pillow", specifier = ">=10.4.0" },
+    { name = "pygame", specifier = ">=2.6.1" },
+    { name = "pylint", marker = "extra == 'dev'", specifier = ">=3.3.1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.1.1" },
+    { name = "scipy", specifier = ">=1.17.1" },
+    { name = "toml", specifier = ">=0.10.2" },
+]
+provides-extras = ["dev", "plot"]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5221,39 +5252,53 @@ wheels = [
 name = "robot-sf"
 source = { editable = "." }
 dependencies = [
-    { name = "geopandas" },
     { name = "gymnasium", version = "0.29.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-8-robot-sf-imitation'" },
     { name = "gymnasium", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-robot-sf-rllib' or extra != 'group-8-robot-sf-imitation'" },
     { name = "jsonschema" },
     { name = "loguru" },
     { name = "matplotlib" },
-    { name = "moviepy" },
     { name = "networkx" },
     { name = "numba" },
     { name = "numpy" },
     { name = "orjson" },
-    { name = "osmnx" },
-    { name = "pandas" },
     { name = "pillow" },
     { name = "psutil" },
-    { name = "pygame" },
-    { name = "pyproj" },
+    { name = "pysocialforce" },
     { name = "python-motion-planning" },
     { name = "pyvisgraph" },
     { name = "pyyaml" },
-    { name = "rich" },
     { name = "scipy" },
     { name = "shapely" },
-    { name = "svgelements" },
+    { name = "tqdm" },
 ]
 
 [package.optional-dependencies]
-analysis = [
-    { name = "seaborn" },
-]
-analytics = [
+all = [
     { name = "duckdb" },
+    { name = "geopandas" },
+    { name = "moviepy" },
+    { name = "optuna" },
+    { name = "optuna-dashboard" },
+    { name = "osmnx" },
+    { name = "pandas" },
     { name = "pyarrow" },
+    { name = "pygame" },
+    { name = "pyproj" },
+    { name = "sb3-contrib" },
+    { name = "scikit-learn" },
+    { name = "seaborn" },
+    { name = "stable-baselines3" },
+    { name = "svgelements" },
+    { name = "tensorboard" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "wandb" },
+]
+benchmark = [
+    { name = "duckdb" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "seaborn" },
 ]
 browser = [
     { name = "playwright" },
@@ -5264,14 +5309,14 @@ criticality = [
 gpu = [
     { name = "torch" },
 ]
+maps = [
+    { name = "geopandas" },
+    { name = "osmnx" },
+    { name = "pyproj" },
+    { name = "svgelements" },
+]
 orca = [
     { name = "pyrvo2" },
-]
-progress = [
-    { name = "tqdm" },
-]
-recurrent = [
-    { name = "sb3-contrib" },
 ]
 rllib = [
     { name = "ray", extra = ["rllib"], marker = "extra == 'extra-8-robot-sf-rllib'" },
@@ -5289,13 +5334,17 @@ socnav = [
 training = [
     { name = "optuna" },
     { name = "optuna-dashboard" },
+    { name = "sb3-contrib" },
     { name = "scikit-learn" },
     { name = "stable-baselines3" },
     { name = "tensorboard" },
     { name = "torch" },
+    { name = "tqdm" },
     { name = "wandb" },
 ]
 viz = [
+    { name = "moviepy" },
+    { name = "pygame" },
     { name = "seaborn" },
 ]
 
@@ -5331,54 +5380,74 @@ imitation = [
 [package.metadata]
 requires-dist = [
     { name = "cma", marker = "extra == 'criticality'", specifier = ">=3.3.0" },
-    { name = "duckdb", marker = "extra == 'analytics'", specifier = ">=1.5.4" },
-    { name = "geopandas", specifier = ">=1.1.4" },
+    { name = "duckdb", marker = "extra == 'all'", specifier = ">=1.5.4" },
+    { name = "duckdb", marker = "extra == 'benchmark'", specifier = ">=1.5.4" },
+    { name = "geopandas", marker = "extra == 'all'", specifier = ">=1.1.4" },
+    { name = "geopandas", marker = "extra == 'maps'", specifier = ">=1.1.4" },
     { name = "gymnasium", specifier = ">=0.29,<1.2" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "matplotlib", specifier = ">=3.11.0" },
-    { name = "moviepy", specifier = ">=2.0.0" },
+    { name = "moviepy", marker = "extra == 'all'", specifier = ">=2.0.0" },
+    { name = "moviepy", marker = "extra == 'viz'", specifier = ">=2.0.0" },
     { name = "networkx", specifier = ">=3.6.1,<4.0" },
     { name = "numba", specifier = ">=0.66.0" },
     { name = "numpy", specifier = ">=2.4.6" },
     { name = "opencv-python-headless", marker = "extra == 'socnav'", specifier = "==5.0.0.93" },
+    { name = "optuna", marker = "extra == 'all'", specifier = ">=4.9.0" },
     { name = "optuna", marker = "extra == 'training'", specifier = ">=4.9.0" },
+    { name = "optuna-dashboard", marker = "extra == 'all'", specifier = ">=0.20.0" },
     { name = "optuna-dashboard", marker = "extra == 'training'", specifier = ">=0.20.0" },
     { name = "orjson", specifier = ">=3.11.5" },
-    { name = "osmnx", specifier = ">=2.1.0" },
-    { name = "pandas", specifier = ">=3.0.3" },
+    { name = "osmnx", marker = "extra == 'all'", specifier = ">=2.1.0" },
+    { name = "osmnx", marker = "extra == 'maps'", specifier = ">=2.1.0" },
+    { name = "pandas", marker = "extra == 'all'", specifier = ">=3.0.3" },
+    { name = "pandas", marker = "extra == 'benchmark'", specifier = ">=3.0.3" },
     { name = "pillow", specifier = ">=10.4.0" },
     { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.61.0" },
     { name = "psutil", specifier = ">=6.1.0" },
-    { name = "pyarrow", marker = "extra == 'analytics'", specifier = ">=25.0.0" },
+    { name = "pyarrow", marker = "extra == 'all'", specifier = ">=25.0.0" },
+    { name = "pyarrow", marker = "extra == 'benchmark'", specifier = ">=25.0.0" },
     { name = "pyassimp", marker = "extra == 'socnav'", specifier = "==5.2.5" },
-    { name = "pygame", specifier = ">=2.6.1" },
+    { name = "pygame", marker = "extra == 'all'", specifier = ">=2.6.1" },
+    { name = "pygame", marker = "extra == 'viz'", specifier = ">=2.6.1" },
     { name = "pyopengl", marker = "extra == 'socnav'", specifier = "==3.1.10" },
-    { name = "pyproj", specifier = ">=3.6" },
+    { name = "pyproj", marker = "extra == 'all'", specifier = ">=3.6" },
+    { name = "pyproj", marker = "extra == 'maps'", specifier = ">=3.6" },
     { name = "pyrvo2", marker = "extra == 'orca'", directory = "third_party/python-rvo2" },
+    { name = "pysocialforce", editable = "fast-pysf" },
     { name = "python-motion-planning", specifier = ">=2.0.1,<3" },
     { name = "pyvisgraph", specifier = ">=0.2.1" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ray", extras = ["rllib"], marker = "extra == 'rllib'", specifier = ">=2.53.0" },
-    { name = "rich", specifier = ">=15.0.0" },
-    { name = "sb3-contrib", marker = "extra == 'recurrent'", specifier = ">=2.9.0,<2.10.0" },
+    { name = "sb3-contrib", marker = "extra == 'all'", specifier = ">=2.9.0,<2.10.0" },
+    { name = "sb3-contrib", marker = "extra == 'training'", specifier = ">=2.9.0,<2.10.0" },
     { name = "scikit-fmm", marker = "extra == 'socnav'", specifier = ">=2024.5" },
     { name = "scikit-image", marker = "extra == 'socnav'", specifier = "==0.26.0" },
+    { name = "scikit-learn", marker = "extra == 'all'", specifier = ">=1.9.0" },
     { name = "scikit-learn", marker = "extra == 'training'", specifier = ">=1.9.0" },
     { name = "scipy", specifier = ">=1.17.1" },
-    { name = "seaborn", marker = "extra == 'analysis'", specifier = ">=0.13.2" },
+    { name = "seaborn", marker = "extra == 'all'", specifier = ">=0.13.2" },
+    { name = "seaborn", marker = "extra == 'benchmark'", specifier = ">=0.13.2" },
     { name = "seaborn", marker = "extra == 'viz'", specifier = ">=0.13.2" },
     { name = "shapely", specifier = ">=2.1.2" },
+    { name = "stable-baselines3", marker = "extra == 'all'", specifier = ">=2.9.0" },
     { name = "stable-baselines3", marker = "extra == 'training'", specifier = ">=2.9.0" },
-    { name = "svgelements", specifier = ">=1.9.6" },
+    { name = "svgelements", marker = "extra == 'all'", specifier = ">=1.9.6" },
+    { name = "svgelements", marker = "extra == 'maps'", specifier = ">=1.9.6" },
+    { name = "tensorboard", marker = "extra == 'all'", specifier = ">=2.21.0" },
     { name = "tensorboard", marker = "extra == 'training'", specifier = ">=2.21.0" },
     { name = "tensorflow", marker = "extra == 'sacadrl'", specifier = ">=2.15.0" },
+    { name = "torch", marker = "extra == 'all'", specifier = ">=2.13.0,<2.14.0" },
     { name = "torch", marker = "extra == 'training'", specifier = ">=2.13.0,<2.14.0" },
     { name = "torch", extras = ["cuda"], marker = "extra == 'gpu'", specifier = ">=2.13.0,<2.14.0" },
-    { name = "tqdm", marker = "extra == 'progress'", specifier = ">=4.68.4" },
+    { name = "tqdm", specifier = ">=4.68.4" },
+    { name = "tqdm", marker = "extra == 'all'", specifier = ">=4.68.4" },
+    { name = "tqdm", marker = "extra == 'training'", specifier = ">=4.68.4" },
+    { name = "wandb", marker = "extra == 'all'", specifier = ">=0.28.0" },
     { name = "wandb", marker = "extra == 'training'", specifier = ">=0.28.0" },
 ]
-provides-extras = ["analysis", "analytics", "browser", "criticality", "gpu", "orca", "progress", "recurrent", "rllib", "sacadrl", "socnav", "training", "viz"]
+provides-extras = ["all", "benchmark", "browser", "criticality", "gpu", "maps", "orca", "rllib", "sacadrl", "socnav", "training", "viz"]
 
 [package.metadata.requires-dev]
 carla = [{ name = "carla", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==0.9.16" }]
@@ -6507,6 +6576,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7", size = 87085, upload-time = "2024-10-24T14:58:29.895Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289", size = 26610, upload-time = "2024-10-24T14:58:28.029Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #5799.

Splits robot_sf's heavy default dependency list into a **slim core** install plus
PEP 621 extras — `[viz]`, `[maps]`, `[training]`, `[benchmark]`, and `[all]` —
and adds import guards that raise clear `install robot_sf[<extra>]` errors when
an optional feature is used without its extra.

> ⚠️ Issue #5799 explicitly flags this as **not** a cheap-lane task ("packaging
> change, do deliberately"). This PR was produced under a packet-bound auxiliary
> worker contract and implemented deliberately: every dependency move was
> verified against the actual import graph, and the full install matrix was
> proven green (see Validation). Remaining slimming (moving `matplotlib`/`pillow`
> fully behind `[viz]`) needs import-guard work inside the forbidden
> `planner/classic_global_planner.py` and `nav/map_config.py` and is left as a
> clearly-scoped follow-up.

## What changed

### Slim core (`uv pip install -e .`, no extras)
The default `dependencies` now contain only what `import robot_sf`, the gym-env
factory, the social-force simulator, and route/global planning need. With no
extras, `import robot_sf` works and a robot env can be created, reset, and
stepped (random/social-force smoke passes).

### New/adjusted extras
| Extra | Provides |
| --- | --- |
| `[viz]` | `pygame`, `moviepy`, `seaborn` |
| `[maps]` | `osmnx`, `geopandas`, `pyproj`, `svgelements` |
| `[training]` | `stable-baselines3`, `torch`, `scikit-learn`, `optuna`, `tensorboard`, `wandb`, `sb3-contrib`, `tqdm` (absorbs former `recurrent`/`progress`) |
| `[benchmark]` | `pandas`, `duckdb`, `pyarrow`, `seaborn` |
| `[all]` | the four primary extras above |

Specialized planner/runtime backends (`rllib`, `sacadrl`, `orca`, `socnav`,
`browser`, `criticality`, `gpu`) stay standalone; `[all]` intentionally omits
them so `uv sync --all-extras` stays resolvable alongside the `imitation` dev
group (see `[tool.uv] conflicts`). Dropped the unused `rich` runtime dep (not
imported anywhere in `robot_sf`) and the stale unused `svgelements` core dep
(moved under `[maps]`).

### Import guards (clear `install robot_sf[<extra>]` errors)
Representative modules resolve their optional dependency through the **existing
canonical** `robot_sf.common.optional_import` helper, extended with
`require_extra` / `missing_extra_error`. This adds **no new `except ImportError`
spellings**, so the optional-import guard inventory ratchet
(`tests/test_optional_import_guard_inventory.py`) stays green:

- `robot_sf/render/sim_view.py` → `pygame` (`[viz]`)
- `robot_sf/nav/osm_map_builder.py` → `geopandas`/`pandas` (`[maps]`/`[benchmark]`)
- `robot_sf/nav/geojson_map_builder.py` → `geopandas`/`pandas` (`[maps]`)
- `robot_sf/training/distributional_rl.py` → `torch` (`[training]`)
- `robot_sf/research/aggregation.py` → `pandas` (`[benchmark]`)

Example error without the extra:
```
ModuleNotFoundError: The optional dependency 'geopandas' is required for this
feature but is not installed. Install it with the 'maps' extra, e.g.:
    uv pip install -e ".[maps]"   # editable worktree
    pip install "robot_sf[maps]"      # from a built wheel
```

### Docs / tests
- `docs/ENVIRONMENT.md` + `README.md` quickstart document the slim core and the
  extras matrix.
- `tests/test_extras_install_guards.py` covers the helper contracts, the
  representative guarded modules (static AST), the `[all]` aggregation, and core
  slimness.

## Validation

- **Slim core (no extras):** `uv venv /tmp/sf-core && uv pip install -e .` →
  `python -c 'import robot_sf'` ✔; random/social-force smoke
  (`make_robot_env()` → reset → step) ✔.
- **Per-extra matrix:** for `viz maps training benchmark`,
  `uv pip install -e ".[<extra>]"` then import the representative module ✔.
  Friendly `install robot_sf[<extra>]` errors fire for each extra when missing ✔.
- **Targeted tests:** `pytest tests/test_simulator_force_factory.py
  tests/demo/test_run_robot_sf_smoke.py tests/test_robot_sf_import_smoke.py
  tests/test_optional_import_guard_inventory.py tests/test_extras_install_guards.py
  tests/test_ci_script_contract.py` → 119 passed (serial).
- **Lint:** `uv run ruff check .` and `uv run ruff format --check .` clean.
- **Regression:** `pytest tests/render/ tests/nav/ tests/gym_env/` → 220 passed.
- **Full env:** `uv sync --all-extras` resolves (320 pkgs) and
  `uv lock --check` passes.
- **pr_ready_check:** ruff/format/2672-suite tests pass. Two
  `tests/test_ci_script_contract.py` tests
  (`..._preflights_analytics_dependencies`,
  `..._rejects_process_substitution_body_paths`) fail **only** under the full
  xdist suite; confirmed pre-existing on `origin/main` (they fail there too under
  the same conditions and pass when run serially or in-file). These exercise
  `scripts/dev/*` (unchanged by this PR) and are xdist-isolation flakes, not
  regressions from this change.

## Scope / follow-ups

- `matplotlib` and `pillow` remain in core because they are imported at module
  load by `nav/map_config.py` and `planner/classic_global_planner.py` (the latter
  uses `matplotlib.colors` in a visualizer class). Moving them fully behind
  `[viz]` requires import-guard edits inside those files and is tracked as a
  follow-up; this PR delivers the safe, high-value subset (pygame/moviepy/seaborn,
  the OSM stack, the training stack, and pandas move out of core).
- `pygame` is also a declared dependency of the vendored `pysocialforce` (core),
  so it is typically present transitively; the `[viz]` guard is a correct safety
  net and explicit metadata either way.

## Evidence classification

Support/tooling + packaging change. No benchmark, metric, or paper-facing claim.
Target claim: slimmer default install via extras + clear import-guard errors,
proven by the green install matrix and targeted tests above.

Closes #5799.
