### PR TITLE
fix(ci): refresh evidence-registry baseline and review companion for factory-v2 drift (#6108)

### DIFF
--- a/scripts/validation/evidence_registry_baseline.json
+++ b/scripts/validation/evidence_registry_baseline.json
@@ -192,11 +192,13 @@
       "uncommitted_artifact_missing_location": 1
     },
     "docs/context/evidence/issue_3425_slurm_to_claim_h600_trace_2026-07/checklist_13268.json": {
+      "dangling_commit": 1,
       "duplicate_campaign_id": 1,
       "missing_config_path": 1,
       "missing_config_sha256": 1
     },
     "docs/context/evidence/issue_3425_slurm_to_claim_h600_trace_2026-07/checklist_13273.json": {
+      "dangling_commit": 1,
       "duplicate_campaign_id": 1,
       "missing_config_path": 1,
       "missing_config_sha256": 1
@@ -229,8 +231,8 @@
     "docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json": {
       "uncommitted_artifact_missing_location": 7
     },
-    "docs/context/evidence/issue_3810_h600_interpretation_2026-07/h600_source_reports_manifest.json": {
-      "uncommitted_artifact_missing_location": 6
+    "docs/context/evidence/issue_3810_h600_interpretation_2026-07/h600_source_reports_recovery.json": {
+      "hash_without_artifact_path": 8
     },
     "docs/context/evidence/issue_3810_h600_interpretation_2026-07/snqi_weight_set_h600_preflight.json": {
       "artifact_hash_mismatch": 1,
@@ -331,23 +333,23 @@
       "hash_without_artifact_path": 1
     }
   },
-  "generated_at": "2026-07-20T16:06:58Z",
+  "generated_at": "2026-07-22T15:00:00Z",
   "linter": "scripts/tools/lint_evidence_registry.py",
   "schema_version": 1,
   "summary": {
     "by_code": {
       "artifact_hash_mismatch": 14,
       "config_missing_at_commit": 4,
-      "dangling_commit": 16,
+      "dangling_commit": 18,
       "duplicate_campaign_id": 6,
-      "hash_without_artifact_path": 85,
+      "hash_without_artifact_path": 93,
       "invalid_sha256": 1,
       "missing_commit": 28,
       "missing_config_path": 49,
       "missing_config_sha256": 53,
-      "uncommitted_artifact_missing_location": 158
+      "uncommitted_artifact_missing_location": 152
     },
     "files_with_findings": 87,
-    "total_findings": 414
+    "total_findings": 418
   }
 }

--- a/scripts/validation/evidence_registry_baseline_review.yaml
+++ b/scripts/validation/evidence_registry_baseline_review.yaml
@@ -17,7 +17,7 @@ source_issue_addendum: 5981
 prior_baseline_commit: 9fa96c01bf1c8152459f5fa8c481e938fb1e6725
 prior_baseline_total_findings: 359
 prior_baseline_files_with_findings: 73
-refreshed_baseline_total_findings: 414
+refreshed_baseline_total_findings: 418
 refreshed_baseline_files_with_findings: 87
 decision_summary: >-
   Fourteen evidence files merged after the 2026-07-11 baseline introduced 52 findings across
@@ -54,6 +54,12 @@ decision_summary: >-
   remaining findings on the canonical #4848 path
   (duplicate_campaign_id, missing_config_path, missing_config_sha256) are separate campaign
   provenance concerns outside issue #5986's dangling-commit scope and remain tracked here.
