### PR TITLE
test(benchmark): cover camera-ready config types (#6078)

### DIFF
--- a/RESULT.md
+++ b/RESULT.md
@@ -1,36 +1,40 @@
-# PR #6091 Review Fix Result
+# PR #5834 Review Fix Result
 
 ## Fixed comments
 
-- Added `_minimal_campaign()` to `test_config_dataclasses_are_frozen`, so the frozen
-  immutability assertion now covers `CampaignConfig` as well as the other camera-ready config
-  dataclasses.
+- Synchronized `proto-butterfly-video` with current `origin/main`
+  (`f7645fdffea168f279f4c838798780ee55a14c5b`) using a normal merge commit; the current main
+  commit is an ancestor of the pushed PR head.
+- Reconciled scope in a PR comment: successor PR #5933 already supplies the six-file prototype;
+  the only production delta remaining in #5834 is the one-file renderer-style change from stacked
+  #5953.
+- Added direct renderer-focused proof for the remaining delta. The test renders `layout="print"`,
+  checks the final 5.906-inch output width, and verifies shared `INK`/`ORANGE` role colors plus
+  redundant A/B marker/linestyle encoding.
 
 ## Validation
 
-- `uv run pytest -q tests/benchmark/test_camera_ready_config_types.py` — 26 passed.
-- `uv run ruff check tests/benchmark/test_camera_ready_config_types.py` — passed.
-- `uv run ruff format --check tests/benchmark/test_camera_ready_config_types.py` — passed.
-- `git diff --check` — passed.
+- `uv run ruff check tests/tools/test_butterfly_trace_tooling.py scripts/repro/butterfly_hinge_figure_proto.py` — passed.
+- `uv run ruff format --check tests/tools/test_butterfly_trace_tooling.py scripts/repro/butterfly_hinge_figure_proto.py` — passed.
+- `scripts/dev/run_focused_tests.sh tests/tools/test_butterfly_trace_tooling.py -q` — passed.
+- `git merge-base --is-ancestor origin/main HEAD` — passed.
+- `git diff --stat origin/main...HEAD` — two files: the one-file renderer delta and its focused test.
+- Existing `output/` files were only counted (5 files); no generated output artifact was added to git.
 
 ## Commit
 
-- `b74daa0fe4639693a6155d6908c8b8b43376a677`
-  (`test(benchmark): cover CampaignConfig immutability`)
-- Pushed to `cheap/cheap-issue-6078-8927f68f18b3`, the head branch of PR #6091.
+- Pushed commit: `e13541f0adc44246efa9b61409206808a39f6a91`
+- PR head verified at the same SHA.
+- Exact-head GitHub checks were running when this result was recorded.
 
 ## Review state
 
-- The code-fix push was re-queried and the PR head was `b74daa0fe4639693a6155d6908c8b8b43376a677`.
-- GitHub reported no unresolved GraphQL review threads and no REST inline review comments before
-  or after the push; therefore there was no thread to resolve.
-- No additional unresolved review blockers were observed.
-
-## Artifact decision
-
-- Five pre-existing ignored files under `output/` were observed. They are unrelated generated
-  local artifacts and were not modified or used as dependencies for this test fix.
+- Post-push GraphQL review-thread query: zero thread nodes; zero unresolved threads.
+- Resolved thread IDs: none; there were no unresolved review-thread nodes to resolve.
+- Scope-reconciliation comment: https://github.com/ll7/robot_sf_ll7/pull/5834#issuecomment-5037858742
 
 ## Blockers
 
-- None.
+- No local or inline-review blocker remains within the authorized scope.
+- External blocker: exact-head GitHub CI had not completed when this result was recorded; no CI
+  result is claimed here.

--- a/RESULT.md
+++ b/RESULT.md
@@ -17,13 +17,11 @@
 
 - `b74daa0fe4639693a6155d6908c8b8b43376a677`
   (`test(benchmark): cover CampaignConfig immutability`)
-- `3b1608b8ec3dec3c7bf49c552fd31dc9adebc0fe`
-  (`docs: record PR 6091 review fix result`)
 - Pushed to `cheap/cheap-issue-6078-8927f68f18b3`, the head branch of PR #6091.
 
 ## Review state
 
-- The PR head was re-queried after push and is `3b1608b8ec3dec3c7bf49c552fd31dc9adebc0fe`.
+- The code-fix push was re-queried and the PR head was `b74daa0fe4639693a6155d6908c8b8b43376a677`.
 - GitHub reported no unresolved GraphQL review threads and no REST inline review comments before
   or after the push; therefore there was no thread to resolve.
 - No additional unresolved review blockers were observed.

--- a/RESULT.md
+++ b/RESULT.md
@@ -17,11 +17,13 @@
 
 - `b74daa0fe4639693a6155d6908c8b8b43376a677`
   (`test(benchmark): cover CampaignConfig immutability`)
+- `3b1608b8ec3dec3c7bf49c552fd31dc9adebc0fe`
+  (`docs: record PR 6091 review fix result`)
 - Pushed to `cheap/cheap-issue-6078-8927f68f18b3`, the head branch of PR #6091.
 
 ## Review state
 
-- The PR head was re-queried after push and is `b74daa0fe4639693a6155d6908c8b8b43376a677`.
+- The PR head was re-queried after push and is `3b1608b8ec3dec3c7bf49c552fd31dc9adebc0fe`.
 - GitHub reported no unresolved GraphQL review threads and no REST inline review comments before
   or after the push; therefore there was no thread to resolve.
 - No additional unresolved review blockers were observed.

--- a/RESULT.md
+++ b/RESULT.md
@@ -1,40 +1,36 @@
-# PR #5834 Review Fix Result
+# PR #6091 Review Fix Result
 
 ## Fixed comments
 
-- Synchronized `proto-butterfly-video` with current `origin/main`
-  (`f7645fdffea168f279f4c838798780ee55a14c5b`) using a normal merge commit; the current main
-  commit is an ancestor of the pushed PR head.
-- Reconciled scope in a PR comment: successor PR #5933 already supplies the six-file prototype;
-  the only production delta remaining in #5834 is the one-file renderer-style change from stacked
-  #5953.
-- Added direct renderer-focused proof for the remaining delta. The test renders `layout="print"`,
-  checks the final 5.906-inch output width, and verifies shared `INK`/`ORANGE` role colors plus
-  redundant A/B marker/linestyle encoding.
+- Added `_minimal_campaign()` to `test_config_dataclasses_are_frozen`, so the frozen
+  immutability assertion now covers `CampaignConfig` as well as the other camera-ready config
+  dataclasses.
 
 ## Validation
 
-- `uv run ruff check tests/tools/test_butterfly_trace_tooling.py scripts/repro/butterfly_hinge_figure_proto.py` — passed.
-- `uv run ruff format --check tests/tools/test_butterfly_trace_tooling.py scripts/repro/butterfly_hinge_figure_proto.py` — passed.
-- `scripts/dev/run_focused_tests.sh tests/tools/test_butterfly_trace_tooling.py -q` — passed.
-- `git merge-base --is-ancestor origin/main HEAD` — passed.
-- `git diff --stat origin/main...HEAD` — two files: the one-file renderer delta and its focused test.
-- Existing `output/` files were only counted (5 files); no generated output artifact was added to git.
+- `uv run pytest -q tests/benchmark/test_camera_ready_config_types.py` — 26 passed.
+- `uv run ruff check tests/benchmark/test_camera_ready_config_types.py` — passed.
+- `uv run ruff format --check tests/benchmark/test_camera_ready_config_types.py` — passed.
+- `git diff --check` — passed.
 
 ## Commit
 
-- Pushed commit: `e13541f0adc44246efa9b61409206808a39f6a91`
-- PR head verified at the same SHA.
-- Exact-head GitHub checks were running when this result was recorded.
+- `b74daa0fe4639693a6155d6908c8b8b43376a677`
+  (`test(benchmark): cover CampaignConfig immutability`)
+- Pushed to `cheap/cheap-issue-6078-8927f68f18b3`, the head branch of PR #6091.
 
 ## Review state
 
-- Post-push GraphQL review-thread query: zero thread nodes; zero unresolved threads.
-- Resolved thread IDs: none; there were no unresolved review-thread nodes to resolve.
-- Scope-reconciliation comment: https://github.com/ll7/robot_sf_ll7/pull/5834#issuecomment-5037858742
+- The PR head was re-queried after push and is `b74daa0fe4639693a6155d6908c8b8b43376a677`.
+- GitHub reported no unresolved GraphQL review threads and no REST inline review comments before
+  or after the push; therefore there was no thread to resolve.
+- No additional unresolved review blockers were observed.
+
+## Artifact decision
+
+- Five pre-existing ignored files under `output/` were observed. They are unrelated generated
+  local artifacts and were not modified or used as dependencies for this test fix.
 
 ## Blockers
 
-- No local or inline-review blocker remains within the authorized scope.
-- External blocker: exact-head GitHub CI had not completed when this result was recorded; no CI
-  result is claimed here.
+- None.

--- a/tests/benchmark/test_camera_ready_config_types.py
+++ b/tests/benchmark/test_camera_ready_config_types.py
@@ -1,0 +1,337 @@
+"""Unit tests for camera-ready config dataclasses and constants.
+
+Covers ``robot_sf/benchmark/camera_ready/_config_types.py`` (issue #6078): the pure frozen
+configuration dataclasses and module-level constants that form the package-local owner for the
+#3385 camera-ready decomposition. Tests assert the declared defaults, frozen immutability,
+absence of shared mutable default state, frozen-dataclass equality semantics, and the public
+package re-export surface.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.camera_ready import (
+    DEFAULT_SEED_SETS_PATH,
+    AmvProfileConfig,
+    CampaignConfig,
+    PlannerSpec,
+    ScenarioCandidateSelection,
+    SeedPolicy,
+    SnqiContractConfig,
+    TuningSpec,
+)
+from robot_sf.benchmark.camera_ready import _config_types as config_types
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+
+def test_default_seed_sets_path_is_configs_relative() -> None:
+    """DEFAULT_SEED_SETS_PATH points at the canonical seed-sets config under configs/."""
+    assert DEFAULT_SEED_SETS_PATH == Path("configs/benchmarks/seed_sets_v1.yaml")
+    # The package re-export must be the exact same object, not a copy.
+    assert DEFAULT_SEED_SETS_PATH is config_types.DEFAULT_SEED_SETS_PATH
+
+
+def test_amv_dimensions_are_the_four_paper_axes() -> None:
+    """_AMV_DIMENSIONS enumerates the four AMV coverage axes in their canonical order."""
+    assert config_types._AMV_DIMENSIONS == ("use_case", "context", "speed_regime", "maneuver_type")
+
+
+def test_tuning_source_constants_and_vocabulary() -> None:
+    """The three tuning-source provenance labels and their closed vocabulary tuple."""
+    assert config_types.TUNING_SOURCE_DECLARED == "declared"
+    assert config_types.TUNING_SOURCE_BACKFILLED == "backfilled"
+    assert config_types.TUNING_SOURCE_UNKNOWN == "unknown"
+    assert config_types._TUNING_SOURCES == ("declared", "backfilled", "unknown")
+
+
+def test_enforcement_vocabulary_tuples() -> None:
+    """The tuning-effort and checkpoint-provenance enforcement mode vocabularies."""
+    assert config_types._TUNING_EFFORT_ENFORCEMENT == ("off", "warn", "error")
+    assert config_types._CHECKPOINT_PROVENANCE_ENFORCEMENT == ("off", "error")
+
+
+# ---------------------------------------------------------------------------
+# AmvProfileConfig
+# ---------------------------------------------------------------------------
+
+
+def test_amv_profile_config_defaults() -> None:
+    """AmvProfileConfig defaults to the v1 paper profile with empty required dimensions."""
+    profile = AmvProfileConfig()
+
+    assert profile.name == "amv-paper-v1"
+    assert profile.contract_version == "1"
+    assert profile.coverage_enforcement == "warn"
+    # Every AMV axis is present but empty by default.
+    assert set(profile.required_dimensions) == set(config_types._AMV_DIMENSIONS)
+    assert all(value == () for value in profile.required_dimensions.values())
+
+
+def test_amv_profile_config_required_dimensions_can_be_overridden() -> None:
+    """required_dimensions accepts per-axis value tuples via the default factory."""
+    profile = AmvProfileConfig(
+        required_dimensions={"use_case": ("doorway", "crossing")},
+    )
+
+    assert profile.required_dimensions["use_case"] == ("doorway", "crossing")
+
+
+# ---------------------------------------------------------------------------
+# SeedPolicy
+# ---------------------------------------------------------------------------
+
+
+def test_seed_policy_defaults() -> None:
+    """SeedPolicy defaults to scenario-default seeding against the canonical seed-set file."""
+    policy = SeedPolicy()
+
+    assert policy.mode == "scenario-default"
+    assert policy.seed_set is None
+    assert policy.seeds == ()
+    assert policy.seed_sets_path == DEFAULT_SEED_SETS_PATH
+
+
+# ---------------------------------------------------------------------------
+# ScenarioCandidateSelection
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_candidate_selection_defaults() -> None:
+    """ScenarioCandidateSelection defaults to an empty, unnamed selection."""
+    selection = ScenarioCandidateSelection()
+
+    assert selection.names == ()
+    assert selection.selection_name is None
+
+
+# ---------------------------------------------------------------------------
+# TuningSpec
+# ---------------------------------------------------------------------------
+
+
+def test_tuning_spec_defaults_to_unknown_source() -> None:
+    """A bare TuningSpec records an unknown source and otherwise blank provenance."""
+    spec = TuningSpec()
+
+    assert spec.parameters_touched == ()
+    assert spec.tuning_scenario_ids == ()
+    assert spec.eval_set_disjoint is None
+    assert spec.budget_runs is None
+    assert spec.budget_hours is None
+    assert spec.tuned_by is None
+    assert spec.tuned_at_utc is None
+    assert spec.source == config_types.TUNING_SOURCE_UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# PlannerSpec
+# ---------------------------------------------------------------------------
+
+
+def test_planner_spec_required_fields_and_defaults() -> None:
+    """PlannerSpec only requires key/algo; every other field has an experimental default."""
+    spec = PlannerSpec(key="orca", algo="orca")
+
+    assert spec.key == "orca"
+    assert spec.algo == "orca"
+    assert spec.human_model_variant is None
+    assert spec.human_model_source is None
+    assert spec.benchmark_profile == "baseline-safe"
+    assert spec.algo_config_path is None
+    assert spec.socnav_missing_prereq_policy == "fail-fast"
+    assert spec.availability_gate is None
+    assert spec.fail_closed_reason is None
+    assert spec.adapter_impact_eval is False
+    assert spec.observation_mode is None
+    assert spec.workers_override is None
+    assert spec.horizon_override is None
+    assert spec.dt_override is None
+    assert spec.enabled is True
+    assert spec.planner_group == "experimental"
+    assert spec.planner_group_explicit is False
+    assert spec.tuning is None
+
+
+def test_planner_spec_carries_declared_tuning_block() -> None:
+    """PlannerSpec accepts an author-declared TuningSpec with a declared source."""
+    spec = PlannerSpec(
+        key="cadrl",
+        algo="cadrl",
+        tuning=TuningSpec(
+            parameters_touched=("lr",),
+            eval_set_disjoint=True,
+            source=config_types.TUNING_SOURCE_DECLARED,
+        ),
+    )
+
+    assert spec.tuning is not None
+    assert spec.tuning.parameters_touched == ("lr",)
+    assert spec.tuning.eval_set_disjoint is True
+    assert spec.tuning.source == "declared"
+
+
+# ---------------------------------------------------------------------------
+# SnqiContractConfig
+# ---------------------------------------------------------------------------
+
+
+def test_snqi_contract_config_defaults() -> None:
+    """SnqiContractConfig defaults to enabled, warn-enforcement with documented thresholds."""
+    contract = SnqiContractConfig()
+
+    assert contract.enabled is True
+    assert contract.enforcement == "warn"
+    assert contract.rank_alignment_warn_threshold == 0.5
+    assert contract.rank_alignment_fail_threshold == 0.3
+    assert contract.outcome_separation_warn_threshold == 0.05
+    assert contract.outcome_separation_fail_threshold == 0.0
+    assert contract.max_component_dominance_warn_threshold == 0.24
+    assert contract.max_component_dominance_fail_threshold == 0.27
+    assert contract.calibration_seed == 123
+    assert contract.calibration_trials == 3000
+
+
+# ---------------------------------------------------------------------------
+# CampaignConfig
+# ---------------------------------------------------------------------------
+
+
+def _minimal_campaign() -> CampaignConfig:
+    """Build a CampaignConfig exercising only the required fields."""
+    return CampaignConfig(
+        name="smoke-campaign",
+        scenario_matrix_path=Path("configs/benchmarks/matrix.yaml"),
+        planners=(PlannerSpec(key="sf", algo="sf"),),
+    )
+
+
+def test_campaign_config_required_fields_and_defaults() -> None:
+    """CampaignConfig requires name/scenario_matrix_path/planners and defaults enforcement off."""
+    cfg = _minimal_campaign()
+
+    assert cfg.name == "smoke-campaign"
+    assert cfg.scenario_matrix_path == Path("configs/benchmarks/matrix.yaml")
+    assert len(cfg.planners) == 1
+    assert cfg.planners[0].key == "sf"
+    # Backwards-compatible enforcement defaults.
+    assert cfg.tuning_effort_enforcement == "off"
+    assert cfg.checkpoint_provenance_enforcement == "off"
+    assert cfg.arm_isolation == "in_process"
+
+
+def test_campaign_config_provides_composite_subconfig_defaults() -> None:
+    """CampaignConfig fills in nested subconfig defaults without caller intervention."""
+    cfg = _minimal_campaign()
+
+    assert isinstance(cfg.amv_profile, AmvProfileConfig)
+    assert cfg.amv_profile == AmvProfileConfig()
+    assert isinstance(cfg.seed_policy, SeedPolicy)
+    assert cfg.seed_policy == SeedPolicy()
+    assert isinstance(cfg.scenario_candidates, ScenarioCandidateSelection)
+    assert isinstance(cfg.snqi_contract, SnqiContractConfig)
+    assert cfg.snqi_contract == SnqiContractConfig()
+    assert cfg.synthetic_actuation_profile is None
+    assert cfg.latency_stress_profile is None
+
+
+def test_campaign_config_requires_name_and_matrix() -> None:
+    """CampaignConfig must be constructed with the three required fields."""
+    with pytest.raises(TypeError):
+        CampaignConfig(  # type: ignore[call-arg]
+            scenario_matrix_path=Path("configs/benchmarks/matrix.yaml"),
+            planners=(),
+        )
+
+
+def test_campaign_config_mutable_defaults_are_fresh_per_instance() -> None:
+    """Factory-backed mutable defaults must not be shared across CampaignConfig instances."""
+    first = _minimal_campaign()
+    second = _minimal_campaign()
+
+    # field(default_factory=...) guarantees independent mutable containers.
+    assert first.amv_profile is not second.amv_profile
+    assert first.scenario_candidates is not second.scenario_candidates
+    assert first.scenario_amv_overrides is not second.scenario_amv_overrides
+    assert first.snqi_contract is not second.snqi_contract
+    # Mutating one instance's default must not bleed into the other.
+    first.scenario_amv_overrides["s1"] = {"use_case": "doorway"}
+    assert second.scenario_amv_overrides == {}
+
+
+def test_campaign_config_seed_policy_default_is_a_frozen_shared_instance() -> None:
+    """seed_policy uses a shared default instance; that is safe because SeedPolicy is frozen."""
+    first = _minimal_campaign()
+    second = _minimal_campaign()
+
+    # This documents the real declaration (default=SeedPolicy(), not a factory). Sharing is safe
+    # because SeedPolicy is frozen and therefore immutable; mutating it must raise.
+    assert first.seed_policy is second.seed_policy
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        first.seed_policy.mode = "fixed"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Frozen / equality semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "instance",
+    [
+        AmvProfileConfig(),
+        SeedPolicy(),
+        ScenarioCandidateSelection(),
+        TuningSpec(),
+        PlannerSpec(key="k", algo="a"),
+        SnqiContractConfig(),
+    ],
+)
+def test_config_dataclasses_are_frozen(instance: object) -> None:
+    """Every config dataclass is frozen: assigning to a field must raise."""
+    field_names = [f.name for f in dataclasses.fields(instance)]
+    assert field_names, "expected at least one field on the dataclass"
+    first_field = field_names[0]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(instance, first_field, None)
+
+
+def test_frozen_dataclasses_compare_by_value() -> None:
+    """Equal frozen config dataclasses with equal fields compare equal and distinct hash."""
+    left = PlannerSpec(key="k", algo="a", tuning=TuningSpec(source="declared"))
+    right = PlannerSpec(key="k", algo="a", tuning=TuningSpec(source="declared"))
+
+    assert left == right
+    assert hash(left) == hash(right)
+    assert left != PlannerSpec(key="k", algo="b")
+
+
+# ---------------------------------------------------------------------------
+# Public package re-export surface
+# ---------------------------------------------------------------------------
+
+
+def test_public_symbols_are_re_exported_from_package() -> None:
+    """The package __init__ re-exports each config type and the shared seed-sets path."""
+    import robot_sf.benchmark.camera_ready as pkg
+
+    expected = {
+        "DEFAULT_SEED_SETS_PATH",
+        "AmvProfileConfig",
+        "CampaignConfig",
+        "PlannerSpec",
+        "ScenarioCandidateSelection",
+        "SeedPolicy",
+        "SnqiContractConfig",
+        "TuningSpec",
+        "load_campaign_config",
+    }
+    assert expected.issubset(set(pkg.__all__))
+    for name in expected:
+        assert hasattr(pkg, name), f"package is missing re-exported symbol {name!r}"

--- a/tests/benchmark/test_camera_ready_config_types.py
+++ b/tests/benchmark/test_camera_ready_config_types.py
@@ -291,6 +291,7 @@ def test_campaign_config_seed_policy_default_is_a_frozen_shared_instance() -> No
         TuningSpec(),
         PlannerSpec(key="k", algo="a"),
         SnqiContractConfig(),
+        _minimal_campaign(),
     ],
 )
 def test_config_dataclasses_are_frozen(instance: object) -> None:


### PR DESCRIPTION
## Summary

Adds focused unit-test coverage for `robot_sf/benchmark/camera_ready/_config_types.py`, the frozen config-dataclass module identified by the `test_coverage_gap` signal in #6078 as having no filename-matching test file under `tests/`.

This is a bounded test-only slice: the source module is unchanged.

## What is covered

The new file `tests/benchmark/test_camera_ready_config_types.py` (26 tests) asserts the declared contract of `_config_types.py`:

- **Module-level constants**: `DEFAULT_SEED_SETS_PATH` (configs-relative + re-export identity), `_AMV_DIMENSIONS` (the four paper axes), the three `TUNING_SOURCE_*` labels with their closed `_TUNING_SOURCES` vocabulary, and the `_TUNING_EFFORT_ENFORCEMENT` / `_CHECKPOINT_PROVENANCE_ENFORCEMENT` mode tuples.
- **Per-dataclass defaults**: `AmvProfileConfig` (v1 profile, all four axes empty), `SeedPolicy`, `ScenarioCandidateSelection`, `TuningSpec` (default source = `unknown`), `PlannerSpec` (only `key`/`algo` required; experimental defaults), `SnqiContractConfig` (thresholds + calibration), and `CampaignConfig` (required fields + off-by-default enforcement).
- **Frozen immutability**: parametrized assertion that assignment raises `FrozenInstanceError` for every dataclass.
- **No shared mutable default state**: factory-backed mutable defaults (`amv_profile`, `scenario_candidates`, `scenario_amv_overrides`, `snqi_contract`) are fresh per instance; mutating one instance's default does not bleed into another.
- **`seed_policy` shared frozen default**: documents that `default=SeedPolicy()` (not a factory) is safe because `SeedPolicy` is frozen.
- **Frozen-dataclass equality/hashing**: equal-by-value comparison and matching hashes.
- **Public re-export surface**: the package `__init__` `__all__` and importability for every re-exported symbol.

## Related issue

Closes #6078.

## Validation

Declared CPU validation contract (run against a full worktree-local `.venv`):

```
uv run pytest -q tests/benchmark/test_camera_ready_config_types.py   # 26 passed
uv run ruff check tests/benchmark/test_camera_ready_config_types.py  # All checks passed!
uv run ruff format --check tests/benchmark/test_camera_ready_config_types.py  # already formatted
```

## Scope

- Owned path: `tests/benchmark/test_camera_ready_config_types.py` (new file only).
- No changes to `robot_sf/benchmark/camera_ready/**`, `configs/**`, `maps/**`, `model/**`, or any other source.
- No scratch/status files committed.
- Frozen head `1fa49fde4aad20f96f443255d6d2b0d37ed5e108` unchanged.

This is a test-only change; no benchmark claim, so the evidence tier is N/A.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation for camera-ready configuration defaults, overrides, immutability, and equality behavior.
  * Added coverage ensuring configuration instances safely isolate mutable values.
  * Verified expected public configuration exports remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->