+  Factory-v2 addendum (issue #6108): commit 5d13acf8c replaced the prior
+  h600_source_reports_manifest.json (6 uncommitted_artifact_missing_location) with
+  h600_source_reports_recovery.json (8 hash_without_artifact_path). Two issue_3425 checklist
+  files also gained dangling_commit findings (checkout-dependent git history shift). Total
+  findings increased from 414 to 418; all three deltas follow the same legacy-provenance-debt
+  pattern as the existing 414 findings and are dispositioned as baseline below.
 disposition_legend:
   baseline: >-
     Finding kept as reviewed legacy debt; the file is now tracked in the committed baseline so the
@@ -161,6 +167,15 @@ reviewed_files:
       This is the legacy provenance gap identified by Issue #5972; repairing the external artifact
       binding is outside this baseline reconciliation, so the finding is explicitly dispositioned
       as baseline under the existing strict-CI policy.
+  - path: docs/context/evidence/issue_3810_h600_interpretation_2026-07/h600_source_reports_recovery.json
+    codes: [hash_without_artifact_path]
+    disposition: baseline
+    reason: >-
+      Source-reports recovery file (replaces prior h600_source_reports_manifest.json with the
+      recovered h600 source artifacts). Carries 8 sha256 checksums without a bindable committed
+      artifact path; same artifact-provenance-backfill-required pattern as the legacy 85
+      hash_without_artifact_path findings. Recovering the external/private artifact locations is
+      a provenance backfill task outside this baseline reconciliation.
 reviewed_baseline_increases:
   - path: docs/context/evidence/issue_1344_paired_amv_primary_2026-05-20/nominal_campaign_summary.json
     codes: [dangling_commit]
@@ -202,3 +217,19 @@ reviewed_baseline_increases:
       ordinary branch/tag reachability in a pristine full-history single-branch checkout. Record
       this checkout-dependent historical provenance finding explicitly; do not rewrite the
       artifact or producer SHA in this baseline reconciliation.
+  - path: docs/context/evidence/issue_3425_slurm_to_claim_h600_trace_2026-07/checklist_13268.json
+    codes: [dangling_commit]
+    disposition: baseline
+    reason: >-
+      The producer commit is not reachable from main's ordinary branch/tag reachability in a
+      pristine full-history single-branch checkout (checklist artifact generated from a private
+      Slurm job context). Record this checkout-dependent historical provenance finding explicitly;
+      do not rewrite the artifact or producer SHA in this baseline reconciliation.
+  - path: docs/context/evidence/issue_3425_slurm_to_claim_h600_trace_2026-07/checklist_13273.json
+    codes: [dangling_commit]
+    disposition: baseline
+    reason: >-
+      The producer commit is not reachable from main's ordinary branch/tag reachability in a
+      pristine full-history single-branch checkout (checklist artifact generated from a private
+      Slurm job context). Record this checkout-dependent historical provenance finding explicitly;
+      do not rewrite the artifact or producer SHA in this baseline reconciliation.


### PR DESCRIPTION
## Summary

Refresh evidence-registry baseline and review companion after factory-v2 commit 5d13acf8c drifted the tracked evidence file set.

## Linked Issues

- Closes #6108

## What Changed

- Regenerated `scripts/validation/evidence_registry_baseline.json` via `evidence_registry_ratchet.py --write-baseline`
- Added `reviewed_files` entry for `h600_source_reports_recovery.json` (new file, 8 `hash_without_artifact_path`)
- Added `reviewed_baseline_increases` entries for `checklist_13268.json` and `checklist_13273.json` (each gained `dangling_commit: 1`)
- Updated review YAML `decision_summary` and `refreshed_baseline_total_findings` (414 → 418)

## Validation / Proof

- `uv run pytest tests/dev/test_evidence_registry_ratchet.py -v` — 24/24 passed
- `scripts/dev/ruff_fix_format.sh` — all checks passed
- The two tests that were blocking CI (`test_committed_baseline_passes_live_check_on_clean_main`, `test_committed_baseline_reproduces_from_write_baseline`) now pass

## Risks / Rollout

- Low risk: the baseline and review YAML are the only changed files; the ratchet logic is unchanged
- CI should re-green on the next merge sweep

## Downstream Propagation

- Not applicable because: docs-only evidence-registry metadata change, no benchmark/claim/artifact surface affected

## Follow-Up Issues

- None
